### PR TITLE
prevent bp_mem_transducer from overwriting current request

### DIFF
--- a/bp_me/test/common/bp_mem_transducer.v
+++ b/bp_me/test/common/bp_mem_transducer.v
@@ -75,7 +75,7 @@ module bp_mem_transducer
   wire [cce_block_width_p-1:0]    rd_bit_shift = rd_word_offset*dword_width_p; // We rely on receiver to adjust bits
   wire [cce_block_width_p-1:0]   rd_byte_shift = rd_word_offset*num_word_bytes_lp;
 
-  assign v_o = mem_cmd_v_i;
+  assign v_o = mem_cmd_v_i & ready_i;
   assign w_o = v_o & (mem_cmd_cast_i.header.msg_type inside {e_cce_mem_uc_wr, e_cce_mem_wb});
   assign addr_o = (((mem_cmd_cast_i.header.addr - dram_offset_p) >> block_offset_bits_lp) << block_offset_bits_lp);
   assign data_o = mem_cmd_cast_i.data << wr_bit_shift;


### PR DESCRIPTION
In bp_mem, the transducer may accept a new request when it is already processing a request. This causes the initial request to be overwritten, and bp_mem to send back an incorrect response to the first request.