### PR TITLE
Add configs that use FSM CCE, parameterized CCE instantiation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,6 +93,8 @@ hotfix_job:
     - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_processor CFG=e_bp_single_core_cfg" bp_top &
     - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_processor CFG=e_bp_quad_core_cfg" bp_top &
     - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_softcore" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_processor CFG=e_bp_single_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_processor CFG=e_bp_quad_core_ucode_cce_cfg" bp_top &
     - wait
   cache:
     key: "dev"
@@ -132,6 +134,8 @@ check-design:
     - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_processor CFG=e_bp_single_core_cfg" bp_top &
     - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_processor CFG=e_bp_quad_core_cfg" bp_top &
     - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_softcore" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_processor CFG=e_bp_single_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_processor CFG=e_bp_quad_core_ucode_cce_cfg" bp_top &
     - wait
       
 lint-verilator:
@@ -195,15 +199,33 @@ top-mc-verilator:
     - $CI_PROJECT_DIR/ci/regress.sh "mc_sanity_1.sc CFG=e_bp_single_core_cfg" bp_top &
     - $CI_PROJECT_DIR/ci/regress.sh "mc_sanity_2.sc CFG=e_bp_dual_core_cfg" bp_top &
     - $CI_PROJECT_DIR/ci/regress.sh "mc_sanity_4.sc CFG=e_bp_quad_core_cfg" bp_top &
-    - $CI_PROJECT_DIR/ci/regress.sh "mc_sanity_1.sc CFG=e_bp_single_core_cfg" bp_top &
-    - $CI_PROJECT_DIR/ci/regress.sh "mc_sanity_2.sc CFG=e_bp_dual_core_cfg" bp_top &
-    - $CI_PROJECT_DIR/ci/regress.sh "mc_sanity_4.sc CFG=e_bp_quad_core_cfg" bp_top &
     - $CI_PROJECT_DIR/ci/regress.sh "mc_rand_walk_1.sc CFG=e_bp_single_core_cfg" bp_top &
     - $CI_PROJECT_DIR/ci/regress.sh "mc_rand_walk_2.sc CFG=e_bp_dual_core_cfg" bp_top &
     - $CI_PROJECT_DIR/ci/regress.sh "mc_rand_walk_4.sc CFG=e_bp_quad_core_cfg" bp_top &
     - $CI_PROJECT_DIR/ci/regress.sh "mc_work_share_sort_1.sc CFG=e_bp_single_core_cfg" bp_top &
     - $CI_PROJECT_DIR/ci/regress.sh "mc_work_share_sort_2.sc CFG=e_bp_dual_core_cfg" bp_top &
     - $CI_PROJECT_DIR/ci/regress.sh "mc_work_share_sort_4.sc CFG=e_bp_quad_core_cfg" bp_top &
+    - wait
+
+top-mc-verilator-ucode:
+  <<: *job_definition
+  when: manual
+  stage: test-medium
+  tags:
+    - verilator
+  script:
+    - make -C bp_top/syn build.sc CFG=e_bp_single_core_ucode_cce_cfg
+    - make -C bp_top/syn build.sc CFG=e_bp_dual_core_ucode_cce_cfg
+    - make -C bp_top/syn build.sc CFG=e_bp_quad_core_ucode_cce_cfg
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_sanity_1.sc CFG=e_bp_single_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_sanity_2.sc CFG=e_bp_dual_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_sanity_4.sc CFG=e_bp_quad_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_rand_walk_1.sc CFG=e_bp_single_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_rand_walk_2.sc CFG=e_bp_dual_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_rand_walk_4.sc CFG=e_bp_quad_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_work_share_sort_1.sc CFG=e_bp_single_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_work_share_sort_2.sc CFG=e_bp_dual_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_work_share_sort_4.sc CFG=e_bp_quad_core_ucode_cce_cfg" bp_top &
     - wait
 
 lint-vcs:
@@ -310,5 +332,33 @@ top-mc-vcs:
     - $CI_PROJECT_DIR/ci/regress.sh "mc_work_share_sort_4.v TB=bp_processor CFG=e_bp_quad_core_cfg" bp_top &
     - $CI_PROJECT_DIR/ci/regress.sh "mc_work_share_sort_8.v TB=bp_processor CFG=e_bp_oct_core_cfg" bp_top &
     - $CI_PROJECT_DIR/ci/regress.sh "mc_work_share_sort_16.v TB=bp_processor CFG=e_bp_sexta_core_cfg" bp_top &
+    - wait
+
+top-mc-vcs-ucode:
+  <<: *job_definition
+  stage: test-medium
+  tags:
+    - vcs
+  script:
+    - make -C bp_top/syn build.v TB=bp_processor CFG=e_bp_single_core_ucode_cce_cfg
+    - make -C bp_top/syn build.v TB=bp_processor CFG=e_bp_dual_core_ucode_cce_cfg
+    - make -C bp_top/syn build.v TB=bp_processor CFG=e_bp_quad_core_ucode_cce_cfg
+    - make -C bp_top/syn build.v TB=bp_processor CFG=e_bp_oct_core_ucode_cce_cfg
+    - make -C bp_top/syn build.v TB=bp_processor CFG=e_bp_sexta_core_ucode_cce_cfg
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_sanity_1.v TB=bp_processor CFG=e_bp_single_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_sanity_2.v TB=bp_processor CFG=e_bp_dual_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_sanity_4.v TB=bp_processor CFG=e_bp_quad_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_sanity_8.v TB=bp_processor CFG=e_bp_oct_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_sanity_16.v TB=bp_processor CFG=e_bp_sexta_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_rand_walk_1.v TB=bp_processor CFG=e_bp_single_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_rand_walk_2.v TB=bp_processor CFG=e_bp_dual_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_rand_walk_4.v TB=bp_processor CFG=e_bp_quad_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_rand_walk_8.v TB=bp_processor CFG=e_bp_oct_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_rand_walk_16.v TB=bp_processor CFG=e_bp_sexta_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_work_share_sort_1.v TB=bp_processor CFG=e_bp_single_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_work_share_sort_2.v TB=bp_processor CFG=e_bp_dual_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_work_share_sort_4.v TB=bp_processor CFG=e_bp_quad_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_work_share_sort_8.v TB=bp_processor CFG=e_bp_oct_core_ucode_cce_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "mc_work_share_sort_16.v TB=bp_processor CFG=e_bp_sexta_core_ucode_cce_cfg" bp_top &
     - wait
 

--- a/bp_common/src/include/bp_common_aviary_defines.vh
+++ b/bp_common/src/include/bp_common_aviary_defines.vh
@@ -130,6 +130,7 @@ typedef struct packed
 
   integer cce_block_width;
   integer cce_pc_width;
+  integer ucode_cce;
 
   integer l2_en;
   integer l2_sets;
@@ -241,6 +242,7 @@ typedef struct packed
   , localparam num_cce_instr_ram_els_p    = 2**cce_pc_width_p                                      \
   , localparam cce_way_groups_p           = `BSG_MAX(dcache_sets_p, icache_sets_p)                 \
   , localparam cce_instr_width_p          = 34                                                     \
+  , localparam ucode_cce_p                = proc_param_lp.ucode_cce                                \
                                                                                                    \
   , localparam l2_en_p    = proc_param_lp.l2_en                                                    \
   , localparam l2_sets_p  = proc_param_lp.l2_sets                                                  \

--- a/bp_common/src/include/bp_common_aviary_pkg.vh
+++ b/bp_common/src/include/bp_common_aviary_pkg.vh
@@ -6,10 +6,9 @@ package bp_common_aviary_pkg;
   localparam max_cfgs    = 128;
   localparam lg_max_cfgs = `BSG_SAFE_CLOG2(max_cfgs);
 
-  localparam bp_proc_param_s bp_inv_cfg_p = 
+  localparam bp_proc_param_s bp_inv_cfg_p =
     '{default: 1};
 
-  // NOTE: To use this config, need to manually override CCE=1 and LCE=1 at instantiation
   localparam bp_proc_param_s bp_half_core_cfg_p =
     '{cc_x_dim   : 1
       ,cc_y_dim  : 1
@@ -44,6 +43,7 @@ package bp_common_aviary_pkg;
 
       ,cce_block_width      : 512
       ,cce_pc_width         : 8
+      ,ucode_cce            : 0
 
       ,l2_en   : 1
       ,l2_sets : 128
@@ -72,7 +72,7 @@ package bp_common_aviary_pkg;
       ,io_noc_len_width     : 4
       };
 
-  localparam bp_proc_param_s bp_softcore_cfg_p = 
+  localparam bp_proc_param_s bp_softcore_cfg_p =
     '{cc_x_dim   : 1
       ,cc_y_dim  : 1
       ,ic_y_dim  : 1
@@ -87,13 +87,13 @@ package bp_common_aviary_pkg;
       ,vaddr_width: 39
       ,paddr_width: 40
       ,asid_width : 1
-      
+
       ,branch_metadata_fwd_width: 28
       ,btb_tag_width            : 10
       ,btb_idx_width            : 6
       ,bht_idx_width            : 9
       ,ras_idx_width            : 2
-      
+
       ,itlb_els             : 8
       ,dtlb_els             : 8
 
@@ -106,6 +106,7 @@ package bp_common_aviary_pkg;
 
       ,cce_block_width      : 512
       ,cce_pc_width         : 8
+      ,ucode_cce            : 0
 
       ,l2_en   : 1
       ,l2_sets : 128
@@ -168,6 +169,7 @@ package bp_common_aviary_pkg;
 
       ,cce_block_width      : 512
       ,cce_pc_width         : 8
+      ,ucode_cce            : 0
 
       ,l2_en   : 0
       ,l2_sets : 128
@@ -196,7 +198,6 @@ package bp_common_aviary_pkg;
       ,io_noc_len_width     : 4
       };
 
-
   localparam bp_proc_param_s bp_single_core_cfg_p = 
     '{cc_x_dim   : 1
       ,cc_y_dim  : 1
@@ -212,13 +213,13 @@ package bp_common_aviary_pkg;
       ,vaddr_width: 39
       ,paddr_width: 40
       ,asid_width : 1
-      
+
       ,branch_metadata_fwd_width: 28
       ,btb_tag_width            : 10
       ,btb_idx_width            : 6
       ,bht_idx_width            : 9
       ,ras_idx_width            : 2
-      
+
       ,itlb_els             : 8
       ,dtlb_els             : 8
 
@@ -231,6 +232,7 @@ package bp_common_aviary_pkg;
 
       ,cce_block_width      : 512
       ,cce_pc_width         : 8
+      ,ucode_cce            : 0
 
       ,l2_en   : 1
       ,l2_sets : 128
@@ -293,6 +295,7 @@ package bp_common_aviary_pkg;
 
       ,cce_block_width      : 512
       ,cce_pc_width         : 8
+      ,ucode_cce            : 0
 
       ,l2_en   : 0
       ,l2_sets : 128
@@ -321,7 +324,7 @@ package bp_common_aviary_pkg;
       ,io_noc_len_width     : 4
       };
 
-  localparam bp_proc_param_s bp_dual_core_cfg_p = 
+  localparam bp_proc_param_s bp_dual_core_cfg_p =
     '{cc_x_dim   : 2
       ,cc_y_dim  : 1
       ,ic_y_dim  : 1
@@ -336,16 +339,16 @@ package bp_common_aviary_pkg;
       ,vaddr_width: 39
       ,paddr_width: 40
       ,asid_width : 1
-      
+
       ,branch_metadata_fwd_width: 28
       ,btb_tag_width            : 10
       ,btb_idx_width            : 6
       ,bht_idx_width            : 9
       ,ras_idx_width            : 2
-      
+
       ,itlb_els             : 8
       ,dtlb_els             : 8
-      
+
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,icache_sets          : 64
@@ -355,6 +358,7 @@ package bp_common_aviary_pkg;
 
       ,cce_block_width      : 512
       ,cce_pc_width         : 8
+      ,ucode_cce            : 0
 
       ,l2_en   : 1
       ,l2_sets : 128
@@ -383,7 +387,7 @@ package bp_common_aviary_pkg;
       ,io_noc_len_width     : 4
       };
 
-  localparam bp_proc_param_s bp_tri_core_cfg_p = 
+  localparam bp_proc_param_s bp_tri_core_cfg_p =
     '{cc_x_dim   : 3
       ,cc_y_dim  : 1
       ,ic_y_dim  : 1
@@ -398,16 +402,16 @@ package bp_common_aviary_pkg;
       ,vaddr_width: 39
       ,paddr_width: 40
       ,asid_width : 1
-      
+
       ,branch_metadata_fwd_width: 28
       ,btb_tag_width            : 10
       ,btb_idx_width            : 6
       ,bht_idx_width            : 9
       ,ras_idx_width            : 2
-      
+
       ,itlb_els             : 8
       ,dtlb_els             : 8
-      
+
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,icache_sets          : 64
@@ -417,6 +421,7 @@ package bp_common_aviary_pkg;
 
       ,cce_block_width      : 512
       ,cce_pc_width         : 8
+      ,ucode_cce            : 0
 
       ,l2_en   : 1
       ,l2_sets : 128
@@ -479,6 +484,7 @@ package bp_common_aviary_pkg;
 
       ,cce_block_width      : 512
       ,cce_pc_width         : 8
+      ,ucode_cce            : 0
 
       ,l2_en   : 1
       ,l2_sets : 128
@@ -541,6 +547,7 @@ package bp_common_aviary_pkg;
 
       ,cce_block_width      : 512
       ,cce_pc_width         : 8
+      ,ucode_cce            : 0
 
       ,l2_en   : 1
       ,l2_sets : 128
@@ -603,6 +610,7 @@ package bp_common_aviary_pkg;
 
       ,cce_block_width      : 512
       ,cce_pc_width         : 8
+      ,ucode_cce            : 0
 
       ,l2_en   : 1
       ,l2_sets : 128
@@ -665,6 +673,7 @@ package bp_common_aviary_pkg;
 
       ,cce_block_width      : 512
       ,cce_pc_width         : 8
+      ,ucode_cce            : 0
 
       ,l2_en   : 1
       ,l2_sets : 128
@@ -727,6 +736,7 @@ package bp_common_aviary_pkg;
 
       ,cce_block_width      : 512
       ,cce_pc_width         : 8
+      ,ucode_cce            : 0
 
       ,l2_en   : 1
       ,l2_sets : 128
@@ -789,6 +799,7 @@ package bp_common_aviary_pkg;
 
       ,cce_block_width      : 512
       ,cce_pc_width         : 8
+      ,ucode_cce            : 0
 
       ,l2_en   : 1
       ,l2_sets : 128
@@ -851,6 +862,7 @@ package bp_common_aviary_pkg;
 
       ,cce_block_width      : 512
       ,cce_pc_width         : 8
+      ,ucode_cce            : 0
 
       ,l2_en   : 1
       ,l2_sets : 128
@@ -878,9 +890,587 @@ package bp_common_aviary_pkg;
       ,io_noc_cid_width     : 2
       ,io_noc_len_width     : 4
       };
-   
+
+  localparam bp_proc_param_s bp_half_core_ucode_cce_cfg_p =
+    '{cc_x_dim   : 1
+      ,cc_y_dim  : 1
+      ,ic_y_dim  : 1
+      ,mc_y_dim  : 0
+      ,cac_x_dim : 0
+      ,sac_x_dim : 0
+      ,cacc_type : e_cacc_vdp
+      ,sacc_type : e_sacc_vdp
+
+      ,coherent_l1: 1
+
+      ,vaddr_width: 39
+      ,paddr_width: 40
+      ,asid_width : 1
+
+      ,branch_metadata_fwd_width: 28
+      ,btb_tag_width            : 10
+      ,btb_idx_width            : 6
+      ,bht_idx_width            : 9
+      ,ras_idx_width            : 2
+
+      ,itlb_els             : 8
+      ,dtlb_els             : 8
+
+      ,dcache_sets          : 64
+      ,dcache_assoc         : 8
+      ,icache_sets          : 64
+      ,icache_assoc         : 8
+      ,acache_sets          : 64
+      ,acache_assoc         : 8
+
+      ,cce_block_width      : 512
+      ,cce_pc_width         : 8
+      ,ucode_cce            : 1
+
+      ,l2_en   : 1
+      ,l2_sets : 128
+      ,l2_assoc: 8
+
+      ,fe_queue_fifo_els: 8
+      ,fe_cmd_fifo_els  : 4
+
+      ,async_coh_clk       : 0
+      ,coh_noc_max_credits : 8
+      ,coh_noc_flit_width  : 128
+      ,coh_noc_cid_width   : 2
+      ,coh_noc_len_width   : 3
+
+      ,async_mem_clk         : 1
+      ,mem_noc_max_credits   : 8
+      ,mem_noc_flit_width    : 64
+      ,mem_noc_cid_width     : 2
+      ,mem_noc_len_width     : 4
+
+      ,async_io_clk         : 1
+      ,io_noc_did_width     : 3
+      ,io_noc_max_credits   : 16
+      ,io_noc_flit_width    : 64
+      ,io_noc_cid_width     : 2
+      ,io_noc_len_width     : 4
+      };
+
+  localparam bp_proc_param_s bp_single_core_ucode_cce_cfg_p =
+    '{cc_x_dim   : 1
+      ,cc_y_dim  : 1
+      ,ic_y_dim  : 1
+      ,mc_y_dim  : 0
+      ,cac_x_dim : 0
+      ,sac_x_dim : 0
+      ,cacc_type : e_cacc_vdp
+      ,sacc_type : e_sacc_vdp
+
+      ,coherent_l1: 1
+
+      ,vaddr_width: 39
+      ,paddr_width: 40
+      ,asid_width : 1
+
+      ,branch_metadata_fwd_width: 28
+      ,btb_tag_width            : 10
+      ,btb_idx_width            : 6
+      ,bht_idx_width            : 9
+      ,ras_idx_width            : 2
+
+      ,itlb_els             : 8
+      ,dtlb_els             : 8
+
+      ,dcache_sets          : 64
+      ,dcache_assoc         : 8
+      ,icache_sets          : 64
+      ,icache_assoc         : 8
+      ,acache_sets          : 64
+      ,acache_assoc         : 8
+
+      ,cce_block_width      : 512
+      ,cce_pc_width         : 8
+      ,ucode_cce            : 1
+
+      ,l2_en   : 1
+      ,l2_sets : 128
+      ,l2_assoc: 8
+
+      ,fe_queue_fifo_els: 8
+      ,fe_cmd_fifo_els  : 4
+
+      ,async_coh_clk       : 0
+      ,coh_noc_max_credits : 8
+      ,coh_noc_flit_width  : 128
+      ,coh_noc_cid_width   : 2
+      ,coh_noc_len_width   : 3
+
+      ,async_mem_clk         : 1
+      ,mem_noc_max_credits   : 8
+      ,mem_noc_flit_width    : 64
+      ,mem_noc_cid_width     : 2
+      ,mem_noc_len_width     : 4
+
+      ,async_io_clk         : 1
+      ,io_noc_did_width     : 3
+      ,io_noc_max_credits   : 16
+      ,io_noc_flit_width    : 64
+      ,io_noc_cid_width     : 2
+      ,io_noc_len_width     : 4
+      };
+
+  localparam bp_proc_param_s bp_dual_core_ucode_cce_cfg_p =
+    '{cc_x_dim   : 2
+      ,cc_y_dim  : 1
+      ,ic_y_dim  : 1
+      ,mc_y_dim  : 0
+      ,cac_x_dim : 0
+      ,sac_x_dim : 0
+      ,cacc_type : e_cacc_vdp
+      ,sacc_type : e_sacc_vdp
+
+      ,coherent_l1: 1
+
+      ,vaddr_width: 39
+      ,paddr_width: 40
+      ,asid_width : 1
+
+      ,branch_metadata_fwd_width: 28
+      ,btb_tag_width            : 10
+      ,btb_idx_width            : 6
+      ,bht_idx_width            : 9
+      ,ras_idx_width            : 2
+
+      ,itlb_els             : 8
+      ,dtlb_els             : 8
+
+      ,dcache_sets          : 64
+      ,dcache_assoc         : 8
+      ,icache_sets          : 64
+      ,icache_assoc         : 8
+      ,acache_sets          : 64
+      ,acache_assoc         : 8
+
+      ,cce_block_width      : 512
+      ,cce_pc_width         : 8
+      ,ucode_cce            : 1
+
+      ,l2_en   : 1
+      ,l2_sets : 128
+      ,l2_assoc: 8
+
+      ,fe_queue_fifo_els: 8
+      ,fe_cmd_fifo_els  : 4
+
+      ,async_coh_clk       : 0
+      ,coh_noc_max_credits : 8
+      ,coh_noc_flit_width  : 128
+      ,coh_noc_cid_width   : 2
+      ,coh_noc_len_width   : 3
+
+      ,async_mem_clk         : 1
+      ,mem_noc_max_credits   : 8
+      ,mem_noc_flit_width    : 64
+      ,mem_noc_cid_width     : 2
+      ,mem_noc_len_width     : 4
+
+      ,async_io_clk         : 1
+      ,io_noc_did_width     : 3
+      ,io_noc_max_credits   : 16
+      ,io_noc_flit_width    : 64
+      ,io_noc_cid_width     : 2
+      ,io_noc_len_width     : 4
+      };
+
+  localparam bp_proc_param_s bp_tri_core_ucode_cce_cfg_p =
+    '{cc_x_dim   : 3
+      ,cc_y_dim  : 1
+      ,ic_y_dim  : 1
+      ,mc_y_dim  : 0
+      ,cac_x_dim : 0
+      ,sac_x_dim : 0
+      ,cacc_type : e_cacc_vdp
+      ,sacc_type : e_sacc_vdp
+
+      ,coherent_l1: 1
+
+      ,vaddr_width: 39
+      ,paddr_width: 40
+      ,asid_width : 1
+
+      ,branch_metadata_fwd_width: 28
+      ,btb_tag_width            : 10
+      ,btb_idx_width            : 6
+      ,bht_idx_width            : 9
+      ,ras_idx_width            : 2
+
+      ,itlb_els             : 8
+      ,dtlb_els             : 8
+
+      ,dcache_sets          : 64
+      ,dcache_assoc         : 8
+      ,icache_sets          : 64
+      ,icache_assoc         : 8
+      ,acache_sets          : 64
+      ,acache_assoc         : 8
+
+      ,cce_block_width      : 512
+      ,cce_pc_width         : 8
+      ,ucode_cce            : 1
+
+      ,l2_en   : 1
+      ,l2_sets : 128
+      ,l2_assoc: 8
+
+      ,fe_queue_fifo_els: 8
+      ,fe_cmd_fifo_els  : 4
+
+      ,async_coh_clk       : 0
+      ,coh_noc_max_credits : 8
+      ,coh_noc_flit_width  : 128
+      ,coh_noc_cid_width   : 2
+      ,coh_noc_len_width   : 3
+
+      ,async_mem_clk         : 1
+      ,mem_noc_max_credits   : 8
+      ,mem_noc_flit_width    : 64
+      ,mem_noc_cid_width     : 2
+      ,mem_noc_len_width     : 4
+
+      ,async_io_clk         : 1
+      ,io_noc_did_width     : 3
+      ,io_noc_max_credits   : 16
+      ,io_noc_flit_width    : 64
+      ,io_noc_cid_width     : 2
+      ,io_noc_len_width     : 4
+      };
+
+  localparam bp_proc_param_s bp_quad_core_ucode_cce_cfg_p =
+    '{cc_x_dim   : 2
+      ,cc_y_dim  : 2
+      ,ic_y_dim  : 1
+      ,mc_y_dim  : 0
+      ,cac_x_dim : 0
+      ,sac_x_dim : 0
+      ,cacc_type : e_cacc_vdp
+      ,sacc_type : e_sacc_vdp
+
+      ,coherent_l1: 1
+
+      ,vaddr_width: 39
+      ,paddr_width: 40
+      ,asid_width : 1
+
+      ,branch_metadata_fwd_width: 28
+      ,btb_tag_width            : 10
+      ,btb_idx_width            : 6
+      ,bht_idx_width            : 9
+      ,ras_idx_width            : 2
+
+      ,itlb_els             : 8
+      ,dtlb_els             : 8
+
+      ,dcache_sets          : 64
+      ,dcache_assoc         : 8
+      ,icache_sets          : 64
+      ,icache_assoc         : 8
+      ,acache_sets          : 64
+      ,acache_assoc         : 8
+
+      ,cce_block_width      : 512
+      ,cce_pc_width         : 8
+      ,ucode_cce            : 1
+
+      ,l2_en   : 1
+      ,l2_sets : 128
+      ,l2_assoc: 8
+
+      ,fe_queue_fifo_els: 8
+      ,fe_cmd_fifo_els  : 4
+
+      ,async_coh_clk       : 0
+      ,coh_noc_max_credits : 8
+      ,coh_noc_flit_width  : 128
+      ,coh_noc_cid_width   : 2
+      ,coh_noc_len_width   : 3
+
+      ,async_mem_clk         : 1
+      ,mem_noc_max_credits   : 8
+      ,mem_noc_flit_width    : 64
+      ,mem_noc_cid_width     : 2
+      ,mem_noc_len_width     : 4
+
+      ,async_io_clk         : 1
+      ,io_noc_did_width     : 3
+      ,io_noc_max_credits   : 16
+      ,io_noc_flit_width    : 64
+      ,io_noc_cid_width     : 2
+      ,io_noc_len_width     : 4
+      };
+
+  localparam bp_proc_param_s bp_hexa_core_ucode_cce_cfg_p =
+    '{cc_x_dim   : 3
+      ,cc_y_dim  : 2
+      ,ic_y_dim  : 1
+      ,mc_y_dim  : 0
+      ,cac_x_dim : 0
+      ,sac_x_dim : 0
+      ,cacc_type : e_cacc_vdp
+      ,sacc_type : e_sacc_vdp
+
+      ,coherent_l1: 1
+
+      ,vaddr_width: 39
+      ,paddr_width: 40
+      ,asid_width : 1
+
+      ,branch_metadata_fwd_width: 28
+      ,btb_tag_width            : 10
+      ,btb_idx_width            : 6
+      ,bht_idx_width            : 9
+      ,ras_idx_width            : 2
+
+      ,itlb_els             : 8
+      ,dtlb_els             : 8
+
+      ,dcache_sets          : 64
+      ,dcache_assoc         : 8
+      ,icache_sets          : 64
+      ,icache_assoc         : 8
+      ,acache_sets          : 64
+      ,acache_assoc         : 8
+
+      ,cce_block_width      : 512
+      ,cce_pc_width         : 8
+      ,ucode_cce            : 1
+
+      ,l2_en   : 1
+      ,l2_sets : 128
+      ,l2_assoc: 8
+
+      ,fe_queue_fifo_els: 8
+      ,fe_cmd_fifo_els  : 4
+
+      ,async_coh_clk       : 0
+      ,coh_noc_max_credits : 8
+      ,coh_noc_flit_width  : 128
+      ,coh_noc_cid_width   : 2
+      ,coh_noc_len_width   : 3
+
+      ,async_mem_clk         : 1
+      ,mem_noc_max_credits   : 8
+      ,mem_noc_flit_width    : 64
+      ,mem_noc_cid_width     : 2
+      ,mem_noc_len_width     : 4
+
+      ,async_io_clk         : 1
+      ,io_noc_did_width     : 3
+      ,io_noc_max_credits   : 16
+      ,io_noc_flit_width    : 64
+      ,io_noc_cid_width     : 2
+      ,io_noc_len_width     : 4
+      };
+
+  localparam bp_proc_param_s bp_oct_core_ucode_cce_cfg_p =
+    '{cc_x_dim   : 4
+      ,cc_y_dim  : 2
+      ,ic_y_dim  : 1
+      ,mc_y_dim  : 0
+      ,cac_x_dim : 0
+      ,sac_x_dim : 0
+      ,cacc_type : e_cacc_vdp
+      ,sacc_type : e_sacc_vdp
+
+      ,coherent_l1: 1
+
+      ,vaddr_width: 39
+      ,paddr_width: 40
+      ,asid_width : 1
+
+      ,branch_metadata_fwd_width: 28
+      ,btb_tag_width            : 10
+      ,btb_idx_width            : 6
+      ,bht_idx_width            : 9
+      ,ras_idx_width            : 2
+
+      ,itlb_els             : 8
+      ,dtlb_els             : 8
+
+      ,dcache_sets          : 64
+      ,dcache_assoc         : 8
+      ,icache_sets          : 64
+      ,icache_assoc         : 8
+      ,acache_sets          : 64
+      ,acache_assoc         : 8
+
+      ,cce_block_width      : 512
+      ,cce_pc_width         : 8
+      ,ucode_cce            : 1
+
+      ,l2_en   : 1
+      ,l2_sets : 128
+      ,l2_assoc: 8
+
+      ,fe_queue_fifo_els: 8
+      ,fe_cmd_fifo_els  : 4
+
+      ,async_coh_clk       : 0
+      ,coh_noc_max_credits : 8
+      ,coh_noc_flit_width  : 128
+      ,coh_noc_cid_width   : 2
+      ,coh_noc_len_width   : 3
+
+      ,async_mem_clk         : 1
+      ,mem_noc_max_credits   : 8
+      ,mem_noc_flit_width    : 64
+      ,mem_noc_cid_width     : 2
+      ,mem_noc_len_width     : 4
+
+      ,async_io_clk         : 1
+      ,io_noc_did_width     : 3
+      ,io_noc_max_credits   : 16
+      ,io_noc_flit_width    : 64
+      ,io_noc_cid_width     : 2
+      ,io_noc_len_width     : 4
+      };
+
+  localparam bp_proc_param_s bp_twelve_core_ucode_cce_cfg_p =
+    '{cc_x_dim   : 4
+      ,cc_y_dim  : 3
+      ,ic_y_dim  : 1
+      ,mc_y_dim  : 0
+      ,cac_x_dim : 0
+      ,sac_x_dim : 0
+      ,cacc_type : e_cacc_vdp
+      ,sacc_type : e_sacc_vdp
+
+      ,coherent_l1: 1
+
+      ,vaddr_width: 39
+      ,paddr_width: 40
+      ,asid_width : 1
+
+      ,branch_metadata_fwd_width: 28
+      ,btb_tag_width            : 10
+      ,btb_idx_width            : 6
+      ,bht_idx_width            : 9
+      ,ras_idx_width            : 2
+
+      ,itlb_els             : 8
+      ,dtlb_els             : 8
+
+      ,dcache_sets          : 64
+      ,dcache_assoc         : 8
+      ,icache_sets          : 64
+      ,icache_assoc         : 8
+      ,acache_sets          : 64
+      ,acache_assoc         : 8
+
+      ,cce_block_width      : 512
+      ,cce_pc_width         : 8
+      ,ucode_cce            : 1
+
+      ,l2_en   : 1
+      ,l2_sets : 128
+      ,l2_assoc: 8
+
+      ,fe_queue_fifo_els: 8
+      ,fe_cmd_fifo_els  : 4
+
+      ,async_coh_clk       : 0
+      ,coh_noc_max_credits : 8
+      ,coh_noc_flit_width  : 128
+      ,coh_noc_cid_width   : 2
+      ,coh_noc_len_width   : 3
+
+      ,async_mem_clk         : 1
+      ,mem_noc_max_credits   : 8
+      ,mem_noc_flit_width    : 64
+      ,mem_noc_cid_width     : 2
+      ,mem_noc_len_width     : 4
+
+      ,async_io_clk         : 1
+      ,io_noc_did_width     : 3
+      ,io_noc_max_credits   : 16
+      ,io_noc_flit_width    : 64
+      ,io_noc_cid_width     : 2
+      ,io_noc_len_width     : 4
+      };
+
+  localparam bp_proc_param_s bp_sexta_core_ucode_cce_cfg_p =
+    '{cc_x_dim   : 4
+      ,cc_y_dim  : 4
+      ,ic_y_dim  : 1
+      ,mc_y_dim  : 0
+      ,cac_x_dim : 0
+      ,sac_x_dim : 0
+      ,cacc_type : e_cacc_vdp
+      ,sacc_type : e_sacc_vdp
+
+      ,coherent_l1: 1
+
+      ,vaddr_width: 39
+      ,paddr_width: 40
+      ,asid_width : 1
+
+      ,branch_metadata_fwd_width: 28
+      ,btb_tag_width            : 10
+      ,btb_idx_width            : 6
+      ,bht_idx_width            : 9
+      ,ras_idx_width            : 2
+
+      ,itlb_els             : 8
+      ,dtlb_els             : 8
+
+      ,dcache_sets          : 64
+      ,dcache_assoc         : 8
+      ,icache_sets          : 64
+      ,icache_assoc         : 8
+      ,acache_sets          : 64
+      ,acache_assoc         : 8
+
+      ,cce_block_width      : 512
+      ,cce_pc_width         : 8
+      ,ucode_cce            : 1
+
+      ,l2_en   : 1
+      ,l2_sets : 128
+      ,l2_assoc: 8
+
+      ,fe_queue_fifo_els: 8
+      ,fe_cmd_fifo_els  : 4
+
+      ,async_coh_clk       : 0
+      ,coh_noc_max_credits : 8
+      ,coh_noc_flit_width  : 128
+      ,coh_noc_cid_width   : 2
+      ,coh_noc_len_width   : 3
+
+      ,async_mem_clk         : 1
+      ,mem_noc_max_credits   : 8
+      ,mem_noc_flit_width    : 64
+      ,mem_noc_cid_width     : 2
+      ,mem_noc_len_width     : 4
+
+      ,async_io_clk         : 1
+      ,io_noc_did_width     : 3
+      ,io_noc_max_credits   : 16
+      ,io_noc_flit_width    : 64
+      ,io_noc_cid_width     : 1
+      ,io_noc_len_width     : 4
+      };
+
+
   typedef enum bit [lg_max_cfgs-1:0] 
-  { e_bp_accelerator_quad_core_cfg    = 14
+  {
+    e_bp_sexta_core_ucode_cce_cfg     = 23
+    ,e_bp_twelve_core_ucode_cce_cfg   = 22
+    ,e_bp_oct_core_ucode_cce_cfg      = 21
+    ,e_bp_hexa_core_ucode_cce_cfg     = 20
+    ,e_bp_quad_core_ucode_cce_cfg     = 19
+    ,e_bp_tri_core_ucode_cce_cfg      = 18
+    ,e_bp_dual_core_ucode_cce_cfg     = 17
+    ,e_bp_single_core_ucode_cce_cfg   = 16
+    ,e_bp_half_core_ucode_cce_cfg     = 15
+    ,e_bp_accelerator_quad_core_cfg   = 14
     ,e_bp_accelerator_single_core_cfg = 13
     ,e_bp_sexta_core_cfg              = 12
     ,e_bp_twelve_core_cfg             = 11
@@ -897,9 +1487,18 @@ package bp_common_aviary_pkg;
     ,e_bp_inv_cfg                     = 0
   } bp_params_e;
 
-  /* verilator lint_off WIDTH */     
+  /* verilator lint_off WIDTH */
   parameter bp_proc_param_s [max_cfgs-1:0] all_cfgs_gp =
-  { bp_accelerator_quad_core_cfg_p
+  { bp_sexta_core_ucode_cce_cfg_p
+    ,bp_twelve_core_ucode_cce_cfg_p
+    ,bp_oct_core_ucode_cce_cfg_p
+    ,bp_hexa_core_ucode_cce_cfg_p
+    ,bp_quad_core_ucode_cce_cfg_p
+    ,bp_tri_core_ucode_cce_cfg_p
+    ,bp_dual_core_ucode_cce_cfg_p
+    ,bp_single_core_ucode_cce_cfg_p
+    ,bp_half_core_ucode_cce_cfg_p
+    ,bp_accelerator_quad_core_cfg_p
     ,bp_accelerator_single_core_cfg_p
     ,bp_sexta_core_cfg_p
     ,bp_twelve_core_cfg_p

--- a/bp_me/src/v/cce/bp_cce_fsm.v
+++ b/bp_me/src/v/cce/bp_cce_fsm.v
@@ -110,7 +110,7 @@ module bp_cce_fsm
   `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
   bp_cfg_bus_s cfg_bus_cast_i;
   assign cfg_bus_cast_i = cfg_bus_i;
-  wire cce_normal_mode = (~cfg_bus_cast_i.freeze & (cfg_bus_cast_i.cce_mode == e_cce_mode_normal));
+  wire cce_normal_mode = (cfg_bus_cast_i.cce_mode == e_cce_mode_normal);
 
   // CCE FSM
 
@@ -765,7 +765,12 @@ module bp_cce_fsm
         if (cce_normal_mode) begin
           state_n = SEND_SYNC;
         // only issue uncached request if number of outstanding is less than max allowed
-        end else if (lce_req_v_i & mem_cmd_ready_i & (uc_cnt < max_uc_req_lp)) begin
+        // only process uncached requests
+        // cached requests will stall on the input port
+        end else if (lce_req_v_i
+                     & ((lce_req.header.msg_type == e_lce_req_type_uc_wr)
+                        | (lce_req.header.msg_type == e_lce_req_type_uc_rd))
+                     & mem_cmd_ready_i & (uc_cnt < max_uc_req_lp)) begin
 
           // handshaking
           mem_cmd_v_o = lce_req_v_i & mem_cmd_ready_i;

--- a/bp_me/src/v/cce/bp_cce_fsm.v
+++ b/bp_me/src/v/cce/bp_cce_fsm.v
@@ -745,7 +745,7 @@ module bp_cce_fsm
         // Next state depends on the CCE mode, as set by config bus
         state_n = cnt_0_clr
                   ? cce_normal_mode
-                    ? READY
+                    ? SEND_SYNC
                     : UNCACHED_ONLY
                   : CLEAR_DIR;
 

--- a/bp_me/src/v/cce/bp_cce_msg.v
+++ b/bp_me/src/v/cce/bp_cce_msg.v
@@ -367,7 +367,12 @@ module bp_cce_msg
 
           uc_cnt_dec = mem_resp_yumi_o;
 
-        end else if (lce_req_v_i) begin
+        // process uncached read or write requests
+        // cached requests will stall on the input port until normal mode is entered
+        end else if (lce_req_v_i
+                     & ((lce_req.header.msg_type == e_lce_req_type_uc_rd)
+                        | (lce_req.header.msg_type == e_lce_req_type_uc_wr))
+                    ) begin
           // uncached read first sends a memory cmd, uncached store sends memory data cmd
           uc_state_n = (lce_req.header.msg_type == e_lce_req_type_uc_rd)
                        ? e_uc_send_mem_cmd

--- a/bp_me/src/v/cce/bp_cce_wrapper.v
+++ b/bp_me/src/v/cce/bp_cce_wrapper.v
@@ -64,12 +64,12 @@ module bp_cce_wrapper
   bp_cfg_bus_s cfg_bus_cast_i;
   assign cfg_bus_cast_i = cfg_bus_i;
 
-  if (ucode_cce_p == 1) begin
+  if (ucode_cce_p == 1) begin : ucode
     bp_cce
     #(.bp_params_p(bp_params_p))
     cce
      (.*);
-  end else begin
+  end else begin : fsm
     bp_cce_fsm
     #(.bp_params_p(bp_params_p))
     cce

--- a/bp_me/src/v/cce/bp_cce_wrapper.v
+++ b/bp_me/src/v/cce/bp_cce_wrapper.v
@@ -1,0 +1,79 @@
+/**
+ *
+ * Name:
+ *   bp_cce_wrapper.v
+ *
+ * Description:
+ *   This is the top level module for the CCE.
+ *
+ *   It instantiates either the microcode or FSM CCE, based on the param in bp_params_p.
+ *
+ */
+
+module bp_cce_wrapper
+  import bp_common_pkg::*;
+  import bp_common_aviary_pkg::*;
+  import bp_cce_pkg::*;
+  import bp_common_cfg_link_pkg::*;
+  import bp_me_pkg::*;
+  #(parameter bp_params_e bp_params_p      = e_bp_inv_cfg
+    `declare_bp_proc_params(bp_params_p)
+
+    // Interface Widths
+    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
+    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+    `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
+  )
+  (input                                               clk_i
+   , input                                             reset_i
+
+   // Configuration Interface
+   , input [cfg_bus_width_lp-1:0]                      cfg_bus_i
+   , output [cce_instr_width_p-1:0]                    cfg_cce_ucode_data_o
+
+   // LCE-CCE Interface
+   , input [lce_cce_req_width_lp-1:0]                  lce_req_i
+   , input                                             lce_req_v_i
+   , output logic                                      lce_req_yumi_o
+
+   , input [lce_cce_resp_width_lp-1:0]                 lce_resp_i
+   , input                                             lce_resp_v_i
+   , output logic                                      lce_resp_yumi_o
+
+   // ready->valid
+   , output logic [lce_cmd_width_lp-1:0]               lce_cmd_o
+   , output logic                                      lce_cmd_v_o
+   , input                                             lce_cmd_ready_i
+
+   // CCE-MEM Interface
+   , input [cce_mem_msg_width_lp-1:0]                  mem_resp_i
+   , input                                             mem_resp_v_i
+   , output logic                                      mem_resp_yumi_o
+
+   // ready->valid
+   , output logic [cce_mem_msg_width_lp-1:0]           mem_cmd_o
+   , output logic                                      mem_cmd_v_o
+   , input                                             mem_cmd_ready_i
+
+  );
+
+  // Config Interface
+  `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
+
+  // Config bus casting
+  bp_cfg_bus_s cfg_bus_cast_i;
+  assign cfg_bus_cast_i = cfg_bus_i;
+
+  if (ucode_cce_p == 1) begin
+    bp_cce
+    #(.bp_params_p(bp_params_p))
+    cce
+     (.*);
+  end else begin
+    bp_cce_fsm
+    #(.bp_params_p(bp_params_p))
+    cce
+     (.*);
+  end
+
+endmodule

--- a/bp_me/syn/Makefile
+++ b/bp_me/syn/Makefile
@@ -85,19 +85,19 @@ lint.me:
 	@echo "ME lint not supported"
 
 regress.me.sc: dirs.sc
-	$(MAKE) -j 1 build.sc sim.sc TB=bp_cce NUM_INSTR_P=$(NUM_INSTR_P)
-	$(MAKE) -j 1 build.sc sim.sc TB=bp_cce NUM_INSTR_P=$(NUM_INSTR_P) SKIP_INIT_P=1
-	$(MAKE) -j 1 build.sc sim.sc TB=bp_cce_fsm NUM_INSTR_P=$(NUM_INSTR_P)
-	$(MAKE) -j 1 build.sc sim.sc TB=bp_cce_fsm NUM_INSTR_P=$(NUM_INSTR_P) SKIP_INIT_P=1
+	$(MAKE) -j 1 build.sc sim.sc TB=bp_cce NUM_INSTR_P=$(NUM_INSTR_P) PROG=normal
+	$(MAKE) -j 1 build.sc sim.sc TB=bp_cce NUM_INSTR_P=$(NUM_INSTR_P) SKIP_INIT_P=1 PROG=uncached
+	$(MAKE) -j 1 build.sc sim.sc TB=bp_cce_fsm NUM_INSTR_P=$(NUM_INSTR_P) PROG=normal
+	$(MAKE) -j 1 build.sc sim.sc TB=bp_cce_fsm NUM_INSTR_P=$(NUM_INSTR_P) SKIP_INIT_P=1 PROG=uncached
 
 #	$(MAKE) -j 1 build.sc sim.sc TB=bp_cce_alu
 #	$(MAKE) -j 1 build.sc sim.sc TB=bp_cce_gad
 
 regress.me.v: dirs.v
-	$(MAKE) -j 1 build.v sim.v TB=bp_cce NUM_INSTR_P=$(NUM_INSTR_P)
-	$(MAKE) -j 1 build.v sim.v TB=bp_cce NUM_INSTR_P=$(NUM_INSTR_P) SKIP_INIT_P=1
-	$(MAKE) -j 1 build.v sim.v TB=bp_cce_fsm NUM_INSTR_P=$(NUM_INSTR_P)
-	$(MAKE) -j 1 build.v sim.v TB=bp_cce_fsm NUM_INSTR_P=$(NUM_INSTR_P) SKIP_INIT_P=1
+	$(MAKE) -j 1 build.v sim.v TB=bp_cce NUM_INSTR_P=$(NUM_INSTR_P) PROG=normal
+	$(MAKE) -j 1 build.v sim.v TB=bp_cce NUM_INSTR_P=$(NUM_INSTR_P) SKIP_INIT_P=1 PROG=uncached
+	$(MAKE) -j 1 build.v sim.v TB=bp_cce_fsm NUM_INSTR_P=$(NUM_INSTR_P) PROG=normal
+	$(MAKE) -j 1 build.v sim.v TB=bp_cce_fsm NUM_INSTR_P=$(NUM_INSTR_P) SKIP_INIT_P=1 PROG=uncached
 
 regress: regress.me
 regress.me: lint.me regress.me.sc regress.me.v

--- a/bp_top/src/v/bp_l2e_tile.v
+++ b/bp_top/src/v/bp_l2e_tile.v
@@ -113,7 +113,7 @@ bp_cfg_buffered
    ,.cce_ucode_data_i(cfg_cce_ucode_data_li)
    );
 
-bp_cce
+bp_cce_wrapper
  #(.bp_params_p(bp_params_p))
  cce
   (.clk_i(clk_i)

--- a/bp_top/src/v/bp_tile.v
+++ b/bp_top/src/v/bp_tile.v
@@ -196,7 +196,7 @@ bp_core
    ,.external_irq_i(external_irq_li)
    );
 
-bp_cce
+bp_cce_wrapper
  #(.bp_params_p(bp_params_p))
  cce
   (.clk_i(clk_i)

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -219,6 +219,8 @@ $BP_ME_DIR/src/v/cce/bp_cce_reg.v
 $BP_ME_DIR/src/v/cce/bp_cce_spec_bits.v
 $BP_ME_DIR/src/v/cce/bp_cce_src_sel.v
 $BP_ME_DIR/src/v/cce/bp_io_cce.v
+$BP_ME_DIR/src/v/cce/bp_cce_fsm.v
+$BP_ME_DIR/src/v/cce/bp_cce_wrapper.v
 # Network
 $BP_ME_DIR/src/v/cce/bp_uce.v
 $BP_ME_DIR/src/v/wormhole/bp_me_addr_to_cce_id.v

--- a/bp_top/test/tb/bp_processor/testbench.v
+++ b/bp_top/test/tb/bp_processor/testbench.v
@@ -331,15 +331,15 @@ bind bp_be_top
      ,.mem_resp_yumi_i(dram_resp_ready_li & dram_resp_v_lo)
      );
 
-  bind bp_cce
+  bind bp_cce_wrapper
     bp_me_nonsynth_cce_tracer
       #(.bp_params_p(bp_params_p))
       bp_cce_tracer
        (.clk_i(clk_i & (testbench.cce_trace_p == 1))
         ,.reset_i(reset_i)
-        ,.freeze_i(bp_cce.cfg_bus_cast_i.freeze)
+        ,.freeze_i(cfg_bus_cast_i.freeze)
   
-        ,.cce_id_i(bp_cce.cfg_bus_cast_i.cce_id)
+        ,.cce_id_i(cfg_bus_cast_i.cce_id)
   
         // To CCE
         ,.lce_req_i(lce_req_i)


### PR DESCRIPTION
This change adds the fsm_cce_p parameter to bp_params_p, which is used to determine which CCE variant is instantiated in the design. A new bp_cce_wrapper module is added that does the conditional instantiation of the CCE type. Using a wrapper encapsulates the conditional instantiation and provides a common module for nonsynth tracers to bind to.

New configs are added that use the FSM CCE instead of microcode CCE.

PR addresses Issue #417 