### PR TITLE
Poison the Long Pipe Input

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -295,7 +295,7 @@ bp_be_pipe_mem
      ,.instr_i(reservation_r.instr)
      ,.rs1_i(reservation_r.rs1)
      ,.rs2_i(reservation_r.rs2)
-     ,.v_i(reservation_r.v & reservation_r.decode.pipe_long_v)
+     ,.v_i(reservation_r.v & reservation_r.decode.pipe_long_v & ~reservation_r.poison)
      ,.ready_o(pipe_long_ready_lo)
 
      ,.flush_i(flush_i)


### PR DESCRIPTION
We need to poison the v_i to the long pipe when instruction is not valid due to a branch mispredict.