### PR TITLE
Adding autotrigger for CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ cache: &global_cache
     - $CI_PROJECT_DIR/external/
   policy: pull
 
-update-cache:
+update-cache: &update-cache-manual
   <<: *job_definition
   when: manual
   stage: prereq
@@ -69,6 +69,16 @@ update-cache:
       - $CI_PROJECT_DIR/external/
       - $CI_PROJECT_DIR/bp_common/test/mem/
     policy: push
+
+update-cache-auto:
+    <<: *update-cache-manual
+    when: always
+    only:
+      changes:
+        - Makefile
+        - Makefile.common
+        - bp_common/test/*
+        - external/*
 
 hotfix_job:
   <<: *job_definition

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ tools:
 progs: update_tests
 	$(MAKE) -C $(BP_COMMON_DIR)/test all_mem all_dump all_nbf
 
-ucode:
+ucode: update_libs
 	$(MAKE) -C $(BP_ME_DIR)/src/asm roms
 
 libs: update_libs


### PR DESCRIPTION
This should get of those false negative failures where you update a tool / test and it passes locally but fails in CI.