### PR TITLE
Update FSM CCE for dev

### DIFF
--- a/bp_me/src/v/cce/bp_cce_fsm.v
+++ b/bp_me/src/v/cce/bp_cce_fsm.v
@@ -26,21 +26,17 @@ module bp_cce_fsm
     , localparam lg_lce_sets_lp            = `BSG_SAFE_CLOG2(lce_sets_p)
     , localparam ptag_width_lp              = (paddr_width_p-lg_lce_sets_lp
                                               -lg_block_size_in_bytes_lp)
-    , localparam entry_width_lp            = (ptag_width_lp+`bp_coh_bits)
-    , localparam tag_set_width_lp          = (entry_width_lp*lce_assoc_p)
-    , localparam way_group_width_lp        = (tag_set_width_lp*num_lce_p)
-    , localparam way_group_offset_high_lp  = (lg_block_size_in_bytes_lp+lg_lce_sets_lp)
-    , localparam num_way_groups_lp         = (lce_sets_p/num_cce_p)
+    , localparam num_way_groups_lp         = `BSG_CDIV(lce_sets_p, num_cce_p)
     , localparam lg_num_way_groups_lp      = `BSG_SAFE_CLOG2(num_way_groups_lp)
     , localparam inst_ram_addr_width_lp    = `BSG_SAFE_CLOG2(num_cce_instr_ram_els_p)
     , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
-    , localparam set_shift_lp              = (num_cce_p == 1) ? 0 : lg_num_cce_lp
 
     // interface widths
     `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
     `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
 
     , localparam counter_max = 256
+    , localparam hash_index_width_lp=$clog2((2**lg_lce_sets_lp+num_cce_p-1)/num_cce_p)
   )
   (input                                               clk_i
    , input                                             reset_i
@@ -76,18 +72,12 @@ module bp_cce_fsm
    , input                                             mem_cmd_ready_i
   );
 
-  // stub unused ports
-  assign mem_resp_o = '0;
-  assign mem_resp_v_o = '0;
-  assign mem_cmd_yumi_o = '0;
   // stub cfg ucode output, since FSM CCE has no ucode
   assign cfg_cce_ucode_data_o = '0;
 
   //synopsys translate_off
   initial begin
     assert (lce_sets_p > 1) else $error("Number of LCE sets must be greater than 1");
-    assert (num_cce_p >= 1 && `BSG_IS_POW2(num_cce_p))
-      else $error("Number of CCE must be power of two");
     assert (counter_max > num_way_groups_lp) else $error("Counter max value not large enough");
   end
   //synopsys translate_on
@@ -116,6 +106,7 @@ module bp_cce_fsm
   `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
   bp_cfg_bus_s cfg_bus_cast_i;
   assign cfg_bus_cast_i = cfg_bus_i;
+  wire cce_normal_mode = (~cfg_bus_cast_i.freeze & (cfg_bus_cast_i.cce_mode == e_cce_mode_normal));
 
   // CCE FSM
 
@@ -127,12 +118,76 @@ module bp_cce_fsm
   // filled by LCE Request
   logic [dword_width_p-1:0] uc_data_r, uc_data_n;
 
+  // convert MSHR addr (excluding block offset bits) into way group
+  logic [`BSG_SAFE_CLOG2(num_cce_p)-1:0] mshr_addr_cce_id_lo;
+  logic [hash_index_width_lp-1:0] mshr_addr_wg_id_lo;
+  wire [lg_lce_sets_lp-1:0] mshr_addr_addr_rev =
+    {<< {mshr_r.paddr[lg_block_size_in_bytes_lp+:lg_lce_sets_lp]}};
+
+  bsg_hash_bank
+    #(.banks_p(num_cce_p) // number of CCE's to spread way groups over
+      ,.width_p(lg_lce_sets_lp) // width of address input
+      )
+    mshr_addr_to_wg_id
+     (.i(mshr_addr_addr_rev)
+      ,.bank_o(mshr_addr_cce_id_lo)
+      ,.index_o(mshr_addr_wg_id_lo)
+      );
+
+  // convert mem_resp.addr into way group
+  logic [`BSG_SAFE_CLOG2(num_cce_p)-1:0] mem_resp_addr_cce_id_lo;
+  logic [hash_index_width_lp-1:0] mem_resp_addr_wg_id_lo;
+  wire [lg_lce_sets_lp-1:0] mem_resp_addr_addr_rev =
+    {<< {mem_resp.header.addr[lg_block_size_in_bytes_lp+:lg_lce_sets_lp]}};
+
+  bsg_hash_bank
+    #(.banks_p(num_cce_p) // number of CCE's to spread way groups over
+      ,.width_p(lg_lce_sets_lp) // width of address input
+      )
+    mem_resp_addr_to_wg_id
+     (.i(mem_resp_addr_addr_rev)
+      ,.bank_o(mem_resp_addr_cce_id_lo)
+      ,.index_o(mem_resp_addr_wg_id_lo)
+      );
+
+  // convert lce_resp.addr into way group
+  logic [`BSG_SAFE_CLOG2(num_cce_p)-1:0] lce_resp_addr_cce_id_lo;
+  logic [hash_index_width_lp-1:0] lce_resp_addr_wg_id_lo;
+  wire [lg_lce_sets_lp-1:0] lce_resp_addr_addr_rev =
+    {<< {lce_resp.header.addr[lg_block_size_in_bytes_lp+:lg_lce_sets_lp]}};
+
+  bsg_hash_bank
+    #(.banks_p(num_cce_p) // number of CCE's to spread way groups over
+      ,.width_p(lg_lce_sets_lp) // width of address input
+      )
+    lce_resp_addr_to_wg_id
+     (.i(lce_resp_addr_addr_rev)
+      ,.bank_o(lce_resp_addr_cce_id_lo)
+      ,.index_o(lce_resp_addr_wg_id_lo)
+      );
+
+  // convert lce_req.addr into way group
+  logic [`BSG_SAFE_CLOG2(num_cce_p)-1:0] lce_req_addr_cce_id_lo;
+  logic [hash_index_width_lp-1:0] lce_req_addr_wg_id_lo;
+  wire [lg_lce_sets_lp-1:0] lce_req_addr_addr_rev =
+    {<< {lce_req.header.addr[lg_block_size_in_bytes_lp+:lg_lce_sets_lp]}};
+
+  bsg_hash_bank
+    #(.banks_p(num_cce_p) // number of CCE's to spread way groups over
+      ,.width_p(lg_lce_sets_lp) // width of address input
+      )
+    lce_req_addr_to_wg_id
+     (.i(lce_req_addr_addr_rev)
+      ,.bank_o(lce_req_addr_cce_id_lo)
+      ,.index_o(lce_req_addr_wg_id_lo)
+      );
+
   // Pending Bits
   logic pending_li, pending_lo;
   logic pending_v_lo, pending_w_v, pending_r_v;
   logic [lg_num_way_groups_lp-1:0] pending_w_way_group, pending_r_way_group;
   // The read way group always comes from the MSHR
-  assign pending_r_way_group = mshr_r.paddr[(way_group_offset_high_lp-1) -: lg_num_way_groups_lp];
+  assign pending_r_way_group = mshr_addr_wg_id_lo;
 
   // bit to tell FSM that it can't use pending bit module write port
   logic pending_busy;
@@ -168,11 +223,13 @@ module bp_cce_fsm
   logic [ptag_width_lp-1:0] dir_lru_tag_lo, dir_tag_lo;
   logic dir_busy_lo;
 
-  logic [lg_num_way_groups_lp-1:0] dir_way_group_li;
+  logic [lg_num_way_groups_lp-1:0] dir_set_li;
   logic [lg_num_lce_lp-1:0] dir_lce_li;
   logic [lg_lce_assoc_lp-1:0] dir_way_li, dir_lru_way_li;
   logic [ptag_width_lp-1:0] dir_tag_li;
   logic [`bp_coh_bits-1:0] dir_coh_state_li;
+
+
 
   // GAD signals
   logic gad_v;
@@ -191,21 +248,19 @@ module bp_cce_fsm
 
   // Directory
   bp_cce_dir
-    #(.num_way_groups_p(num_way_groups_lp)
+    #(.sets_p(num_way_groups_lp)
       ,.num_lce_p(num_lce_p)
-      ,.num_cce_p(num_cce_p)
       ,.lce_assoc_p(lce_assoc_p)
       ,.tag_width_p(ptag_width_lp)
       )
     directory
      (.clk_i(clk_i)
       ,.reset_i(reset_i)
-      ,.cce_id_i(cfg_bus_cast_i.cce_id)
 
-      ,.way_group_i(dir_way_group_li)
+      ,.set_i(dir_set_li[0+:lg_num_way_groups_lp])
       ,.lce_i(dir_lce_li)
       ,.way_i(dir_way_li)
-      ,.lru_way_i(dir_lru_way_li)
+      ,.lru_way_i(mshr_r.lru_way_id)
 
       ,.r_cmd_i(dir_r_cmd)
       ,.r_v_i(dir_r_v)
@@ -215,7 +270,7 @@ module bp_cce_fsm
 
       ,.w_cmd_i(dir_w_cmd)
       ,.w_v_i(dir_w_v)
-      ,.w_clr_wg_i(dir_wg_clr)
+      ,.w_clr_row_i(dir_wg_clr)
 
       ,.sharers_v_o(sharers_v_lo)
       ,.sharers_hits_o(sharers_hits_lo)
@@ -229,6 +284,7 @@ module bp_cce_fsm
       ,.busy_o(dir_busy_lo)
 
       ,.tag_o(dir_tag_lo)
+
       );
 
   // GAD logic - auxiliary directory information logic
@@ -246,7 +302,7 @@ module bp_cce_fsm
       ,.sharers_ways_i(sharers_ways_lo)
       ,.sharers_coh_states_i(sharers_coh_states_lo)
 
-      ,.req_lce_i(mshr_r.lce_id)
+      ,.req_lce_i(lg_num_lce_lp'(mshr_r.lce_id))
       ,.req_type_flag_i(mshr_r.flags[e_flag_sel_rqf])
       ,.lru_dirty_flag_i(mshr_r.flags[e_flag_sel_ldf])
       ,.lru_cached_excl_flag_i(mshr_r.flags[e_flag_sel_lef])
@@ -269,7 +325,7 @@ module bp_cce_fsm
   typedef enum logic [5:0] {
     RESET
     , CLEAR_DIR
-    , SEND_SET_CLEAR
+    , UNCACHED_ONLY
     , SEND_SYNC
     , SYNC_ACK
     , READY
@@ -296,7 +352,6 @@ module bp_cce_fsm
     , TRANSFER_WB_CMD
     , TRANSFER_WB_RESP
 
-    , READ_MEM
     , SEND_SET_TAG
 
     , UC_REQ
@@ -364,7 +419,7 @@ module bp_cce_fsm
 
        // write-port
        ,.w_v_i(spec_w_v)
-       ,.w_way_group_i(mshr_r.paddr[way_group_offset_high_lp-1 -: lg_num_way_groups_lp])
+       ,.w_way_group_i(mshr_addr_wg_id_lo[0+:lg_num_way_groups_lp])
        ,.spec_v_i(spec_v_li)
        ,.spec_i(spec_bits_li.spec)
        ,.squash_v_i(squash_v_li)
@@ -375,8 +430,8 @@ module bp_cce_fsm
        ,.state_i(spec_bits_li.state)
 
        // read-port
-       ,.r_v_i(mem_resp_v_i & mem_resp.payload.speculative)
-       ,.r_way_group_i(mem_resp.addr[way_group_offset_high_lp-1 -: lg_num_way_groups_lp])
+       ,.r_v_i(mem_resp_v_i & mem_resp.header.payload.speculative)
+       ,.r_way_group_i(mem_resp_addr_wg_id_lo[0+:lg_num_way_groups_lp])
        ,.data_o(spec_bits_lo)
        ,.v_o(spec_bits_v_lo)
        );
@@ -387,7 +442,7 @@ module bp_cce_fsm
   bsg_decode
     #(.num_out_p(num_lce_p))
     req_lce_id_to_one_hot
-    (.i(mshr_r.lce_id)
+    (.i(lg_num_lce_lp'(mshr_r.lce_id))
      ,.o(req_lce_id_one_hot)
      );
 
@@ -435,6 +490,7 @@ module bp_cce_fsm
      ,.o(pe_lce_id_one_hot)
      );
 
+  wire lce_resp_coh_ack_yumi = lce_resp_v_i & (lce_resp.header.msg_type == e_lce_cce_coh_ack) & ~pending_busy;
 
   always_comb begin
     state_n = state_r;
@@ -453,7 +509,7 @@ module bp_cce_fsm
     mem_cmd_v_o = '0;
     mem_resp_yumi_o = '0;
 
-    lce_cmd.msg.cmd.src_id = cfg_bus_cast_i.cce_id;
+    lce_cmd.header.src_id = cfg_bus_cast_i.cce_id;
 
     // up down counter
     cnt_inc = '0;
@@ -479,7 +535,7 @@ module bp_cce_fsm
     dir_wg_clr = '0;
     dir_r_cmd = e_rdw_op;
     dir_w_cmd = e_wde_op;
-    dir_way_group_li = mshr_r.paddr[(way_group_offset_high_lp-1) -: lg_num_way_groups_lp];
+    dir_set_li = mshr_addr_wg_id_lo;
     dir_lce_li = mshr_r.lce_id;
     dir_way_li = mshr_r.way_id;
     dir_lru_way_li = mshr_r.lru_way_id;
@@ -507,7 +563,7 @@ module bp_cce_fsm
 
       // Speculative access response
       // Note: speculative access is only supported for cached requests
-      if (mem_resp.payload.speculative) begin
+      if (mem_resp.header.payload.speculative) begin
         if (spec_bits_lo.spec) begin // speculation not resolved yet
           // do nothing, wait for speculation to be resolved
           // Note: this blocks memory responses behind the speculative response from being
@@ -520,8 +576,7 @@ module bp_cce_fsm
 
           pending_busy = 1'b1;
           pending_w_v = 1'b1;
-          pending_w_way_group =
-            mem_resp.addr[(way_group_offset_high_lp-1) -: lg_num_way_groups_lp];
+          pending_w_way_group = mem_resp_addr_wg_id_lo;
           pending_li = 1'b0;
 
         end
@@ -534,21 +589,20 @@ module bp_cce_fsm
           lce_cmd_busy = 1'b1;
 
           // output command message
-          lce_cmd.dst_id = mem_resp.payload.lce_id;
+          lce_cmd.header.dst_id = mem_resp.header.payload.lce_id;
 
           // Data is copied directly from the Mem Data Response
-          lce_cmd.msg_type = e_lce_cmd_data;
-          lce_cmd.way_id = mem_resp.payload.way_id;
-          lce_cmd.msg.dt_cmd.data = mem_resp.data;
-          lce_cmd.msg.dt_cmd.addr = mem_resp.addr;
+          lce_cmd.header.msg_type = e_lce_cmd_data;
+          lce_cmd.header.way_id = mem_resp.header.payload.way_id;
+          lce_cmd.data = mem_resp.data;
+          lce_cmd.header.addr = mem_resp.header.addr;
           // modify the coherence state
-          lce_cmd.msg.dt_cmd.state = spec_bits_lo.state;
+          lce_cmd.header.state = bp_coh_states_e'(spec_bits_lo.state);
 
           if (lce_cmd_ready_i) begin
             pending_busy = 1'b1;
             pending_w_v = 1'b1;
-            pending_w_way_group =
-              mem_resp.addr[(way_group_offset_high_lp-1) -: lg_num_way_groups_lp];
+            pending_w_way_group = mem_resp_addr_wg_id_lo;
             pending_li = 1'b0;
           end
 
@@ -562,20 +616,19 @@ module bp_cce_fsm
           lce_cmd_busy = 1'b1;
 
           // output command message
-          lce_cmd.dst_id = mem_resp.payload.lce_id;
+          lce_cmd.header.dst_id = mem_resp.header.payload.lce_id;
 
           // Data is copied directly from the Mem Data Response
-          lce_cmd.msg_type = e_lce_cmd_data;
-          lce_cmd.way_id = mem_resp.payload.way_id;
-          lce_cmd.msg.dt_cmd.data = mem_resp.data;
-          lce_cmd.msg.dt_cmd.addr = mem_resp.addr;
-          lce_cmd.msg.dt_cmd.state = mem_resp.payload.state;
+          lce_cmd.header.msg_type = e_lce_cmd_data;
+          lce_cmd.header.way_id = mem_resp.header.payload.way_id;
+          lce_cmd.data = mem_resp.data;
+          lce_cmd.header.addr = mem_resp.header.addr;
+          lce_cmd.header.state = mem_resp.header.payload.state;
 
           if (lce_cmd_ready_i) begin
             pending_busy = 1'b1;
             pending_w_v = 1'b1;
-            pending_w_way_group =
-              mem_resp.addr[(way_group_offset_high_lp-1) -: lg_num_way_groups_lp];
+            pending_w_way_group = mem_resp_addr_wg_id_lo;
             pending_li = 1'b0;
           end
 
@@ -583,8 +636,8 @@ module bp_cce_fsm
 
       end // speculative response
 
-      else if ((mem_resp.msg_type.cce_mem_cmd == e_cce_mem_rd)
-               | (mem_resp.msg_type.cce_mem_cmd == e_cce_mem_wr)) begin
+      else if ((mem_resp.header.msg_type == e_cce_mem_rd)
+               | (mem_resp.header.msg_type == e_cce_mem_wr)) begin
 
         // handshaking
         lce_cmd_v_o = mem_resp_v_i;
@@ -598,23 +651,22 @@ module bp_cce_fsm
         if (lce_cmd_ready_i) begin
           pending_busy = 1'b1;
           pending_w_v = 1'b1;
-          pending_w_way_group =
-            mem_resp.addr[(way_group_offset_high_lp-1) -: lg_num_way_groups_lp];
+          pending_w_way_group = mem_resp_addr_wg_id_lo;
           pending_li = 1'b0;
         end
 
-        lce_cmd.dst_id = mem_resp.payload.lce_id;
-        lce_cmd.msg_type = e_lce_cmd_data;
-        lce_cmd.way_id = mem_resp.payload.way_id;
-        lce_cmd.msg.dt_cmd.data = mem_resp.data;
-        lce_cmd.msg.dt_cmd.addr = mem_resp.addr;
-        lce_cmd.msg.dt_cmd.state = mem_resp.payload.state;
+        lce_cmd.header.dst_id = mem_resp.header.payload.lce_id;
+        lce_cmd.header.msg_type = e_lce_cmd_data;
+        lce_cmd.header.way_id = mem_resp.header.payload.way_id;
+        lce_cmd.data = mem_resp.data;
+        lce_cmd.header.addr = mem_resp.header.addr;
+        lce_cmd.header.state = mem_resp.header.payload.state;
 
       end // rd, wr
 
       // Uncached load response - forward data to LCE
       // This transaction does not modify the pending bits
-      else if (mem_resp.msg_type.cce_mem_cmd == e_cce_mem_uc_rd) begin
+      else if (mem_resp.header.msg_type == e_cce_mem_uc_rd) begin
 
         // handshaking
         lce_cmd_v_o = mem_resp_v_i;
@@ -623,17 +675,17 @@ module bp_cce_fsm
         // block FSM from using LCE Command network
         lce_cmd_busy = 1'b1;
 
-        lce_cmd.dst_id = mem_resp.payload.lce_id;
-        lce_cmd.msg_type = e_lce_cmd_uc_data;
-        lce_cmd.way_id = '0;
-        lce_cmd.msg.dt_cmd.data[0+:dword_width_p] = mem_resp.data[0+:dword_width_p];
-        lce_cmd.msg.dt_cmd.addr = mem_resp.addr;
+        lce_cmd.header.dst_id = mem_resp.header.payload.lce_id;
+        lce_cmd.header.msg_type = e_lce_cmd_uc_data;
+        lce_cmd.header.way_id = '0;
+        lce_cmd.data[0+:dword_width_p] = mem_resp.data[0+:dword_width_p];
+        lce_cmd.header.addr = mem_resp.header.addr;
 
       end // uc_rd
 
       // Uncached store response, send UC Store Done to requesting LCE,
       // don't modify pending bits 
-      else if (mem_resp.msg_type.cce_mem_cmd == e_cce_mem_uc_wr) begin
+      else if (mem_resp.header.msg_type == e_cce_mem_uc_wr) begin
 
         // handshaking
         lce_cmd_v_o = mem_resp_v_i;
@@ -642,23 +694,22 @@ module bp_cce_fsm
         // block FSM from using LCE Command network
         lce_cmd_busy = 1'b1;
 
-        lce_cmd.dst_id = mem_resp.payload.lce_id;
-        lce_cmd.msg_type = e_lce_cmd_uc_st_done;
-        lce_cmd.way_id = '0;
-        lce_cmd.msg.cmd.addr = mem_resp.addr;
+        lce_cmd.header.dst_id = mem_resp.header.payload.lce_id;
+        lce_cmd.header.msg_type = e_lce_cmd_uc_st_done;
+        lce_cmd.header.way_id = '0;
+        lce_cmd.header.addr = mem_resp.header.addr;
 
       end // uc_wr
 
       // Dequeue memory writeback response, don't do anything with it
       // decrement pending bit
       // also set pending_busy to block FSM if needed
-      else if (mem_resp.msg_type.cce_mem_cmd == e_cce_mem_wb) begin
+      else if (mem_resp.header.msg_type == e_cce_mem_wb) begin
 
         mem_resp_yumi_o = 1'b1;
         pending_busy = 1'b1;
         pending_w_v = 1'b1;
-        pending_w_way_group =
-          mem_resp.addr[(way_group_offset_high_lp-1) -: lg_num_way_groups_lp];
+        pending_w_way_group = mem_resp_addr_wg_id_lo;
         pending_li = 1'b0;
 
       end // wb
@@ -668,13 +719,12 @@ module bp_cce_fsm
     // Dequeue coherence ack when it arrives
     // Does not conflict with other dequeues of LCE Response
     // Decrements pending bit on arrival, so arbitrate with memory ports for access
-    if (lce_resp_v_i & (lce_resp.msg_type == e_lce_cce_coh_ack) & ~pending_busy) begin
+    if (lce_resp_v_i & (lce_resp.header.msg_type == e_lce_cce_coh_ack) & ~pending_busy) begin
         lce_resp_yumi_o = 1'b1;
         // inform FSM that pending bit is being used
         pending_busy = 1'b1;
         pending_w_v = 1'b1;
-        pending_w_way_group =
-          lce_resp.addr[(way_group_offset_high_lp-1) -: lg_num_way_groups_lp];
+        pending_w_way_group = lce_resp_addr_wg_id_lo;
         pending_li = 1'b0;
     end
 
@@ -682,7 +732,7 @@ module bp_cce_fsm
     // FSM
     case (state_r)
       RESET: begin
-        state_n = (reset_i | cfg_bus_cast_i.freeze) ? RESET : CLEAR_DIR;
+        state_n = CLEAR_DIR;
         cnt_0_clr = 1'b1;
         cnt_1_clr = 1'b1;
         ack_cnt_clr = 1'b1;
@@ -692,7 +742,7 @@ module bp_cce_fsm
         dir_wg_clr = 1'b1;
 
         // increment through all way-groups (outer loop) and all LCE's (inner loop)
-        dir_way_group_li = cnt_0[0+:lg_num_way_groups_lp];
+        dir_set_li = cnt_0[0+:lg_num_way_groups_lp];
         dir_lce_li = cnt_1[0+:lg_num_lce_lp];
 
         // clear the LCE counter back to 0 after reaching max LCE ID
@@ -701,78 +751,76 @@ module bp_cce_fsm
         cnt_1_inc = ~cnt_1_clr;
 
         state_n = ((cnt_0 == num_way_groups_lp-1) & (cnt_1 == num_lce_p-1))
-                  ? SEND_SET_CLEAR
+                  ? cce_normal_mode
+                    ? READY
+                    : UNCACHED_ONLY
                   : CLEAR_DIR;
 
         // clear way group counter when moving to the next state
-        cnt_0_clr = (state_n == SEND_SET_CLEAR);
+        cnt_0_clr = (state_n != CLEAR_DIR);
         // increment the way group counter whenever the LCE counter resets to 0, except when it
         // is being cleared
         cnt_0_inc = cnt_1_clr & ~cnt_0_clr;
 
-        // override next state if in uncached mode
-        state_n = ((state_n == SEND_SET_CLEAR) & (cfg_bus_cast_i.cce_mode == e_cce_mode_uncached))
-                  ? READY
-                  : state_n;
-      end
-      SEND_SET_CLEAR: begin
-        // output a valid set clear command
-        lce_cmd_v_o = 1'b1;
+      end // CLEAR_DIR
+      UNCACHED_ONLY: begin
 
-        // LCE Cmd Common Fields
-        lce_cmd.dst_id = cnt_1[0+:lg_num_lce_lp];
-        lce_cmd.msg_type = e_lce_cmd_set_clear;
+        // clear the MSHR
+        mshr_n = '0;
+        // clear the ack counter
+        cnt_0_clr = 1'b1;
+        cnt_1_clr = 1'b1;
+        ack_cnt_clr = 1'b1;
+        cnt_rst = 1'b1;
 
-        // Sub message fields
-        // cnt_0 holds the current way-group being targeted by the set clear command, which
-        // needs to be translated into an LCE relative set index
-        lce_cmd.msg.cmd.addr = ((paddr_width_p'(cnt_0) << set_shift_lp) + paddr_width_p'(cfg_bus_cast_i.cce_id))
-                               << lg_block_size_in_bytes_lp;
+        state_n = UNCACHED_ONLY;
 
-        // Assign Command subtype to msg field
-        lce_cmd.msg.cmd = lce_cmd.msg.cmd;
+        if (cce_normal_mode) begin
+          state_n = SEND_SYNC;
+        end else if (lce_req_v_i) begin
+          mshr_n.lce_id = lce_req.header.src_id;
+          mshr_n.paddr = lce_req.header.addr;
+          // uncached request
+          // request will be dequeued in the next state
+          if (lce_req.header.msg_type == e_lce_req_type_uc_rd | lce_req.header.msg_type == e_lce_req_type_uc_wr) begin
+            uc_data_n = lce_req.data;
+            mshr_n.uc_req_size = lce_req.header.uc_size;
+            mshr_n.flags[e_flag_sel_ucf] = 1'b1;
+            mshr_n.flags[e_flag_sel_rqf] = (lce_req.header.msg_type == e_lce_req_type_uc_wr);
 
-        // reset set counter to 0 if command is accepted and current count is max
-        cnt_0_clr = lce_cmd_ready_i & (cnt_0 == (num_way_groups_lp-1));
-        // increment set counter when not clearing it and command is accepted
-        cnt_0_inc = lce_cmd_ready_i & ~cnt_0_clr;
-
-        // send syncs once last command is accepted
-        state_n = (lce_cmd_ready_i & (cnt_0 == num_way_groups_lp-1) & (cnt_1 == num_lce_p-1))
-                  ? SEND_SYNC
-                  : SEND_SET_CLEAR;
-
-        // clear the counters if moving to sending sync commands
-        cnt_1_clr = (state_n == SEND_SYNC);
-
-        // only increment the LCE counter if it isn't being cleared
-        // this avoids a clear then increment in the same cycle
-        cnt_1_inc = cnt_0_clr & ~cnt_1_clr;
-
-      end
+            state_n = UC_REQ;
+          end else begin
+            state_n = ERROR;
+          end
+        end // lce_req_v
+      end // UNCACHED_ONLY
       SEND_SYNC: begin
-        lce_cmd_v_o = 1'b1;
+        if (~lce_cmd_busy) begin
+          lce_cmd_v_o = 1'b1;
 
-        // LCE Cmd Common Fields
-        lce_cmd.dst_id = cnt_1[0+:lg_num_lce_lp];
-        lce_cmd.msg_type = e_lce_cmd_sync;
+          // LCE Cmd Common Fields
+          lce_cmd.header.dst_id = cnt_1[0+:lg_num_lce_lp];
+          lce_cmd.header.msg_type = e_lce_cmd_sync;
 
-        state_n = (lce_cmd_ready_i) ? SYNC_ACK : SEND_SYNC;
-        cnt_1_inc = lce_cmd_ready_i;
+          state_n = (lce_cmd_ready_i) ? SYNC_ACK : SEND_SYNC;
+          cnt_1_inc = lce_cmd_ready_i;
+        end
       end
       SYNC_ACK: begin
-        lce_resp_yumi_o = lce_resp_v_i;
-        state_n = (lce_resp_v_i)
-                  ? (ack_cnt == num_lce_p-1)
-                    ? READY
-                    : SEND_SYNC
-                  : SYNC_ACK;
-        state_n = (lce_resp_v_i & (lce_resp.msg_type != e_lce_cce_sync_ack))
-                  ? ERROR
-                  : state_n;
-        ack_cnt_clr = (state_n == READY);
-        ack_cnt_inc = lce_resp_v_i & ~ack_cnt_clr;
-        cnt_1_clr = (state_n == READY);
+        if (~lce_resp_coh_ack_yumi) begin
+          lce_resp_yumi_o = lce_resp_v_i;
+          state_n = (lce_resp_v_i)
+                    ? (ack_cnt == num_lce_p-1)
+                      ? READY
+                      : SEND_SYNC
+                    : SYNC_ACK;
+          state_n = (lce_resp_v_i & (lce_resp.header.msg_type != e_lce_cce_sync_ack))
+                    ? ERROR
+                    : state_n;
+          ack_cnt_clr = (state_n == READY);
+          ack_cnt_inc = lce_resp_v_i & ~ack_cnt_clr;
+          cnt_1_clr = (state_n == READY);
+        end
       end
       READY: begin
         // clear the MSHR
@@ -784,74 +832,67 @@ module bp_cce_fsm
         cnt_rst = 1'b1;
 
         if (lce_req_v_i) begin
-          mshr_n.lce_id = lce_req.src_id;
+          mshr_n.lce_id = lce_req.header.src_id;
           state_n = ERROR;
           // cached request
-          if (lce_req.msg_type == e_lce_req_type_rd | lce_req.msg_type == e_lce_req_type_wr) begin
-            mshr_n.paddr = lce_req.addr;
-            mshr_n.lru_way_id = lce_req.msg.req.lru_way_id;
-            mshr_n.flags[e_flag_sel_ldf] = lce_req.msg.req.lru_dirty;
-            mshr_n.flags[e_flag_sel_rqf] = (lce_req.msg_type == e_lce_req_type_wr);
-            mshr_n.flags[e_flag_sel_nerf] = lce_req.msg.req.non_exclusive;
+          if (lce_req.header.msg_type == e_lce_req_type_rd | lce_req.header.msg_type == e_lce_req_type_wr) begin
+            mshr_n.paddr = lce_req.header.addr;
+            mshr_n.lru_way_id = lce_req.header.lru_way_id;
+            mshr_n.flags[e_flag_sel_ldf] = lce_req.header.lru_dirty;
+            mshr_n.flags[e_flag_sel_rqf] = (lce_req.header.msg_type == e_lce_req_type_wr);
+            mshr_n.flags[e_flag_sel_nerf] = lce_req.header.non_exclusive;
 
             state_n = READ_PENDING;
 
           // uncached request
           // request will be dequeued in the next state
-          end else if (lce_req.msg_type == e_lce_req_type_uc_rd | lce_req.msg_type == e_lce_req_type_uc_wr) begin
-            mshr_n.paddr = lce_req.addr;
-            uc_data_n = lce_req.msg.uc_req.data;
-            mshr_n.uc_req_size = lce_req.msg.uc_req.uc_size;
+          end else if (lce_req.header.msg_type == e_lce_req_type_uc_rd | lce_req.header.msg_type == e_lce_req_type_uc_wr) begin
+            mshr_n.paddr = lce_req.header.addr;
+            uc_data_n = lce_req.data;
+            mshr_n.uc_req_size = lce_req.header.uc_size;
             mshr_n.flags[e_flag_sel_ucf] = 1'b1;
-            mshr_n.flags[e_flag_sel_rqf] = (lce_req.msg_type == e_lce_req_type_uc_wr);
+            mshr_n.flags[e_flag_sel_rqf] = (lce_req.header.msg_type == e_lce_req_type_uc_wr);
 
             state_n = UC_REQ;
           end
         end
-      end
+      end // READY
       UC_REQ: begin
+        // send uncached request to memory
+        mem_cmd_v_o = 1'b1;
+
         // Uncached Store
         if (mshr_r.flags[e_flag_sel_rqf]) begin
-          mem_cmd_v_o = 1'b1;
-          mem_cmd.msg_type = e_cce_mem_uc_wr;
-          mem_cmd.addr = mshr_r.paddr;
-          mem_cmd.payload.lce_id = mshr_r.lce_id;
-          mem_cmd.payload.way_id = '0;
-          mem_cmd.payload.speculative = '0;
+          mem_cmd.header.msg_type = e_cce_mem_uc_wr;
           mem_cmd.data = {{(cce_block_width_p-dword_width_p){1'b0}}, uc_data_r};
-          mem_cmd.size =
-            (bp_lce_cce_uc_req_size_e'(mshr_r.uc_req_size) == e_lce_uc_req_1)
-            ? e_mem_size_1
-            : (bp_lce_cce_uc_req_size_e'(mshr_r.uc_req_size) == e_lce_uc_req_2)
-              ? e_mem_size_2
-              : (bp_lce_cce_uc_req_size_e'(mshr_r.uc_req_size) == e_lce_uc_req_4)
-                ? e_mem_size_4
-                : e_mem_size_8
-            ;
-          state_n = (mem_cmd_ready_i) ? READY : UC_REQ;
-          lce_req_yumi_o = mem_cmd_ready_i;
-
         // Uncached Load
         end else begin
-          mem_cmd_v_o = 1'b1;
-          mem_cmd.msg_type = e_cce_mem_uc_rd;
-          mem_cmd.addr = mshr_r.paddr;
-          mem_cmd.payload.lce_id = mshr_r.lce_id;
-          mem_cmd.payload.way_id = '0;
-          mem_cmd.payload.speculative = '0;
-          mem_cmd.size =
-            (bp_lce_cce_uc_req_size_e'(mshr_r.uc_req_size) == e_lce_uc_req_1)
-            ? e_mem_size_1
-            : (bp_lce_cce_uc_req_size_e'(mshr_r.uc_req_size) == e_lce_uc_req_2)
-              ? e_mem_size_2
-              : (bp_lce_cce_uc_req_size_e'(mshr_r.uc_req_size) == e_lce_uc_req_4)
-                ? e_mem_size_4
-                : e_mem_size_8
-            ;
-          state_n = (mem_cmd_ready_i) ? READY : UC_REQ;
-          lce_req_yumi_o = mem_cmd_ready_i;
+          mem_cmd.header.msg_type = e_cce_mem_uc_rd;
         end
-      end
+
+        mem_cmd.header.addr = mshr_r.paddr;
+        mem_cmd.header.payload.lce_id = mshr_r.lce_id;
+        mem_cmd.header.payload.way_id = '0;
+        mem_cmd.header.payload.speculative = '0;
+        mem_cmd.header.size =
+          (bp_lce_cce_uc_req_size_e'(mshr_r.uc_req_size) == e_lce_uc_req_1)
+          ? e_mem_size_1
+          : (bp_lce_cce_uc_req_size_e'(mshr_r.uc_req_size) == e_lce_uc_req_2)
+            ? e_mem_size_2
+            : (bp_lce_cce_uc_req_size_e'(mshr_r.uc_req_size) == e_lce_uc_req_4)
+              ? e_mem_size_4
+              : e_mem_size_8
+          ;
+
+        lce_req_yumi_o = lce_req_v_i & mem_cmd_ready_i;
+
+        state_n = (lce_req_yumi_o)
+                  ? (cce_normal_mode)
+                    ? READY
+                    : UNCACHED_ONLY
+                  : UC_REQ;
+
+      end // UC_REQ
       READ_PENDING: begin
         pending_r_v = 1'b1;
         state_n = (pending_v_lo)
@@ -867,8 +908,7 @@ module bp_cce_fsm
           lce_req_yumi_o = 1'b1;
 
           pending_w_v = 1'b1;
-          pending_w_way_group =
-            lce_req.addr[(way_group_offset_high_lp-1) -: lg_num_way_groups_lp];
+          pending_w_way_group = lce_req_addr_wg_id_lo;
           pending_li = 1'b1;
 
         end else begin
@@ -882,14 +922,14 @@ module bp_cce_fsm
         // writing the pending bit
         if (~pending_busy) begin
           mem_cmd_v_o = 1'b1;
-          mem_cmd.msg_type = (mshr_r.flags[e_flag_sel_rqf]) ? e_cce_mem_wr : e_cce_mem_rd;
-          mem_cmd.addr = (mshr_r.paddr >> lg_block_size_in_bytes_lp) << lg_block_size_in_bytes_lp;
-          mem_cmd.size = e_mem_size_64;
-          mem_cmd.payload.lce_id = mshr_r.lce_id;
-          mem_cmd.payload.way_id = mshr_r.lru_way_id;
+          mem_cmd.header.msg_type = (mshr_r.flags[e_flag_sel_rqf]) ? e_cce_mem_wr : e_cce_mem_rd;
+          mem_cmd.header.addr = (mshr_r.paddr >> lg_block_size_in_bytes_lp) << lg_block_size_in_bytes_lp;
+          mem_cmd.header.size = e_mem_size_64;
+          mem_cmd.header.payload.lce_id = mshr_r.lce_id;
+          mem_cmd.header.payload.way_id = mshr_r.lru_way_id;
           // speculatively issue request for E state
-          mem_cmd.payload.state = e_COH_E;
-          mem_cmd.payload.speculative = 1'b1;
+          mem_cmd.header.payload.state = e_COH_E;
+          mem_cmd.header.payload.speculative = 1'b1;
 
           // set the spec bit and clear all other bits for this entry
           spec_w_v = mem_cmd_ready_i;
@@ -906,7 +946,7 @@ module bp_cce_fsm
 
           pending_w_v = mem_cmd_ready_i;
           pending_li = 1'b1;
-          pending_w_way_group = mshr_r.paddr[(way_group_offset_high_lp-1) -: lg_num_way_groups_lp];
+          pending_w_way_group = mshr_addr_wg_id_lo;
         end
 
       end
@@ -914,7 +954,7 @@ module bp_cce_fsm
         // initiate the directory read
         // At the earliest, data will be valid in the next cycle
         dir_r_v = 1'b1;
-        dir_way_group_li = mshr_r.paddr[way_group_offset_high_lp-1 -: lg_num_way_groups_lp];
+        dir_set_li = mshr_addr_wg_id_lo;
         dir_r_cmd = e_rdw_op;
         dir_lce_li = mshr_r.lce_id;
         dir_lru_way_li = mshr_r.lru_way_id;
@@ -974,7 +1014,7 @@ module bp_cce_fsm
 
         dir_w_v = 1'b1;
         dir_lce_li = mshr_r.lce_id;
-        dir_way_group_li = mshr_r.paddr[way_group_offset_high_lp-1 -: lg_num_way_groups_lp];
+        dir_set_li = mshr_addr_wg_id_lo;
         dir_coh_state_li = mshr_r.next_coh_state;
         if (mshr_r.flags[e_flag_sel_uf]) begin
           dir_w_cmd = e_wds_op;
@@ -994,10 +1034,12 @@ module bp_cce_fsm
               ? REPLACEMENT
               : (mshr_r.flags[e_flag_sel_tf])
                 ? TRANSFER_CMD
-                : READ_MEM;
+                : READY;
 
-        // squash speculative memory request if transfer or upgrade
+        // Resolve speculation
+
         if (mshr_r.flags[e_flag_sel_tf] || mshr_r.flags[e_flag_sel_uf]) begin
+          // squash speculative memory request if transfer or upgrade
           spec_w_v = 1'b1;
           // no longer speculative
           spec_v_li = 1'b1;
@@ -1005,6 +1047,29 @@ module bp_cce_fsm
           // squash the response
           squash_v_li = 1'b1;
           spec_bits_li.squash = 1'b1;
+        end else if (mshr_r.flags[e_flag_sel_rqf]) begin
+          // forward with M state
+          spec_w_v = 1'b1;
+          spec_v_li = 1'b1;
+          fwd_mod_v_li = 1'b1;
+          state_v_li = 1'b1;
+          spec_bits_li.spec = 1'b0;
+          spec_bits_li.state = e_COH_M;
+          spec_bits_li.fwd_mod = 1'b1;
+        end else if (mshr_r.flags[e_flag_sel_cf] | mshr_r.flags[e_flag_sel_nerf]) begin
+          // forward with S state
+          spec_w_v = 1'b1;
+          spec_v_li = 1'b1;
+          fwd_mod_v_li = 1'b1;
+          state_v_li = 1'b1;
+          spec_bits_li.spec = 1'b0;
+          spec_bits_li.state = e_COH_S;
+          spec_bits_li.fwd_mod = 1'b1;
+        end else begin
+          // forward with E state (as requested)
+          spec_w_v = 1'b1;
+          spec_v_li = 1'b1;
+          spec_bits_li.spec = 1'b0;
         end
 
         if (state_n == INV_CMD) begin
@@ -1024,20 +1089,20 @@ module bp_cce_fsm
           if (~lce_cmd_busy) begin
 
             lce_cmd_v_o = 1'b1;
-            lce_cmd.msg_type = e_lce_cmd_invalidate_tag;
+            lce_cmd.header.msg_type = e_lce_cmd_invalidate_tag;
 
             // destination and way come from sharers information
-            lce_cmd.dst_id = pe_lce_id;
-            lce_cmd.way_id = sharers_ways_r[pe_lce_id];
+            lce_cmd.header.dst_id = pe_lce_id;
+            lce_cmd.header.way_id = sharers_ways_r[pe_lce_id];
 
-            lce_cmd.msg.cmd.addr = mshr_r.paddr;
+            lce_cmd.header.addr = mshr_r.paddr;
 
             if (lce_cmd_ready_i) begin
               // message sent, increment count, write directory, clear bit for the destination LCE
               cnt_inc = 1'b1;
               dir_w_v = 1'b1;
               dir_w_cmd = e_wde_op;
-              dir_way_group_li = mshr_r.paddr[way_group_offset_high_lp-1 -: lg_num_way_groups_lp];
+              dir_set_li = mshr_addr_wg_id_lo;
               dir_lce_li = pe_lce_id;
               dir_way_li = sharers_ways_r[pe_lce_id];
               dir_tag_li = '0;
@@ -1064,7 +1129,7 @@ module bp_cce_fsm
         end // pe_v
 
         // dequeue responses as they arrive
-        if (lce_resp_v_i & (lce_resp.msg_type == e_lce_cce_inv_ack)) begin
+        if (lce_resp_v_i & (lce_resp.header.msg_type == e_lce_cce_inv_ack)) begin
           lce_resp_yumi_o = 1'b1;
           cnt_dec = 1'b1;
         end
@@ -1077,10 +1142,10 @@ module bp_cce_fsm
                       ? REPLACEMENT
                       : (mshr_r.flags[e_flag_sel_tf])
                         ? TRANSFER_CMD
-                        : READ_MEM;
+                        : READY;
         end else begin
           // dequeue responses as they arrive
-          if (lce_resp_v_i & (lce_resp.msg_type == e_lce_cce_inv_ack)) begin
+          if (lce_resp_v_i & (lce_resp.header.msg_type == e_lce_cce_inv_ack)) begin
             lce_resp_yumi_o = 1'b1;
             cnt_dec = 1'b1;
             if (cnt == 'd1) begin
@@ -1090,7 +1155,7 @@ module bp_cce_fsm
                           ? REPLACEMENT
                           : (mshr_r.flags[e_flag_sel_tf])
                             ? TRANSFER_CMD
-                            : READ_MEM;
+                            : READY;
             end // cnt == 'd1
           end // inv ack
         end // else
@@ -1101,53 +1166,52 @@ module bp_cce_fsm
           lce_cmd_v_o = 1'b1;
 
           // LCE Cmd Common Fields
-          lce_cmd.dst_id = mshr_r.lce_id;
-          lce_cmd.msg_type = e_lce_cmd_writeback;
-          lce_cmd.way_id = mshr_r.lru_way_id;
+          lce_cmd.header.dst_id = mshr_r.lce_id;
+          lce_cmd.header.msg_type = e_lce_cmd_writeback;
+          lce_cmd.header.way_id = mshr_r.lru_way_id;
 
           // Sub message fields
-          lce_cmd.msg.cmd.addr = mshr_r.lru_paddr;
+          lce_cmd.header.addr = mshr_r.lru_paddr;
 
           state_n = (lce_cmd_ready_i) ? REPLACEMENT_WB_RESP : REPLACEMENT;
         end
       end
       REPLACEMENT_WB_RESP: begin
         if (lce_resp_v_i) begin
-          if (lce_resp.msg_type == e_lce_cce_resp_null_wb) begin
+          if (lce_resp.header.msg_type == e_lce_cce_resp_null_wb) begin
             lce_resp_yumi_o = 1'b1;
             state_n = (mshr_r.flags[e_flag_sel_tf])
                       ? TRANSFER_CMD
-                      : READ_MEM;
+                      : READY;
             // clear the replacement flag
             mshr_n.flags[e_flag_sel_rf] = 1'b0;
             // set null writeback flag
             mshr_n.flags[e_flag_sel_nwbf] = 1'b1;
 
           end
-          else if ((lce_resp.msg_type == e_lce_cce_resp_wb) & ~pending_busy) begin
+          else if ((lce_resp.header.msg_type == e_lce_cce_resp_wb) & ~pending_busy) begin
             // Mem Data Cmd needs to write pending bit, so only send if Mem Data Resp / LCE Data Cmd is
             // not writing the pending bit
             mem_cmd_v_o = lce_resp_v_i;
             lce_resp_yumi_o = lce_resp_v_i & mem_cmd_ready_i;
 
-            mem_cmd.msg_type = e_cce_mem_wb;
-            mem_cmd.addr = (lce_resp.addr >> lg_block_size_in_bytes_lp) << lg_block_size_in_bytes_lp;
-            mem_cmd.payload.lce_id = mshr_r.lce_id;
-            mem_cmd.payload.way_id = '0;
+            mem_cmd.header.msg_type = e_cce_mem_wb;
+            mem_cmd.header.addr = (lce_resp.header.addr >> lg_block_size_in_bytes_lp) << lg_block_size_in_bytes_lp;
+            mem_cmd.header.payload.lce_id = mshr_r.lce_id;
+            mem_cmd.header.payload.way_id = '0;
             mem_cmd.data = lce_resp.data;
-            mem_cmd.size = e_mem_size_64;
+            mem_cmd.header.size = e_mem_size_64;
 
             state_n = (lce_resp_yumi_o)
                       ? (mshr_r.flags[e_flag_sel_tf])
                         ? TRANSFER_CMD
-                        : READ_MEM
+                        : READY
                       : REPLACEMENT_WB_RESP;
 
             // set the pending bit
             pending_w_v = lce_resp_yumi_o;
             pending_li = 1'b1;
-            pending_w_way_group =
-              lce_resp.addr[(way_group_offset_high_lp-1) -: lg_num_way_groups_lp];
+            pending_w_way_group = lce_resp_addr_wg_id_lo;
 
             // clear the replacement flag
             mshr_n.flags[e_flag_sel_rf] = 1'b0;
@@ -1162,15 +1226,15 @@ module bp_cce_fsm
           lce_cmd_v_o = 1'b1;
 
           // LCE Cmd Common Fields
-          lce_cmd.dst_id = mshr_r.tr_lce_id;
-          lce_cmd.msg_type = e_lce_cmd_transfer;
-          lce_cmd.way_id = mshr_r.tr_way_id;
+          lce_cmd.header.dst_id = mshr_r.tr_lce_id;
+          lce_cmd.header.msg_type = e_lce_cmd_transfer;
+          lce_cmd.header.way_id = mshr_r.tr_way_id;
 
           // Sub message fields
-          lce_cmd.msg.cmd.addr = mshr_r.paddr;
-          lce_cmd.msg.cmd.target = mshr_r.lce_id;
-          lce_cmd.msg.cmd.target_way_id = mshr_r.lru_way_id;
-          lce_cmd.msg.cmd.state = mshr_r.next_coh_state;
+          lce_cmd.header.addr = mshr_r.paddr;
+          lce_cmd.header.target = mshr_r.lce_id;
+          lce_cmd.header.target_way_id = mshr_r.lru_way_id;
+          lce_cmd.header.state = mshr_r.next_coh_state;
 
           state_n = (lce_cmd_ready_i) ? TRANSFER_WB_CMD : TRANSFER_CMD;
         end
@@ -1180,44 +1244,43 @@ module bp_cce_fsm
           lce_cmd_v_o = 1'b1;
 
           // LCE Cmd Common Fields
-          lce_cmd.dst_id = mshr_r.tr_lce_id;
-          lce_cmd.msg_type = e_lce_cmd_writeback;
-          lce_cmd.way_id = mshr_r.tr_way_id;
+          lce_cmd.header.dst_id = mshr_r.tr_lce_id;
+          lce_cmd.header.msg_type = e_lce_cmd_writeback;
+          lce_cmd.header.way_id = mshr_r.tr_way_id;
 
           // Sub message fields
-          lce_cmd.msg.cmd.addr = mshr_r.paddr;
+          lce_cmd.header.addr = mshr_r.paddr;
 
           state_n = (lce_cmd_ready_i) ? TRANSFER_WB_RESP : TRANSFER_WB_CMD;
         end
       end
       TRANSFER_WB_RESP: begin
         if (lce_resp_v_i) begin
-          if (lce_resp.msg_type == e_lce_cce_resp_null_wb) begin
+          if (lce_resp.header.msg_type == e_lce_cce_resp_null_wb) begin
             lce_resp_yumi_o = 1'b1;
             state_n = READY;
             mshr_n = '0;
 
           end
-          else if ((lce_resp.msg_type == e_lce_cce_resp_wb) & ~pending_busy) begin
+          else if ((lce_resp.header.msg_type == e_lce_cce_resp_wb) & ~pending_busy) begin
             // Mem Data Cmd needs to write pending bit, so only send if Mem Data Resp / LCE Data Cmd is
             // not writing the pending bit
             mem_cmd_v_o = lce_resp_v_i;
             lce_resp_yumi_o = lce_resp_v_i & mem_cmd_ready_i;
 
-            mem_cmd.msg_type = e_cce_mem_wb;
-            mem_cmd.addr = (lce_resp.addr >> lg_block_size_in_bytes_lp) << lg_block_size_in_bytes_lp;
-            mem_cmd.payload.lce_id = mshr_r.lce_id;
-            mem_cmd.payload.way_id = '0;
+            mem_cmd.header.msg_type = e_cce_mem_wb;
+            mem_cmd.header.addr = (lce_resp.header.addr >> lg_block_size_in_bytes_lp) << lg_block_size_in_bytes_lp;
+            mem_cmd.header.payload.lce_id = mshr_r.lce_id;
+            mem_cmd.header.payload.way_id = '0;
             mem_cmd.data = lce_resp.data;
-            mem_cmd.size = e_mem_size_64;
+            mem_cmd.header.size = e_mem_size_64;
 
             state_n = (lce_resp_yumi_o) ? READY : TRANSFER_WB_RESP;
 
             // set the pending bit
             pending_w_v = lce_resp_yumi_o;
             pending_li = 1'b1;
-            pending_w_way_group =
-              lce_resp.addr[(way_group_offset_high_lp-1) -: lg_num_way_groups_lp];
+            pending_w_way_group = lce_resp_addr_wg_id_lo;
 
           end
         end
@@ -1227,58 +1290,30 @@ module bp_cce_fsm
           lce_cmd_v_o = 1'b1;
 
           // LCE Cmd Common Fields
-          lce_cmd.dst_id = mshr_r.lce_id;
-          lce_cmd.msg_type = e_lce_cmd_set_tag_wakeup;
-          lce_cmd.way_id = mshr_r.way_id;
+          lce_cmd.header.dst_id = mshr_r.lce_id;
+          lce_cmd.header.msg_type = e_lce_cmd_set_tag_wakeup;
+          lce_cmd.header.way_id = mshr_r.way_id;
 
           // Sub message fields
-          lce_cmd.msg.cmd.addr = mshr_r.paddr;
-          lce_cmd.msg.cmd.state = mshr_r.next_coh_state;
+          lce_cmd.header.addr = mshr_r.paddr;
+          lce_cmd.header.state = mshr_r.next_coh_state;
 
           state_n = (lce_cmd_ready_i) ? READY : UPGRADE_STW_CMD;
           mshr_n = (lce_cmd_ready_i) ? '0 : mshr_r;
         end
-      end
-      READ_MEM: begin
-        // request was already issued to mem, resolve the speculation now
-        if (mshr_r.flags[e_flag_sel_rqf]) begin
-          // forward with M state
-          spec_w_v = 1'b1;
-          spec_v_li = 1'b1;
-          fwd_mod_v_li = 1'b1;
-          state_v_li = 1'b1;
-          spec_bits_li.spec = 1'b0;
-          spec_bits_li.state = e_COH_M;
-          spec_bits_li.fwd_mod = 1'b1;
-        end else if (mshr_r.flags[e_flag_sel_cf] | mshr_r.flags[e_flag_sel_nerf]) begin
-          // forward with S state
-          spec_w_v = 1'b1;
-          spec_v_li = 1'b1;
-          fwd_mod_v_li = 1'b1;
-          state_v_li = 1'b1;
-          spec_bits_li.spec = 1'b0;
-          spec_bits_li.state = e_COH_S;
-          spec_bits_li.fwd_mod = 1'b1;
-        end else begin
-          // forward with E state (as requested)
-          spec_w_v = 1'b1;
-          spec_v_li = 1'b1;
-          spec_bits_li.spec = 1'b0;
-        end
-        state_n = READY;
       end
       SEND_SET_TAG: begin
         $error("SEND_SET_TAG");
         lce_cmd_v_o = 1'b1;
 
         // LCE Cmd Common Fields
-        lce_cmd.dst_id = mshr_r.lce_id;
-        lce_cmd.msg_type = e_lce_cmd_set_tag;
-        lce_cmd.way_id = mshr_r.lru_way_id;
+        lce_cmd.header.dst_id = mshr_r.lce_id;
+        lce_cmd.header.msg_type = e_lce_cmd_set_tag;
+        lce_cmd.header.way_id = mshr_r.lru_way_id;
 
         // Sub message fields
-        lce_cmd.msg.cmd.addr = mshr_r.paddr;
-        lce_cmd.msg.cmd.state = mshr_r.next_coh_state;
+        lce_cmd.header.addr = mshr_r.paddr;
+        lce_cmd.header.state = mshr_r.next_coh_state;
 
         state_n = (lce_cmd_ready_i) ? READY : SEND_SET_TAG;
         mshr_n = (lce_cmd_ready_i) ? '0 : mshr_r;


### PR DESCRIPTION
Update the FSM CCE.

regress_riscv.v/sc and regress_beebs.v passed
spot checks on 2, 4, and 8 core using atomic_queue_demo and mc_xxx tests passed under VCS

This change commits only the updates to the FSM CCE and does not replace the ucode CCE with the FSM CCE in the design. Additional (simple) change is required to substitute in the FSM CCE for use.