### PR TITLE
Disabling tlb lookup on fencei instructions

### DIFF
--- a/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
@@ -487,7 +487,7 @@ assign load_access_fault_v  = load_op_tl_lo & (mode_fault_v | did_fault_v);
 assign store_access_fault_v = store_op_tl_lo & (mode_fault_v | did_fault_v);
 
 // D-TLB connections
-assign dtlb_r_v     = dcache_cmd_v;
+assign dtlb_r_v     = dcache_cmd_v & ~fencei_cmd_v;
 assign dtlb_r_vtag  = mmu_cmd.vaddr.tag;
 assign dtlb_w_v     = ptw_tlb_w_v & ~itlb_not_dtlb_resp;
 assign dtlb_w_vtag  = ptw_tlb_w_vtag;


### PR DESCRIPTION
The issue was that when we changed the fencei instruction from a privileged instruction to a dcache instruction, it then started doing a tlb lookup in parallel to the fence instruction, as if it were a load.

This is fine for the tests with VM disabled because the tlb lookup is passthrough anyway.  But VM tests immediately faulted.  Simultaneously, the tests are poorly written, such that any machine unknown supervisor mode exception will cause a finish, with whatever register happens to correspond to the exit code (in this case ra)