### PR TITLE
LCE-CCE Interface Refactor

### DIFF
--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_req.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_req.v
@@ -115,7 +115,7 @@ module bp_be_dcache_lce_req
   bp_me_addr_to_cce_id
    #(.bp_params_p(bp_params_p))
    req_map
-    (.paddr_i(lce_req.addr)
+    (.paddr_i(lce_req.header.addr)
 
      ,.cce_id_o(req_cce_id_lo)
      );
@@ -124,7 +124,7 @@ module bp_be_dcache_lce_req
   bp_me_addr_to_cce_id
    #(.bp_params_p(bp_params_p))
    resp_map
-    (.paddr_i(lce_resp.addr)
+    (.paddr_i(lce_resp.header.addr)
 
      ,.cce_id_o(resp_cce_id_lo)
      );
@@ -145,18 +145,17 @@ module bp_be_dcache_lce_req
 
     lce_req_v_o = 1'b0;
 
-    lce_req.dst_id = req_cce_id_lo;
-    lce_req.src_id = lce_id_i;
-    lce_req.msg_type = e_lce_req_type_rd;
-    lce_req.addr = miss_addr_r;
-    lce_req.msg = '0;
+    lce_req.header.dst_id = req_cce_id_lo;
+    lce_req.header.src_id = lce_id_i;
+    lce_req.header.msg_type = e_lce_req_type_rd;
+    lce_req.header.addr = miss_addr_r;
 
     lce_resp_v_o = 1'b0;
 
-    lce_resp.dst_id = resp_cce_id_lo;
-    lce_resp.src_id = lce_id_i;
-    lce_resp.msg_type = bp_lce_cce_resp_type_e'('0);
-    lce_resp.addr = miss_addr_r;
+    lce_resp.header.dst_id = resp_cce_id_lo;
+    lce_resp.header.src_id = lce_id_i;
+    lce_resp.header.msg_type = bp_lce_cce_resp_type_e'('0);
+    lce_resp.header.addr = miss_addr_r;
     lce_resp.data = '0;
 
     unique case (state_r)
@@ -198,12 +197,12 @@ module bp_be_dcache_lce_req
         else if (uncached_store_req_i) begin
           lce_req_v_o = ~credits_full_i & lce_req_ready_i;
 
-          lce_req.msg.uc_req.data = store_data_i;
-          lce_req.msg.uc_req.uc_size = bp_lce_cce_uc_req_size_e'(size_op_i);
-          lce_req.addr = miss_addr_i;
-          lce_req.msg_type = e_lce_req_type_uc_wr;
-          lce_req.src_id = lce_id_i;
-          lce_req.dst_id = req_cce_id_lo;
+          lce_req.data = store_data_i;
+          lce_req.header.uc_size = bp_lce_cce_uc_req_size_e'(size_op_i);
+          lce_req.header.addr = miss_addr_i;
+          lce_req.header.msg_type = e_lce_req_type_uc_wr;
+          lce_req.header.src_id = lce_id_i;
+          lce_req.header.dst_id = req_cce_id_lo;
 
           cache_miss_o = ~lce_req_ready_i | credits_full_i;
           state_n = e_READY;
@@ -223,21 +222,20 @@ module bp_be_dcache_lce_req
 
         lce_req_v_o = 1'b1;
 
-        lce_req.msg.req.pad = '0;
-        lce_req.msg.req.lru_dirty = dirty_lru_flopped_r
+        lce_req.header.lru_dirty = dirty_lru_flopped_r
           ? bp_lce_cce_lru_dirty_e'(dirty_r)
           : bp_lce_cce_lru_dirty_e'(dirty_i[lru_way_i]);
-        lce_req.msg.req.lru_way_id = dirty_lru_flopped_r
+        lce_req.header.lru_way_id = dirty_lru_flopped_r
           ? lru_way_r
           : lru_way_i;
-        lce_req.msg.req.non_exclusive = e_lce_req_excl;
+        lce_req.header.non_exclusive = e_lce_req_excl;
 
-        lce_req.addr = miss_addr_r;
-        lce_req.msg_type = load_not_store_r 
+        lce_req.header.addr = miss_addr_r;
+        lce_req.header.msg_type = load_not_store_r 
           ? e_lce_req_type_rd
           : e_lce_req_type_wr;
-        lce_req.src_id = lce_id_i;
-        lce_req.dst_id = req_cce_id_lo;
+        lce_req.header.src_id = lce_id_i;
+        lce_req.header.dst_id = req_cce_id_lo;
 
         cache_miss_o = 1'b1;
         state_n = lce_req_ready_i
@@ -249,12 +247,12 @@ module bp_be_dcache_lce_req
       e_SEND_UNCACHED_LOAD_REQ: begin
         lce_req_v_o = 1'b1;
 
-        lce_req.msg.uc_req.data = '0;
-        lce_req.msg.uc_req.uc_size = bp_lce_cce_uc_req_size_e'(size_op_r);
-        lce_req.addr = miss_addr_r;
-        lce_req.msg_type = e_lce_req_type_uc_rd;
-        lce_req.src_id = lce_id_i;
-        lce_req.dst_id = req_cce_id_lo;
+        lce_req.data = '0;
+        lce_req.header.uc_size = bp_lce_cce_uc_req_size_e'(size_op_r);
+        lce_req.header.addr = miss_addr_r;
+        lce_req.header.msg_type = e_lce_req_type_uc_rd;
+        lce_req.header.src_id = lce_id_i;
+        lce_req.header.dst_id = req_cce_id_lo;
 
         cache_miss_o = 1'b1;
         state_n = lce_req_ready_i
@@ -292,7 +290,7 @@ module bp_be_dcache_lce_req
       // send out coh ack to CCE.
       e_SEND_COH_ACK: begin
         lce_resp_v_o = 1'b1;
-        lce_resp.msg_type = e_lce_cce_coh_ack;
+        lce_resp.header.msg_type = e_lce_cce_coh_ack;
 
         cache_miss_o = 1'b1;
         state_n = lce_resp_yumi_i

--- a/bp_common/src/include/bp_common_me_if.vh
+++ b/bp_common/src/include/bp_common_me_if.vh
@@ -1,9 +1,8 @@
 /**
  * bp_common_me_if.vh
  *
- * This file defines the interface between the CCEs and LCEs, and the CCEs and memory in the
- * BlackParrot coherence system. For ease of reuse and flexiblity, this interface is defined as a
- * collection of parameterized structs.
+ * This file defines the interface between the CCEs and LCEs in the BlackParrot coherence system.
+ * The interface is defined as a set of parameterized structs.
  *
  */
 
@@ -19,42 +18,25 @@
  * The following enums and structs define the LCE-CCE Interface within a BlackParrot coherence
  * system.
  *
- * There are 5 logical networks/message types:
+ * There are 3 message classes:
  * 1. LCE Request
  * 2. LCE Response
- * 3. LCE Data Response
- * 4. LCE Command
- * 5. LCE Data Command
+ * 3. LCE Command
  *
- * These five logical message types are carried on three networks:
+ * These three message types are carried on three physical networks:
  * 1. Request (low priority)
- * 2. Command (medium priority), LCE Commands and Data Commands
- * 3. Response (high priority), LCE Responses and Data Responses
+ * 2. Command (medium priority)
+ * 3. Response (high priority)
  *
  * A Request message may cause a Command message, and a Command message may cause a Response.
  * A higher priority message may not cause a lower priority message to be sent, which avoids
- * a circular dependency between message classes.
+ * a circular dependency between message classes, and prevents certain instances of deadlock.
  *
- * LCE Request Processing Flow:
- *  At a high level, a cache miss is handled by an LCE Request being sent to the CCE, followed by
- *  a series of commands and and responses that handle invalidating, evicting, and writing-back
- *  blocks as needed, sending data and tags to the LCE, and concluding with the LCE sending a response
- *  to the CCE managing the transaction. The length of a coherence transaction depends on the type of
- *  request (read- or write-miss), the current state of the requested block, and the current state of
- *  the cache way that the miss will be filled into.
- *
- *
- * Clients should use the declare_bp_me_if() macro to declare all of the interface structs at once.
+ * Users should use the declare_bp_lce_cce_if macro to declare all of the interface structs
+ * at once. The declare_*_widths macros can be used to declare needed packet and header
+ * widths in module parameter lists.
  *
  */
-
-
-/* TODO list
-
-1. Align cache block data fields in Command and Response messages to physical network flit boundary
-
-*/
-
 
 /*
  * 
@@ -65,19 +47,6 @@
  */
 
 `define declare_bp_lce_cce_if(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp, data_width_mp, cce_block_width_mp) \
-  typedef struct packed                                                                                  \
-  {                                                                                                      \
-    logic [`bp_lce_req_pad(lce_assoc_mp, data_width_mp)-1:0]  pad;                                       \
-    bp_lce_cce_lru_dirty_e                                    lru_dirty;                                 \
-    logic [`BSG_SAFE_CLOG2(lce_assoc_mp)-1:0]                 lru_way_id;                                \
-    bp_lce_cce_req_non_excl_e                                 non_exclusive;                             \
-  }  bp_lce_cce_req_req_s;                                                                               \
-                                                                                                         \
-  typedef struct packed                                                                                  \
-  {                                                                                                      \
-    logic [data_width_mp-1:0]  data;                                                                     \
-    bp_lce_cce_uc_req_size_e   uc_size;                                                                  \
-  }  bp_lce_cce_req_uc_req_s;                                                                            \
                                                                                                          \
 /*                                                                                                       \
  * bp_lce_cce_req_s defines an LCE request sent by an LCE to a CCE on a cache miss. An LCE enters        \
@@ -94,56 +63,46 @@
  */                                                                                                      \
   typedef struct packed                                                                                  \
   {                                                                                                      \
-    union packed                                                                                         \
-    {                                                                                                    \
-      bp_lce_cce_req_req_s     req;                                                                      \
-      bp_lce_cce_req_uc_req_s  uc_req;                                                                   \
-    }                                        msg;                                                        \
-    logic [paddr_width_mp-1:0]               addr;                                                       \
-    bp_lce_cce_req_type_e                    msg_type;                                                   \
-    logic [lce_id_width_mp-1:0]              src_id;                                                     \
-    logic [cce_id_width_mp-1:0]              dst_id;                                                     \
-  }  bp_lce_cce_req_s;                                                                                   \
+    bp_lce_cce_uc_req_size_e                     uc_size;                                                \
+    bp_lce_cce_lru_dirty_e                       lru_dirty;                                              \
+    logic [`BSG_SAFE_CLOG2(lce_assoc_mp)-1:0]    lru_way_id;                                             \
+    bp_lce_cce_req_non_excl_e                    non_exclusive;                                          \
+    logic [paddr_width_mp-1:0]                   addr;                                                   \
+    logic [lce_id_width_mp-1:0]                  src_id;                                                 \
+    bp_lce_cce_data_length_e                     data_length;                                            \
+    bp_lce_cce_req_type_e                        msg_type;                                               \
+    logic [cce_id_width_mp-1:0]                  dst_id;                                                 \
+  } bp_lce_cce_req_header_s;                                                                             \
                                                                                                          \
-  // CCE to LCE Command                                                                                  \
-  // This command does not include data                                                                  \
   typedef struct packed                                                                                  \
   {                                                                                                      \
-    logic [`bp_lce_cmd_pad(cce_id_width_mp, lce_id_width_mp, lce_assoc_mp, paddr_width_mp, cce_block_width_mp)-1:0]\
-                                                 pad;                                                    \
-    logic [`BSG_SAFE_CLOG2(lce_assoc_mp)-1:0]    target_way_id;                                          \
-    logic [lce_id_width_mp-1:0]                  target;                                                 \
-    logic [`bp_coh_bits-1:0]                     state;                                                  \
-    logic [paddr_width_mp-1:0]                   addr;                                                   \
-    logic [cce_id_width_mp-1:0]                  src_id;                                                 \
-  }  bp_lce_cmd_cmd_s;                                                                                   \
-                                                                                                         \
-  // LCE Data and Tag Command                                                                            \
-  // This command sends data and cache tag to an LCE                                                     \
-  typedef struct packed                                                                                  \
-  {                                                                                                      \
-    logic [cce_block_width_mp-1:0]               data;                                                   \
-    logic [`bp_coh_bits-1:0]                     state;                                                  \
-    logic [paddr_width_mp-1:0]                   addr;                                                   \
-  }  bp_lce_cmd_dt_s;                                                                                    \
+    logic [data_width_mp-1:0]                    data;                                                   \
+    bp_lce_cce_req_header_s                      header;                                                 \
+  } bp_lce_cce_req_s;                                                                                    \
                                                                                                          \
 /**                                                                                                      \
  *  bp_lce_cmd_s is the generic message for LCE Command and LCE Data Command that is sent across the     \
  *  Command network from CCE to LCE.                                                                     \
  *  Although not required, It is designed to be sent through a wormhole routed network that will send    \
- *  the minimum number of flits required, based on the msg_type field.                                   \
- *  msg_type: indicates the type of message and implies the size of the message payload                  \
+ *  the minimum number of flits required, based on the data_length field.                                \
  */                                                                                                      \
   typedef struct packed                                                                                  \
   {                                                                                                      \
-    union packed                                                                                         \
-    {                                                                                                    \
-      bp_lce_cmd_dt_s                 dt_cmd;                                                            \
-      bp_lce_cmd_cmd_s                cmd;                                                               \
-    }                                            msg;                                                    \
+    logic [`BSG_SAFE_CLOG2(lce_assoc_mp)-1:0]    target_way_id;                                          \
+    logic [lce_id_width_mp-1:0]                  target;                                                 \
+    bp_coh_states_e                              state;                                                  \
     logic [`BSG_SAFE_CLOG2(lce_assoc_mp)-1:0]    way_id;                                                 \
+    logic [paddr_width_mp-1:0]                   addr;                                                   \
+    logic [cce_id_width_mp-1:0]                  src_id;                                                 \
+    bp_lce_cce_data_length_e                     data_length;                                            \
     bp_lce_cmd_type_e                            msg_type;                                               \
     logic [lce_id_width_mp-1:0]                  dst_id;                                                 \
+  } bp_lce_cmd_header_s;                                                                                 \
+                                                                                                         \
+  typedef struct packed                                                                                  \
+  {                                                                                                      \
+    logic [cce_block_width_mp-1:0]               data;                                                   \
+    bp_lce_cmd_header_s                          header;                                                 \
   } bp_lce_cmd_s;                                                                                        \
                                                                                                          \
 /**                                                                                                      \
@@ -152,11 +111,17 @@
  */                                                                                                      \
   typedef struct packed                                                                                  \
   {                                                                                                      \
-    logic [cce_block_width_mp-1:0]               data;                                                   \
     logic [paddr_width_mp-1:0]                   addr;                                                   \
-    bp_lce_cce_resp_type_e                       msg_type;                                               \
     logic [lce_id_width_mp-1:0]                  src_id;                                                 \
+    bp_lce_cce_data_length_e                     data_length;                                            \
+    bp_lce_cce_resp_type_e                       msg_type;                                               \
     logic [cce_id_width_mp-1:0]                  dst_id;                                                 \
+  } bp_lce_cce_resp_header_s;                                                                            \
+                                                                                                         \
+  typedef struct packed                                                                                  \
+  {                                                                                                      \
+    logic [cce_block_width_mp-1:0]               data;                                                   \
+    bp_lce_cce_resp_header_s                     header;                                                 \
   } bp_lce_cce_resp_s;                                                                                   \
 
 
@@ -166,6 +131,29 @@
  * These enums define the options for fields of the LCE-CCE Interface messages. Clients should use
  * the enums to set and compare fields of messages, rather than examining the bit pattern directly.
  */
+
+/*
+ * bp_lce_cce_data_length_e specifies how many 64-bit data chunks are sent following the header
+ */
+typedef enum bit [3:0]
+{
+  e_lce_data_length_0   = 4'b0000
+  ,e_lce_data_length_1  = 4'b0001
+  ,e_lce_data_length_2  = 4'b0010
+  ,e_lce_data_length_3  = 4'b0011
+  ,e_lce_data_length_4  = 4'b0100
+  ,e_lce_data_length_5  = 4'b0101
+  ,e_lce_data_length_6  = 4'b0110
+  ,e_lce_data_length_7  = 4'b0111
+  ,e_lce_data_length_8  = 4'b1000
+  ,e_lce_data_length_9  = 4'b1001
+  ,e_lce_data_length_10 = 4'b1010
+  ,e_lce_data_length_11 = 4'b1011
+  ,e_lce_data_length_12 = 4'b1100
+  ,e_lce_data_length_13 = 4'b1101
+  ,e_lce_data_length_14 = 4'b1110
+  ,e_lce_data_length_15 = 4'b1111
+} bp_lce_cce_data_length_e;
 
 /*
  * bp_lce_cce_req_type_e specifies whether the containing message is related to a read or write
@@ -295,51 +283,44 @@ typedef enum bit [2:0]
 } bp_lce_cce_resp_type_e;
 
 /*
- * Width macros for packed unions. Clients should not need to modify or use these.
+ * Width macros for headers. Users should not need to call these directly. Instead, use the message
+ * width macros defined further below.
  */
 
-`define bp_lce_req_no_pad_width(lce_assoc_mp) \
-  ($bits(bp_lce_cce_req_non_excl_e)+`BSG_SAFE_CLOG2(lce_assoc_mp)+$bits(bp_lce_cce_lru_dirty_e))
+`define bp_lce_cce_req_header_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp) \
+  (cce_id_width_mp+$bits(bp_lce_cce_req_type_e)+$bits(bp_lce_cce_data_length_e)+lce_id_width_mp     \
+   +paddr_width_mp+$bits(bp_lce_cce_req_non_excl_e)+`BSG_SAFE_CLOG2(lce_assoc_mp)                   \
+   +$bits(bp_lce_cce_lru_dirty_e)+$bits(bp_lce_cce_uc_req_size_e))
 
-`define bp_lce_uc_req_width(data_width_mp) \
-  (data_width_mp+$bits(bp_lce_cce_uc_req_size_e))
+`define bp_lce_cmd_header_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp)     \
+  (cce_id_width_mp+$bits(bp_lce_cmd_type_e)+$bits(bp_lce_cce_data_length_e)+lce_id_width_mp         \
+   +paddr_width_mp+(2*`BSG_SAFE_CLOG2(lce_assoc_mp))+$bits(bp_coh_states_e)+lce_id_width_mp)
 
-`define bp_lce_req_pad(lce_assoc_mp, data_width_mp)                                        \
-  (`bp_lce_uc_req_width(data_width_mp)-`bp_lce_req_no_pad_width(lce_assoc_mp))
+`define bp_lce_cce_resp_header_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp)              \
+  (cce_id_width_mp+$bits(bp_lce_cce_resp_type_e)+$bits(bp_lce_cce_data_length_e)+lce_id_width_mp    \
+   +paddr_width_mp)
 
-`define bp_lce_req_msg_u_width(data_width_mp) \
-  (`bp_lce_uc_req_width(data_width_mp))
-
-`define bp_lce_cmd_no_pad_width(cce_id_width_mp, lce_id_width_mp, lce_assoc_mp, paddr_width_mp)       \
-  (cce_id_width_mp+paddr_width_mp+`bp_coh_bits+lce_id_width_mp+`BSG_SAFE_CLOG2(lce_assoc_mp))
-
-`define bp_lce_cmd_pad(cce_id_width_mp, lce_id_width_mp, lce_assoc_mp, paddr_width_mp, cce_block_width_mp) \
-  (cce_block_width_mp+paddr_width_mp+`bp_coh_bits \
-   -`bp_lce_cmd_no_pad_width(cce_id_width_mp, lce_id_width_mp, lce_assoc_mp, paddr_width_mp))
-
-`define bp_lce_cmd_msg_u_width(cce_block_width_mp, paddr_width_mp) \
-  (cce_block_width_mp+paddr_width_mp+`bp_coh_bits)
-
+`define declare_bp_lce_cce_if_header_widths(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp)                               \
+    , localparam lce_cce_req_header_width_lp=`bp_lce_cce_req_header_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp) \
+    , localparam lce_cmd_header_width_lp=`bp_lce_cmd_header_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp)         \
+    , localparam lce_cce_resp_header_width_lp=`bp_lce_cce_resp_header_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp)
 
 /*
  * Width macros for LCE-CCE Message Networks
  */
 
-`define bp_lce_cce_req_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, data_width_mp) \
-  (cce_id_width_mp+lce_id_width_mp+$bits(bp_lce_cce_req_type_e) \
-   +paddr_width_mp+`bp_lce_req_msg_u_width(data_width_mp))
+`define bp_lce_cce_req_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp, data_width_mp) \
+  (`bp_lce_cce_req_header_width(cce_id_width_mp,lce_id_width_mp,paddr_width_mp,lce_assoc_mp)+data_width_mp)
 
-`define bp_lce_cmd_width(lce_id_width_mp, lce_assoc_mp, paddr_width_mp, cce_block_width_mp) \
-  (lce_id_width_mp+$bits(bp_lce_cmd_type_e)+`BSG_SAFE_CLOG2(lce_assoc_mp) \
-   +`bp_lce_cmd_msg_u_width(cce_block_width_mp, paddr_width_mp))
+`define bp_lce_cmd_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp, cce_block_width_mp) \
+  (`bp_lce_cmd_header_width(cce_id_width_mp,lce_id_width_mp,paddr_width_mp,lce_assoc_mp)+cce_block_width_mp)
 
 `define bp_lce_cce_resp_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, cce_block_width_mp) \
-  (cce_id_width_mp+lce_id_width_mp+$bits(bp_lce_cce_resp_type_e) \
-   +paddr_width_mp+cce_block_width_mp)
+  (`bp_lce_cce_resp_header_width(cce_id_width_mp,lce_id_width_mp,paddr_width_mp)+cce_block_width_mp)
 
-`define declare_bp_lce_cce_if_widths(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp, data_width_mp, cce_block_width_mp) \
-    , localparam lce_cce_req_width_lp=`bp_lce_cce_req_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, data_width_mp)        \
-    , localparam lce_cce_resp_width_lp=`bp_lce_cce_resp_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, cce_block_width_mp) \
-    , localparam lce_cmd_width_lp=`bp_lce_cmd_width(lce_id_width_mp, lce_assoc_mp, paddr_width_mp, cce_block_width_mp)
+`define declare_bp_lce_cce_if_widths(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp, data_width_mp, cce_block_width_mp)    \
+    , localparam lce_cce_req_width_lp=`bp_lce_cce_req_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp, data_width_mp) \
+    , localparam lce_cmd_width_lp=`bp_lce_cmd_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp, cce_block_width_mp)    \
+    , localparam lce_cce_resp_width_lp=`bp_lce_cce_resp_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, cce_block_width_mp)
 
 `endif

--- a/bp_fe/src/v/bp_fe_lce_cmd.v
+++ b/bp_fe/src/v/bp_fe_lce_cmd.v
@@ -88,8 +88,8 @@ module bp_fe_lce_cmd
  
   logic [index_width_lp-1:0] lce_cmd_addr_index;
   logic [tag_width_lp-1:0] lce_cmd_addr_tag;
-  assign lce_cmd_addr_index = lce_cmd_li.msg.cmd.addr[block_offset_width_lp+:index_width_lp];
-  assign lce_cmd_addr_tag = lce_cmd_li.msg.cmd.addr[block_offset_width_lp+index_width_lp+:tag_width_lp];
+  assign lce_cmd_addr_index = lce_cmd_li.header.addr[block_offset_width_lp+:index_width_lp];
+  assign lce_cmd_addr_tag = lce_cmd_li.header.addr[block_offset_width_lp+index_width_lp+:tag_width_lp];
  
   // lce pkt
   //
@@ -135,7 +135,7 @@ module bp_fe_lce_cmd
     lce_cmd_yumi_o = 1'b0;
 
     lce_resp = '0;
-    lce_resp.src_id = lce_id_i;
+    lce_resp.header.src_id = lce_id_i;
     lce_resp_v_o = 1'b0;
 
     lce_cmd_out = '0;
@@ -181,7 +181,7 @@ module bp_fe_lce_cmd
       end
 
       e_lce_cmd_uncached_only: begin
-        if (lce_cmd_li.msg_type == e_lce_cmd_set_clear) begin
+        if (lce_cmd_li.header.msg_type == e_lce_cmd_set_clear) begin
           tag_mem_pkt.index        = lce_cmd_addr_index;
           tag_mem_pkt.state        = e_COH_I;
           tag_mem_pkt.tag          = '0;
@@ -192,9 +192,9 @@ module bp_fe_lce_cmd
           stat_mem_pkt_v_o         = lce_cmd_v_i;
           lce_cmd_yumi_o           = tag_mem_pkt_yumi_i & stat_mem_pkt_yumi_i;
 
-        end else if (lce_cmd_li.msg_type == e_lce_cmd_sync) begin
-          lce_resp.dst_id = lce_cmd_li.msg.cmd.src_id;
-          lce_resp.msg_type = e_lce_cce_sync_ack;
+        end else if (lce_cmd_li.header.msg_type == e_lce_cmd_sync) begin
+          lce_resp.header.dst_id = lce_cmd_li.header.src_id;
+          lce_resp.header.msg_type = e_lce_cce_sync_ack;
           lce_resp_v_o = lce_cmd_v_i;
           lce_cmd_yumi_o = lce_resp_yumi_i;
           state_n = ((cnt_r == cnt_width_lp'(num_cce_p-1)) & lce_resp_yumi_i)
@@ -206,10 +206,10 @@ module bp_fe_lce_cmd
           // sync messages, and when the lce_resp is sent
           cnt_inc = ~cnt_clear & lce_resp_yumi_i;
 
-        end else if (lce_cmd_li.msg_type == e_lce_cmd_uc_data) begin
+        end else if (lce_cmd_li.header.msg_type == e_lce_cmd_uc_data) begin
           data_mem_pkt.index = miss_addr_i[block_offset_width_lp+:index_width_lp];
-          data_mem_pkt.way_id = lce_cmd_li.way_id;
-          data_mem_pkt.data = lce_cmd_li.msg.dt_cmd.data;
+          data_mem_pkt.way_id = lce_cmd_li.header.way_id;
+          data_mem_pkt.data = lce_cmd_li.data;
           data_mem_pkt.opcode = e_icache_lce_data_mem_uncached;
           data_mem_pkt_v_o = lce_cmd_v_i;
           lce_cmd_yumi_o = data_mem_pkt_yumi_i;
@@ -220,24 +220,24 @@ module bp_fe_lce_cmd
       end
 
       e_lce_cmd_ready: begin
-        if (lce_cmd_li.msg_type == e_lce_cmd_transfer) begin
+        if (lce_cmd_li.header.msg_type == e_lce_cmd_transfer) begin
           data_mem_pkt.index  = lce_cmd_addr_index;
-          data_mem_pkt.way_id = lce_cmd_li.way_id;
+          data_mem_pkt.way_id = lce_cmd_li.header.way_id;
           data_mem_pkt.opcode = e_icache_lce_data_mem_read;
           data_mem_pkt_v_o    = lce_cmd_v_i;
           state_n             = data_mem_pkt_yumi_i ? e_lce_cmd_send_transfer : e_lce_cmd_ready;
 
-        end else if (lce_cmd_li.msg_type == e_lce_cmd_writeback) begin
-          lce_resp.dst_id   = lce_cmd_li.msg.cmd.src_id;
-          lce_resp.msg_type = e_lce_cce_resp_null_wb;
-          lce_resp.addr     = lce_cmd_li.msg.cmd.addr;
+        end else if (lce_cmd_li.header.msg_type == e_lce_cmd_writeback) begin
+          lce_resp.header.dst_id   = lce_cmd_li.header.src_id;
+          lce_resp.header.msg_type = e_lce_cce_resp_null_wb;
+          lce_resp.header.addr     = lce_cmd_li.header.addr;
           lce_resp_v_o      = lce_cmd_v_i;
           lce_cmd_yumi_o    = lce_resp_yumi_i;
 
-        end else if (lce_cmd_li.msg_type == e_lce_cmd_set_tag) begin
+        end else if (lce_cmd_li.header.msg_type == e_lce_cmd_set_tag) begin
           tag_mem_pkt.index  = lce_cmd_addr_index;
-          tag_mem_pkt.way_id = lce_cmd_li.way_id;
-          tag_mem_pkt.state  = lce_cmd_li.msg.cmd.state;
+          tag_mem_pkt.way_id = lce_cmd_li.header.way_id;
+          tag_mem_pkt.state  = lce_cmd_li.header.state;
           tag_mem_pkt.tag    = lce_cmd_addr_tag;
           tag_mem_pkt.opcode = e_tag_mem_set_tag;
           tag_mem_pkt_v_o    = lce_cmd_v_i;
@@ -245,10 +245,10 @@ module bp_fe_lce_cmd
           lce_cmd_yumi_o     = tag_mem_pkt_yumi_i;
           set_tag_received_o = tag_mem_pkt_yumi_i;
 
-        end else if (lce_cmd_li.msg_type == e_lce_cmd_set_tag_wakeup) begin
+        end else if (lce_cmd_li.header.msg_type == e_lce_cmd_set_tag_wakeup) begin
           tag_mem_pkt.index  = lce_cmd_addr_index;
-          tag_mem_pkt.way_id = lce_cmd_li.way_id;
-          tag_mem_pkt.state  = lce_cmd_li.msg.cmd.state;
+          tag_mem_pkt.way_id = lce_cmd_li.header.way_id;
+          tag_mem_pkt.state  = lce_cmd_li.header.state;
           tag_mem_pkt.tag    = lce_cmd_addr_tag;
           tag_mem_pkt.opcode = e_tag_mem_set_tag;
           tag_mem_pkt_v_o    = lce_cmd_v_i;
@@ -256,9 +256,9 @@ module bp_fe_lce_cmd
           lce_cmd_yumi_o     = tag_mem_pkt_yumi_i;
           set_tag_wakeup_received_o = tag_mem_pkt_yumi_i;
 
-        end else if (lce_cmd_li.msg_type == e_lce_cmd_invalidate_tag) begin
+        end else if (lce_cmd_li.header.msg_type == e_lce_cmd_invalidate_tag) begin
           tag_mem_pkt.index = lce_cmd_addr_index;
-          tag_mem_pkt.way_id = lce_cmd_li.way_id;
+          tag_mem_pkt.way_id = lce_cmd_li.header.way_id;
           tag_mem_pkt.state = e_COH_I;
           tag_mem_pkt.opcode = e_tag_mem_invalidate;
           tag_mem_pkt_v_o = flag_invalidate_r
@@ -270,23 +270,23 @@ module bp_fe_lce_cmd
                 ? 1'b1  
                 : tag_mem_pkt_yumi_i);
 
-          lce_resp.dst_id = lce_cmd_li.msg.cmd.src_id;
-          lce_resp.msg_type = e_lce_cce_inv_ack;
-          lce_resp.addr = lce_cmd_li.msg.cmd.addr;
+          lce_resp.header.dst_id = lce_cmd_li.header.src_id;
+          lce_resp.header.msg_type = e_lce_cce_inv_ack;
+          lce_resp.header.addr = lce_cmd_li.header.addr;
           lce_resp_v_o = (flag_invalidate_r | tag_mem_pkt_yumi_i);
           lce_cmd_yumi_o = lce_resp_yumi_i;
 
-        end else if (lce_cmd_li.msg_type == e_lce_cmd_data) begin
+        end else if (lce_cmd_li.header.msg_type == e_lce_cmd_data) begin
           data_mem_pkt.index = miss_addr_i[block_offset_width_lp+:index_width_lp];
-          data_mem_pkt.way_id = lce_cmd_li.way_id;
-          data_mem_pkt.data = lce_cmd_li.msg.dt_cmd.data;
+          data_mem_pkt.way_id = lce_cmd_li.header.way_id;
+          data_mem_pkt.data = lce_cmd_li.data;
           data_mem_pkt.opcode = e_icache_lce_data_mem_write;
           data_mem_pkt_v_o = lce_cmd_v_i;
 
           tag_mem_pkt.index  = miss_addr_i[block_offset_width_lp+:index_width_lp];
-          tag_mem_pkt.way_id = lce_cmd_li.way_id;
-          tag_mem_pkt.state  = lce_cmd_li.msg.dt_cmd.state;
-          tag_mem_pkt.tag    = lce_cmd_li.msg.dt_cmd.addr[block_offset_width_lp+index_width_lp+:tag_width_lp];
+          tag_mem_pkt.way_id = lce_cmd_li.header.way_id;
+          tag_mem_pkt.state  = lce_cmd_li.header.state;
+          tag_mem_pkt.tag    = lce_cmd_li.header.addr[block_offset_width_lp+index_width_lp+:tag_width_lp];
           tag_mem_pkt.opcode = e_tag_mem_set_tag;
           tag_mem_pkt_v_o    = lce_cmd_v_i;
 
@@ -295,17 +295,17 @@ module bp_fe_lce_cmd
           cce_data_received_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
           set_tag_received_o  = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
 
-        end else if (lce_cmd_li.msg_type == e_lce_cmd_uc_data) begin
+        end else if (lce_cmd_li.header.msg_type == e_lce_cmd_uc_data) begin
           data_mem_pkt.index = miss_addr_i[block_offset_width_lp+:index_width_lp];
-          data_mem_pkt.way_id = lce_cmd_li.way_id;
-          data_mem_pkt.data = lce_cmd_li.msg.dt_cmd.data;
+          data_mem_pkt.way_id = lce_cmd_li.header.way_id;
+          data_mem_pkt.data = lce_cmd_li.data;
           data_mem_pkt.opcode = e_icache_lce_data_mem_uncached;
           data_mem_pkt_v_o = lce_cmd_v_i;
           lce_cmd_yumi_o = data_mem_pkt_yumi_i;
 
           uncached_data_received_o = data_mem_pkt_yumi_i;
 
-        end else if (lce_cmd_li.msg_type == e_lce_cmd_set_clear) begin
+        end else if (lce_cmd_li.header.msg_type == e_lce_cmd_set_clear) begin
           tag_mem_pkt.index        = lce_cmd_addr_index;
           tag_mem_pkt.state        = e_COH_I;
           tag_mem_pkt.tag          = '0;
@@ -322,12 +322,12 @@ module bp_fe_lce_cmd
       e_lce_cmd_send_transfer: begin
         flag_data_buffered_n = ~lce_cmd_ready_i;
         data_n               = flag_data_buffered_r ? data_r : data_mem_data_i;
-        lce_cmd_out.msg.dt_cmd.data = flag_data_buffered_r ? data_r : data_mem_data_i;
-        lce_cmd_out.msg.dt_cmd.addr = lce_cmd_li.msg.cmd.addr;
-        lce_cmd_out.msg.dt_cmd.state = lce_cmd_li.msg.cmd.state;
-        lce_cmd_out.way_id   = lce_cmd_li.msg.cmd.target_way_id;
-        lce_cmd_out.msg_type = e_lce_cmd_data;
-        lce_cmd_out.dst_id   = lce_cmd_li.msg.cmd.target;
+        lce_cmd_out.data = flag_data_buffered_r ? data_r : data_mem_data_i;
+        lce_cmd_out.header.addr = lce_cmd_li.header.addr;
+        lce_cmd_out.header.state = lce_cmd_li.header.state;
+        lce_cmd_out.header.way_id   = lce_cmd_li.header.target_way_id;
+        lce_cmd_out.header.msg_type = e_lce_cmd_data;
+        lce_cmd_out.header.dst_id   = lce_cmd_li.header.target;
         lce_cmd_v_o          = lce_cmd_ready_i;
         lce_cmd_yumi_o       = lce_cmd_v_o;
         state_n              = lce_cmd_v_o ? e_lce_cmd_ready : e_lce_cmd_send_transfer;

--- a/bp_fe/src/v/bp_fe_lce_req.v
+++ b/bp_fe/src/v/bp_fe_lce_req.v
@@ -82,7 +82,7 @@ module bp_fe_lce_req
   bp_me_addr_to_cce_id
    #(.bp_params_p(bp_params_p))
    req_map
-    (.paddr_i(lce_req.addr)
+    (.paddr_i(lce_req.header.addr)
 
      ,.cce_id_o(req_cce_id_lo)
      );
@@ -91,7 +91,7 @@ module bp_fe_lce_req
   bp_me_addr_to_cce_id
    #(.bp_params_p(bp_params_p))
    resp_map
-    (.paddr_i(lce_resp.addr)
+    (.paddr_i(lce_resp.header.addr)
 
      ,.cce_id_o(resp_cce_id_lo)
      );
@@ -111,25 +111,24 @@ module bp_fe_lce_req
 
     lce_req_v_o           = 1'b0;
 
-    lce_req.dst_id        = req_cce_id_lo;
-    lce_req.src_id        = lce_id_i;
-    lce_req.msg_type      = e_lce_req_type_rd;
-    lce_req.addr          = miss_addr_r;
+    lce_req.header.dst_id        = req_cce_id_lo;
+    lce_req.header.src_id        = lce_id_i;
+    lce_req.header.msg_type      = e_lce_req_type_rd;
+    lce_req.header.addr          = miss_addr_r;
 
-    lce_req.msg.req.non_exclusive = e_lce_req_non_excl;
-    lce_req.msg.req.lru_dirty     = e_lce_req_lru_clean;
-    lce_req.msg.req.lru_way_id    = lru_flopped_r
+    lce_req.header.non_exclusive = e_lce_req_non_excl;
+    lce_req.header.lru_dirty     = e_lce_req_lru_clean;
+    lce_req.header.lru_way_id    = lru_flopped_r
                                     ? lru_way_r
                                     : lru_way_i;
-    lce_req.msg.req.pad    = '0;
 
 
     lce_resp_v_o          = 1'b0;
 
-    lce_resp.dst_id       = resp_cce_id_lo;
-    lce_resp.src_id       = lce_id_i;
-    lce_resp.msg_type     = bp_lce_cce_resp_type_e'('0);
-    lce_resp.addr         = miss_addr_r;
+    lce_resp.header.dst_id       = resp_cce_id_lo;
+    lce_resp.header.src_id       = lce_id_i;
+    lce_resp.header.msg_type     = bp_lce_cce_resp_type_e'('0);
+    lce_resp.header.addr         = miss_addr_r;
     lce_resp.data         = '0;
   
     cache_miss_o = 1'b0;
@@ -169,15 +168,15 @@ module bp_fe_lce_req
         lce_req_v_o = 1'b1;
         cache_miss_o = 1'b1;
 
-        lce_req.msg_type = e_lce_req_type_uc_rd;
+        lce_req.header.msg_type = e_lce_req_type_uc_rd;
         // TODO: this may need to change depending on what the LCE and CCE behavior spec is
         // In order for the uncached load to replay successfully and extract the correct
         // 32-bits, we fetch the aligned 64-bits containing the desired 32-bits.
         // Zero out the byte offset bits so the address is 64-bit aligned.
-        lce_req.addr = {miss_addr_r[paddr_width_p-1:byte_offset_width_lp]
-                        , {byte_offset_width_lp{1'b0}}};
-        lce_req.msg.uc_req.uc_size = e_lce_uc_req_8;
-        lce_req.msg.uc_req.data = '0;
+        lce_req.header.addr = {miss_addr_r[paddr_width_p-1:byte_offset_width_lp]
+                               , {byte_offset_width_lp{1'b0}}};
+        lce_req.header.uc_size = e_lce_uc_req_8;
+        lce_req.data = '0;
 
         state_n = lce_req_ready_i
           ? e_lce_req_sleep 
@@ -211,7 +210,7 @@ module bp_fe_lce_req
 
       e_lce_req_send_coh_ack: begin
         lce_resp_v_o = 1'b1;
-        lce_resp.msg_type = e_lce_cce_coh_ack;
+        lce_resp.header.msg_type = e_lce_cce_coh_ack;
         cache_miss_o = 1'b1;
         state_n = lce_resp_yumi_i
           ? e_lce_req_ready

--- a/bp_me/src/include/v/bp_me_cce_mem_if.vh
+++ b/bp_me/src/include/v/bp_me_cce_mem_if.vh
@@ -64,7 +64,7 @@ typedef enum bit [2:0]
     logic [`BSG_SAFE_CLOG2(lce_assoc_mp)-1:0]    way_id;      \
     bp_coh_states_e                              state;       \
     logic                                        speculative; \
-  }  bp_cce_mem_msg_payload_s
+  } bp_cce_mem_msg_payload_s;
 
 
 /*
@@ -77,12 +77,17 @@ typedef enum bit [2:0]
 `define declare_bp_cce_mem_msg_s(addr_width_mp, data_width_mp)  \
   typedef struct packed                                         \
   {                                                             \
-    logic [data_width_mp-1:0]                    data;          \
     bp_cce_mem_msg_payload_s                     payload;       \
     bp_cce_mem_req_size_e                        size;          \
     logic [addr_width_mp-1:0]                    addr;          \
     bp_cce_mem_cmd_type_e                        msg_type;      \
-  }  bp_cce_mem_msg_s
+  } bp_cce_mem_msg_header_s;                                    \
+                                                                \
+  typedef struct packed                                         \
+  {                                                             \
+    logic [data_width_mp-1:0]                    data;          \
+    bp_cce_mem_msg_header_s                      header;        \
+  } bp_cce_mem_msg_s;
 
 /*
  * Width Macros
@@ -90,12 +95,15 @@ typedef enum bit [2:0]
 
 // CCE-MEM Interface
 `define bp_cce_mem_msg_payload_width(lce_id_width_mp, lce_assoc_mp) \
-  (lce_id_width_mp+`BSG_SAFE_CLOG2(lce_assoc_mp)+`bp_coh_bits+1)
+  (lce_id_width_mp+`BSG_SAFE_CLOG2(lce_assoc_mp)+$bits(bp_coh_states_e)+1)
 
-`define bp_cce_mem_msg_width(addr_width_mp, data_width_mp, lce_id_width_mp, lce_assoc_mp) \
-  ($bits(bp_cce_mem_cmd_type_e)+addr_width_mp+data_width_mp \
+`define bp_cce_mem_msg_header_width(addr_width_mp, lce_id_width_mp, lce_assoc_mp) \
+  ($bits(bp_cce_mem_cmd_type_e)+addr_width_mp \
    +`bp_cce_mem_msg_payload_width(lce_id_width_mp, lce_assoc_mp)\
    +$bits(bp_cce_mem_req_size_e))
+
+`define bp_cce_mem_msg_width(addr_width_mp, data_width_mp, lce_id_width_mp, lce_assoc_mp) \
+  (`bp_cce_mem_msg_header_width(addr_width_mp,lce_id_width_mp,lce_assoc_mp)+data_width_mp)
 
 /*
  *
@@ -107,9 +115,11 @@ typedef enum bit [2:0]
 
 `define declare_bp_me_if(paddr_width_mp, data_width_mp, lce_id_width_mp, lce_assoc_mp) \
   `declare_bp_cce_mem_msg_payload_s(lce_id_width_mp, lce_assoc_mp);                    \
-  `declare_bp_cce_mem_msg_s(paddr_width_mp, data_width_mp);                            \
+  `declare_bp_cce_mem_msg_s(paddr_width_mp, data_width_mp);
 
 `define declare_bp_me_if_widths(paddr_width_mp, data_width_mp, lce_id_width_mp, lce_assoc_mp) \
+  , localparam cce_mem_msg_payload_width_lp=`bp_cce_mem_msg_payload_width(lce_id_width_mp, lce_assoc_mp) \
+  , localparam cce_mem_msg_header_width_lp=`bp_cce_mem_msg_header_width(paddr_width_mp, lce_id_width_mp, lce_assoc_mp) \
   , localparam cce_mem_msg_width_lp=`bp_cce_mem_msg_width(paddr_width_mp, data_width_mp, lce_id_width_mp, lce_assoc_mp)
 
 

--- a/bp_me/src/include/v/bp_mem_wormhole.vh
+++ b/bp_me/src/include/v/bp_mem_wormhole.vh
@@ -11,16 +11,40 @@
 `include "bsg_noc_links.vh"
 `include "bsg_wormhole_router.vh"
 
-`define declare_bp_mem_wormhole_payload_s(cord_width_mp, cid_width_mp, data_width_mp, struct_name_mp) \
-    typedef struct packed                                               \
-    {                                                                   \
-      logic [data_width_mp-1:0]     data;                               \
-      logic [cord_width_mp-1:0]     src_cord;                           \
-      logic [cid_width_mp-1:0]      src_cid;                            \
-    } struct_name_mp
-    
-`define bp_mem_wormhole_payload_width(cord_width_mp, cid_width_mp, data_width_mp) \
-  (cord_width_mp+cid_width_mp+data_width_mp)
+`define declare_bp_mem_wormhole_packet_s(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_width_mp, data_width_mp, struct_name_mp) \
+  typedef struct packed                 \
+  {                                     \
+    logic [data_width_mp-1:0] data;     \
+    logic [`bp_mem_wormhole_packet_pad_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_width_mp)-1:0] \
+                              pad;      \
+    logic [msg_width_mp-1:0]  msg;      \
+    logic [cid_width_mp-1:0]  src_cid;  \
+    logic [cord_width_mp-1:0] src_cord; \
+    logic [cid_width_mp-1:0]  cid;      \
+    logic [len_width_mp-1:0]  len;      \
+    logic [cord_width_mp-1:0] cord;     \
+  }  struct_name_mp
+
+`define bp_mem_wormhole_packet_pad_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_width_mp) \
+  ((2*cord_width_mp+2*cid_width_mp+len_width_mp+msg_width_mp)%flit_width_mp==0   \
+   ? flit_width_mp                                                               \
+   : (2*cord_width_mp+2*cid_width_mp+len_width_mp+msg_width_mp)%flit_width_mp    \
+   )
+
+`define bp_mem_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_width_mp, data_width_mp) \
+  (cid_width_mp   \
+   +cord_width_mp \
+   +cid_width_mp  \
+   +msg_width_mp  \
+   +`bp_mem_wormhole_packet_pad_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_width_mp) \
+   +data_width_mp \
+   )
+
+`define bp_mem_wormhole_packet_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_width_mp, data_width_mp) \
+  (cord_width_mp   \
+   +len_width_mp   \
+   +`bp_mem_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_width_mp, data_width_mp) \
+   )
 
 `define declare_bp_lce_wormhole_packet_s(cord_width_mp, cid_width_mp, len_width_mp, msg_width_mp, flit_width_mp, data_width_mp, struct_name_mp) \
   typedef struct packed              \

--- a/bp_me/src/include/v/bp_mem_wormhole.vh
+++ b/bp_me/src/include/v/bp_mem_wormhole.vh
@@ -22,5 +22,23 @@
 `define bp_mem_wormhole_payload_width(cord_width_mp, cid_width_mp, data_width_mp) \
   (cord_width_mp+cid_width_mp+data_width_mp)
 
+`define declare_bp_lce_wormhole_packet_s(cord_width_mp, cid_width_mp, len_width_mp, msg_width_mp, flit_width_mp, data_width_mp, struct_name_mp) \
+  typedef struct packed              \
+  {                                  \
+    logic [data_width_mp-1:0] data;  \
+    logic [`bp_lce_wormhole_packet_pad_width(cord_width_mp, cid_width_mp, len_width_mp, msg_width_mp, flit_width_mp)] \
+                              pad;   \
+    logic [msg_width_mp-1:0]  msg;   \
+    logic [cid_width_mp-1:0]  cid;   \
+    logic [len_width_mp-1:0]  len;   \
+    logic [cord_width_mp-1:0] cord;  \
+  } struct_name_mp
+
+`define bp_lce_wormhole_packet_pad_width(cord_width_mp, cid_width_mp, len_width_mp, msg_width_mp, flit_width_mp) \
+  ((cord_width_mp+cid_width_mp+len_width_mp+msg_width_mp)%flit_width_mp==0   \
+   ? flit_width_mp                                                           \
+   : cord_width_mp+cid_width_mp+len_width_mp+msg_width_mp)%flit_width_mp     \
+   )
+
 `endif
 

--- a/bp_me/src/v/cache/bp_me_cache_dma_to_cce.v
+++ b/bp_me/src/v/cache/bp_me_cache_dma_to_cce.v
@@ -174,13 +174,13 @@ module bp_me_cache_dma_to_cce
   logic mem_cmd_v_lo;
   bp_cce_mem_msg_s mem_cmd_lo;
   
-  assign mem_cmd_lo.msg_type = (send_dma_pkt_r.write_not_read)? 
-                                e_cce_mem_wb : e_cce_mem_rd;
-  assign mem_cmd_lo.addr     = (num_mem_p == 1)? send_dma_pkt_r.addr : 
-                               {send_dma_pkt_r.addr[paddr_width_p-1:block_offset_width_lp], 
+  assign mem_cmd_lo.header.msg_type = (send_dma_pkt_r.write_not_read)? 
+                                       e_cce_mem_wb : e_cce_mem_rd;
+  assign mem_cmd_lo.header.addr = (num_mem_p == 1)? send_dma_pkt_r.addr : 
+                                {send_dma_pkt_r.addr[paddr_width_p-1:block_offset_width_lp], 
                                 dma_pkt_rr_tag_r, send_dma_pkt_r.addr[block_offset_width_lp-1:0]};
-  assign mem_cmd_lo.payload  = '0;
-  assign mem_cmd_lo.size     = e_mem_size_64;
+  assign mem_cmd_lo.header.payload  = '0;
+  assign mem_cmd_lo.header.size     = e_mem_size_64;
   assign mem_cmd_lo.data     = (send_dma_pkt_r.write_not_read)? data_r : '0;
   
   assign mem_cmd_o           = mem_cmd_lo;
@@ -287,8 +287,8 @@ module bp_me_cache_dma_to_cce
   ,.yumi_i (two_fifo_yumi_li)
   );
 
-  assign piso_v_li = two_fifo_v_lo & (mem_resp_li.msg_type == e_cce_mem_rd);
-  assign two_fifo_yumi_li = two_fifo_v_lo & ((mem_resp_li.msg_type == e_cce_mem_wb) | piso_ready_lo);
+  assign piso_v_li = two_fifo_v_lo & (mem_resp_li.header.msg_type == e_cce_mem_rd);
+  assign two_fifo_yumi_li = two_fifo_v_lo & ((mem_resp_li.header.msg_type == e_cce_mem_wb) | piso_ready_lo);
   
   bsg_parallel_in_serial_out 
  #(.width_p(dword_width_p)

--- a/bp_me/src/v/cache/bp_me_cce_to_cache.v
+++ b/bp_me/src/v/cache/bp_me_cce_to_cache.v
@@ -84,7 +84,7 @@ module bp_me_cce_to_cache
   assign mem_cmd_yumi_o = mem_cmd_yumi_lo;
   
   logic [paddr_width_p-1:0] cmd_addr;
-  assign cmd_addr = mem_cmd.addr;
+  assign cmd_addr = mem_cmd.header.addr;
   
   logic [block_size_in_words_lp-1:0][dword_width_p-1:0] cmd_data;
   assign cmd_data = mem_cmd.data;
@@ -101,10 +101,10 @@ module bp_me_cce_to_cache
   (.clk_i(clk_i)
   ,.reset_i(reset_i)
   ,.v_i(small_fifo_v_li)
-  ,.data_i({mem_cmd.msg_type, mem_cmd.addr, mem_cmd.size, mem_cmd.payload})
+  ,.data_i({mem_cmd.header.msg_type, mem_cmd.header.addr, mem_cmd.header.size, mem_cmd.header.payload})
   ,.ready_o(small_fifo_ready_lo)
   ,.v_o(small_fifo_v_lo)
-  ,.data_o({mem_resp.msg_type, mem_resp.addr, mem_resp.size, mem_resp.payload})
+  ,.data_o({mem_resp.header.msg_type, mem_resp.header.addr, mem_resp.header.size, mem_resp.header.payload})
   ,.yumi_i(small_fifo_yumi_li)
   );
   
@@ -171,7 +171,7 @@ module bp_me_cce_to_cache
       READY: begin
         if (mem_cmd_v_i & small_fifo_ready_lo)
           begin
-            case (mem_cmd.size)
+            case (mem_cmd.header.size)
               e_mem_size_1
               ,e_mem_size_2
               ,e_mem_size_4
@@ -187,11 +187,11 @@ module bp_me_cce_to_cache
       end
       SEND: begin
         v_o = 1'b1;
-        case (mem_cmd.msg_type)
+        case (mem_cmd.header.msg_type)
           e_cce_mem_rd
           ,e_cce_mem_wr
           ,e_cce_mem_uc_rd:
-            case (mem_cmd.size)
+            case (mem_cmd.header.size)
               e_mem_size_1: cache_pkt.opcode = LB;
               e_mem_size_2: cache_pkt.opcode = LH;
               e_mem_size_4: cache_pkt.opcode = LW;
@@ -203,7 +203,7 @@ module bp_me_cce_to_cache
             endcase
           e_cce_mem_uc_wr
           ,e_cce_mem_wb   :
-            case (mem_cmd.size)
+            case (mem_cmd.header.size)
               e_mem_size_1: cache_pkt.opcode = SB;
               e_mem_size_2: cache_pkt.opcode = SH;
               e_mem_size_4: cache_pkt.opcode = SW;
@@ -286,7 +286,7 @@ module bp_me_cce_to_cache
       RESP_READY: begin
         if (small_fifo_v_lo)
           begin
-            case (mem_resp.size)
+            case (mem_resp.header.size)
               e_mem_size_1
               ,e_mem_size_2
               ,e_mem_size_4

--- a/bp_me/src/v/cce/bp_cce.v
+++ b/bp_me/src/v/cce/bp_cce.v
@@ -161,7 +161,7 @@ module bp_cce
   bp_cce_mshr_s mshr;
 
   logic null_wb_flag_li;
-  assign null_wb_flag_li = (lce_resp_v_i & (lce_resp_li.msg_type == e_lce_cce_resp_null_wb));
+  assign null_wb_flag_li = (lce_resp_v_i & (lce_resp_li.header.msg_type == e_lce_cce_resp_null_wb));
 
   logic [`bp_cce_inst_num_gpr-1:0][`bp_cce_inst_gpr_width-1:0] gpr_r_lo;
   logic [dword_width_p-1:0] nc_data_r_lo;
@@ -216,7 +216,7 @@ module bp_cce
 
       ,.lce_req_v_i(lce_req_v_i)
       ,.lce_resp_v_i(lce_resp_v_i)
-      ,.lce_resp_type_i(lce_resp_li.msg_type)
+      ,.lce_resp_type_i(lce_resp_li.header.msg_type)
       ,.mem_resp_v_i(mem_resp_v_i)
       ,.pending_v_i('0)
 
@@ -370,8 +370,8 @@ module bp_cce
       ,.decoded_inst_i(decoded_inst_lo)
       ,.lce_req_i(lce_req_li)
       ,.null_wb_flag_i(null_wb_flag_li)
-      ,.lce_resp_type_i(lce_resp_li.msg_type)
-      ,.mem_resp_type_i(mem_resp_li.msg_type)
+      ,.lce_resp_type_i(lce_resp_li.header.msg_type)
+      ,.mem_resp_type_i(mem_resp_li.header.msg_type)
       ,.alu_res_i(alu_res_lo)
       ,.mov_src_i(src_a)
 
@@ -639,7 +639,7 @@ module bp_cce
           e_src_mem_resp_v: src_a[0] = mem_resp_v_i;
           e_src_pending_v: src_a = '0; // TODO: v2
           e_src_lce_resp_v: src_a[0] = lce_resp_v_i;
-          e_src_lce_resp_type: src_a[0+:$bits(bp_lce_cce_resp_type_e)] = lce_resp_li.msg_type;
+          e_src_lce_resp_type: src_a[0+:$bits(bp_lce_cce_resp_type_e)] = lce_resp_li.header.msg_type;
           e_src_special_0: src_a[0] = 1'b0;
           e_src_special_1: src_a[0] = 1'b1;
           e_src_cce_id: src_a[0+:lg_num_cce_lp] = cfg_bus_cast_i.cce_id;
@@ -711,7 +711,7 @@ module bp_cce
           e_src_mem_resp_v: src_b[0] = mem_resp_v_i;
           e_src_pending_v: src_b = '0; // TODO: v2
           e_src_lce_resp_v: src_b[0] = lce_resp_v_i;
-          e_src_lce_resp_type: src_b[0+:$bits(bp_lce_cce_resp_type_e)] = lce_resp_li.msg_type;
+          e_src_lce_resp_type: src_b[0+:$bits(bp_lce_cce_resp_type_e)] = lce_resp_li.header.msg_type;
           e_src_special_0: src_b[0] = 1'b0;
           e_src_special_1: src_b[0] = 1'b1;
           e_src_cce_id: src_b[0+:lg_num_cce_lp] = cfg_bus_cast_i.cce_id;

--- a/bp_me/src/v/cce/bp_cce_msg_cached.v
+++ b/bp_me/src/v/cce/bp_cce_msg_cached.v
@@ -386,7 +386,7 @@ module bp_cce_msg_cached
           lce_cmd.data = mem_resp_li.data;
           lce_cmd.header.addr = mem_resp_li.header.addr;
           // modify the coherence state
-          lce_cmd.header.state = spec_bits_lo.state;
+          lce_cmd.header.state = bp_coh_states_e'(spec_bits_lo.state);
 
           if (lce_cmd_ready_i) begin
             pending_w_busy_o = 1'b1;
@@ -692,7 +692,7 @@ module bp_cce_msg_cached
           lce_cmd.header.src_id = cce_id_i;
           lce_cmd.header.addr = lce_cmd_addr;
 
-          lce_cmd.header.state = '0;
+          lce_cmd.header.state = e_COH_I;
           lce_cmd.header.target = '0;
           lce_cmd.header.target_way_id = '0;
 

--- a/bp_me/src/v/cce/bp_cce_msg_cached.v
+++ b/bp_me/src/v/cce/bp_cce_msg_cached.v
@@ -166,7 +166,7 @@ module bp_cce_msg_cached
   logic [`BSG_SAFE_CLOG2(num_cce_p)-1:0] spec_rd_cce_id_lo;
   logic [hash_index_width_lp-1:0] spec_rd_wg_id_lo;
   wire [lg_lce_sets_lp-1:0] spec_rd_addr_rev =
-    {<< {mem_resp_li.addr[lg_block_size_in_bytes_lp+:lg_lce_sets_lp]}};
+    {<< {mem_resp_li.header.addr[lg_block_size_in_bytes_lp+:lg_lce_sets_lp]}};
 
   bsg_hash_bank
     #(.banks_p(num_cce_p) // number of CCE's to spread way groups over
@@ -223,7 +223,7 @@ module bp_cce_msg_cached
        ,.state_i(decoded_inst_i.spec_bits.state)
 
        // read-port
-       ,.r_v_i(mem_resp_v_i & mem_resp_li.payload.speculative)
+       ,.r_v_i(mem_resp_v_i & mem_resp_li.header.payload.speculative)
        ,.r_way_group_i(spec_rd_wg_id_lo[0+:lg_num_way_groups_lp])
        ,.data_o(spec_bits_lo)
        ,.v_o(spec_bits_v_lo)
@@ -351,7 +351,7 @@ module bp_cce_msg_cached
     if (mem_resp_v_i) begin
       // Speculative access response
       // Note: speculative access is only supported for cached requests
-      if (mem_resp_li.payload.speculative) begin
+      if (mem_resp_li.header.payload.speculative) begin
 
         if (spec_bits_lo.spec) begin // speculation not resolved yet
           // do nothing, wait for speculation to be resolved
@@ -365,7 +365,7 @@ module bp_cce_msg_cached
 
           pending_w_busy_o = 1'b1;
           pending_w_v_o = 1'b1;
-          pending_w_addr_lo = mem_resp_li.addr;
+          pending_w_addr_lo = mem_resp_li.header.addr;
           pending_o = 1'b0;
 
         end
@@ -378,20 +378,20 @@ module bp_cce_msg_cached
           lce_cmd_busy_o = 1'b1;
 
           // output command message
-          lce_cmd.dst_id = mem_resp_li.payload.lce_id;
+          lce_cmd.header.dst_id = mem_resp_li.header.payload.lce_id;
 
           // Data is copied directly from the Mem Data Response
-          lce_cmd.msg_type = e_lce_cmd_data;
-          lce_cmd.way_id = mem_resp_li.payload.way_id;
-          lce_cmd.msg.dt_cmd.data = mem_resp_li.data;
-          lce_cmd.msg.dt_cmd.addr = mem_resp_li.addr;
+          lce_cmd.header.msg_type = e_lce_cmd_data;
+          lce_cmd.header.way_id = mem_resp_li.header.payload.way_id;
+          lce_cmd.data = mem_resp_li.data;
+          lce_cmd.header.addr = mem_resp_li.header.addr;
           // modify the coherence state
-          lce_cmd.msg.dt_cmd.state = spec_bits_lo.state;
+          lce_cmd.header.state = spec_bits_lo.state;
 
           if (lce_cmd_ready_i) begin
             pending_w_busy_o = 1'b1;
             pending_w_v_o = 1'b1;
-            pending_w_addr_lo = mem_resp_li.addr;
+            pending_w_addr_lo = mem_resp_li.header.addr;
             pending_o = 1'b0;
           end
 
@@ -405,19 +405,19 @@ module bp_cce_msg_cached
           lce_cmd_busy_o = 1'b1;
 
           // output command message
-          lce_cmd.dst_id = mem_resp_li.payload.lce_id;
+          lce_cmd.header.dst_id = mem_resp_li.header.payload.lce_id;
 
           // Data is copied directly from the Mem Data Response
-          lce_cmd.msg_type = e_lce_cmd_data;
-          lce_cmd.way_id = mem_resp_li.payload.way_id;
-          lce_cmd.msg.dt_cmd.data = mem_resp_li.data;
-          lce_cmd.msg.dt_cmd.addr = mem_resp_li.addr;
-          lce_cmd.msg.dt_cmd.state = mem_resp_li.payload.state;
+          lce_cmd.header.msg_type = e_lce_cmd_data;
+          lce_cmd.header.way_id = mem_resp_li.header.payload.way_id;
+          lce_cmd.data = mem_resp_li.data;
+          lce_cmd.header.addr = mem_resp_li.header.addr;
+          lce_cmd.header.state = mem_resp_li.header.payload.state;
 
           if (lce_cmd_ready_i) begin
             pending_w_busy_o = 1'b1;
             pending_w_v_o = 1'b1;
-            pending_w_addr_lo = mem_resp_li.addr;
+            pending_w_addr_lo = mem_resp_li.header.addr;
             pending_o = 1'b0;
           end
 
@@ -426,8 +426,8 @@ module bp_cce_msg_cached
       end // speculative response
 
       // Memory Response with cached data
-      else if ((mem_resp_li.msg_type == e_cce_mem_rd)
-               | (mem_resp_li.msg_type == e_cce_mem_wr)) begin
+      else if ((mem_resp_li.header.msg_type == e_cce_mem_rd)
+               | (mem_resp_li.header.msg_type == e_cce_mem_wr)) begin
 
         // handshaking
         lce_cmd_v_o = mem_resp_v_i;
@@ -437,20 +437,20 @@ module bp_cce_msg_cached
         lce_cmd_busy_o = 1'b1;
 
         // output command message
-        lce_cmd.dst_id = mem_resp_li.payload.lce_id;
+        lce_cmd.header.dst_id = mem_resp_li.header.payload.lce_id;
 
         // Data is copied directly from the Mem Data Response
-        lce_cmd.msg_type = e_lce_cmd_data;
-        lce_cmd.way_id = mem_resp_li.payload.way_id;
-        lce_cmd.msg.dt_cmd.data = mem_resp_li.data;
-        lce_cmd.msg.dt_cmd.addr = mem_resp_li.addr;
-        lce_cmd.msg.dt_cmd.state = mem_resp_li.payload.state;
+        lce_cmd.header.msg_type = e_lce_cmd_data;
+        lce_cmd.header.way_id = mem_resp_li.header.payload.way_id;
+        lce_cmd.data = mem_resp_li.data;
+        lce_cmd.header.addr = mem_resp_li.header.addr;
+        lce_cmd.header.state = mem_resp_li.header.payload.state;
 
         // Clear the pending bit in the cycle that the LCE Command ready_i goes high
         // Pending bit only cleared if this is a cached request response
         if (lce_cmd_ready_i) begin
           pending_w_v_o = 1'b1;
-          pending_w_addr_lo = mem_resp_li.addr;
+          pending_w_addr_lo = mem_resp_li.header.addr;
           pending_o = 1'b0;
           // TODO: only blocking on cycle that message sends because Mem Cmd are sent to a full width buffer, so it only
           // takes a single cycle to send Mem Cmd.
@@ -464,7 +464,7 @@ module bp_cce_msg_cached
 
       // Uncached load response - forward data to LCE
       // This transaction does not modify the pending bits
-      else if (mem_resp_li.msg_type == e_cce_mem_uc_rd) begin
+      else if (mem_resp_li.header.msg_type == e_cce_mem_uc_rd) begin
 
         // handshaking
         lce_cmd_v_o = mem_resp_v_i;
@@ -475,23 +475,23 @@ module bp_cce_msg_cached
 
         // output command message
 
-        lce_cmd.dst_id = mem_resp_li.payload.lce_id;
+        lce_cmd.header.dst_id = mem_resp_li.header.payload.lce_id;
 
         // Data is copied directly from the Mem Data Response
         // For uncached responses, only the least significant 64-bits will be valid
-        lce_cmd.msg_type = e_lce_cmd_uc_data;
-        lce_cmd.way_id = '0;
-        lce_cmd.msg.dt_cmd.data[0+:dword_width_p] = mem_resp_li.data[0+:dword_width_p];
-        lce_cmd.msg.dt_cmd.addr = mem_resp_li.addr;
+        lce_cmd.header.msg_type = e_lce_cmd_uc_data;
+        lce_cmd.header.way_id = '0;
+        lce_cmd.data[0+:dword_width_p] = mem_resp_li.data[0+:dword_width_p];
+        lce_cmd.header.addr = mem_resp_li.header.addr;
 
       end // uncached read response
 
       // Writeback response - clears the pending bit
-      else if (mem_resp_li.msg_type == e_cce_mem_wb) begin
+      else if (mem_resp_li.header.msg_type == e_cce_mem_wb) begin
 
         mem_resp_yumi_o = 1'b1;
         pending_w_v_o = 1'b1;
-        pending_w_addr_lo = mem_resp_li.addr;
+        pending_w_addr_lo = mem_resp_li.header.addr;
         pending_o = 1'b0;
         pending_w_busy_o = 1'b1;
 
@@ -499,7 +499,7 @@ module bp_cce_msg_cached
 
       // Uncached store response - send uncached store done command on LCE Command
       // This transaction does not modify the pending bits
-      else if (mem_resp_li.msg_type == e_cce_mem_uc_wr) begin
+      else if (mem_resp_li.header.msg_type == e_cce_mem_uc_wr) begin
 
         // handshaking
         lce_cmd_v_o = lce_cmd_ready_i & mem_resp_v_i;
@@ -509,12 +509,12 @@ module bp_cce_msg_cached
         lce_cmd_busy_o = 1'b1;
 
         // after store response is received, need to send uncached store done command to LCE
-        lce_cmd.dst_id = mem_resp_li.payload.lce_id;
-        lce_cmd.msg_type = e_lce_cmd_uc_st_done;
-        lce_cmd.way_id = '0;
+        lce_cmd.header.dst_id = mem_resp_li.header.payload.lce_id;
+        lce_cmd.header.msg_type = e_lce_cmd_uc_st_done;
+        lce_cmd.header.way_id = '0;
 
-        lce_cmd.msg.cmd.src_id = cce_id_i;
-        lce_cmd.msg.cmd.addr = mem_resp_li.addr;
+        lce_cmd.header.src_id = cce_id_i;
+        lce_cmd.header.addr = mem_resp_li.header.addr;
 
       end // uncached store response
 
@@ -526,12 +526,12 @@ module bp_cce_msg_cached
     // automatically dequeue coherence ack and decrement pending bit
     // memory response has priority for using the pending bit write port and will stall
     // the LCE Response if the port is busy
-    if (lce_resp_v_i & (lce_resp.msg_type == e_lce_cce_coh_ack) & ~pending_w_busy_o) begin
+    if (lce_resp_v_i & (lce_resp.header.msg_type == e_lce_cce_coh_ack) & ~pending_w_busy_o) begin
       lce_resp_yumi_o = 1'b1;
       pending_w_busy_o = 1'b1;
       // clear pending bit
       pending_w_v_o = 1'b1;
-      pending_w_addr_lo = lce_resp.addr;
+      pending_w_addr_lo = lce_resp.header.addr;
       pending_o = 1'b0;
     end
 
@@ -614,17 +614,17 @@ module bp_cce_msg_cached
         if (decoded_inst_i.mem_cmd_v & ~pending_w_busy_o) begin
 
           // set some defaults - cached load/store miss request
-          mem_cmd_lo.msg_type = (mshr.flags[e_flag_sel_rqf]) ? e_cce_mem_wr : e_cce_mem_rd;
-          mem_cmd_lo.addr = mem_cmd_addr;
-          mem_cmd_lo.size = e_mem_size_64;
-          mem_cmd_lo.payload.lce_id = mshr.lce_id;
-          mem_cmd_lo.payload.way_id = mshr.lru_way_id;
-          mem_cmd_lo.payload.state = mshr.next_coh_state;
+          mem_cmd_lo.header.msg_type = (mshr.flags[e_flag_sel_rqf]) ? e_cce_mem_wr : e_cce_mem_rd;
+          mem_cmd_lo.header.addr = mem_cmd_addr;
+          mem_cmd_lo.header.size = e_mem_size_64;
+          mem_cmd_lo.header.payload.lce_id = mshr.lce_id;
+          mem_cmd_lo.header.payload.way_id = mshr.lru_way_id;
+          mem_cmd_lo.header.payload.state = mshr.next_coh_state;
           mem_cmd_lo.data = '0;
 
           // set speculative bit if needed
           if (decoded_inst_i.spec_w_v & decoded_inst_i.spec_bits.spec) begin
-            mem_cmd_lo.payload.speculative = 1'b1;
+            mem_cmd_lo.header.payload.speculative = 1'b1;
           end
 
           // Uncached request
@@ -632,13 +632,13 @@ module bp_cce_msg_cached
             mem_cmd_v_o = mem_cmd_ready_i;
             // load or store
             if (mshr.flags[e_flag_sel_rqf]) begin
-              mem_cmd_lo.msg_type = e_cce_mem_uc_wr;
+              mem_cmd_lo.header.msg_type = e_cce_mem_uc_wr;
               mem_cmd_lo.data = {(cce_block_width_p-dword_width_p)'('0),nc_data_i};
             end else begin
-              mem_cmd_lo.msg_type = e_cce_mem_uc_rd;
+              mem_cmd_lo.header.msg_type = e_cce_mem_uc_rd;
             end
 
-            mem_cmd_lo.size =
+            mem_cmd_lo.header.size =
               (mshr.uc_req_size == e_lce_uc_req_1)
               ? e_mem_size_1
               : (mshr.uc_req_size == e_lce_uc_req_2)
@@ -656,16 +656,16 @@ module bp_cce_msg_cached
 
             // Writeback command - override default command fields as needed
             if (decoded_inst_i.mem_cmd == e_cce_mem_wb) begin
-              mem_cmd_lo.msg_type = e_cce_mem_wb;
+              mem_cmd_lo.header.msg_type = e_cce_mem_wb;
               mem_cmd_lo.data = lce_resp.data;
-              mem_cmd_lo.payload.lce_id = lce_resp.src_id;
-              mem_cmd_lo.payload.way_id = '0;
-              mem_cmd_lo.payload.state = e_COH_I;
+              mem_cmd_lo.header.payload.lce_id = lce_resp.header.src_id;
+              mem_cmd_lo.header.payload.way_id = '0;
+              mem_cmd_lo.header.payload.state = e_COH_I;
             end
 
             // align mem_cmd address to cache block boundary, since all cached requests are for full
             // blocks
-            mem_cmd_lo.addr = (mem_cmd_addr >> lg_block_size_in_bytes_lp) << lg_block_size_in_bytes_lp;
+            mem_cmd_lo.header.addr = (mem_cmd_addr >> lg_block_size_in_bytes_lp) << lg_block_size_in_bytes_lp;
 
             // write pending bit
             pending_w_v_o = mem_cmd_ready_i;
@@ -685,25 +685,25 @@ module bp_cce_msg_cached
         else if (decoded_inst_i.lce_cmd_v & ~lce_cmd_busy_o) begin
           lce_cmd_v_o = lce_cmd_ready_i;
 
-          lce_cmd.dst_id = lce_cmd_lce;
-          lce_cmd.msg_type = decoded_inst_i.lce_cmd;
-          lce_cmd.way_id = lce_cmd_way;
+          lce_cmd.header.dst_id = lce_cmd_lce;
+          lce_cmd.header.msg_type = decoded_inst_i.lce_cmd;
+          lce_cmd.header.way_id = lce_cmd_way;
 
-          lce_cmd.msg.cmd.src_id = cce_id_i;
-          lce_cmd.msg.cmd.addr = lce_cmd_addr;
+          lce_cmd.header.src_id = cce_id_i;
+          lce_cmd.header.addr = lce_cmd_addr;
 
-          lce_cmd.msg.cmd.state = '0;
-          lce_cmd.msg.cmd.target = '0;
-          lce_cmd.msg.cmd.target_way_id = '0;
+          lce_cmd.header.state = '0;
+          lce_cmd.header.target = '0;
+          lce_cmd.header.target_way_id = '0;
 
           if ((decoded_inst_i.lce_cmd == e_lce_cmd_set_tag)
               | (decoded_inst_i.lce_cmd == e_lce_cmd_set_tag_wakeup)) begin
-            lce_cmd.msg.cmd.state = mshr.next_coh_state;
+            lce_cmd.header.state = mshr.next_coh_state;
           end
           else if (decoded_inst_i.lce_cmd == e_lce_cmd_transfer) begin
-            lce_cmd.msg.cmd.state = mshr.next_coh_state;
-            lce_cmd.msg.cmd.target = mshr.lce_id;
-            lce_cmd.msg.cmd.target_way_id = mshr.lru_way_id;
+            lce_cmd.header.state = mshr.next_coh_state;
+            lce_cmd.header.target = mshr.lce_id;
+            lce_cmd.header.target_way_id = mshr.lru_way_id;
           end
 
         end // lce_cmd
@@ -717,10 +717,10 @@ module bp_cce_msg_cached
           if (~pending_w_busy_o) begin
             lce_req_yumi_o = decoded_inst_i.lce_req_yumi;
             // set pending bit if not an uncached request
-            if (~(lce_req_li.msg_type == e_lce_req_type_uc_rd
-                  | lce_req_li.msg_type == e_lce_req_type_uc_wr)) begin
+            if (~(lce_req_li.header.msg_type == e_lce_req_type_uc_rd
+                  | lce_req_li.header.msg_type == e_lce_req_type_uc_wr)) begin
               pending_w_v_o = 1'b1;
-              pending_w_addr_lo = lce_req_li.addr;
+              pending_w_addr_lo = lce_req_li.header.addr;
               pending_o = 1'b1;
             end
           end
@@ -742,7 +742,7 @@ module bp_cce_msg_cached
             fence_dec = mem_resp_v_i & mem_resp_yumi_o;
             // clear pending bit
             pending_w_v_o = 1'b1;
-            pending_w_addr_lo = mem_resp_li.addr;
+            pending_w_addr_lo = mem_resp_li.header.addr;
             pending_o = 1'b0;
           end
         end
@@ -775,14 +775,14 @@ module bp_cce_msg_cached
           if (~lce_cmd_busy_o) begin
 
             lce_cmd_v_o = lce_cmd_ready_i;
-            lce_cmd.msg_type = decoded_inst_i.lce_cmd;
+            lce_cmd.header.msg_type = decoded_inst_i.lce_cmd;
 
             // destination and way come from sharers information
-            lce_cmd.dst_id = pe_lce_id;
-            lce_cmd.way_id = sharers_ways_r[pe_lce_id];
+            lce_cmd.header.dst_id = pe_lce_id;
+            lce_cmd.header.way_id = sharers_ways_r[pe_lce_id];
 
-            lce_cmd.msg.cmd.src_id = cce_id_i;
-            lce_cmd.msg.cmd.addr = lce_cmd_addr;
+            lce_cmd.header.src_id = cce_id_i;
+            lce_cmd.header.addr = lce_cmd_addr;
 
             if (lce_cmd_ready_i) begin
               // message sent, increment count, write directory, clear bit for the destination LCE
@@ -812,7 +812,7 @@ module bp_cce_msg_cached
         end // pe_v
 
         // dequeue responses as they arrive
-        if (lce_resp_v_i & (lce_resp.msg_type == e_lce_cce_inv_ack)) begin
+        if (lce_resp_v_i & (lce_resp.header.msg_type == e_lce_cce_inv_ack)) begin
           lce_resp_yumi_o = 1'b1;
           cnt_dec = 1'b1;
         end
@@ -825,7 +825,7 @@ module bp_cce_msg_cached
           state_n = READY;
         end else begin
           msg_inv_busy_o = 1'b1;
-          if (lce_resp_v_i & (lce_resp.msg_type == e_lce_cce_inv_ack)) begin
+          if (lce_resp_v_i & (lce_resp.header.msg_type == e_lce_cce_inv_ack)) begin
             lce_resp_yumi_o = 1'b1;
             cnt_dec = 1'b1;
             if (cnt == 'd1) begin

--- a/bp_me/src/v/cce/bp_io_cce.v
+++ b/bp_me/src/v/cce/bp_io_cce.v
@@ -47,56 +47,56 @@ module bp_io_cce
   assign io_cmd_o       = io_cmd_cast_o;
 
   bp_cce_mem_req_size_e io_cmd_size;
-  assign io_cmd_size = (lce_req_cast_i.msg.uc_req.uc_size == e_lce_uc_req_1)
+  assign io_cmd_size = (lce_req_cast_i.header.uc_size == e_lce_uc_req_1)
                         ? e_mem_size_1
-                        : (lce_req_cast_i.msg.uc_req.uc_size == e_lce_uc_req_2)
+                        : (lce_req_cast_i.header.uc_size == e_lce_uc_req_2)
                           ? e_mem_size_2
-                          : (lce_req_cast_i.msg.uc_req.uc_size == e_lce_uc_req_4)
+                          : (lce_req_cast_i.header.uc_size == e_lce_uc_req_4)
                             ? e_mem_size_4
                             : e_mem_size_8;
 
   assign lce_req_yumi_o  = lce_req_v_i & io_cmd_ready_i;
   assign io_cmd_v_o      = lce_req_yumi_o;
-  wire lce_req_wr_not_rd = (lce_req_cast_i.msg_type == e_lce_req_type_uc_wr);
+  wire lce_req_wr_not_rd = (lce_req_cast_i.header.msg_type == e_lce_req_type_uc_wr);
   always_comb
     if (lce_req_wr_not_rd)
       begin
-        io_cmd_cast_o                     = '0;
-        io_cmd_cast_o.msg_type            = e_cce_mem_uc_wr;
-        io_cmd_cast_o.addr                = lce_req_cast_i.addr;
-        io_cmd_cast_o.size                = io_cmd_size;
-        io_cmd_cast_o.payload.lce_id      = lce_req_cast_i.src_id;
-        io_cmd_cast_o.data                = lce_req_cast_i.msg.uc_req.data;
+        io_cmd_cast_o                       = '0;
+        io_cmd_cast_o.header.msg_type       = e_cce_mem_uc_wr;
+        io_cmd_cast_o.header.addr           = lce_req_cast_i.header.addr;
+        io_cmd_cast_o.header.size           = io_cmd_size;
+        io_cmd_cast_o.header.payload.lce_id = lce_req_cast_i.header.src_id;
+        io_cmd_cast_o.data                  = lce_req_cast_i.data;
       end
     else
       begin
-        io_cmd_cast_o                     = '0;
-        io_cmd_cast_o.msg_type            = e_cce_mem_uc_rd;
-        io_cmd_cast_o.addr                = lce_req_cast_i.addr;
-        io_cmd_cast_o.size                = io_cmd_size;
-        io_cmd_cast_o.payload.lce_id      = lce_req_cast_i.src_id;
-        io_cmd_cast_o.data                = lce_req_cast_i.msg.uc_req.data;
+        io_cmd_cast_o                       = '0;
+        io_cmd_cast_o.header.msg_type       = e_cce_mem_uc_rd;
+        io_cmd_cast_o.header.addr           = lce_req_cast_i.header.addr;
+        io_cmd_cast_o.header.size           = io_cmd_size;
+        io_cmd_cast_o.header.payload.lce_id = lce_req_cast_i.header.src_id;
+        io_cmd_cast_o.data                  = lce_req_cast_i.data;
       end
 
   assign io_resp_yumi_o  = io_resp_v_i & lce_cmd_ready_i;
   assign lce_cmd_v_o     = io_resp_yumi_o;
-  wire io_resp_wr_not_rd = (io_resp_cast_i.msg_type == e_cce_mem_uc_wr);
+  wire io_resp_wr_not_rd = (io_resp_cast_i.header.msg_type == e_cce_mem_uc_wr);
   always_comb
     if (io_resp_wr_not_rd)
       begin
-        lce_cmd_cast_o                = '0;
-        lce_cmd_cast_o.dst_id         = io_resp_cast_i.payload.lce_id;
-        lce_cmd_cast_o.msg_type       = e_lce_cmd_uc_st_done;
-        lce_cmd_cast_o.msg.cmd.addr   = io_resp_cast_i.addr;
-        lce_cmd_cast_o.msg.cmd.src_id = cce_id_i;
+        lce_cmd_cast_o                 = '0;
+        lce_cmd_cast_o.header.dst_id   = io_resp_cast_i.header.payload.lce_id;
+        lce_cmd_cast_o.header.msg_type = e_lce_cmd_uc_st_done;
+        lce_cmd_cast_o.header.addr     = io_resp_cast_i.header.addr;
+        lce_cmd_cast_o.header.src_id   = cce_id_i;
       end
     else
       begin
         lce_cmd_cast_o                  = '0;
-        lce_cmd_cast_o.dst_id           = io_resp_cast_i.payload.lce_id;
-        lce_cmd_cast_o.msg_type         = e_lce_cmd_uc_data;
-        lce_cmd_cast_o.msg.dt_cmd.data  = io_resp_cast_i.data;
-        lce_cmd_cast_o.msg.dt_cmd.addr  = io_resp_cast_i.addr;
+        lce_cmd_cast_o.header.dst_id    = io_resp_cast_i.header.payload.lce_id;
+        lce_cmd_cast_o.header.msg_type  = e_lce_cmd_uc_data;
+        lce_cmd_cast_o.data             = io_resp_cast_i.data;
+        lce_cmd_cast_o.header.addr      = io_resp_cast_i.header.addr;
       end
 
 endmodule

--- a/bp_me/src/v/wormhole/bp_me_cce_to_mem_link_client.v
+++ b/bp_me/src/v/wormhole/bp_me_cce_to_mem_link_client.v
@@ -41,10 +41,10 @@ module bp_me_cce_to_mem_link_client
   );
   
   `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
-  `declare_bp_mem_wormhole_payload_s(cord_width_p, cid_width_p, cce_mem_msg_width_lp, mem_cmd_payload_s);
-  `declare_bp_mem_wormhole_payload_s(cord_width_p, cid_width_p, cce_mem_msg_width_lp, mem_resp_payload_s);
-  `declare_bsg_wormhole_concentrator_packet_s(cord_width_p, len_width_p, cid_width_p, $bits(mem_cmd_payload_s), mem_cmd_packet_s);
-  `declare_bsg_wormhole_concentrator_packet_s(cord_width_p, len_width_p, cid_width_p, $bits(mem_resp_payload_s), mem_resp_packet_s);
+  `declare_bp_mem_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-cce_block_width_p, cce_block_width_p, mem_cmd_packet_s);
+  `declare_bp_mem_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-cce_block_width_p, cce_block_width_p, mem_resp_packet_s);
+
+  localparam payload_width_lp = `bp_mem_wormhole_payload_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-cce_block_width_p, cce_block_width_p);
 
   // We save coordinates between sending and receiving. This assumes we get responses in-order
   logic [cord_width_p-1:0] fifo_cord_li, fifo_cord_lo;
@@ -55,7 +55,7 @@ module bp_me_cce_to_mem_link_client
   logic mem_cmd_packet_v_lo, mem_cmd_packet_yumi_li;
   mem_resp_packet_s mem_resp_packet_lo;
   bsg_wormhole_router_adapter
-   #(.max_payload_width_p($bits(mem_cmd_payload_s)+cid_width_p)
+   #(.max_payload_width_p(payload_width_lp)
      ,.len_width_p(len_width_p)
      ,.cord_width_p(cord_width_p)
      ,.flit_width_p(flit_width_p)
@@ -75,15 +75,13 @@ module bp_me_cce_to_mem_link_client
       ,.v_i(mem_resp_v_i)
       ,.ready_o(mem_resp_ready_o)
       );
-  mem_cmd_payload_s mem_cmd_payload_lo;
-  assign mem_cmd_payload_lo = mem_cmd_packet_lo.payload;
-  assign mem_cmd_o = mem_cmd_payload_lo.data;
+  assign mem_cmd_o = {mem_cmd_packet_lo.data, mem_cmd_packet_lo.msg};
   assign mem_cmd_v_o = mem_cmd_packet_v_lo & fifo_ready_lo;
   assign mem_cmd_packet_yumi_li = mem_cmd_yumi_i;
   
   wire bypass_fifo = mem_resp_v_i & ~fifo_v_lo;
-  assign fifo_cord_li = mem_cmd_payload_lo.src_cord;
-  assign fifo_cid_li  = mem_cmd_payload_lo.src_cid;
+  assign fifo_cord_li = mem_cmd_packet_lo.src_cord;
+  assign fifo_cid_li  = mem_cmd_packet_lo.src_cid;
   assign fifo_v_li    = mem_cmd_yumi_i & ~bypass_fifo;
   bsg_fifo_1r1w_small 
   #(.width_p(cord_width_p+cid_width_p)
@@ -103,14 +101,15 @@ module bp_me_cce_to_mem_link_client
     );
   assign fifo_yumi_li = fifo_v_lo & mem_resp_v_i;
 
-  wire [cord_width_p-1:0] src_cord_lo = bypass_fifo ? mem_cmd_payload_lo.src_cord : fifo_cord_lo;
-  wire [cid_width_p-1:0]  src_cid_lo  = bypass_fifo ? mem_cmd_payload_lo.src_cid  : fifo_cid_lo;
+  wire [cord_width_p-1:0] src_cord_lo = bypass_fifo ? mem_cmd_packet_lo.src_cord : fifo_cord_lo;
+  wire [cid_width_p-1:0]  src_cid_lo  = bypass_fifo ? mem_cmd_packet_lo.src_cid  : fifo_cid_lo;
   
   wire [cord_width_p-1:0] dst_cord_lo = src_cord_lo;
   wire [cid_width_p-1:0]  dst_cid_lo  = src_cid_lo;
 
   bp_me_wormhole_packet_encode_mem_resp
    #(.bp_params_p(bp_params_p)
+     ,.flit_width_p(flit_width_p)
      ,.cord_width_p(cord_width_p)
      ,.cid_width_p(cid_width_p)
      ,.len_width_p(len_width_p)

--- a/bp_me/src/v/wormhole/bp_me_cce_to_mem_link_master.v
+++ b/bp_me/src/v/wormhole/bp_me_cce_to_mem_link_master.v
@@ -52,14 +52,15 @@ assign mem_cmd_cast_i = mem_cmd_i;
 assign mem_resp_o = mem_resp_cast_o;
 
 // CCE-MEM IF to Wormhole routed interface
-`declare_bp_mem_wormhole_payload_s(cord_width_p, cid_width_p, cce_mem_msg_width_lp, mem_cmd_payload_s);
-`declare_bp_mem_wormhole_payload_s(cord_width_p, cid_width_p, cce_mem_msg_width_lp, mem_resp_payload_s);
-`declare_bsg_wormhole_concentrator_packet_s(cord_width_p, len_width_p, cid_width_p, $bits(mem_cmd_payload_s), mem_cmd_packet_s);
-`declare_bsg_wormhole_concentrator_packet_s(cord_width_p, len_width_p, cid_width_p, $bits(mem_resp_payload_s), mem_resp_packet_s);
+`declare_bp_mem_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-cce_block_width_p, cce_block_width_p, mem_cmd_packet_s);
+`declare_bp_mem_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-cce_block_width_p, cce_block_width_p, mem_resp_packet_s);
+
+localparam payload_width_lp = `bp_mem_wormhole_payload_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-cce_block_width_p, cce_block_width_p);
 
 mem_cmd_packet_s mem_cmd_packet_li;
 bp_me_wormhole_packet_encode_mem_cmd
  #(.bp_params_p(bp_params_p)
+   ,.flit_width_p(flit_width_p)
    ,.cord_width_p(cord_width_p)
    ,.cid_width_p(cid_width_p)
    ,.len_width_p(len_width_p)
@@ -75,7 +76,7 @@ bp_me_wormhole_packet_encode_mem_cmd
 
 mem_resp_packet_s mem_resp_packet_lo;
 bsg_wormhole_router_adapter
- #(.max_payload_width_p($bits(mem_cmd_payload_s)+cid_width_p)
+ #(.max_payload_width_p(payload_width_lp)
    ,.len_width_p(len_width_p)
    ,.cord_width_p(cord_width_p)
    ,.flit_width_p(flit_width_p)
@@ -95,9 +96,7 @@ bsg_wormhole_router_adapter
    ,.v_o(mem_resp_v_o)
    ,.yumi_i(mem_resp_yumi_i)
    );
-mem_resp_payload_s mem_resp_payload_lo;
-assign mem_resp_payload_lo = mem_resp_packet_lo.payload;
-assign mem_resp_cast_o = mem_resp_payload_lo.data;
+assign mem_resp_cast_o = {mem_resp_packet_lo.data, mem_resp_packet_lo.msg};
 
 endmodule
 

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_cmd.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_cmd.v
@@ -33,7 +33,7 @@ module bp_me_wormhole_packet_encode_lce_cmd
   assign packet_o = packet_cast_o;
 
   localparam lce_cmd_cmd_len_lp = 
-    `BSG_CDIV(lce_cmd_packet_width_lp-$bits(payload_cast_i.msg.cmd.pad), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cmd_packet_width_lp-$bits(payload_cast_i.data), coh_noc_flit_width_p) - 1;
   localparam lce_cmd_data_len_lp = 
     `BSG_CDIV(lce_cmd_packet_width_lp, coh_noc_flit_width_p) - 1;
   localparam lce_cmd_uc_data_len_lp =
@@ -44,7 +44,7 @@ module bp_me_wormhole_packet_encode_lce_cmd
   bp_me_lce_id_to_cord
    #(.bp_params_p(bp_params_p))
    router_cord
-    (.lce_id_i(payload_cast_i.dst_id)
+    (.lce_id_i(payload_cast_i.header.dst_id)
      ,.lce_cord_o(lce_cord_li)
      ,.lce_cid_o(lce_cid_li)
      );
@@ -54,7 +54,7 @@ module bp_me_wormhole_packet_encode_lce_cmd
     packet_cast_o.cid     = lce_cid_li;
     packet_cast_o.cord    = lce_cord_li;
 
-    case (payload_cast_i.msg_type)
+    case (payload_cast_i.header.msg_type)
       e_lce_cmd_sync
       ,e_lce_cmd_set_clear
       ,e_lce_cmd_transfer

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_req.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_req.v
@@ -32,19 +32,23 @@ module bp_me_wormhole_packet_encode_lce_req
   assign payload_cast_i = payload_i;
   assign packet_o = packet_cast_o;
 
+  // TODO: remove commented code after testing. Normal request and UC Rd have length = header = full msg - dword_width_p
+  // UC Store is header + dword_width_p = full length
   localparam lce_cce_req_req_len_lp =
-    `BSG_CDIV(lce_cce_req_packet_width_lp-$bits(payload_cast_i.msg.req.pad), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_req_packet_width_lp-$bits(payload_cast_i.data), coh_noc_flit_width_p) - 1;
+    //`BSG_CDIV(lce_cce_req_packet_width_lp-$bits(payload_cast_i.msg.req.pad), coh_noc_flit_width_p) - 1;
   localparam lce_cce_req_uc_wr_len_lp =
     `BSG_CDIV(lce_cce_req_packet_width_lp, coh_noc_flit_width_p) - 1;
   localparam lce_cce_req_uc_rd_len_lp =
-    `BSG_CDIV(lce_cce_req_packet_width_lp-$bits(payload_cast_i.msg.uc_req.data), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_req_packet_width_lp-$bits(payload_cast_i.data), coh_noc_flit_width_p) - 1;
+    //`BSG_CDIV(lce_cce_req_packet_width_lp-$bits(payload_cast_i.msg.uc_req.data), coh_noc_flit_width_p) - 1;
 
   logic [coh_noc_cord_width_p-1:0] cce_cord_li;
   logic [coh_noc_cid_width_p-1:0]  cce_cid_li;
   bp_me_cce_id_to_cord
    #(.bp_params_p(bp_params_p))
    router_cord
-    (.cce_id_i(payload_cast_i.dst_id)
+    (.cce_id_i(payload_cast_i.header.dst_id)
      ,.cce_cord_o(cce_cord_li)
      ,.cce_cid_o(cce_cid_li)
      );
@@ -54,7 +58,7 @@ module bp_me_wormhole_packet_encode_lce_req
     packet_cast_o.cid     = cce_cid_li;
     packet_cast_o.cord    = cce_cord_li;
 
-    case (payload_cast_i.msg_type)
+    case (payload_cast_i.header.msg_type)
       e_lce_req_type_rd
       ,e_lce_req_type_wr  : packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_req_len_lp);
       e_lce_req_type_uc_rd: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_uc_wr_len_lp);

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_resp.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_resp.v
@@ -42,7 +42,7 @@ module bp_me_wormhole_packet_encode_lce_resp
   bp_me_cce_id_to_cord
    #(.bp_params_p(bp_params_p))
    router_cord
-    (.cce_id_i(payload_cast_i.dst_id)
+    (.cce_id_i(payload_cast_i.header.dst_id)
      ,.cce_cord_o(cce_cord_li)
      ,.cce_cid_o(cce_cid_li)
      );
@@ -52,7 +52,7 @@ module bp_me_wormhole_packet_encode_lce_resp
     packet_cast_o.cid     = cce_cid_li;
     packet_cast_o.cord    = cce_cord_li;
 
-    case (payload_cast_i.msg_type)
+    case (payload_cast_i.header.msg_type)
       e_lce_cce_sync_ack
       ,e_lce_cce_inv_ack
       ,e_lce_cce_coh_ack    : packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_ack_len_lp);

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v
@@ -20,14 +20,13 @@ module bp_me_wormhole_packet_encode_mem_cmd
     `declare_bp_proc_params(bp_params_p)
     `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
 
+    , parameter flit_width_p = "inv"
     , parameter cord_width_p = "inv"
     , parameter cid_width_p = "inv"
     , parameter len_width_p = "inv"
 
-    , localparam mem_cmd_payload_width_lp =
-        `bp_mem_wormhole_payload_width(cord_width_p, cid_width_p, cce_mem_msg_width_lp)
     , localparam mem_cmd_packet_width_lp = 
-        `bsg_wormhole_concentrator_packet_width(cord_width_p, len_width_p, cid_width_p, mem_cmd_payload_width_lp)
+        `bp_mem_wormhole_packet_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-cce_block_width_p, cce_block_width_p)
     )
    (input [cce_mem_msg_width_lp-1:0]       mem_cmd_i
    
@@ -40,16 +39,13 @@ module bp_me_wormhole_packet_encode_mem_cmd
     );
 
   `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
-  `declare_bp_mem_wormhole_payload_s(cord_width_p, cid_width_p, cce_mem_msg_width_lp, bp_cmd_wormhole_payload_s);
-  `declare_bsg_wormhole_concentrator_packet_s(cord_width_p, len_width_p, cid_width_p, $bits(bp_cmd_wormhole_payload_s), bp_cmd_wormhole_packet_s);
+  `declare_bp_mem_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-cce_block_width_p, cce_block_width_p, bp_cmd_wormhole_packet_s);
 
   bp_cce_mem_msg_s mem_cmd_cast_i;
   bp_cmd_wormhole_packet_s packet_cast_o;
 
   assign mem_cmd_cast_i = mem_cmd_i;
   assign packet_o       = packet_cast_o;
-
-  bp_cmd_wormhole_payload_s payload_li;
 
   localparam mem_cmd_req_len_lp =
     `BSG_CDIV(mem_cmd_packet_width_lp-$bits(mem_cmd_cast_i.data), mem_noc_flit_width_p) - 1;
@@ -71,11 +67,11 @@ module bp_me_wormhole_packet_encode_mem_cmd
   logic [len_width_p-1:0] data_cmd_len_li;
 
   always_comb begin
-    payload_li.data       = mem_cmd_i;
-    payload_li.src_cord   = src_cord_i;
-    payload_li.src_cid    = src_cid_i;
+    packet_cast_o.data       = mem_cmd_cast_i.data;
+    packet_cast_o.msg        = mem_cmd_cast_i[0+:cce_mem_msg_width_lp-cce_block_width_p];
+    packet_cast_o.src_cord   = src_cord_i;
+    packet_cast_o.src_cid    = src_cid_i;
 
-    packet_cast_o.payload = payload_li;
     packet_cast_o.cord    = dst_cord_i;
     packet_cast_o.cid     = dst_cid_i;
 

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v
@@ -75,7 +75,7 @@ module bp_me_wormhole_packet_encode_mem_cmd
     packet_cast_o.cord    = dst_cord_i;
     packet_cast_o.cid     = dst_cid_i;
 
-    case (mem_cmd_cast_i.size)
+    case (mem_cmd_cast_i.header.size)
       e_mem_size_1 : data_cmd_len_li = len_width_p'(mem_cmd_data_len_1_lp);
       e_mem_size_2 : data_cmd_len_li = len_width_p'(mem_cmd_data_len_2_lp);
       e_mem_size_4 : data_cmd_len_li = len_width_p'(mem_cmd_data_len_4_lp);
@@ -86,7 +86,7 @@ module bp_me_wormhole_packet_encode_mem_cmd
       default: data_cmd_len_li = '0;
     endcase
 
-    case (mem_cmd_cast_i.msg_type)
+    case (mem_cmd_cast_i.header.msg_type)
       e_cce_mem_rd
       ,e_cce_mem_wr
       ,e_cce_mem_uc_rd: packet_cast_o.len = len_width_p'(mem_cmd_req_len_lp);

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
@@ -73,7 +73,7 @@ module bp_me_wormhole_packet_encode_mem_resp
     packet_cast_o.cord    = dst_cord_i;
     packet_cast_o.cid     = dst_cid_i;
 
-    case (mem_resp_cast_i.size)
+    case (mem_resp_cast_i.header.size)
       e_mem_size_1 : data_resp_len_li = len_width_p'(mem_resp_data_len_1_lp);
       e_mem_size_2 : data_resp_len_li = len_width_p'(mem_resp_data_len_2_lp);
       e_mem_size_4 : data_resp_len_li = len_width_p'(mem_resp_data_len_4_lp);
@@ -84,7 +84,7 @@ module bp_me_wormhole_packet_encode_mem_resp
       default: data_resp_len_li = '0;
     endcase
 
-    case (mem_resp_cast_i.msg_type)
+    case (mem_resp_cast_i.header.msg_type)
       e_cce_mem_rd
       ,e_cce_mem_wr
       ,e_cce_mem_uc_rd: packet_cast_o.len = data_resp_len_li;

--- a/bp_me/test/common/bp_cce_mmio_cfg_loader.v
+++ b/bp_me/test/common/bp_cce_mmio_cfg_loader.v
@@ -32,12 +32,12 @@ module bp_cce_mmio_cfg_loader
    , input                                           reset_i
 
    // Config channel
-   , output logic [cce_mem_msg_width_lp-1:0]          io_cmd_o
+   , output logic [cce_mem_msg_width_lp-1:0]         io_cmd_o
    , output logic                                    io_cmd_v_o
    , input                                           io_cmd_yumi_i
 
    // We don't need a response from the cfg network
-   , input [cce_mem_msg_width_lp-1:0]                 io_resp_i
+   , input [cce_mem_msg_width_lp-1:0]                io_resp_i
    , input                                           io_resp_v_i
    , output                                          io_resp_ready_o
    
@@ -192,10 +192,10 @@ module bp_cce_mmio_cfg_loader
       io_cmd_v_o = (cfg_w_v_lo | cfg_r_v_lo) & ~credits_full_lo;
 
       // uncached store
-      io_cmd_cast_o.msg_type      = cfg_w_v_lo ? e_cce_mem_uc_wr : e_cce_mem_uc_rd;
-      io_cmd_cast_o.addr          = local_addr_lo; 
-      io_cmd_cast_o.payload       = '0;
-      io_cmd_cast_o.size          = e_mem_size_8;
+      io_cmd_cast_o.header.msg_type      = cfg_w_v_lo ? e_cce_mem_uc_wr : e_cce_mem_uc_rd;
+      io_cmd_cast_o.header.addr          = local_addr_lo;
+      io_cmd_cast_o.header.payload       = '0;
+      io_cmd_cast_o.header.size          = e_mem_size_8;
       io_cmd_cast_o.data          = cfg_data_lo;
     end
 

--- a/bp_me/test/common/bp_cce_nonsynth_tracer.v
+++ b/bp_me/test/common/bp_cce_nonsynth_tracer.v
@@ -18,23 +18,16 @@ module bp_cce_nonsynth_tracer
     , localparam cce_trace_file_p = "cce"
 
     // Derived parameters
-    , localparam block_size_in_bytes_lp      = (cce_block_width_p/8)
-    , localparam lg_num_lce_lp             = `BSG_SAFE_CLOG2(num_lce_p)
-    , localparam lg_num_cce_lp             = `BSG_SAFE_CLOG2(num_cce_p)
+    , localparam block_size_in_bytes_lp    = (cce_block_width_p/8)
     , localparam lg_block_size_in_bytes_lp = `BSG_SAFE_CLOG2(block_size_in_bytes_lp)
-    , localparam lg_lce_assoc_lp           = `BSG_SAFE_CLOG2(lce_assoc_p)
-    , localparam lg_lce_sets_lp            = `BSG_SAFE_CLOG2(lce_sets_p)
-    , localparam tag_width_lp              = (paddr_width_p-lg_lce_sets_lp
-                                              -lg_block_size_in_bytes_lp)
-    , localparam entry_width_lp            = (tag_width_lp+`bp_coh_bits)
-    , localparam tag_set_width_lp          = (entry_width_lp*lce_assoc_p)
-    , localparam way_group_width_lp        = (tag_set_width_lp*num_lce_p)
-    , localparam way_group_offset_high_lp  = (lg_block_size_in_bytes_lp+lg_lce_sets_lp)
-    , localparam num_way_groups_lp         = (lce_sets_p/num_cce_p)
+
+    // number of way groups managed by this CCE
+    , localparam num_way_groups_lp         = `BSG_CDIV(lce_sets_p, num_cce_p)
     , localparam lg_num_way_groups_lp      = `BSG_SAFE_CLOG2(num_way_groups_lp)
 
-`declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-`declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+    `declare_bp_lce_cce_if_header_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p)
+    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+    `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
   )
   (input                                        clk_i
    , input                                      reset_i
@@ -75,28 +68,21 @@ module bp_cce_nonsynth_tracer
    , input [cce_id_width_p-1:0]                 cce_id_i
   );
 
-  // Define structure variables for output queues
-
+  // LCE-CCE and Mem-CCE Interface
   `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
   `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p);
 
   bp_lce_cce_req_s           lce_req;
-  bp_lce_cce_req_req_s       lce_req_req;
-  bp_lce_cce_req_uc_req_s    lce_req_uc_req;
   bp_lce_cce_resp_s          lce_resp;
   bp_lce_cmd_s               lce_cmd;
-  bp_lce_cmd_cmd_s           lce_cmd_cmd;
 
-  bp_cce_mem_msg_s           mem_cmd_lo, mem_resp_li;
+  bp_cce_mem_msg_s           mem_cmd, mem_resp;
 
   assign lce_req             = lce_req_i;
-  assign lce_req_req         = lce_req.msg.req;
-  assign lce_req_uc_req      = lce_req.msg.uc_req;
   assign lce_resp            = lce_resp_i;
   assign lce_cmd             = lce_cmd_i;
-  assign lce_cmd_cmd         = lce_cmd.msg.cmd;
-  assign mem_cmd_lo          = mem_cmd_i;
-  assign mem_resp_li         = mem_resp_i;
+  assign mem_cmd             = mem_cmd_i;
+  assign mem_resp            = mem_resp_i;
 
   integer file;
   string file_name;
@@ -117,93 +103,92 @@ module bp_cce_nonsynth_tracer
     if (~reset_i) begin
       // inbound messages
       if (lce_req_v_i & lce_req_yumi_i) begin
-        if (lce_req.msg_type == e_lce_req_type_rd | lce_req.msg_type == e_lce_req_type_wr) begin
-        $fdisplay(file, "[%t]: CCE[%0d] REQ LCE[%0d] addr[%H] wr[%0b] ne[%0b] uc[%0b] lruWay[%0d] lruDirty[%0b] tag[%H] set[%0d]"
-                 , $time, cce_id_i, lce_req.src_id, lce_req.addr, (lce_req.msg_type == e_lce_req_type_wr)
-                 , lce_req_req.non_exclusive
+        if (lce_req.header.msg_type == e_lce_req_type_rd | lce_req.header.msg_type == e_lce_req_type_wr) begin
+        $fdisplay(file, "[%t]: CCE[%0d] REQ LCE[%0d] addr[%H] wr[%0b] ne[%0b] uc[%0b] lruWay[%0d] lruDirty[%0b]"
+                 , $time, cce_id_i, lce_req.header.src_id, lce_req.header.addr, (lce_req.header.msg_type == e_lce_req_type_wr)
+                 , lce_req.header.non_exclusive
                  , 1'b0
-                 , lce_req_req.lru_way_id, lce_req_req.lru_dirty
-                 , lce_req.addr[(paddr_width_p-1)-:tag_width_lp]
-                 , lce_req.addr[lg_block_size_in_bytes_lp+:lg_lce_sets_lp]);
+                 , lce_req.header.lru_way_id, lce_req.header.lru_dirty
+                 );
         end
-        if (lce_req.msg_type == e_lce_req_type_uc_rd | lce_req.msg_type == e_lce_req_type_uc_wr) begin
-        $fdisplay(file, "[%t]: CCE[%0d] REQ LCE[%0d] addr[%H] wr[%0b] ne[%0b] uc[%0b] lruWay[%0d] lruDirty[%0b] tag[%H] set[%0d]"
-                 , $time, cce_id_i, lce_req.src_id, lce_req.addr, (lce_req.msg_type == e_lce_req_type_uc_wr)
+        if (lce_req.header.msg_type == e_lce_req_type_uc_rd | lce_req.header.msg_type == e_lce_req_type_uc_wr) begin
+        $fdisplay(file, "[%t]: CCE[%0d] REQ LCE[%0d] addr[%H] wr[%0b] ne[%0b] uc[%0b] lruWay[%0d] lruDirty[%0b]"
+                 , $time, cce_id_i, lce_req.header.src_id, lce_req.header.addr, (lce_req.header.msg_type == e_lce_req_type_uc_wr)
                  , 1'b0
                  , 1'b1
                  , '0, '0
-                 , lce_req.addr[(paddr_width_p-1)-:tag_width_lp]
-                 , lce_req.addr[lg_block_size_in_bytes_lp+:lg_lce_sets_lp]);
+                 );
         end
       end
       if (lce_resp_v_i & lce_resp_yumi_i) begin
-        if ((lce_resp.msg_type == e_lce_cce_sync_ack)
-            | (lce_resp.msg_type == e_lce_cce_inv_ack)
-            | (lce_resp.msg_type == e_lce_cce_coh_ack)) begin
+        if ((lce_resp.header.msg_type == e_lce_cce_sync_ack)
+            | (lce_resp.header.msg_type == e_lce_cce_inv_ack)
+            | (lce_resp.header.msg_type == e_lce_cce_coh_ack)) begin
         $fdisplay(file, "[%t]: CCE[%0d] RESP LCE[%0d] addr[%H] ack[%4b]"
-                 , $time, cce_id_i, lce_resp.src_id, lce_resp.addr, lce_resp.msg_type);
+                 , $time, cce_id_i, lce_resp.header.src_id, lce_resp.header.addr, lce_resp.header.msg_type);
         end
-        if ((lce_resp.msg_type == e_lce_cce_resp_wb)
-            | (lce_resp.msg_type == e_lce_cce_resp_null_wb)) begin
+        if ((lce_resp.header.msg_type == e_lce_cce_resp_wb)
+            | (lce_resp.header.msg_type == e_lce_cce_resp_null_wb)) begin
         $fdisplay(file, "[%t]: CCE[%0d] DATA RESP LCE[%0d] addr[%H] null_wb[%0b] %H"
-                 , $time, cce_id_i, lce_resp.src_id, lce_resp.addr
-                 , (lce_resp.msg_type == e_lce_cce_resp_null_wb)
+                 , $time, cce_id_i, lce_resp.header.src_id, lce_resp.header.addr
+                 , (lce_resp.header.msg_type == e_lce_cce_resp_null_wb)
                  , lce_resp.data);
         end
       end
       if (mem_resp_v_i & mem_resp_yumi_i) begin
-        if (mem_resp_li.msg_type == e_cce_mem_wb | mem_resp_li.msg_type == e_cce_mem_uc_wr) begin
+        if (mem_resp.header.msg_type == e_cce_mem_wb | mem_resp.header.msg_type == e_cce_mem_uc_wr) begin
         $fdisplay(file, "[%t]: CCE[%0d] MEM RESP wb[%0b] uc[%0b] addr[%H] lce[%0d] way[%0d]"
-                 , $time, cce_id_i, (mem_resp_li.msg_type == e_cce_mem_wb)
-                 , (mem_resp_li.msg_type == e_cce_mem_uc_wr)
-                 , mem_resp_li.addr
-                 , mem_resp_li.payload.lce_id, mem_resp_li.payload.way_id);
+                 , $time, cce_id_i, (mem_resp.header.msg_type == e_cce_mem_wb)
+                 , (mem_resp.header.msg_type == e_cce_mem_uc_wr)
+                 , mem_resp.header.addr
+                 , mem_resp.header.payload.lce_id, mem_resp.header.payload.way_id);
         end
-        if (mem_resp_li.msg_type == e_cce_mem_rd | mem_resp_li.msg_type == e_cce_mem_wr
-            | mem_resp_li.msg_type == e_cce_mem_uc_rd) begin
+        if (mem_resp.header.msg_type == e_cce_mem_rd | mem_resp.header.msg_type == e_cce_mem_wr
+            | mem_resp.header.msg_type == e_cce_mem_uc_rd) begin
         $fdisplay(file, "[%t]: CCE[%0d] MEM DATA RESP wr[%0b] addr[%H] lce[%0d] way[%0d] state[%3b] spec[%0b] uc[%0b] %H"
-                 , $time, cce_id_i, (mem_resp_li.msg_type == e_cce_mem_wr), mem_resp_li.addr
-                 , mem_resp_li.payload.lce_id, mem_resp_li.payload.way_id, mem_resp_li.payload.state
-                 , mem_resp_li.payload.speculative
-                 , (mem_resp_li.msg_type == e_cce_mem_uc_rd), mem_resp_li.data);
+                 , $time, cce_id_i, (mem_resp.header.msg_type == e_cce_mem_wr), mem_resp.header.addr
+                 , mem_resp.header.payload.lce_id, mem_resp.header.payload.way_id, mem_resp.header.payload.state
+                 , mem_resp.header.payload.speculative
+                 , (mem_resp.header.msg_type == e_cce_mem_uc_rd), mem_resp.data);
         end
       end
       // outbound messages
       if (lce_cmd_v_i & lce_cmd_ready_i) begin
-        if (lce_cmd.msg_type == e_lce_cmd_data) begin
-        $fdisplay(file, "[%t]: CCE[%0d] DATA CMD LCE[%0d] cmd[%4b] addr[%H] st[%3b] way[%0d] set[%0d] %H"
-                 , $time, cce_id_i, lce_cmd.dst_id, lce_cmd.msg_type, lce_cmd.msg.dt_cmd.addr
-                 , lce_cmd.msg.dt_cmd.state, lce_cmd.way_id
-                 , lce_cmd.msg.dt_cmd.addr[lg_block_size_in_bytes_lp+:lg_lce_sets_lp]
-                 , lce_cmd.msg.dt_cmd.data);
-        end
-        else if (lce_cmd.msg_type == e_lce_cmd_uc_data) begin
+        if (lce_cmd.header.msg_type == e_lce_cmd_data) begin
         $fdisplay(file, "[%t]: CCE[%0d] DATA CMD LCE[%0d] cmd[%4b] addr[%H] st[%3b] way[%0d] %H"
-                 , $time, cce_id_i, lce_cmd.dst_id, lce_cmd.msg_type, lce_cmd.msg.dt_cmd.addr
-                 , lce_cmd.msg.dt_cmd.state, lce_cmd.way_id
-                 , lce_cmd.msg.dt_cmd.data);
+                 , $time, cce_id_i, lce_cmd.header.dst_id, lce_cmd.header.msg_type, lce_cmd.header.addr
+                 , lce_cmd.header.state, lce_cmd.header.way_id
+                 , lce_cmd.data
+                 );
+        end
+        else if (lce_cmd.header.msg_type == e_lce_cmd_uc_data) begin
+        $fdisplay(file, "[%t]: CCE[%0d] DATA CMD LCE[%0d] cmd[%4b] addr[%H] st[%3b] way[%0d] %H"
+                 , $time, cce_id_i, lce_cmd.header.dst_id, lce_cmd.header.msg_type, lce_cmd.header.addr
+                 , lce_cmd.header.state, lce_cmd.header.way_id
+                 , lce_cmd.data
+                 );
         end
 
         else begin
-        $fdisplay(file, "[%t]: CCE[%0d] CMD LCE[%0d] addr[%H] cmd[%4b] way[%0d] st[%3b] tgt[%0d] tgtWay[%0d] set[%0d]"
-                 , $time, cce_id_i, lce_cmd.dst_id, lce_cmd_cmd.addr, lce_cmd.msg_type, lce_cmd.way_id
-                 , lce_cmd_cmd.state, lce_cmd_cmd.target, lce_cmd_cmd.target_way_id
-                 , lce_cmd_cmd.addr[lg_block_size_in_bytes_lp+:lg_lce_sets_lp]);
+        $fdisplay(file, "[%t]: CCE[%0d] CMD LCE[%0d] addr[%H] cmd[%4b] way[%0d] st[%3b] tgt[%0d] tgtWay[%0d]"
+                 , $time, cce_id_i, lce_cmd.header.dst_id, lce_cmd.header.addr, lce_cmd.header.msg_type, lce_cmd.header.way_id
+                 , lce_cmd.header.state, lce_cmd.header.target, lce_cmd.header.target_way_id
+                 );
         end
       end
       if (mem_cmd_v_i & mem_cmd_ready_i) begin
-        if (mem_cmd_lo.msg_type == e_cce_mem_rd | mem_cmd_lo.msg_type == e_cce_mem_wr
-            | mem_cmd_lo.msg_type == e_cce_mem_uc_rd) begin
+        if (mem_cmd.header.msg_type == e_cce_mem_rd | mem_cmd.header.msg_type == e_cce_mem_wr
+            | mem_cmd.header.msg_type == e_cce_mem_uc_rd) begin
         $fdisplay(file, "[%t]: CCE[%0d] MEM CMD wr[%0b] addr[%H] lce[%0d] way[%0d] spec[%0b] uc[%0b]"
-                 , $time, cce_id_i, mem_cmd_lo.msg_type, mem_cmd_lo.addr, mem_cmd_lo.payload.lce_id
-                 , mem_cmd_lo.payload.way_id, mem_cmd_lo.payload.speculative
-                 , (mem_cmd_lo.msg_type == e_cce_mem_uc_rd));
+                 , $time, cce_id_i, mem_cmd.header.msg_type, mem_cmd.header.addr, mem_cmd.header.payload.lce_id
+                 , mem_cmd.header.payload.way_id, mem_cmd.header.payload.speculative
+                 , (mem_cmd.header.msg_type == e_cce_mem_uc_rd));
         end
-        if (mem_cmd_lo.msg_type == e_cce_mem_uc_wr | mem_cmd_lo.msg_type == e_cce_mem_wb) begin
+        if (mem_cmd.header.msg_type == e_cce_mem_uc_wr | mem_cmd.header.msg_type == e_cce_mem_wb) begin
         $fdisplay(file, "[%t]: CCE[%0d] MEM DATA CMD wb[%0b] addr[%H] lce[%0d] way[%0d] state[%3b] uc[%0b] %H"
-                 , $time, cce_id_i, (mem_cmd_lo.msg_type == e_cce_mem_wb), mem_cmd_lo.addr
-                 , mem_cmd_lo.payload.lce_id, mem_cmd_lo.payload.way_id, mem_cmd_lo.payload.state
-                 , (mem_cmd_lo.msg_type == e_cce_mem_uc_wr), mem_cmd_lo.data);
+                 , $time, cce_id_i, (mem_cmd.header.msg_type == e_cce_mem_wb), mem_cmd.header.addr
+                 , mem_cmd.header.payload.lce_id, mem_cmd.header.payload.way_id, mem_cmd.header.payload.state
+                 , (mem_cmd.header.msg_type == e_cce_mem_uc_wr), mem_cmd.data);
         end
       end
     end // reset & trace

--- a/bp_me/test/common/bp_mem_nonsynth_tracer.v
+++ b/bp_me/test/common/bp_mem_nonsynth_tracer.v
@@ -44,35 +44,35 @@ assign mem_resp_cast_i = mem_resp_i;
 
 always_ff @(posedge clk_i) begin
   if (mem_cmd_yumi_i)
-    case (mem_cmd_cast_i.msg_type)
+    case (mem_cmd_cast_i.header.msg_type)
       e_cce_mem_rd: 
-        $fwrite(file, "[%t] CMD RD: (%x) %b\n", $time, mem_cmd_cast_i.addr, mem_cmd_cast_i.size);
+        $fwrite(file, "[%t] CMD RD: (%x) %b\n", $time, mem_cmd_cast_i.header.addr, mem_cmd_cast_i.header.size);
       e_cce_mem_wr:
-        $fwrite(file, "[%t] CMD WR: (%x) %b\n", $time, mem_cmd_cast_i.addr, mem_cmd_cast_i.size);
+        $fwrite(file, "[%t] CMD WR: (%x) %b\n", $time, mem_cmd_cast_i.header.addr, mem_cmd_cast_i.header.size);
       e_cce_mem_uc_rd:
-        $fwrite(file, "[%t] CMD UCRD: (%x) %b\n", $time, mem_cmd_cast_i.addr, mem_cmd_cast_i.size);
+        $fwrite(file, "[%t] CMD UCRD: (%x) %b\n", $time, mem_cmd_cast_i.header.addr, mem_cmd_cast_i.header.size);
       e_cce_mem_uc_wr:
-        $fwrite(file, "[%t] CMD UCWR: (%x) %b %x\n", $time, mem_cmd_cast_i.addr, mem_cmd_cast_i.size, mem_cmd_cast_i.data);
+        $fwrite(file, "[%t] CMD UCWR: (%x) %b %x\n", $time, mem_cmd_cast_i.header.addr, mem_cmd_cast_i.header.size, mem_cmd_cast_i.data);
       e_cce_mem_wb:
-        $fwrite(file, "[%t] CMD WB: (%x) %b %x\n", $time, mem_cmd_cast_i.addr, mem_cmd_cast_i.size, mem_cmd_cast_i.data);
+        $fwrite(file, "[%t] CMD WB: (%x) %b %x\n", $time, mem_cmd_cast_i.header.addr, mem_cmd_cast_i.header.size, mem_cmd_cast_i.data);
       default: 
-        $fwrite(file, "[%t] CMD ERROR: unknown cmd_type %x received!", $time, mem_resp_cast_i.msg_type);
+        $fwrite(file, "[%t] CMD ERROR: unknown cmd_type %x received!", $time, mem_resp_cast_i.header.msg_type);
     endcase
 
   if (mem_resp_v_i)
-    case (mem_resp_cast_i.msg_type)
+    case (mem_resp_cast_i.header.msg_type)
       e_cce_mem_rd:
-        $fwrite(file, "[%t] RESP RD: (%x) %b %x\n", $time, mem_resp_cast_i.addr, mem_resp_cast_i.size, mem_resp_cast_i.data);
+        $fwrite(file, "[%t] RESP RD: (%x) %b %x\n", $time, mem_resp_cast_i.header.addr, mem_resp_cast_i.header.size, mem_resp_cast_i.data);
       e_cce_mem_wr:
-        $fwrite(file, "[%t] RESP WR: (%x) %b %x\n", $time, mem_resp_cast_i.addr, mem_resp_cast_i.size, mem_resp_cast_i.data);
+        $fwrite(file, "[%t] RESP WR: (%x) %b %x\n", $time, mem_resp_cast_i.header.addr, mem_resp_cast_i.header.size, mem_resp_cast_i.data);
       e_cce_mem_uc_rd:
-        $fwrite(file, "[%t] RESP UCRD: (%x) %b %x\n", $time, mem_resp_cast_i.addr, mem_resp_cast_i.size, mem_resp_cast_i.data);
+        $fwrite(file, "[%t] RESP UCRD: (%x) %b %x\n", $time, mem_resp_cast_i.header.addr, mem_resp_cast_i.header.size, mem_resp_cast_i.data);
       e_cce_mem_uc_wr:
-        $fwrite(file, "[%t] RESP UCWR: (%x) %b\n", $time, mem_resp_cast_i.addr, mem_resp_cast_i.size);
+        $fwrite(file, "[%t] RESP UCWR: (%x) %b\n", $time, mem_resp_cast_i.header.addr, mem_resp_cast_i.header.size);
       e_cce_mem_wb:
-        $fwrite(file, "[%t] RESP WB: (%x) %b\n", $time, mem_resp_cast_i.addr, mem_resp_cast_i.size);
+        $fwrite(file, "[%t] RESP WB: (%x) %b\n", $time, mem_resp_cast_i.header.addr, mem_resp_cast_i.header.size);
       default: 
-        $fwrite(file, "[%t] ERROR: unknown resp_type %x received!", $time, mem_resp_cast_i.msg_type);
+        $fwrite(file, "[%t] ERROR: unknown resp_type %x received!", $time, mem_resp_cast_i.header.msg_type);
     endcase
 end
 

--- a/bp_me/test/common/bp_mem_transducer.v
+++ b/bp_me/test/common/bp_mem_transducer.v
@@ -66,30 +66,31 @@ module bp_mem_transducer
      );
 
   // Only handle word aligned accesses
-  wire [cce_block_width_p-1:0]  wr_word_offset = mem_cmd_cast_i.addr[byte_offset_bits_lp+:word_offset_bits_lp];
-  wire [cce_block_width_p-1:0]  wr_byte_offset = mem_cmd_cast_i.addr[0+:byte_offset_bits_lp];
+  wire [cce_block_width_p-1:0]  wr_word_offset = mem_cmd_cast_i.header.addr[byte_offset_bits_lp+:word_offset_bits_lp];
+  wire [cce_block_width_p-1:0]  wr_byte_offset = mem_cmd_cast_i.header.addr[0+:byte_offset_bits_lp];
   wire [cce_block_width_p-1:0]    wr_bit_shift = wr_word_offset*dword_width_p + wr_byte_offset*8;
   wire [cce_block_width_p-1:0]   wr_byte_shift = wr_word_offset*num_word_bytes_lp + wr_byte_offset;
-  wire [cce_block_width_p-1:0]  rd_word_offset = mem_cmd_r.addr[byte_offset_bits_lp+:word_offset_bits_lp];
-  wire [cce_block_width_p-1:0]  rd_byte_offset = mem_cmd_r.addr[0+:byte_offset_bits_lp];
+  wire [cce_block_width_p-1:0]  rd_word_offset = mem_cmd_r.header.addr[byte_offset_bits_lp+:word_offset_bits_lp];
+  wire [cce_block_width_p-1:0]  rd_byte_offset = mem_cmd_r.header.addr[0+:byte_offset_bits_lp];
   wire [cce_block_width_p-1:0]    rd_bit_shift = rd_word_offset*dword_width_p; // We rely on receiver to adjust bits
   wire [cce_block_width_p-1:0]   rd_byte_shift = rd_word_offset*num_word_bytes_lp;
 
   assign v_o = mem_cmd_yumi_o;
-  assign w_o = v_o & (mem_cmd_cast_i.msg_type inside {e_cce_mem_uc_wr, e_cce_mem_wb});
-  assign addr_o = (((mem_cmd_cast_i.addr - dram_offset_p) >> block_offset_bits_lp) << block_offset_bits_lp);
+  assign w_o = v_o & (mem_cmd_cast_i.header.msg_type inside {e_cce_mem_uc_wr, e_cce_mem_wb});
+  assign addr_o = (((mem_cmd_cast_i.header.addr - dram_offset_p) >> block_offset_bits_lp) << block_offset_bits_lp);
   assign data_o = mem_cmd_cast_i.data << wr_bit_shift;
-  assign write_mask_o = ((1 << (1 << mem_cmd_cast_i.size)) - 1) << wr_byte_shift;
+  assign write_mask_o = ((1 << (1 << mem_cmd_cast_i.header.size)) - 1) << wr_byte_shift;
 
-  wire [cce_block_width_p-1:0] data_li = (mem_cmd_r.msg_type == e_cce_mem_uc_rd)
+  wire [cce_block_width_p-1:0] data_li = (mem_cmd_r.header.msg_type == e_cce_mem_uc_rd)
                                          ? data_i >> rd_bit_shift
                                          : data_i;
 
   assign mem_resp_cast_o = '{data     : data_li
-                             ,payload : mem_cmd_r.payload
-                             ,size    : mem_cmd_r.size
-                             ,addr    : mem_cmd_r.addr
-                             ,msg_type: mem_cmd_r.msg_type
+	                           ,header  : '{payload : mem_cmd_r.header.payload
+                                          ,size    : mem_cmd_r.header.size
+                                          ,addr    : mem_cmd_r.header.addr
+                                          ,msg_type: mem_cmd_r.header.msg_type
+																				 }
                              };
 
   assign mem_cmd_yumi_o = mem_cmd_v_i & ready_i;

--- a/bp_top/src/v/bp_cfg.v
+++ b/bp_top/src/v/bp_cfg.v
@@ -78,9 +78,9 @@ bsg_dff_reset
 assign mem_cmd_yumi_o = mem_cmd_v_i & mem_resp_v_o;
 
 wire                        cfg_v_li    = mem_cmd_yumi_o;
-wire                        cfg_w_v_li  = cfg_v_li & (mem_cmd_cast_i.msg_type == e_cce_mem_uc_wr);
-wire                        cfg_r_v_li  = cfg_v_li & (mem_cmd_cast_i.msg_type == e_cce_mem_uc_rd);
-wire [cfg_addr_width_p-1:0] cfg_addr_li = mem_cmd_cast_i.addr[0+:cfg_addr_width_p];
+wire                        cfg_w_v_li  = cfg_v_li & (mem_cmd_cast_i.header.msg_type == e_cce_mem_uc_wr);
+wire                        cfg_r_v_li  = cfg_v_li & (mem_cmd_cast_i.header.msg_type == e_cce_mem_uc_rd);
+wire [cfg_addr_width_p-1:0] cfg_addr_li = mem_cmd_cast_i.header.addr[0+:cfg_addr_width_p];
 wire [cfg_data_width_p-1:0] cfg_data_li = mem_cmd_cast_i.data[0+:cfg_data_width_p];
 
 always_ff @(posedge clk_i)
@@ -191,10 +191,11 @@ assign cfg_bus_cast_o = '{freeze: freeze_r
                           };
 
 assign mem_resp_v_o    = mem_resp_ready_i & read_ready_r;
-assign mem_resp_cast_o = '{msg_type: mem_cmd_cast_i.msg_type
-                           ,addr   : mem_cmd_cast_i.addr
-                           ,payload: mem_cmd_cast_i.payload
-                           ,size   : mem_cmd_cast_i.size
+assign mem_resp_cast_o = '{header : '{msg_type: mem_cmd_cast_i.header.msg_type
+                                      ,addr   : mem_cmd_cast_i.header.addr
+                                      ,payload: mem_cmd_cast_i.header.payload
+                                      ,size   : mem_cmd_cast_i.header.size
+																			}
                            // TODO: Add all mode bits to mux
                            ,data   : irf_r_v_li 
                                      ? irf_data_i 

--- a/bp_top/src/v/bp_clint_slice.v
+++ b/bp_top/src/v/bp_clint_slice.v
@@ -42,7 +42,7 @@ logic plic_cmd_v;
 logic wr_not_rd;
 
 bp_local_addr_s local_addr;
-assign local_addr = mem_cmd_li.addr;
+assign local_addr = mem_cmd_li.header.addr;
 
 always_comb
   begin
@@ -51,7 +51,7 @@ always_comb
     mipi_cmd_v     = 1'b0;
     plic_cmd_v     = 1'b0;
 
-    wr_not_rd = mem_cmd_li.msg_type inside {e_cce_mem_wb, e_cce_mem_uc_wr};
+    wr_not_rd = mem_cmd_li.header.msg_type inside {e_cce_mem_wb, e_cce_mem_uc_wr};
 
     unique 
     casez ({local_addr.dev, local_addr.addr})
@@ -147,10 +147,12 @@ wire [dword_width_p-1:0] rdata_lo = plic_cmd_v
 
 bp_cce_mem_msg_s mem_resp_lo;
 assign mem_resp_lo =
-  '{msg_type       : mem_cmd_li.msg_type
-    ,addr          : mem_cmd_li.addr
-    ,payload       : mem_cmd_li.payload
-    ,size          : mem_cmd_li.size
+  '{header : '{
+    msg_type       : mem_cmd_li.header.msg_type
+    ,addr          : mem_cmd_li.header.addr
+    ,payload       : mem_cmd_li.header.payload
+    ,size          : mem_cmd_li.header.size
+    }
     ,data          : cce_block_width_p'(rdata_lo)
     };
 assign mem_resp_o = mem_resp_lo;

--- a/bp_top/src/v/bp_io_link_to_lce.v
+++ b/bp_top/src/v/bp_io_link_to_lce.v
@@ -61,11 +61,11 @@ module bp_io_link_to_lce
   assign lce_cmd_yumi_o = io_resp_v_o;
 
   bp_lce_cce_uc_req_size_e lce_req_size;
-  assign lce_req_size = (io_cmd_li.size == e_mem_size_1)
+  assign lce_req_size = (io_cmd_li.header.size == e_mem_size_1)
                         ? e_lce_uc_req_1
-                        : (io_cmd_li.size == e_mem_size_2)
+                        : (io_cmd_li.header.size == e_mem_size_2)
                           ? e_lce_uc_req_2
-                          : (io_cmd_li.size == e_mem_size_4)
+                          : (io_cmd_li.header.size == e_mem_size_4)
                             ? e_lce_uc_req_4
                             : e_lce_uc_req_8;
 
@@ -78,28 +78,28 @@ module bp_io_link_to_lce
   bp_me_addr_to_cce_id
    #(.bp_params_p(bp_params_p))
    addr_map
-    (.paddr_i(io_cmd_li.addr)
+    (.paddr_i(io_cmd_li.header.addr)
 
      ,.cce_id_o(cce_id_lo)
      );
 
-  wire io_cmd_wr_not_rd = (io_cmd_li.msg_type == e_cce_mem_uc_wr);
-  wire lce_cmd_wr_not_rd = (lce_cmd_li.msg_type == e_lce_cmd_uc_st_done);
+  wire io_cmd_wr_not_rd = (io_cmd_li.header.msg_type == e_cce_mem_uc_wr);
+  wire lce_cmd_wr_not_rd = (lce_cmd_li.header.msg_type == e_lce_cmd_uc_st_done);
   always_comb
     begin
       lce_req_lo                    = '0;
-      lce_req_lo.msg.uc_req.data    = io_cmd_li.data;
-      lce_req_lo.msg.uc_req.uc_size = lce_req_size;
-      lce_req_lo.addr               = io_cmd_li.addr;
-      lce_req_lo.msg_type           = io_cmd_wr_not_rd ? e_lce_req_type_uc_wr : e_lce_req_type_uc_rd;
-      lce_req_lo.src_id             = lce_id_i;
-      lce_req_lo.dst_id             = cce_id_lo;
+      lce_req_lo.data               = io_cmd_li.data;
+      lce_req_lo.header.uc_size     = lce_req_size;
+      lce_req_lo.header.addr        = io_cmd_li.header.addr;
+      lce_req_lo.header.msg_type    = io_cmd_wr_not_rd ? e_lce_req_type_uc_wr : e_lce_req_type_uc_rd;
+      lce_req_lo.header.src_id      = lce_id_i;
+      lce_req_lo.header.dst_id      = cce_id_lo;
 
-      io_resp_lo                = '0;
-      io_resp_lo.data           = lce_cmd_li.msg.dt_cmd.data;
-      io_resp_lo.size           = io_resp_size;
-      io_resp_lo.addr           = lce_cmd_wr_not_rd ? lce_cmd_li.msg.cmd.addr : lce_cmd_li.msg.dt_cmd.addr;
-      io_resp_lo.msg_type       = lce_cmd_wr_not_rd ? e_cce_mem_uc_wr : e_cce_mem_uc_rd;
+      io_resp_lo                 = '0;
+      io_resp_lo.data            = lce_cmd_li.data;
+      io_resp_lo.header.size     = io_resp_size;
+      io_resp_lo.header.addr     = lce_cmd_li.header.addr;
+      io_resp_lo.header.msg_type = lce_cmd_wr_not_rd ? e_cce_mem_uc_wr : e_cce_mem_uc_rd;
     end
 
 endmodule

--- a/bp_top/src/v/bp_io_tile.v
+++ b/bp_top/src/v/bp_io_tile.v
@@ -176,8 +176,8 @@ module bp_io_tile
   bp_global_addr_s global_addr_lo;
   bp_local_addr_s  local_addr_lo;
 
-  assign global_addr_lo = cce_io_cmd_lo.addr;
-  assign local_addr_lo  = cce_io_cmd_lo.addr;
+  assign global_addr_lo = cce_io_cmd_lo.header.addr;
+  assign local_addr_lo  = cce_io_cmd_lo.header.addr;
 
   wire is_host_addr  = (~local_addr_lo.nonlocal && (local_addr_lo.dev == host_dev_gp));
   assign dst_did_lo  = is_host_addr ? '1 : global_addr_lo.did;

--- a/bp_top/src/v/bp_tile.v
+++ b/bp_top/src/v/bp_tile.v
@@ -462,8 +462,8 @@ for (genvar i = 0; i < 2; i++)
   /* TODO: Extract local memory map to module */
   localparam clint_device_id_lp = 1;
   localparam cfg_device_id_lp   = 2;
-  wire local_cmd_li    = (cce_mem_cmd_lo.addr < 32'h8000_0000);
-  wire [3:0] device_li =  cce_mem_cmd_lo.addr[20+:4];
+  wire local_cmd_li    = (cce_mem_cmd_lo.header.addr < 32'h8000_0000);
+  wire [3:0] device_li =  cce_mem_cmd_lo.header.addr[20+:4];
 
   assign cce_mem_cmd_ready_li = cache_mem_cmd_ready_lo & cfg_mem_cmd_ready_lo & clint_mem_cmd_ready_lo;
 

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -141,6 +141,8 @@ $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter_out.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_decoder_dor.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_input_control.v  
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.v 
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_stream_in.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_stream_out.v
 # Common files
 $BP_COMMON_DIR/src/v/bsg_fifo_1r1w_rolly.v
 $BP_COMMON_DIR/src/v/bp_pma.v

--- a/bp_top/test/common/bp_nonsynth_host.v
+++ b/bp_top/test/common/bp_nonsynth_host.v
@@ -68,7 +68,7 @@ always_comb
     finish_data_cmd_v = 1'b0;
 
     unique
-    casez (io_cmd_cast_i.addr)
+    casez (io_cmd_cast_i.header.addr)
       putchar_base_addr_gp: putchar_data_cmd_v = io_cmd_v_i; 
       getchar_base_addr_gp: getchar_data_cmd_v = io_cmd_v_i;
       finish_base_addr_gp: finish_data_cmd_v = io_cmd_v_i;
@@ -81,7 +81,7 @@ logic [num_core_p-1:0] finish_w_v_li;
 // Memory-mapped I/O is 64 bit aligned
 localparam byte_offset_width_lp = 3;
 wire [lg_num_core_lp-1:0] io_cmd_core_enc =
-  io_cmd_cast_i.addr[byte_offset_width_lp+:lg_num_core_lp];
+  io_cmd_cast_i.header.addr[byte_offset_width_lp+:lg_num_core_lp];
 
 bsg_decode_with_v
  #(.num_out_p(num_core_p))
@@ -159,10 +159,13 @@ bsg_one_fifo
 assign io_resp_v_o = io_resp_v_lo & io_resp_ready_i;
 
 assign io_resp_lo =
-  '{msg_type       : io_cmd_cast_i.msg_type
-    ,addr          : io_cmd_cast_i.addr
-    ,payload       : io_cmd_cast_i.payload
-    ,size          : io_cmd_cast_i.size
+  '{header:
+    '{
+    msg_type       : io_cmd_cast_i.header.msg_type
+    ,addr          : io_cmd_cast_i.header.addr
+    ,payload       : io_cmd_cast_i.header.payload
+    ,size          : io_cmd_cast_i.header.size
+    }
     ,data          : ch
     };
 

--- a/bp_top/test/tb/bp_top_trace_demo/testbench.v
+++ b/bp_top/test/tb/bp_top_trace_demo/testbench.v
@@ -145,7 +145,7 @@ wrapper
        ,.rd_addr_i(be_calculator.wb_pkt.rd_addr)
        ,.rd_data_i(be_calculator.wb_pkt.rd_data)
        );
-/*
+
   bind bp_be_top
     bp_nonsynth_cosim
      #(.bp_params_p(bp_params_p))
@@ -170,7 +170,7 @@ wrapper
        ,.interrupt_v_i(be_mem.csr.trap_pkt_cast_o._interrupt)
        ,.cause_i(be_mem.csr.trap_pkt_cast_o.cause)
        );
-*/
+
   bind bp_be_director
     bp_be_nonsynth_npc_tracer
      #(.bp_params_p(bp_params_p))

--- a/bp_top/test/tb/bp_top_trace_demo/testbench.v
+++ b/bp_top/test/tb/bp_top_trace_demo/testbench.v
@@ -145,7 +145,7 @@ wrapper
        ,.rd_addr_i(be_calculator.wb_pkt.rd_addr)
        ,.rd_data_i(be_calculator.wb_pkt.rd_data)
        );
-
+/*
   bind bp_be_top
     bp_nonsynth_cosim
      #(.bp_params_p(bp_params_p))
@@ -170,7 +170,7 @@ wrapper
        ,.interrupt_v_i(be_mem.csr.trap_pkt_cast_o._interrupt)
        ,.cause_i(be_mem.csr.trap_pkt_cast_o.cause)
        );
-
+*/
   bind bp_be_director
     bp_be_nonsynth_npc_tracer
      #(.bp_params_p(bp_params_p))


### PR DESCRIPTION
This change refactors the LCE-CCE Interface. It is effectively a simplification and normalization of the interface in preparation for removing serialization/deserialization from the coherence components.

Functionally, none of the existing LCE or CCE components changed.