### PR TITLE
Removing wormhole streamers from flist

### DIFF
--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -141,8 +141,6 @@ $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter_out.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_decoder_dor.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_input_control.v  
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.v 
-$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_stream_in.v
-$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_stream_out.v
 # Common files
 $BP_COMMON_DIR/src/v/bsg_fifo_1r1w_rolly.v
 $BP_COMMON_DIR/src/v/bp_pma.v


### PR DESCRIPTION
These modules are being updated upstream. For now, they're unused so remove from flist