### PR TITLE
removed underscore in front of DVE

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -27,7 +27,7 @@ export URG       ?= urg
 export VERILATOR ?= verilator
 export DC_SHELL  ?= dc_shell
 # Some environments have issues with setting DVE as an environment variable
-export _DVE      ?= dve
+export DVE	 ?= dve
 export GTKWAVE   ?= gtkwave
 export PYTHON    ?= python3
 


### PR DESCRIPTION
removing the underscore in front of DVE due to it may not be setting the environment variable $DVE correctly