### PR TITLE
Retime I$ and D$ tag comparison

### DIFF
--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -339,6 +339,7 @@ module bp_be_dcache
 
   // data_mem
   //
+  
   logic [dcache_assoc_p-1:0] data_mem_v_li;
   logic data_mem_w_li;
   logic [dcache_assoc_p-1:0][index_width_lp+word_offset_width_lp-1:0] data_mem_addr_li;
@@ -361,12 +362,56 @@ module bp_be_dcache
         ,.write_mask_i(data_mem_mask_li[i])
         ,.data_o(data_mem_data_lo[i])
         );
+  end // block: data_mem
+
+  // miss_detect
+  //
+  logic [dcache_assoc_p-1:0] tag_match_tl;
+  logic [dcache_assoc_p-1:0] load_hit_tl;
+  logic [dcache_assoc_p-1:0] store_hit_tl;
+  logic load_hit_v_tl;
+  logic store_hit_v_tl;
+  logic [way_id_width_lp-1:0] load_hit_way_tl;
+  logic [way_id_width_lp-1:0] store_hit_way_tl;
+  logic [paddr_width_p-1:0]  paddr_tl;
+  logic [ptag_width_lp-1:0] addr_tag_tl;
+
+  assign paddr_tl = {ptag_i, page_offset_tl_r};
+  
+  assign addr_tag_tl = paddr_tl[block_offset_width_lp+index_width_lp+:ptag_width_lp];
+
+  for (genvar i = 0; i < dcache_assoc_p; i++) begin: tag_comp_tl
+    assign tag_match_tl[i] = addr_tag_tl == tag_mem_data_lo[i].tag;
+    assign load_hit_tl[i] = tag_match_tl[i] & (tag_mem_data_lo[i].coh_state != e_COH_I);
+    assign store_hit_tl[i] = tag_match_tl[i] & ((tag_mem_data_lo[i].coh_state == e_COH_M)
+                                                || (tag_mem_data_lo[i].coh_state == e_COH_E));
   end
+
+  bsg_priority_encode
+    #(.width_p(dcache_assoc_p)
+      ,.lo_to_hi_p(1)
+      )
+    pe_load_hit_tl
+    (.i(load_hit_tl)
+      ,.v_o(load_hit_v_tl)
+      ,.addr_o(load_hit_way_tl)
+      );
+  
+  bsg_priority_encode
+    #(.width_p(dcache_assoc_p)
+      ,.lo_to_hi_p(1)
+      )
+    pe_store_hit_tl
+    (.i(store_hit_tl)
+      ,.v_o(store_hit_v_tl)
+      ,.addr_o(store_hit_way_tl)
+      );
+
+  
 
   // TV stage
   //
   logic v_tv_r;
-  logic tv_we;
   logic lr_op_tv_r;
   logic sc_op_tv_r;
   logic load_op_tv_r;
@@ -386,6 +431,15 @@ module bp_be_dcache
   logic [ptag_width_lp-1:0] addr_tag_tv;
   logic [index_width_lp-1:0] addr_index_tv;
   logic [word_offset_width_lp-1:0] addr_word_offset_tv;
+  logic [dcache_assoc_p-1:0] tag_match_tv;
+  logic [dcache_assoc_p-1:0] load_hit_tv;
+  logic [dcache_assoc_p-1:0] store_hit_tv;
+  logic load_hit;
+  logic store_hit;
+  logic [way_id_width_lp-1:0] load_hit_way;
+  logic [way_id_width_lp-1:0] store_hit_way;
+   
+   
 
   assign tv_we = v_tl_r & ~poison_i & ~tlb_miss_i & ~fencei_req;
 
@@ -410,6 +464,17 @@ module bp_be_dcache
       fencei_op_tv_r <= '0;
       paddr_tv_r <= '0;
       tag_info_tv_r <= '0;
+      tag_match_tv <= '0;      
+      load_hit_tv <= '0;       
+      store_hit_tv <= '0;
+      load_hit <= '0; 
+      store_hit <= '0; 
+      load_hit_way <= '0;
+      store_hit_way <= '0;
+      addr_tag_tv <= '0;
+       
+       
+      
 
     end
     else begin
@@ -427,9 +492,18 @@ module bp_be_dcache
         half_op_tv_r <= half_op_tl_r;
         byte_op_tv_r <= byte_op_tl_r;
         fencei_op_tv_r <= fencei_op_tl_r;
-        paddr_tv_r <= {ptag_i, page_offset_tl_r};
+        paddr_tv_r <= paddr_tl;
         tag_info_tv_r <= tag_mem_data_lo;
         uncached_tv_r <= uncached_i;
+	tag_match_tv <= tag_match_tl;      
+	load_hit_tv <= load_hit_tl;       
+        store_hit_tv <= store_hit_tl;
+        load_hit <= load_hit_v_tl;	 
+        store_hit <= store_hit_v_tl;	 
+        load_hit_way <= load_hit_way_tl;
+        store_hit_way <= store_hit_way_tl;
+	addr_tag_tv <= addr_tag_tl;
+
       end
 
       if (tv_we & load_op_tl_r) begin
@@ -442,54 +516,23 @@ module bp_be_dcache
     end
   end
 
-  assign addr_tag_tv = paddr_tv_r[block_offset_width_lp+index_width_lp+:ptag_width_lp];
   assign addr_index_tv = paddr_tv_r[block_offset_width_lp+:index_width_lp];
   assign addr_word_offset_tv = paddr_tv_r[byte_offset_width_lp+:word_offset_width_lp];
 
-  // miss_detect
+  // invalid_detect
   //
-  logic [dcache_assoc_p-1:0] tag_match_tv;
-  logic [dcache_assoc_p-1:0] load_hit_tv;
-  logic [dcache_assoc_p-1:0] store_hit_tv;
   logic [dcache_assoc_p-1:0] invalid_tv;
-  logic load_hit;
-  logic store_hit;
-  logic [way_id_width_lp-1:0] load_hit_way;
-  logic [way_id_width_lp-1:0] store_hit_way;
 
   for (genvar i = 0; i < dcache_assoc_p; i++) begin: tag_comp
-    assign tag_match_tv[i] = addr_tag_tv == tag_info_tv_r[i].tag;
-    assign load_hit_tv[i] = tag_match_tv[i] & (tag_info_tv_r[i].coh_state != e_COH_I);
-    assign store_hit_tv[i] = tag_match_tv[i] & ((tag_info_tv_r[i].coh_state == e_COH_M)
-                                                || (tag_info_tv_r[i].coh_state == e_COH_E));
     assign invalid_tv[i] = (tag_info_tv_r[i].coh_state == e_COH_I);
   end
-
-  bsg_priority_encode
-    #(.width_p(dcache_assoc_p)
-      ,.lo_to_hi_p(1)
-      )
-    pe_load_hit
-    (.i(load_hit_tv)
-      ,.v_o(load_hit)
-      ,.addr_o(load_hit_way)
-      );
-  
-  bsg_priority_encode
-    #(.width_p(dcache_assoc_p)
-      ,.lo_to_hi_p(1)
-      )
-    pe_store_hit
-    (.i(store_hit_tv)
-      ,.v_o(store_hit)
-      ,.addr_o(store_hit_way)
-      );
 
   wire load_miss_tv = ~load_hit & v_tv_r & load_op_tv_r & ~uncached_tv_r;
   wire store_miss_tv = ~store_hit & v_tv_r & store_op_tv_r & ~uncached_tv_r & ~sc_op_tv_r;
   wire lr_miss_tv = v_tv_r & lr_op_tv_r & ~store_hit;
 
   wire miss_tv = load_miss_tv | store_miss_tv | lr_miss_tv;
+
 
   // uncached req
   //

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -339,7 +339,6 @@ module bp_be_dcache
 
   // data_mem
   //
-  
   logic [dcache_assoc_p-1:0] data_mem_v_li;
   logic data_mem_w_li;
   logic [dcache_assoc_p-1:0][index_width_lp+word_offset_width_lp-1:0] data_mem_addr_li;
@@ -362,13 +361,14 @@ module bp_be_dcache
         ,.write_mask_i(data_mem_mask_li[i])
         ,.data_o(data_mem_data_lo[i])
         );
-  end // block: data_mem
+  end
 
   // miss_detect
   //
   logic [dcache_assoc_p-1:0] tag_match_tl;
   logic [dcache_assoc_p-1:0] load_hit_tl;
   logic [dcache_assoc_p-1:0] store_hit_tl;
+  logic [dcache_assoc_p-1:0] invalid_tl;
   logic load_hit_v_tl;
   logic store_hit_v_tl;
   logic [way_id_width_lp-1:0] load_hit_way_tl;
@@ -385,6 +385,7 @@ module bp_be_dcache
     assign load_hit_tl[i] = tag_match_tl[i] & (tag_mem_data_lo[i].coh_state != e_COH_I);
     assign store_hit_tl[i] = tag_match_tl[i] & ((tag_mem_data_lo[i].coh_state == e_COH_M)
                                                 || (tag_mem_data_lo[i].coh_state == e_COH_E));
+    assign invalid_tl[i] = (tag_mem_data_lo[i].coh_state == e_COH_I);
   end
 
   bsg_priority_encode
@@ -407,11 +408,10 @@ module bp_be_dcache
       ,.addr_o(store_hit_way_tl)
       );
 
-  
-
   // TV stage
   //
   logic v_tv_r;
+  logic tv_we;
   logic lr_op_tv_r;
   logic sc_op_tv_r;
   logic load_op_tv_r;
@@ -438,8 +438,7 @@ module bp_be_dcache
   logic store_hit;
   logic [way_id_width_lp-1:0] load_hit_way;
   logic [way_id_width_lp-1:0] store_hit_way;
-   
-   
+  logic [dcache_assoc_p-1:0] invalid_tv;
 
   assign tv_we = v_tl_r & ~poison_i & ~tlb_miss_i & ~fencei_req;
 
@@ -464,18 +463,15 @@ module bp_be_dcache
       fencei_op_tv_r <= '0;
       paddr_tv_r <= '0;
       tag_info_tv_r <= '0;
-      tag_match_tv <= '0;      
-      load_hit_tv <= '0;       
+      tag_match_tv <= '0;
+      load_hit_tv <= '0;
       store_hit_tv <= '0;
-      load_hit <= '0; 
-      store_hit <= '0; 
+      load_hit <= '0;
+      store_hit <= '0;
       load_hit_way <= '0;
       store_hit_way <= '0;
       addr_tag_tv <= '0;
-       
-       
-      
-
+      invalid_tv <= '0;
     end
     else begin
       v_tv_r <= tv_we;
@@ -495,15 +491,15 @@ module bp_be_dcache
         paddr_tv_r <= paddr_tl;
         tag_info_tv_r <= tag_mem_data_lo;
         uncached_tv_r <= uncached_i;
-	tag_match_tv <= tag_match_tl;      
-	load_hit_tv <= load_hit_tl;       
+        tag_match_tv <= tag_match_tl;
+        load_hit_tv <= load_hit_tl;
         store_hit_tv <= store_hit_tl;
-        load_hit <= load_hit_v_tl;	 
-        store_hit <= store_hit_v_tl;	 
+        load_hit <= load_hit_v_tl;
+        store_hit <= store_hit_v_tl;
         load_hit_way <= load_hit_way_tl;
         store_hit_way <= store_hit_way_tl;
-	addr_tag_tv <= addr_tag_tl;
-
+        addr_tag_tv <= addr_tag_tl;
+	invalid_tv <= invalid_tl; 
       end
 
       if (tv_we & load_op_tl_r) begin
@@ -519,20 +515,11 @@ module bp_be_dcache
   assign addr_index_tv = paddr_tv_r[block_offset_width_lp+:index_width_lp];
   assign addr_word_offset_tv = paddr_tv_r[byte_offset_width_lp+:word_offset_width_lp];
 
-  // invalid_detect
-  //
-  logic [dcache_assoc_p-1:0] invalid_tv;
-
-  for (genvar i = 0; i < dcache_assoc_p; i++) begin: tag_comp
-    assign invalid_tv[i] = (tag_info_tv_r[i].coh_state == e_COH_I);
-  end
-
   wire load_miss_tv = ~load_hit & v_tv_r & load_op_tv_r & ~uncached_tv_r;
   wire store_miss_tv = ~store_hit & v_tv_r & store_op_tv_r & ~uncached_tv_r & ~sc_op_tv_r;
   wire lr_miss_tv = v_tv_r & lr_op_tv_r & ~store_hit;
 
   wire miss_tv = load_miss_tv | store_miss_tv | lr_miss_tv;
-
 
   // uncached req
   //

--- a/bp_be/syn/flist.vcs
+++ b/bp_be/syn/flist.vcs
@@ -162,6 +162,7 @@ $BP_BE_DIR/src/v/bp_be_calculator/bp_be_instr_decoder.v
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_int_alu.v
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_fp.v
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_int.v
+$BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_ctrl.v
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_long.v
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_mem.v
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_mul.v
@@ -197,7 +198,6 @@ $BP_FE_DIR/src/v/bp_fe_top.v
 $BP_ME_DIR/src/v/cache/bp_me_cache_dma_to_cce.v
 $BP_ME_DIR/src/v/cache/bp_me_cache_slice.v
 $BP_ME_DIR/src/v/cache/bp_me_cce_to_cache.v
-$BP_ME_DIR/src/v/cache/bp_me_cce_to_cache_buffered.v
 # CCE
 $BP_ME_DIR/src/v/cce/bp_cce.v
 $BP_ME_DIR/src/v/cce/bp_cce_alu.v
@@ -246,14 +246,12 @@ $BP_TOP_DIR/src/v/bp_sacc_tile.v
 $BP_TOP_DIR/src/v/bp_sacc_tile_node.v
 $BP_TOP_DIR/src/v/bp_sacc_complex.v
 $BP_TOP_DIR/src/v/bp_cfg.v
-$BP_TOP_DIR/src/v/bp_cfg_buffered.v
 $BP_TOP_DIR/src/v/bp_core.v
 $BP_TOP_DIR/src/v/bp_core_complex.v
 $BP_TOP_DIR/src/v/bp_core_minimal.v
 $BP_TOP_DIR/src/v/bp_clint.v
 $BP_TOP_DIR/src/v/bp_clint_node.v
 $BP_TOP_DIR/src/v/bp_clint_slice.v
-$BP_TOP_DIR/src/v/bp_clint_slice_buffered.v
 $BP_TOP_DIR/src/v/bp_l2e_tile.v
 $BP_TOP_DIR/src/v/bp_l2e_tile_node.v
 $BP_TOP_DIR/src/v/bp_io_complex.v

--- a/bp_fe/src/v/bp_fe_icache.v
+++ b/bp_fe/src/v/bp_fe_icache.v
@@ -19,7 +19,7 @@ module bp_fe_icache
   import bp_common_pkg::*;
   import bp_common_aviary_pkg::*;
   import bp_fe_pkg::*;
-  import bp_fe_icache_pkg::*;  
+  import bp_fe_icache_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
     `declare_bp_proc_params(bp_params_p)
     `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
@@ -40,7 +40,7 @@ module bp_fe_icache
     , localparam stat_width_lp = `bp_cache_stat_info_width(icache_assoc_p)
     , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
     , parameter debug_p=0
-    )
+    )   
    (input                                              clk_i
     , input                                            reset_i
 
@@ -171,10 +171,10 @@ module bp_fe_icache
   logic [icache_assoc_p-1:0]                                           data_mem_v_li;
   logic                                                                data_mem_w_li;
   logic [icache_assoc_p-1:0][index_width_lp+word_offset_width_lp-1:0]  data_mem_addr_li;
-  logic [icache_assoc_p-1:0][bank_width_lp-1:0]                        data_mem_data_li;
+  logic [icache_assoc_p-1:0][bank_width_lp-1:0]                         data_mem_data_li;
   logic [icache_assoc_p-1:0][data_mem_mask_width_lp-1:0]               data_mem_w_mask_li;
-  logic [icache_assoc_p-1:0][bank_width_lp-1:0]                        data_mem_data_lo;
-
+  logic [icache_assoc_p-1:0][bank_width_lp-1:0]                         data_mem_data_lo;
+ 
   // data memory: banks
   for (genvar bank = 0; bank < icache_assoc_p; bank++)
   begin: data_mems
@@ -191,7 +191,33 @@ module bp_fe_icache
       ,.w_i(data_mem_w_li)
       ,.data_o(data_mem_data_lo[bank])
     );
-  end                                             
+  end   
+
+
+  logic [ptag_width_lp-1:0]    addr_tag_tl;
+  logic [icache_assoc_p-1:0]     hit_v_tl;
+  logic [way_id_width_lp-1:0] hit_index_tl;
+  logic                       hit_tl;
+  logic [paddr_width_p-1:0]   addr_tl;
+   
+  assign addr_tl = {ptag_i, vaddr_tl_r[0+:bp_page_offset_width_gp]};
+
+  assign addr_tag_tl = addr_tl[block_offset_width_lp+index_width_lp+:ptag_width_lp];
+
+  for (genvar i = 0; i < icache_assoc_p; i++) begin: tag_comp_tl
+    assign hit_v_tl[i]   = (tag_tl[i] == addr_tag_tl) && (state_tl[i] != e_COH_I);
+
+  end     
+
+  bsg_priority_encode #(
+
+    .width_p(icache_assoc_p)
+    ,.lo_to_hi_p(1)
+  ) pe_load_hit (
+    .i(hit_v_tl)
+    ,.v_o(hit_tl)
+    ,.addr_o(hit_index_tl)
+  );
 
   // TV stage
   logic v_tv_r;
@@ -199,13 +225,15 @@ module bp_fe_icache
   logic uncached_tv_r;
   logic [paddr_width_p-1:0]                     addr_tv_r;
   logic [vaddr_width_p-1:0]                     vaddr_tv_r; 
-  logic [icache_assoc_p-1:0][ptag_width_lp-1:0]          tag_tv_r;
-  logic [icache_assoc_p-1:0][$bits(bp_coh_states_e)-1:0] state_tv_r;
-  logic [icache_assoc_p-1:0][bank_width_lp-1:0]          ld_data_tv_r;
-  logic [ptag_width_lp-1:0]                     addr_tag_tv;
+  logic [icache_assoc_p-1:0][ptag_width_lp-1:0]     tag_tv_r;
+  logic [icache_assoc_p-1:0][$bits(bp_coh_states_e)-1:0]     state_tv_r;
+  logic [icache_assoc_p-1:0][bank_width_lp-1:0]    ld_data_tv_r;
+  logic [ptag_width_lp-1:0]                      addr_tag_tv_r;
   logic [index_width_lp-1:0]                    addr_index_tv;
   logic [word_offset_width_lp-1:0]              addr_word_offset_tv;
   logic                                         fencei_op_tv_r;
+  logic [way_id_width_lp-1:0] 			hit_index_tv_r;
+  logic 					hit_tv_r;
 
   // Flush ops are non-speculative and so cannot be poisoned
   assign tv_we = v_tl_r & ((~poison_i & ptag_v_i) | fencei_op_tl_r) & ~fencei_req;
@@ -219,42 +247,36 @@ module bp_fe_icache
     else begin
       v_tv_r <= tv_we;
       if (tv_we) begin
-        addr_tv_r    <= {ptag_i, vaddr_tl_r[0+:bp_page_offset_width_gp]};
+        addr_tv_r    <= addr_tl;
         vaddr_tv_r   <= vaddr_tl_r;
         tag_tv_r     <= tag_tl;
         state_tv_r   <= state_tl;
         ld_data_tv_r <= data_mem_data_lo;
         uncached_tv_r <= uncached_i;
         fencei_op_tv_r <= fencei_op_tl_r;
+	hit_index_tv_r <= hit_index_tl;
+	hit_tv_r       <= hit_tl;
+	addr_tag_tv_r  <= addr_tag_tl;
+	 
+ 
       end
     end
   end
 
-  assign addr_tag_tv = addr_tv_r[block_offset_width_lp+index_width_lp+:ptag_width_lp];
   assign addr_index_tv = addr_tv_r[block_offset_width_lp+:index_width_lp];
   assign addr_word_offset_tv = addr_tv_r[byte_offset_width_lp+:word_offset_width_lp];
 
   //cache hit?
-  logic [icache_assoc_p-1:0]     hit_v;
-  logic [way_id_width_lp-1:0] hit_index;
-  logic                       hit;
+  
 
-  for (genvar i = 0; i < icache_assoc_p; i++) begin: tag_comp
-    assign hit_v[i]   = (tag_tv_r[i] == addr_tag_tv) && (state_tv_r[i] != e_COH_I);
+  for (genvar i = 0; i < lce_assoc_p; i++) begin: tag_comp_tv
     assign way_v[i]   = (state_tv_r[i] != e_COH_I);
   end
 
-  bsg_priority_encode #(
-    .width_p(icache_assoc_p)
-    ,.lo_to_hi_p(1)
-  ) pe_load_hit (
-    .i(hit_v)
-    ,.v_o(hit)
-    ,.addr_o(hit_index)
-  );
+
 
   logic miss_tv;
-  assign miss_tv = ~hit & v_tv_r & ~uncached_tv_r;
+  assign miss_tv = ~hit_tv_r & v_tv_r & ~uncached_tv_r;
 
   // uncached request
   logic uncached_load_data_v_r;
@@ -377,7 +399,7 @@ module bp_fe_icache
     ,.els_p(icache_assoc_p)
   ) data_set_select_mux (
     .data_i(ld_data_tv_r)
-    ,.sel_i(hit_index ^ addr_word_offset_tv)
+    ,.sel_i(hit_index_tv_r ^ addr_word_offset_tv)
     ,.data_o(ld_data_way_picked)
   );
 
@@ -391,7 +413,7 @@ module bp_fe_icache
      ,.sel_i(addr_tv_r[3+:`BSG_CDIV(num_dwords_per_bank_lp, 2)])
      ,.data_o(ld_data_dword_picked)
      );
-
+   
   logic [dword_width_p-1:0] final_data;
   bsg_mux #(
     .width_p(dword_width_p)
@@ -404,7 +426,7 @@ module bp_fe_icache
 
   logic lower_upper_sel;
 
-  assign lower_upper_sel             = addr_tv_r[2]; // Select upper/lower 32 bits
+  assign lower_upper_sel             = addr_tv_r[2];
   assign data_o = lower_upper_sel
     ? final_data[instr_width_p+:instr_width_p]
     : final_data[instr_width_p-1:0];
@@ -499,7 +521,7 @@ module bp_fe_icache
   bsg_lru_pseudo_tree_decode #(
      .ways_p(icache_assoc_p)
   ) lru_decode (
-     .way_id_i(hit_index)
+     .way_id_i(hit_index_tv_r)
      ,.data_o(lru_decode_data_lo)
      ,.mask_o(lru_decode_mask_lo)
   );

--- a/bp_fe/src/v/bp_fe_icache.v
+++ b/bp_fe/src/v/bp_fe_icache.v
@@ -40,7 +40,7 @@ module bp_fe_icache
     , localparam stat_width_lp = `bp_cache_stat_info_width(icache_assoc_p)
     , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
     , parameter debug_p=0
-    )   
+    )
    (input                                              clk_i
     , input                                            reset_i
 
@@ -171,10 +171,10 @@ module bp_fe_icache
   logic [icache_assoc_p-1:0]                                           data_mem_v_li;
   logic                                                                data_mem_w_li;
   logic [icache_assoc_p-1:0][index_width_lp+word_offset_width_lp-1:0]  data_mem_addr_li;
-  logic [icache_assoc_p-1:0][bank_width_lp-1:0]                         data_mem_data_li;
+  logic [icache_assoc_p-1:0][bank_width_lp-1:0]                        data_mem_data_li;
   logic [icache_assoc_p-1:0][data_mem_mask_width_lp-1:0]               data_mem_w_mask_li;
-  logic [icache_assoc_p-1:0][bank_width_lp-1:0]                         data_mem_data_lo;
- 
+  logic [icache_assoc_p-1:0][bank_width_lp-1:0]                        data_mem_data_lo;
+
   // data memory: banks
   for (genvar bank = 0; bank < icache_assoc_p; bank++)
   begin: data_mems
@@ -191,14 +191,14 @@ module bp_fe_icache
       ,.w_i(data_mem_w_li)
       ,.data_o(data_mem_data_lo[bank])
     );
-  end   
-
+  end
 
   logic [ptag_width_lp-1:0]    addr_tag_tl;
-  logic [icache_assoc_p-1:0]     hit_v_tl;
-  logic [way_id_width_lp-1:0] hit_index_tl;
-  logic                       hit_tl;
-  logic [paddr_width_p-1:0]   addr_tl;
+  logic [icache_assoc_p-1:0]   hit_v_tl;
+  logic [way_id_width_lp-1:0]  hit_index_tl;
+  logic                        hit_tl;
+  logic [paddr_width_p-1:0]    addr_tl;
+  logic [icache_assoc_p-1:0]  way_v_tl;
    
   assign addr_tl = {ptag_i, vaddr_tl_r[0+:bp_page_offset_width_gp]};
 
@@ -206,11 +206,10 @@ module bp_fe_icache
 
   for (genvar i = 0; i < icache_assoc_p; i++) begin: tag_comp_tl
     assign hit_v_tl[i]   = (tag_tl[i] == addr_tag_tl) && (state_tl[i] != e_COH_I);
-
+    assign way_v_tl[i]   = (state_tl[i] != e_COH_I);
   end     
 
   bsg_priority_encode #(
-
     .width_p(icache_assoc_p)
     ,.lo_to_hi_p(1)
   ) pe_load_hit (
@@ -223,17 +222,18 @@ module bp_fe_icache
   logic v_tv_r;
   logic tv_we;
   logic uncached_tv_r;
-  logic [paddr_width_p-1:0]                     addr_tv_r;
-  logic [vaddr_width_p-1:0]                     vaddr_tv_r; 
-  logic [icache_assoc_p-1:0][ptag_width_lp-1:0]     tag_tv_r;
+  logic [paddr_width_p-1:0]                                  addr_tv_r;
+  logic [vaddr_width_p-1:0] 				     vaddr_tv_r;
+  logic [icache_assoc_p-1:0][ptag_width_lp-1:0]              tag_tv_r;
   logic [icache_assoc_p-1:0][$bits(bp_coh_states_e)-1:0]     state_tv_r;
-  logic [icache_assoc_p-1:0][bank_width_lp-1:0]    ld_data_tv_r;
-  logic [ptag_width_lp-1:0]                      addr_tag_tv_r;
-  logic [index_width_lp-1:0]                    addr_index_tv;
-  logic [word_offset_width_lp-1:0]              addr_word_offset_tv;
-  logic                                         fencei_op_tv_r;
-  logic [way_id_width_lp-1:0] 			hit_index_tv_r;
-  logic 					hit_tv_r;
+  logic [icache_assoc_p-1:0][bank_width_lp-1:0]              ld_data_tv_r;
+  logic [ptag_width_lp-1:0]                                  addr_tag_tv_r;
+  logic [index_width_lp-1:0]                                 addr_index_tv;
+  logic [word_offset_width_lp-1:0]                           addr_word_offset_tv;
+  logic                                                      fencei_op_tv_r;
+  logic [way_id_width_lp-1:0] 			             hit_index_tv_r;
+  logic 					             hit_tv_r;
+  logic [icache_assoc_p-1:0]                                 way_v;
 
   // Flush ops are non-speculative and so cannot be poisoned
   assign tv_we = v_tl_r & ((~poison_i & ptag_v_i) | fencei_op_tl_r) & ~fencei_req;
@@ -247,33 +247,23 @@ module bp_fe_icache
     else begin
       v_tv_r <= tv_we;
       if (tv_we) begin
-        addr_tv_r    <= addr_tl;
-        vaddr_tv_r   <= vaddr_tl_r;
-        tag_tv_r     <= tag_tl;
-        state_tv_r   <= state_tl;
-        ld_data_tv_r <= data_mem_data_lo;
-        uncached_tv_r <= uncached_i;
+        addr_tv_r      <= addr_tl;
+        vaddr_tv_r     <= vaddr_tl_r;
+        tag_tv_r       <= tag_tl;
+        state_tv_r     <= state_tl;
+        ld_data_tv_r   <= data_mem_data_lo;
+        uncached_tv_r  <= uncached_i;
         fencei_op_tv_r <= fencei_op_tl_r;
-	hit_index_tv_r <= hit_index_tl;
-	hit_tv_r       <= hit_tl;
-	addr_tag_tv_r  <= addr_tag_tl;
-	 
- 
+        hit_index_tv_r <= hit_index_tl;
+        hit_tv_r       <= hit_tl;
+        addr_tag_tv_r  <= addr_tag_tl;
+	way_v          <= way_v_tl;
       end
     end
   end
 
   assign addr_index_tv = addr_tv_r[block_offset_width_lp+:index_width_lp];
   assign addr_word_offset_tv = addr_tv_r[byte_offset_width_lp+:word_offset_width_lp];
-
-  //cache hit?
-  
-
-  for (genvar i = 0; i < lce_assoc_p; i++) begin: tag_comp_tv
-    assign way_v[i]   = (state_tv_r[i] != e_COH_I);
-  end
-
-
 
   logic miss_tv;
   assign miss_tv = ~hit_tv_r & v_tv_r & ~uncached_tv_r;
@@ -283,8 +273,7 @@ module bp_fe_icache
   logic [dword_width_p-1:0] uncached_load_data_r;
 
   assign uncached_req = v_tv_r & uncached_tv_r & ~uncached_load_data_v_r;
-  assign fencei_req = v_tv_r & fencei_op_tv_r;
-
+  assign fencei_req = v_tv_r & fencei_op_tv_r; 
  
   // stat memory
   logic                                       stat_mem_v_li;
@@ -413,7 +402,7 @@ module bp_fe_icache
      ,.sel_i(addr_tv_r[3+:`BSG_CDIV(num_dwords_per_bank_lp, 2)])
      ,.data_o(ld_data_dword_picked)
      );
-   
+
   logic [dword_width_p-1:0] final_data;
   bsg_mux #(
     .width_p(dword_width_p)
@@ -426,7 +415,7 @@ module bp_fe_icache
 
   logic lower_upper_sel;
 
-  assign lower_upper_sel             = addr_tv_r[2];
+  assign lower_upper_sel             = addr_tv_r[2]; // Select upper/lower 32 bits
   assign data_o = lower_upper_sel
     ? final_data[instr_width_p+:instr_width_p]
     : final_data[instr_width_p-1:0];


### PR DESCRIPTION
The updated fe_dev branch from my fork contains the reshuffled icache and dcache, both with tag compare moved from the tv stage to the tl stage. In the case of the dcache, miss detection is still handled in tv. Additionally, there may be some accidental changes to submodules or the testing infrastructure, but as of my last commit the testing infrastructure worked and the softcore was passing the beebs and riscv-tests regressions.

