### PR TITLE
[WIP] Experiment with removing issue stage

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.v
@@ -29,7 +29,7 @@ module bp_be_pipe_long
 
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
   bp_be_decode_s decode;
-  rv64_instr_s instr;
+  rv64_instr_rtype_s instr;
   bp_be_wb_pkt_s wb_pkt;
 
   assign decode = decode_i;
@@ -89,7 +89,7 @@ module bp_be_pipe_long
      ,.reset_i(reset_i | flush_i)
      ,.en_i(v_i | v_lo)
 
-     ,.data_i({v_i, instr.t.rtype.rd_addr, decode.fu_op, decode.opw_v})
+     ,.data_i({v_i, instr.rd_addr, decode.fu_op, decode.opw_v})
      ,.data_o({rd_w_v_r, rd_addr_r, fu_op_r, opw_v_r})
      );
 

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.v
@@ -38,11 +38,10 @@ module bp_be_scheduler
 
   , output [isd_status_width_lp-1:0]   isd_status_o
   , input [vaddr_width_p-1:0]          expected_npc_i
-  , input                              poison_iss_i
-  , input                              poison_isd_i
   , input                              dispatch_v_i
   , input                              cache_miss_v_i
   , input                              cmt_v_i
+  , input                              poison_iss_i
   , input                              suppress_iss_i
 
   // Fetch interface
@@ -53,13 +52,18 @@ module bp_be_scheduler
   , output                             fe_queue_roll_o
   , output                             fe_queue_deq_o
 
+  , input [reg_addr_width_p-1:0]       rs1_addr_i
+  , input                              rs1_v_i
+
+  , input [reg_addr_width_p-1:0]       rs2_addr_i
+  , input                              rs2_v_i
+
+
   // Dispatch interface
   , output [dispatch_pkt_width_lp-1:0] dispatch_pkt_o
 
   , input [wb_pkt_width_lp-1:0]        wb_pkt_i
   );
-
-wire unused = &{clk_i, reset_i};
 
 // Declare parameterizable structures
 `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
@@ -73,39 +77,13 @@ assign cfg_bus_cast_i = cfg_bus_i;
 bp_be_isd_status_s  isd_status;
 bp_fe_queue_s     fe_queue_cast_i;
 bp_be_issue_pkt_s issue_pkt;
-rv64_instr_s      fetch_instr;
+rv64_instr_rtype_s fetch_instr;
 bp_be_wb_pkt_s    wb_pkt;
 
 assign isd_status_o    = isd_status;
 assign fe_queue_cast_i = fe_queue_i;
 assign fetch_instr     = fe_queue_cast_i.msg.fetch.instr;
 assign wb_pkt          = wb_pkt_i;
-
-wire issue_v = fe_queue_yumi_o;
-
-bp_be_issue_pkt_s issue_pkt_r;
-logic issue_pkt_v_r, poison_iss_r;
-bsg_dff_reset_en
- #(.width_p(1+$bits(bp_be_issue_pkt_s)))
- issue_pkt_reg
-  (.clk_i(clk_i)
-   ,.reset_i(reset_i | cache_miss_v_i)
-   ,.en_i(issue_v | dispatch_v_i)
-   
-   ,.data_i({issue_v, issue_pkt})
-   ,.data_o({issue_pkt_v_r, issue_pkt_r})
-   );
-
-bsg_dff_reset_en
- #(.width_p(1))
- issue_status_reg
-  (.clk_i(clk_i)
-   ,.reset_i(reset_i)
-   ,.en_i(issue_v | dispatch_v_i | poison_iss_i | poison_isd_i)
-
-   ,.data_i(poison_iss_i | poison_isd_i)
-   ,.data_o(poison_iss_r)
-   );
 
 always_comb
   begin
@@ -121,7 +99,7 @@ always_comb
         issue_pkt.instr                  = fe_queue_cast_i.msg.fetch.instr;
 
         // Pre-decode
-        casez (fetch_instr.t.rtype.opcode)
+        casez (fetch_instr.opcode)
           `RV64_LOAD_OP, `RV64_STORE_OP, `RV64_AMO_OP: issue_pkt.mem_v = 1'b1;
         endcase
         
@@ -132,7 +110,7 @@ always_comb
         endcase
         
         // Decide whether to read from integer regfile (saves power)
-        casez (fetch_instr.t.rtype.opcode)
+        casez (fetch_instr.opcode)
           `RV64_JALR_OP, `RV64_LOAD_OP, `RV64_OP_IMM_OP, `RV64_OP_IMM_32_OP, `RV64_SYSTEM_OP :
             begin 
               issue_pkt.irs1_v = '1; 
@@ -151,7 +129,7 @@ always_comb
         issue_pkt.frs2_v = '0;
 
         // Immediate extraction
-        unique casez (fetch_instr.t.rtype.opcode)
+        unique casez (fetch_instr.opcode)
           `RV64_LUI_OP, `RV64_AUIPC_OP: 
             issue_pkt.imm = `rv64_signext_u_imm(fetch_instr);
           `RV64_JAL_OP: 
@@ -179,7 +157,7 @@ always_comb
   end
 
 // Interface handshakes
-assign fe_queue_yumi_o = ~suppress_iss_i & fe_queue_v_i & (dispatch_v_i | ~issue_pkt_v_r);
+assign fe_queue_yumi_o = ~suppress_iss_i & fe_queue_v_i & dispatch_v_i;
 
 // Queue control signals
 assign fe_queue_clr_o  = suppress_iss_i;
@@ -201,12 +179,12 @@ bp_be_regfile
    ,.rd_addr_i(wb_pkt.rd_addr)
    ,.rd_data_i(wb_pkt.rd_data)
 
-   ,.rs1_r_v_i(issue_v & issue_pkt.irs1_v)
-   ,.rs1_addr_i(issue_pkt.instr.t.rtype.rs1_addr)
+   ,.rs1_r_v_i(rs1_v_i)
+   ,.rs1_addr_i(rs1_addr_i)
    ,.rs1_data_o(irf_rs1)
 
-   ,.rs2_r_v_i(issue_v & issue_pkt.irs2_v)
-   ,.rs2_addr_i(issue_pkt.instr.t.rtype.rs2_addr)
+   ,.rs2_r_v_i(rs2_v_i)
+   ,.rs2_addr_i(rs2_addr_i)
    ,.rs2_data_o(irf_rs2)
    );
 
@@ -217,9 +195,9 @@ bp_fe_exception_code_e fe_exc_isd;
 bp_be_decode_s          decoded;
 bp_be_instr_decoder
  instr_decoder
-   (.fe_exc_not_instr_i(issue_pkt_r.fe_exception_not_instr)
-   ,.fe_exc_i(issue_pkt_r.fe_exception_code)
-   ,.instr_i(issue_pkt_r.instr)
+   (.fe_exc_not_instr_i(issue_pkt.fe_exception_not_instr)
+   ,.fe_exc_i(issue_pkt.fe_exception_code)
+   ,.instr_i(issue_pkt.instr)
 
    ,.decode_o(decoded)
    );
@@ -228,27 +206,26 @@ bp_be_dispatch_pkt_s dispatch_pkt;
 always_comb
   begin
     // Calculator status ISD stage
-    isd_status.isd_v        = (issue_pkt_v_r & dispatch_v_i)
-                              & ~(poison_iss_r | poison_iss_i);
-    isd_status.isd_pc       = issue_pkt_r.pc;
-    isd_status.isd_branch_metadata_fwd = issue_pkt_r.branch_metadata_fwd;
-    isd_status.isd_fence_v  = issue_pkt_v_r & issue_pkt_r.fence_v;
-    isd_status.isd_mem_v    = issue_pkt_v_r & issue_pkt_r.mem_v;
-    isd_status.isd_irs1_v   = issue_pkt_v_r & issue_pkt_r.irs1_v;
-    isd_status.isd_frs1_v   = issue_pkt_v_r & issue_pkt_r.frs1_v;
-    isd_status.isd_rs1_addr = issue_pkt_r.instr.t.rtype.rs1_addr;
-    isd_status.isd_irs2_v   = issue_pkt_v_r & issue_pkt_r.irs2_v;
-    isd_status.isd_frs2_v   = issue_pkt_v_r & issue_pkt_r.frs2_v;
-    isd_status.isd_rs2_addr = issue_pkt_r.instr.t.rtype.rs2_addr;
+    isd_status.isd_v        = fe_queue_yumi_o;
+    isd_status.isd_pc       = issue_pkt.pc;
+    isd_status.isd_branch_metadata_fwd = issue_pkt.branch_metadata_fwd;
+    isd_status.isd_fence_v  = fe_queue_v_i & issue_pkt.fence_v;
+    isd_status.isd_mem_v    = fe_queue_v_i & issue_pkt.mem_v;
+    isd_status.isd_irs1_v   = fe_queue_v_i & issue_pkt.irs1_v;
+    isd_status.isd_frs1_v   = fe_queue_v_i & issue_pkt.frs1_v;
+    isd_status.isd_rs1_addr = issue_pkt.instr.t.rtype.rs1_addr;
+    isd_status.isd_irs2_v   = fe_queue_v_i & issue_pkt.irs2_v;
+    isd_status.isd_frs2_v   = fe_queue_v_i & issue_pkt.frs2_v;
+    isd_status.isd_rs2_addr = issue_pkt.instr.t.rtype.rs2_addr;
 
     // Form dispatch packet
-    dispatch_pkt.v      = issue_pkt_v_r & dispatch_v_i;
-    dispatch_pkt.poison = (poison_iss_r | poison_isd_i | ~dispatch_pkt.v);
+    dispatch_pkt.v      = fe_queue_yumi_o;
+    dispatch_pkt.poison = (~dispatch_pkt.v | poison_iss_i);
     dispatch_pkt.pc     = expected_npc_i;
-    dispatch_pkt.instr  = issue_pkt_r.instr;
+    dispatch_pkt.instr  = issue_pkt.instr;
     dispatch_pkt.rs1    = irf_rs1; // TODO: Add float forwarding
     dispatch_pkt.rs2    = irf_rs2;
-    dispatch_pkt.imm    = issue_pkt_r.imm;
+    dispatch_pkt.imm    = issue_pkt.imm;
     dispatch_pkt.decode = decoded;
   end
 assign dispatch_pkt_o = dispatch_pkt;

--- a/bp_be/src/v/bp_be_top.v
+++ b/bp_be/src/v/bp_be_top.v
@@ -42,6 +42,12 @@ module bp_be_top
    , output                                          fe_queue_deq_o
    , output                                          fe_queue_roll_o
 
+   , input [reg_addr_width_p-1:0]                    rs1_addr_i
+   , input                                           rs1_v_i
+
+   , input [reg_addr_width_p-1:0]                    rs2_addr_i
+   , input                                           rs2_v_i
+
    // FE cmd interface
    , output [fe_cmd_width_lp-1:0]                    fe_cmd_o
    , output                                          fe_cmd_v_o
@@ -106,7 +112,7 @@ bp_be_wb_pkt_s wb_pkt;
 
 bp_be_isd_status_s isd_status;
 logic [vaddr_width_p-1:0] expected_npc_lo;
-logic poison_isd_lo, suppress_iss_lo;
+logic poison_iss_lo, suppress_iss_lo;
 
 logic [rv64_priv_width_gp-1:0] priv_mode_lo;
 logic [ptag_width_p-1:0]       satp_ppn_lo;
@@ -135,7 +141,7 @@ bp_be_director
    ,.fe_cmd_fence_i(fe_cmd_fence_i)
 
    ,.suppress_iss_o(suppress_iss_lo)
-   ,.poison_isd_o(poison_isd_lo)
+   ,.poison_iss_o(poison_iss_lo)
 
    ,.trap_pkt_i(trap_pkt)
    ,.ptw_fill_pkt_i(ptw_fill_pkt)
@@ -172,11 +178,10 @@ bp_be_scheduler
 
    ,.isd_status_o(isd_status)
    ,.expected_npc_i(expected_npc_lo)
-   ,.poison_iss_i(flush)
-   ,.poison_isd_i(poison_isd_lo)
    ,.dispatch_v_i(chk_dispatch_v)
    ,.cache_miss_v_i(trap_pkt.rollback)
    ,.cmt_v_i(commit_pkt.queue_v)
+   ,.poison_iss_i(poison_iss_lo)
    ,.suppress_iss_i(suppress_iss_lo)
 
    ,.fe_queue_i(fe_queue_i)
@@ -186,6 +191,11 @@ bp_be_scheduler
    ,.fe_queue_roll_o(fe_queue_roll_o)
    ,.fe_queue_deq_o(fe_queue_deq_o)
 
+   ,.rs1_addr_i(rs1_addr_i)
+   ,.rs1_v_i(rs1_v_i)
+
+   ,.rs2_addr_i(rs2_addr_i)
+   ,.rs2_v_i(rs2_v_i)
 
    ,.dispatch_pkt_o(dispatch_pkt)
    

--- a/bp_common/src/v/bsg_fifo_1r1w_rolly.v
+++ b/bp_common/src/v/bsg_fifo_1r1w_rolly.v
@@ -1,38 +1,52 @@
 
 module bsg_fifo_1r1w_rolly
-  #(parameter width_p              = "inv"
-    , parameter els_p              = "inv"
-    , parameter ready_THEN_valid_p = 0
-    
-    , localparam ptr_width_lp = `BSG_SAFE_CLOG2(els_p)
-    )
-  (input                  clk_i
-   , input                reset_i
+ import bp_common_pkg::*;
+ import bp_common_aviary_pkg::*;
+ import bp_common_rv64_pkg::*;
+ #(parameter bp_params_e bp_params_p = e_bp_single_core_cfg
+   `declare_bp_proc_params(bp_params_p)
+   `declare_bp_fe_be_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
 
-   , input                clr_v_i
-   , input                deq_v_i
-   , input                roll_v_i
+   , localparam ptr_width_lp = `BSG_SAFE_CLOG2(fe_queue_fifo_els_p)
+   )
+  (input                                    clk_i
+   , input                                  reset_i
 
-   , input [width_p-1:0]  data_i
-   , input                v_i
-   , output               ready_o
+   , input                                  clr_v_i
+   , input                                  deq_v_i
+   , input                                  roll_v_i
+
+   , input [fe_queue_width_lp-1:0]          fe_queue_i
+   , input                                  fe_queue_v_i
+   , output logic                           fe_queue_ready_o
    
-   , output [width_p-1:0] data_o
-   , output               v_o
-   , input                yumi_i
+   , output logic [fe_queue_width_lp-1:0]   fe_queue_o
+   , output logic                           fe_queue_v_o
+   , input                                  fe_queue_yumi_i
+
+   , output logic [reg_addr_width_p-1:0]    rs1_addr_o
+   , output logic                           rs1_v_o
+
+   , output logic [reg_addr_width_p-1:0]    rs2_addr_o
+   , output logic                           rs2_v_o
    );
-  
+
+  `declare_bp_fe_be_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
+  `bp_cast_i(bp_fe_queue_s, fe_queue);
+  `bp_cast_o(bp_fe_queue_s, fe_queue);
+
   // One read pointer, one write pointer, one checkpoint pointer
   // ptr_width + 1 for wrap bit
+  logic [ptr_width_lp:0] wptr_n, rptr_n, cptr_n;
   logic [ptr_width_lp:0] wptr_r, rptr_r, cptr_r;
     
   // Used to catch up on roll and clear
-  logic [ptr_width_lp:0] rptr_jmp, wptr_jmp;
+  logic [ptr_width_lp:0] wptr_jmp, rptr_jmp, cptr_jmp;
 
   // Operations
-  wire enq  = ready_THEN_valid_p ? v_i : ready_o & v_i;
+  wire enq  = fe_queue_ready_o & fe_queue_v_i;
   wire deq  = deq_v_i;
-  wire read = yumi_i;
+  wire read = fe_queue_yumi_i;
   wire clr  = clr_v_i;
   wire roll = roll_v_i;
 
@@ -41,63 +55,92 @@ module bsg_fifo_1r1w_rolly
                     : read 
                        ? ((ptr_width_lp+1)'(1))
                        : ((ptr_width_lp+1)'(0));
-
   assign wptr_jmp = clr
                     ? (rptr_r - wptr_r + (ptr_width_lp+1)'(read))
                     : enq
                        ? ((ptr_width_lp+1)'(1))
                        : ((ptr_width_lp+1)'(0));
+  assign cptr_jmp = 1'b1;
 
   wire empty = (rptr_r[0+:ptr_width_lp] == wptr_r[0+:ptr_width_lp]) 
                & (rptr_r[ptr_width_lp] == wptr_r[ptr_width_lp]);
-  wire full = (cptr_r[0+:ptr_width_lp] == wptr_r[0+:ptr_width_lp]) 
-              & (cptr_r[ptr_width_lp] != wptr_r[ptr_width_lp]);
-
-  assign ready_o = ~clr & ~full;
-  assign v_o     = ~roll & ~empty;
+  wire empty_n = (rptr_n[0+:ptr_width_lp] == wptr_n[0+:ptr_width_lp]) 
+                 & (rptr_n[ptr_width_lp] == wptr_n[ptr_width_lp]);
+  wire full  = (cptr_r[0+:ptr_width_lp] == wptr_r[0+:ptr_width_lp])
+               & (cptr_r[ptr_width_lp] != wptr_r[ptr_width_lp]);
+  wire full_n = (cptr_n[0+:ptr_width_lp] == wptr_n[0+:ptr_width_lp])
+                & (cptr_n[ptr_width_lp] != wptr_n[ptr_width_lp]);
 
   bsg_circular_ptr 
-   #(.slots_p(2*els_p), .max_add_p(1)) 
+   #(.slots_p(2*fe_queue_fifo_els_p), .max_add_p(1))
    cptr
     (.clk(clk_i)
      ,.reset_i(reset_i)
      ,.add_i(deq_v_i)
-    ,.o(cptr_r)
-    ,.n_o()
+     ,.o(cptr_r)
+     ,.n_o(cptr_n)
      );
     
   bsg_circular_ptr 
-   #(.slots_p(2*els_p),.max_add_p(2*els_p-1))
+   #(.slots_p(2*fe_queue_fifo_els_p),.max_add_p(2*fe_queue_fifo_els_p-1))
    wptr
     (.clk(clk_i)
      ,.reset_i(reset_i)
      ,.add_i(wptr_jmp)
      ,.o(wptr_r)
-     ,.n_o()
+     ,.n_o(wptr_n)
      );
 
   bsg_circular_ptr 
-  #(.slots_p(2*els_p), .max_add_p(2*els_p-1))
-  rptr_circ_ptr
+  #(.slots_p(2*fe_queue_fifo_els_p), .max_add_p(2*fe_queue_fifo_els_p-1))
+  rptr
    (.clk(clk_i)
     ,.reset_i(reset_i)
     ,.add_i(rptr_jmp)
     ,.o(rptr_r)
-    ,.n_o()
+    ,.n_o(rptr_n)
     );
   
   bsg_mem_1r1w 
-  #(.width_p(width_p), .els_p(els_p)) 
-  fifo_mem
+  #(.width_p(fe_queue_width_lp), .els_p(fe_queue_fifo_els_p)) 
+  queue_fifo_mem
    (.w_clk_i(clk_i)
     ,.w_reset_i(reset_i)
     ,.w_v_i(enq)
     ,.w_addr_i(wptr_r[0+:ptr_width_lp])
-    ,.w_data_i(data_i)
-    ,.r_v_i(read)
+    ,.w_data_i(fe_queue_cast_i)
+    ,.r_v_i(read & ~empty)
     ,.r_addr_i(rptr_r[0+:ptr_width_lp])
-    ,.r_data_o(data_o)
+    ,.r_data_o(fe_queue_cast_o)
     );
-  
+  assign fe_queue_v_o     = ~roll & ~empty;
+  assign fe_queue_ready_o = ~clr & ~full;
+
+  wire bypass_reg = (wptr_r == rptr_n);
+  rv64_instr_rtype_s fetch_instr;
+  assign fetch_instr = fe_queue_cast_i.msg.fetch.instr;
+  logic [reg_addr_width_p-1:0] rs1_addr_li, rs2_addr_li;
+  logic [reg_addr_width_p-1:0] rs1_addr_lo, rs2_addr_lo;
+  assign rs1_addr_li = fetch_instr.rs1_addr;
+  assign rs2_addr_li = fetch_instr.rs2_addr;
+  bsg_mem_1r1w
+  #(.width_p(2*reg_addr_width_p), .els_p(fe_queue_fifo_els_p), .read_write_same_addr_p(1))
+  reg_fifo_mem
+   (.w_clk_i(clk_i)
+    ,.w_reset_i(reset_i)
+    ,.w_v_i(enq)
+    ,.w_addr_i(wptr_r[0+:ptr_width_lp])
+    ,.w_data_i({rs2_addr_li, rs1_addr_li})
+    ,.r_v_i(1'b1)
+    ,.r_addr_i(rptr_n[0+:ptr_width_lp])
+    ,.r_data_o({rs2_addr_lo, rs1_addr_lo})
+    );
+  // TODO: Save power by predecoding
+  assign rs1_v_o = (fe_queue_yumi_i & ~empty_n) | roll_v_i | (fe_queue_v_i & empty);
+  assign rs2_v_o = (fe_queue_yumi_i & ~empty_n) | roll_v_i | (fe_queue_v_i & empty);
+
+  assign rs1_addr_o = bypass_reg ? rs1_addr_li : rs1_addr_lo;
+  assign rs2_addr_o = bypass_reg ? rs2_addr_li : rs2_addr_lo;
+
 endmodule
 

--- a/bp_top/src/v/bp_core_minimal.v
+++ b/bp_top/src/v/bp_core_minimal.v
@@ -166,11 +166,10 @@ module bp_core_minimal
   wire fe_cmd_fence_li = fe_cmd_v_lo;
 
   logic fe_queue_clr_li, fe_queue_deq_li, fe_queue_roll_li;
+  logic rs1_v_lo, rs2_v_lo;
+  logic [reg_addr_width_p-1:0] rs1_addr_lo, rs2_addr_lo;
   bsg_fifo_1r1w_rolly
-   #(.width_p(fe_queue_width_lp)
-     ,.els_p(fe_queue_fifo_els_p)
-     ,.ready_THEN_valid_p(1)
-     )
+   #(.bp_params_p(bp_params_p))
    fe_queue_fifo
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
@@ -179,13 +178,19 @@ module bp_core_minimal
      ,.deq_v_i(fe_queue_deq_li)
      ,.roll_v_i(fe_queue_roll_li)
 
-     ,.data_i(fe_queue_li)
-     ,.v_i(fe_queue_v_li)
-     ,.ready_o(fe_queue_ready_lo)
+     ,.fe_queue_i(fe_queue_li)
+     ,.fe_queue_v_i(fe_queue_v_li)
+     ,.fe_queue_ready_o(fe_queue_ready_lo)
 
-     ,.data_o(fe_queue_lo)
-     ,.v_o(fe_queue_v_lo)
-     ,.yumi_i(fe_queue_yumi_li)
+     ,.fe_queue_o(fe_queue_lo)
+     ,.fe_queue_v_o(fe_queue_v_lo)
+     ,.fe_queue_yumi_i(fe_queue_yumi_li)
+
+     ,.rs1_v_o(rs1_v_lo)
+     ,.rs1_addr_o(rs1_addr_lo)
+
+     ,.rs2_v_o(rs2_v_lo)
+     ,.rs2_addr_o(rs2_addr_lo)
      );
 
   bp_be_top
@@ -207,6 +212,12 @@ module bp_core_minimal
      ,.fe_queue_i(fe_queue_lo)
      ,.fe_queue_v_i(fe_queue_v_lo)
      ,.fe_queue_yumi_o(fe_queue_yumi_li)
+
+     ,.rs1_addr_i(rs1_addr_lo)
+     ,.rs1_v_i(rs1_v_lo)
+
+     ,.rs2_addr_i(rs2_addr_lo)
+     ,.rs2_v_i(rs2_v_lo)
 
      ,.fe_cmd_o(fe_cmd_li)
      ,.fe_cmd_v_o(fe_cmd_v_li)


### PR DESCRIPTION
This branch is testing replacing the synchronous with an asynchronous regfile (either ff or latch based).  In advanced nodes, memories scale much more poorly than logic, so it's possible the area benefit of hardening for a relatively small (2k) RAM is not that much.  However, there may be a routing overhead.

The advantages of this are:
1) Reduced branch mispredict penalty (1 cycle).
2) O(200-500) flops by removing issue stage.
3) Reduced code complexity for compressed instructions (issue stage complicates this by being outside of the rolly fifo).

Disadvantages are:
1) Less common to have hardened asynchronous 1r1w memories
2) Possibly a timing impact (although, we send our regfile read at the beginning of the cycle, so there should be no timing difference between hardened / not hardened).
3) Timing path complexity if latch-based regfile.
4) Possible area impact

Need to push this through CAD flow to see area / timing impact

TODO:
- [ ] Lots of code cleanup
- [ ] Area and power analysis
- [ ] Adjust core profiler