### PR TITLE
Fix be_mem_top Assertion

### DIFF
--- a/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
@@ -519,7 +519,7 @@ always_ff @(posedge clk_i)
 
 always_ff @(negedge clk_i)
   begin
-    assert (~(mmu_cmd_v_r & dtlb_r_v_lo & dcache_uncached & (mmu_cmd_r.mem_op inside {e_lrw, e_lrd, e_scw, e_scd})))
+    assert ((reset_i !== 1'b0) || ~(mmu_cmd_v_r & dtlb_r_v_lo & dcache_uncached & (mmu_cmd_r.mem_op inside {e_lrw, e_lrd, e_scw, e_scd})))
       else $warning("LR/SC to uncached memory not supported");
   end
 


### PR DESCRIPTION
Originally, when some signals are X, it will be evaluated to ~X which is still X, printing out warning message in simulation.

This fix ensures that when reset_i !== 1'b0 (when it is 1'b1, X or Z), assertion will not be triggered.