### PR TITLE
fully specify TB and CFG in CI file for tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -117,7 +117,7 @@ hotfix_job:
     - make -C bp_top/syn clean
     - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_processor CFG=e_bp_single_core_cfg" bp_top &
     - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_processor CFG=e_bp_quad_core_cfg" bp_top &
-    - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_softcore" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_softcore CFG=e_bp_softcore_cfg" bp_top &
     - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_processor CFG=e_bp_single_core_ucode_cce_cfg" bp_top &
     - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_processor CFG=e_bp_quad_core_ucode_cce_cfg" bp_top &
     - wait
@@ -139,7 +139,7 @@ check-design:
   script:
     - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_processor CFG=e_bp_single_core_cfg" bp_top &
     - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_processor CFG=e_bp_quad_core_cfg" bp_top &
-    - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_softcore" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_softcore CFG=e_bp_softcore_cfg" bp_top &
     - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_processor CFG=e_bp_single_core_ucode_cce_cfg" bp_top &
     - $CI_PROJECT_DIR/ci/regress.sh "check_design.syn TB=bp_processor CFG=e_bp_quad_core_ucode_cce_cfg" bp_top &
     - wait
@@ -150,7 +150,9 @@ lint-verilator:
   tags:
     - verilator
   script:
-    - $CI_PROJECT_DIR/ci/regress.sh lint.sc bp_top
+    - $CI_PROJECT_DIR/ci/regress.sh "lint.sc TB=bp_softcore CFG=e_bp_softcore_cfg" bp_top
+    - $CI_PROJECT_DIR/ci/regress.sh "lint.sc TB=bp_processor CFG=e_bp_single_core_cfg" bp_top
+    - $CI_PROJECT_DIR/ci/regress.sh "lint.sc TB=bp_processor CFG=e_bp_single_core_ucode_cce_cfg" bp_top
  
 me-regress-verilator:
   <<: *job_definition
@@ -167,8 +169,8 @@ top-riscv-verilator:
   tags:
     - verilator
   script:
-    - make -C bp_top/syn build.sc
-    - $CI_PROJECT_DIR/ci/regress.sh regress_riscv.sc bp_top
+    - make -C bp_top/syn build.sc TB=bp_softcore CFG=e_bp_softcore_cfg
+    - $CI_PROJECT_DIR/ci/regress.sh "regress_riscv.sc TB=bp_softcore CFG=e_bp_softcore_fg" bp_top
  
 top-coremark-verilator:
   <<: *job_definition
@@ -177,8 +179,11 @@ top-coremark-verilator:
   tags:
     - verilator
   script:
-    - make -C bp_top/syn build.sc
-    - $CI_PROJECT_DIR/ci/regress.sh "sim.sc PROG=coremark" bp_top
+    - make -C bp_top/syn build.sc TB=bp_processor CFG=e_bp_single_core_cfg
+    - make -C bp_top/syn build.sc TB=bp_softcore CFG=e_bp_softcore_cfg
+    - $CI_PROJECT_DIR/ci/regress.sh "sim.sc TB=bp_processor CFG=e_bp_single_core_cfg PROG=coremark" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "sim.sc TB=bp_softcore CFG=e_bp_softcore_cfg PROG=coremark" bp_top &
+    - wait
 
 # Disabled because it's too long running     
 # TODO: Investigate why
@@ -189,8 +194,11 @@ top-beebs-verilator:
   tags:
     - verilator
   script:
-    - make -C bp_top/syn build.sc
-    - $CI_PROJECT_DIR/ci/regress.sh regress_beebs.sc bp_top
+    - make -C bp_top/syn build.sc TB=bp_processor CFG=e_bp_single_core_cfg
+    - make -C bp_top/syn build.sc TB=bp_softcore CFG=e_bp_softcore_cfg
+    - $CI_PROJECT_DIR/ci/regress.sh "regress_beebs.sc TB=bp_processor CFG=e_bp_single_core_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "regress_beebs.sc TB=bp_softcore CFG=e_bp_softcore_cfg" bp_top &
+    - wait
 
 top-mc-verilator:
   <<: *job_definition
@@ -240,8 +248,9 @@ lint-vcs:
   tags:
     - vcs
   script:
-    - $CI_PROJECT_DIR/ci/regress.sh "lint.v TB=bp_processor" bp_top
-    - $CI_PROJECT_DIR/ci/regress.sh "lint.v TB=bp_softcore" bp_top
+    - $CI_PROJECT_DIR/ci/regress.sh "lint.v TB=bp_softcore CFG=e_bp_softcore_cfg" bp_top
+    - $CI_PROJECT_DIR/ci/regress.sh "lint.v TB=bp_processor CFG=e_bp_single_core_cfg" bp_top
+    - $CI_PROJECT_DIR/ci/regress.sh "lint.v TB=bp_processor CFG=e_bp_single_core_ucode_cce_cfg" bp_top
 
 me-regress-vcs:
   <<: *job_definition
@@ -257,10 +266,10 @@ top-riscv-tests-vcs:
   tags:
     - vcs
   script:
-    - make -C bp_top/syn build.v TB=bp_processor
-    - make -C bp_top/syn build.v TB=bp_softcore
-    - $CI_PROJECT_DIR/ci/regress.sh "regress_riscv.v TB=bp_processor" bp_top &
-    - $CI_PROJECT_DIR/ci/regress.sh "regress_riscv.v TB=bp_softcore" bp_top &
+    - make -C bp_top/syn build.v TB=bp_processor CFG=e_bp_single_core_cfg
+    - make -C bp_top/syn build.v TB=bp_softcore CFG=e_bp_softcore_cfg
+    - $CI_PROJECT_DIR/ci/regress.sh "regress_riscv.v TB=bp_processor CFG=e_bp_single_core_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "regress_riscv.v TB=bp_softcore CFG=e_bp_dual_core_cfg" bp_top &
     - wait
       
 top-coremark-vcs:
@@ -269,10 +278,10 @@ top-coremark-vcs:
   tags:
     - vcs
   script:
-    - make -C bp_top/syn build.v TB=bp_processor
-    - make -C bp_top/syn build.v TB=bp_softcore
-    - $CI_PROJECT_DIR/ci/regress.sh "sim.v TB=bp_processor PROG=coremark" bp_top &
-    - $CI_PROJECT_DIR/ci/regress.sh "sim.v TB=bp_softcore PROG=coremark" bp_top &
+    - make -C bp_top/syn build.v TB=bp_processor CFG=e_bp_single_core_cfg
+    - make -C bp_top/syn build.v TB=bp_softcore CFG=e_bp_softcore_cfg
+    - $CI_PROJECT_DIR/ci/regress.sh "sim.v TB=bp_processor CFG=e_bp_single_core_cfg PROG=coremark" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "sim.v TB=bp_softcore CFG=e_bp_softcore_cfg PROG=coremark" bp_top &
     - wait
 
 top-riscvdv-vcs:
@@ -282,10 +291,10 @@ top-riscvdv-vcs:
   tags:
     - vcs
   script:
-    - make -C bp_top/syn build.v TB=bp_processor
-    - make -C bp_top/syn build.v TB=bp_softcore
-    - $CI_PROJECT_DIR/ci/regress.sh "regress_dv.v TB=bp_processor" bp_top &
-    - $CI_PROJECT_DIR/ci/regress.sh "regress_dv.v TB=bp_softcore" bp_top &
+    - make -C bp_top/syn build.v TB=bp_processor CFG=e_bp_single_core_cfg
+    - make -C bp_top/syn build.v TB=bp_softcore CFG=e_bp_softcore_cfg
+    - $CI_PROJECT_DIR/ci/regress.sh "regress_dv.v TB=bp_processor CFG=e_bp_single_core_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "regress_dv.v TB=bp_softcore CFG=e_bp_softcore_cfg" bp_top &
     - wait
 
 top-beebs-vcs:
@@ -294,10 +303,10 @@ top-beebs-vcs:
   tags:
     - vcs
   script:
-    - make -C bp_top/syn build.v TB=bp_processor
-    - make -C bp_top/syn build.v TB=bp_softcore
-    - $CI_PROJECT_DIR/ci/regress.sh "regress_beebs.v TB=bp_processor" bp_top &
-    - $CI_PROJECT_DIR/ci/regress.sh "regress_beebs.v TB=bp_softcore" bp_top &
+    - make -C bp_top/syn build.v TB=bp_processor CFG=e_bp_single_core_cfg
+    - make -C bp_top/syn build.v TB=bp_softcore CFG=e_bp_softcore_cfg
+    - $CI_PROJECT_DIR/ci/regress.sh "regress_beebs.v TB=bp_processor CFG=e_bp_single_core_cfg" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "regress_beebs.v TB=bp_softcore CFG=e_bp_softcore_cfg" bp_top &
     - wait
 
 top-cache-vcs:
@@ -306,10 +315,10 @@ top-cache-vcs:
   tags:
     - vcs
   script:
-    - make -C bp_top/syn build.v TB=bp_processor
-    - make -C bp_top/syn build.v TB=softcore
-    - $CI_PROJECT_DIR/ci/regress.sh "sim.v TB=bp_processor PROG=cache_hammer" bp_top &
-    - $CI_PROJECT_DIR/ci/regress.sh "sim.v TB=bp_softcore PROG=cache_hammer" bp_top &
+    - make -C bp_top/syn build.v TB=bp_processor CFG=e_bp_single_core_cfg
+    - make -C bp_top/syn build.v TB=bp_softcore CFG=e_bp_softcore_cfg
+    - $CI_PROJECT_DIR/ci/regress.sh "sim.v TB=bp_processor CFG=e_bp_single_core_cfg PROG=cache_hammer" bp_top &
+    - $CI_PROJECT_DIR/ci/regress.sh "sim.v TB=bp_softcore CFG=e_bp_softcore_cfg PROG=cache_hammer" bp_top &
     - wait
 
 top-mc-vcs:


### PR DESCRIPTION
This change fully specifies the TB and CFG params for the Makefiles for all tests in the gitlab CI file. Without fully specifying both parameters, some tests were running with TB=bp_processor and CFG=e_bp_softcore_cfg. I don't believe this is intended to be a supported TB/CFG pair.

Notably, the TB/CFG pair of bp_processor & e_bp_softcore_cfg results in the regress_riscv.v target failing some tests, but this does not appear to be detected by CI. Specifically, the rv64ui-v-* tests and rv64ui-p-fence_i tests report failures when I run them locally. Changing CFG to e_bp_single_core[_ucode_cce]_cfg results in all tests passing.

This pipeline: https://gitlab.com/black-parrot/black-parrot/pipelines/135024242 shows the CI tests reporting pass at a commit where there are failing tests due to the TB/CFG mismatch. Commit is 22579efd (current head of dev as of 4/12/20).