### PR TITLE
Disable cosim for multicore builds

### DIFF
--- a/bp_me/software/scripts/run.sh
+++ b/bp_me/software/scripts/run.sh
@@ -37,12 +37,12 @@ do
     # collect results
     for i in "${!nums[@]}"
     do
-      passes=`grep -rE "PASS" reports/vcs/bp_processor.e_bp_${cfgs[$i]}_core${cce}cfg.sim.${prog}_${nums[$i]}.rpt | wc -l`
-      if [ $passes -eq ${nums[$i]} ]
+      failures=`grep -rE "FAIL" reports/vcs/bp_processor.e_bp_${cfgs[$i]}_core${cce}cfg.sim.${prog}_${nums[$i]}.rpt | wc -l`
+      if [ $failures -gt 0 ]
       then
-        echo "$prog,$p,${cfgs[$i]},PASS" >> regress${cce}results.txt
-      else
         echo "$prog,$p,${cfgs[$i]},FAIL" >> regress${cce}results.txt
+      else
+        echo "$prog,$p,${cfgs[$i]},PASS" >> regress${cce}results.txt
       fi
     done
   done

--- a/bp_top/test/tb/bp_processor/testbench.v
+++ b/bp_top/test/tb/bp_processor/testbench.v
@@ -153,6 +153,7 @@ wrapper
        );
 
   logic cosim_finish_lo;
+  if (num_core_p == 1) begin : cosim
   bind bp_be_top
     bp_nonsynth_cosim
      #(.bp_params_p(bp_params_p))
@@ -183,6 +184,9 @@ wrapper
 
        ,.finish_o(testbench.cosim_finish_lo)
        );
+  end else begin : cosim
+    assign cosim_finish_lo = '0;
+  end
 
   bind bp_be_director
     bp_be_nonsynth_npc_tracer

--- a/bp_top/test/tb/bp_processor/testbench.v
+++ b/bp_top/test/tb/bp_processor/testbench.v
@@ -57,6 +57,12 @@ module testbench
    , input reset_i
    );
 
+initial begin
+  if (num_core_p > 1) begin
+    assert (cosim_p == 0) else $error("cosim_p not supported for num_core_p > 1");
+  end
+end
+
 `declare_bsg_ready_and_link_sif_s(io_noc_flit_width_p, bp_io_noc_ral_link_s);
 `declare_bsg_ready_and_link_sif_s(mem_noc_flit_width_p, bp_mem_noc_ral_link_s);
 `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)


### PR DESCRIPTION
This change instantiates the nonsynth cosim module in bp_processor testbench only if the core count is equal to one, since it is not expected to work for multicore.