### PR TITLE
Added default Dromajo cfg file

### DIFF
--- a/bp_common/syn/Makefile.vcs
+++ b/bp_common/syn/Makefile.vcs
@@ -113,6 +113,7 @@ sim.v: dirs.v
 	-@cp $(MEM_PATH)/$(PROG).dump $(SIM_DIR)/prog.dump
 	-@cp $(MEM_PATH)/$(PROG).mainram $(SIM_DIR)/prog.mainram
 	-@cp $(MEM_PATH)/$(PROG).bootram $(SIM_DIR)/prog.bootram
+	-@cp $(BP_COMMON_DIR)/test/cfg/cosim.cfg $(SIM_DIR)/prog.cfg
 	-@cp $(MEM_PATH)/$(PROG).cfg $(SIM_DIR)/prog.cfg
 	-@cp $(MEM_PATH)/$(PROG).spike $(SIM_DIR)/commit.spike
 	-@cp $(BP_COMMON_DIR)/test/cfg/$(DRAMSIM_CH_CFG) $(SIM_DIR)/dram_ch.ini

--- a/bp_common/syn/Makefile.verilator
+++ b/bp_common/syn/Makefile.verilator
@@ -116,6 +116,7 @@ sim.sc: dirs.sc
 	-@cp $(MEM_PATH)/$(PROG).dump $(SIM_DIR)/prog.dump
 	-@cp $(MEM_PATH)/$(PROG).mainram $(SIM_DIR)/prog.mainram
 	-@cp $(MEM_PATH)/$(PROG).bootram $(SIM_DIR)/prog.bootram
+	-@cp $(BP_COMMON_DIR)/test/cfg/cosim.cfg $(SIM_DIR)/prog.cfg
 	-@cp $(MEM_PATH)/$(PROG).cfg $(SIM_DIR)/prog.cfg
 	-@cp $(MEM_PATH)/$(PROG).spike $(SIM_DIR)/prog.spike
 	-@cp $(BP_COMMON_DIR)/test/cfg/$(DRAMSIM_CH_CFG) $(SIM_DIR)/dram_ch.ini

--- a/bp_common/test/Makefile
+++ b/bp_common/test/Makefile
@@ -204,7 +204,7 @@ riscvdv_dump: $(foreach x, $(BP_RVDV), $(x).dump)
 %.nbf:
 	$(PYTHON) $(MEM2NBF) $(MEM_DIR)/$*.mem > $(MEM_DIR)/$@
 
-%.dromajo: $(%.config)
+%.dromajo:
 	$(DROMAJO) $(MEM_DIR)/$*.riscv --host --maxinsn=$(MAXINSN) --save=$* --memory_size=$(MEMSIZE)
 	$(RISCV_OBJCOPY) --change-addresses 0x80000000 \
 		 -I binary -O elf64-littleriscv -B riscv $*.mainram $(MEM_DIR)/$@.$(MAXINSN).riscv

--- a/bp_common/test/cfg/cosim.cfg
+++ b/bp_common/test/cfg/cosim.cfg
@@ -1,0 +1,9 @@
+{
+  "version":1,
+  "machine":"riscv64",
+  "bios": "prog.elf",
+  "memory_base_addr": 0x80000000,
+  "memory_size": 1,
+  "mmio_start": 0x20000,
+  "mmio_end": 0x80000000
+}

--- a/bp_top/test/tb/bp_processor/testbench.v
+++ b/bp_top/test/tb/bp_processor/testbench.v
@@ -31,7 +31,7 @@ module testbench
    , parameter load_nbf_p                  = 0
    , parameter skip_init_p                 = 0
    , parameter cosim_p                     = 0
-   , parameter cosim_cfg_file_p            = load_nbf_p ? "prog.cfg" : "prog.elf"
+   , parameter cosim_cfg_file_p            = "prog.cfg"
 
    , parameter mem_zero_p         = 1
    , parameter mem_load_p         = preload_mem_p

--- a/bp_top/test/tb/bp_softcore/testbench.v
+++ b/bp_top/test/tb/bp_softcore/testbench.v
@@ -31,7 +31,7 @@ module testbench
    , parameter load_nbf_p                  = 0
    , parameter skip_init_p                 = 0
    , parameter cosim_p                     = 0
-   , parameter cosim_cfg_file_p            = load_nbf_p ? "prog.cfg" : "prog.elf"
+   , parameter cosim_cfg_file_p            = "prog.cfg"
 
    , parameter mem_zero_p         = 1
    , parameter mem_file_p         = "prog.mem"


### PR DESCRIPTION
Added a default input config file to Dromajo to be used during cosim when not running a generated checkpoint.