### PR TITLE
Fixing inferred latches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,7 +81,6 @@ update-cache-auto:
         - external/*
 
 hotfix_job:
-  <<: *job_definition
   only:
     - /^.*hotfix.*$/
   stage: check
@@ -91,6 +90,15 @@ hotfix_job:
   script:
     - make -C bp_top/syn clean
     - $CI_PROJECT_DIR/ci/regress.sh check_design.syn bp_top
+  cache:
+    key: "dev"
+    paths:
+      - $CI_PROJECT_DIR/external/
+    policy: pull
+  artifacts:
+    when: always
+    paths:
+      - "bp_top/syn/reports/"
 
 clean_build:
   <<: *job_definition

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_req.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_req.v
@@ -145,6 +145,7 @@ module bp_be_dcache_lce_req
 
     lce_req_v_o = 1'b0;
 
+    lce_req = '0;
     lce_req.header.dst_id = req_cce_id_lo;
     lce_req.header.src_id = lce_id_i;
     lce_req.header.msg_type = e_lce_req_type_rd;
@@ -152,6 +153,7 @@ module bp_be_dcache_lce_req
 
     lce_resp_v_o = 1'b0;
 
+    lce_resp = '0;
     lce_resp.header.dst_id = resp_cce_id_lo;
     lce_resp.header.src_id = lce_id_i;
     lce_resp.header.msg_type = bp_lce_cce_resp_type_e'('0);

--- a/bp_fe/src/v/bp_fe_lce_req.v
+++ b/bp_fe/src/v/bp_fe_lce_req.v
@@ -111,6 +111,7 @@ module bp_fe_lce_req
 
     lce_req_v_o           = 1'b0;
 
+    lce_req = '0;
     lce_req.header.dst_id        = req_cce_id_lo;
     lce_req.header.src_id        = lce_id_i;
     lce_req.header.msg_type      = e_lce_req_type_rd;
@@ -125,6 +126,7 @@ module bp_fe_lce_req
 
     lce_resp_v_o          = 1'b0;
 
+    lce_resp = '0;
     lce_resp.header.dst_id       = resp_cce_id_lo;
     lce_resp.header.src_id       = lce_id_i;
     lce_resp.header.msg_type     = bp_lce_cce_resp_type_e'('0);

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v
@@ -67,6 +67,8 @@ module bp_me_wormhole_packet_encode_mem_cmd
   logic [len_width_p-1:0] data_cmd_len_li;
 
   always_comb begin
+    packet_cast_o = '0;
+
     packet_cast_o.data       = mem_cmd_cast_i.data;
     packet_cast_o.msg        = mem_cmd_cast_i[0+:cce_mem_msg_width_lp-cce_block_width_p];
     packet_cast_o.src_cord   = src_cord_i;

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
@@ -65,6 +65,8 @@ module bp_me_wormhole_packet_encode_mem_resp
   logic [len_width_p-1:0] data_resp_len_li;
 
   always_comb begin
+    packet_cast_o = '0;
+
     packet_cast_o.data       = mem_resp_cast_i.data;
     packet_cast_o.msg        = mem_resp_cast_i[0+:cce_mem_msg_width_lp-cce_block_width_p];
     packet_cast_o.src_cord   = src_cord_i;


### PR DESCRIPTION
Inferred latches snuck in for the pad fields of the messages.  Easy fix is setting pad to 0.

Also minor CI enhancement where hotfix reuses the cache from dev instead of building its own toolchain.