### PR TITLE
Fix verilator lint target

### DIFF
--- a/bp_common/syn/Makefile.verilator
+++ b/bp_common/syn/Makefile.verilator
@@ -49,8 +49,10 @@ lint.sc: dirs.sc
 	-@echo $(BUILD_DIR)/testbench.v               >> $(BUILD_DIR)/flist.vcs
 	-@echo $(BUILD_DIR)/test_bp.cpp               >> $(BUILD_DIR)/flist.vcs
 	cd $(BUILD_DIR); $(VV) $(LINT_OPTS) --top-module $(TOP_MODULE) \
-		config.vlt -f flist.vcs $(HDL_PARAMS) $(HDL_DEFINES) |& tee $(LINT_LOG)
-
+		config.vlt -f flist.vcs $(HDL_PARAMS) $(HDL_DEFINES) 2>&1 | tee $(LINT_LOG)
+	-@grep -E "Exiting due to .* error\(s\)" -A 5 $(LINT_LOG) > $(LINT_ERROR)
+	-@test -s $(LINT_ERROR) && echo "FAILED" >> $(LINT_REPORT) \
+	|| { rm -f $(LINT_ERROR); echo "PASS" >> $(LINT_REPORT); }
 
 VBUILD_LOG    ?= $(LOG_DIR)/$(TB).$(CFG).vbuild.log
 VBUILD_REPORT ?= $(REPORT_DIR)/$(TB).$(CFG).vbuild.rpt

--- a/bp_fe/src/v/bp_fe_bht.v
+++ b/bp_fe/src/v/bp_fe_bht.v
@@ -72,7 +72,7 @@ if (debug_p)
      always_ff @(negedge clk_i)
        begin
          if (w_v_r | r_v_r)
-	       $write("v=%b c=%b W[%h] (=%b); v=%b %h R[%h] (=%b) p=%b ",w_v_r,correct_r,idx_w_r,mem[idx_w_r],r_v_r,idx_r_r,mem[idx_r_r],predict_o);
+	       $write("v=%b c=%b W[%h] (=%b); v=%b R[%h] (=%b) p=%b ",w_v_r,correct_r,idx_w_r,mem[idx_w_r],r_v_r,idx_r_r,mem[idx_r_r],predict_o);
 
 	  if (w_v_r & ~correct_r)
 	    $write("X\n");


### PR DESCRIPTION
This change fixes the Verilator lint target so it should run correctly on CI. Note that Verilator reports failure due to mem_cap_in_bytes_p being set larger that Verilator likes in the bp_softcore testbench, as it is set to 2**29. The setting in bp_processor of 2**25 seems to be okay.

A small typo is also fixed in the bp_fe_bht.v file in a debug print statement, which removes an old format string item.