### PR TITLE
Add partial fill support to Cache Service Interface

### DIFF
--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -488,12 +488,6 @@ module bp_be_dcache
     );
 
 
-  wire load_miss_tv = ~load_hit & v_tv_r & load_op_tv_r & ~uncached_tv_r;
-  wire store_miss_tv = ~store_hit & v_tv_r & store_op_tv_r & ~uncached_tv_r & ~sc_op_tv_r;
-  wire lr_miss_tv = v_tv_r & lr_op_tv_r & ~store_hit ;
-
-  wire miss_tv = load_miss_tv | store_miss_tv | lr_miss_tv;
-
   // uncached req
   //
   logic uncached_load_req;

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce.v
@@ -1,5 +1,5 @@
 /**
- *  Name: 
+ *  Name:
  *    bp_be_dcache_lce.v
  *
  *
@@ -21,11 +21,11 @@
  *    cache. cache_miss_o is raised immediately once load_miss_i or
  *    store_miss_i is raised. cache_miss_o remains asserted until the miss
  *    is resolved.
- *     
+ *
  *      LCE sends responses back to CCE through lce_cce_resp. Both
  *    lce_cce_req or cce_lce_cmd could send response back, and when both
  *    modules want to send the response, lce_cce_req always get the higher
- *    priority in arbitration. We want to prioritize the types of acknowledge 
+ *    priority in arbitration. We want to prioritize the types of acknowledge
  *    that are sent later in the chain of coherence messages which resolves
  *    coherence transaction, otherwise it could create back-pressure in
  *    network and cause a deadlock.
@@ -48,9 +48,9 @@ module bp_be_dcache_lce
   import bp_be_dcache_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p) 
-   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache)
-    
+   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache)
+
     , localparam block_size_in_words_lp = dcache_assoc_p
     , localparam bank_width_lp = dcache_block_width_p / dcache_assoc_p
     , localparam num_dwords_per_bank_lp = bank_width_lp / dword_width_p
@@ -77,21 +77,21 @@ module bp_be_dcache_lce
     , output logic cache_req_ready_o
     , input [dcache_req_metadata_width_lp-1:0] cache_req_metadata_i
     , input cache_req_metadata_v_i
- 
+
     , output logic cache_req_complete_o
-    
+
     // data_mem
     , output logic data_mem_pkt_v_o
     , output logic [dcache_data_mem_pkt_width_lp-1:0] data_mem_pkt_o
     , input data_mem_pkt_yumi_i
     , input [dcache_block_width_p-1:0] data_mem_i
-  
+
     // tag_mem
     , output logic tag_mem_pkt_v_o
     , output logic [dcache_tag_mem_pkt_width_lp-1:0] tag_mem_pkt_o
     , input tag_mem_pkt_yumi_i
     , input [ptag_width_lp-1:0] tag_mem_i
-    
+
     // stat_mem
     , output logic stat_mem_pkt_v_o
     , output logic [dcache_stat_mem_pkt_width_lp-1:0] stat_mem_pkt_o
@@ -125,8 +125,8 @@ module bp_be_dcache_lce
   // casting structs
   //
   `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache);
- 
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache);
+
   bp_lce_cce_req_s lce_req;
   bp_lce_cce_resp_s lce_resp;
   bp_lce_cmd_s lce_cmd_in, lce_cmd_out;
@@ -195,7 +195,7 @@ module bp_be_dcache_lce
       ,.reset_i(reset_i)
 
       ,.lce_id_i(lce_id_i)
-  
+
       ,.cache_req_i(cache_req_i)
       ,.cache_req_v_i(cache_req_v_i)
       ,.cache_req_ready_o(cache_req_ready_o)
@@ -207,7 +207,7 @@ module bp_be_dcache_lce
       ,.cce_data_received_i(cce_data_received)
       ,.uncached_data_received_i(uncached_data_received)
       ,.set_tag_wakeup_received_i(set_tag_wakeup_received)
-      
+
       ,.coherence_blocked_i(coherence_blocked_li)
       ,.cmd_ready_i(cmd_ready_lo)
       ,.credits_ready_i(~credits_full_o)
@@ -291,4 +291,3 @@ module bp_be_dcache_lce
   end
 
 endmodule
-

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce.v
@@ -79,6 +79,8 @@ module bp_be_dcache_lce
     , input cache_req_metadata_v_i
 
     , output logic cache_req_complete_o
+    , output logic cache_req_critical_o
+
 
     // data_mem
     , output logic data_mem_pkt_v_o
@@ -243,6 +245,7 @@ module bp_be_dcache_lce
       ,.cce_data_received_o(cce_data_received)
       ,.uncached_data_received_o(uncached_data_received)
       ,.cache_req_complete_o(cache_req_complete_o)
+      ,.cache_req_critical_o(cache_req_critical_o)
 
       ,.lce_cmd_i(lce_cmd_in)
       ,.lce_cmd_v_i(lce_cmd_v_i)

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce.v
@@ -47,24 +47,28 @@ module bp_be_dcache_lce
   import bp_common_cfg_link_pkg::*;
   import bp_be_dcache_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
+   ,parameter assoc_p = 8
+   ,parameter sets_p = 64
+   ,parameter block_width_p = 512
+   ,parameter fill_width_p = 512
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
-   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache)
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, dcache)
 
-    , localparam block_size_in_words_lp = dcache_assoc_p
-    , localparam bank_width_lp = dcache_block_width_p / dcache_assoc_p
+    , localparam block_size_in_words_lp = assoc_p
+    , localparam bank_width_lp = block_width_p / assoc_p
     , localparam num_dwords_per_bank_lp = bank_width_lp / dword_width_p
     , localparam bypass_data_mask_width_lp = (dword_width_p >> 3)
     , localparam data_mem_mask_width_lp = (bank_width_lp >> 3)
     , localparam byte_offset_width_lp = `BSG_SAFE_CLOG2(bank_width_lp>>3)
     , localparam word_offset_width_lp = `BSG_SAFE_CLOG2(block_size_in_words_lp)
     , localparam block_offset_width_lp = (word_offset_width_lp+byte_offset_width_lp)
-    , localparam index_width_lp = `BSG_SAFE_CLOG2(dcache_sets_p)
+    , localparam index_width_lp = `BSG_SAFE_CLOG2(sets_p)
     , localparam ptag_width_lp = (paddr_width_p-bp_page_offset_width_gp)
-    , localparam way_id_width_lp = `BSG_SAFE_CLOG2(dcache_assoc_p)
+    , localparam way_id_width_lp = `BSG_SAFE_CLOG2(assoc_p)
 
     , localparam stat_info_width_lp=
-      `bp_cache_stat_info_width(dcache_assoc_p)
+      `bp_cache_stat_info_width(assoc_p)
   )
   (
     input clk_i
@@ -86,7 +90,7 @@ module bp_be_dcache_lce
     , output logic data_mem_pkt_v_o
     , output logic [dcache_data_mem_pkt_width_lp-1:0] data_mem_pkt_o
     , input data_mem_pkt_yumi_i
-    , input [dcache_block_width_p-1:0] data_mem_i
+    , input [block_width_p-1:0] data_mem_i
 
     // tag_mem
     , output logic tag_mem_pkt_v_o
@@ -127,7 +131,7 @@ module bp_be_dcache_lce
   // casting structs
   //
   `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache);
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, dcache);
 
   bp_lce_cce_req_s lce_req;
   bp_lce_cce_resp_s lce_resp;
@@ -191,7 +195,11 @@ module bp_be_dcache_lce
   assign coherence_blocked_li = lce_cmd_v_i & ~lce_cmd_yumi_o;
 
   bp_be_dcache_lce_req
-    #(.bp_params_p(bp_params_p))
+    #(.bp_params_p(bp_params_p)
+    ,.assoc_p(assoc_p)
+    ,.sets_p(sets_p)
+    ,.block_width_p(block_width_p)
+    ,.fill_width_p(fill_width_p))
     lce_req_inst
       (.clk_i(clk_i)
       ,.reset_i(reset_i)
@@ -230,7 +238,11 @@ module bp_be_dcache_lce
   logic lce_cmd_to_lce_resp_yumi_li;
 
   bp_be_dcache_lce_cmd
-    #(.bp_params_p(bp_params_p))
+    #(.bp_params_p(bp_params_p)
+     ,.assoc_p(assoc_p)
+     ,.sets_p(sets_p)
+     ,.block_width_p(block_width_p)
+     ,.fill_width_p(fill_width_p))
     lce_cmd_inst
       (.clk_i(clk_i)
       ,.reset_i(reset_i)

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_cmd.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_cmd.v
@@ -57,6 +57,7 @@ module bp_be_dcache_lce_cmd
     , output logic cce_data_received_o
     , output logic uncached_data_received_o
     , output logic cache_req_complete_o
+    , output logic cache_req_critical_o
 
     // CCE_LCE_cmd
     , input [lce_cmd_width_lp-1:0] lce_cmd_i
@@ -214,6 +215,7 @@ module bp_be_dcache_lce_cmd
     uncached_data_received_o = 1'b0;
     cce_data_received_o = 1'b0;
     cache_req_complete_o = 1'b0;
+    cache_req_critical_o = 1'b0;
 
     lce_cmd_yumi_o = 1'b0;
 
@@ -311,6 +313,7 @@ module bp_be_dcache_lce_cmd
               data_mem_pkt.index = miss_addr_i[block_offset_width_lp+:index_width_lp];
               data_mem_pkt.way_id = lce_cmd_li.header.way_id[0+:way_id_width_lp];
               data_mem_pkt.data = lce_cmd_li.data;
+              data_mem_pkt.fill_mask = {dcache_assoc_p{1'b1}};
               data_mem_pkt.opcode = e_cache_data_mem_uncached;
               data_mem_pkt_v_o = lce_cmd_v_i;
 
@@ -318,6 +321,7 @@ module bp_be_dcache_lce_cmd
 
               uncached_data_received_o = data_mem_pkt_yumi_i;
               cache_req_complete_o = data_mem_pkt_yumi_i;
+              cache_req_critical_o = data_mem_pkt_yumi_i;
 
             end
 
@@ -443,6 +447,7 @@ module bp_be_dcache_lce_cmd
             data_mem_pkt.index = miss_addr_i[block_offset_width_lp+:index_width_lp];
             data_mem_pkt.way_id = lce_cmd_li.header.way_id[0+:way_id_width_lp];
             data_mem_pkt.data = lce_cmd_li.data;
+            data_mem_pkt.fill_mask = {dcache_assoc_p{1'b1}};
             data_mem_pkt.opcode = e_cache_data_mem_write;
             data_mem_pkt_v_o = lce_cmd_v_i;
 
@@ -457,6 +462,7 @@ module bp_be_dcache_lce_cmd
 
             cce_data_received_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
             cache_req_complete_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+            cache_req_critical_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
 
           end
 
@@ -464,6 +470,7 @@ module bp_be_dcache_lce_cmd
             data_mem_pkt.index = miss_addr_i[block_offset_width_lp+:index_width_lp];
             data_mem_pkt.way_id = lce_cmd_li.header.way_id[0+:way_id_width_lp];
             data_mem_pkt.data = lce_cmd_li.data;
+            data_mem_pkt.fill_mask = {dcache_assoc_p{1'b1}};
             data_mem_pkt.opcode = e_cache_data_mem_uncached;
             data_mem_pkt_v_o = lce_cmd_v_i;
 
@@ -471,6 +478,8 @@ module bp_be_dcache_lce_cmd
 
             uncached_data_received_o = data_mem_pkt_yumi_i;
             cache_req_complete_o = data_mem_pkt_yumi_i;
+            cache_req_critical_o = data_mem_pkt_yumi_i;
+
           end
 
           e_lce_cmd_set_clear: begin

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_req.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_req.v
@@ -26,23 +26,27 @@ module bp_be_dcache_lce_req
   import bp_be_dcache_pkg::*;
   import bp_common_aviary_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
+   ,parameter assoc_p = 8
+   ,parameter sets_p = 64
+   ,parameter block_width_p = 512
+   ,parameter fill_width_p = 512
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
-   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache)
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, dcache)
 
     , localparam cfg_bus_width_lp= `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
-    , localparam block_size_in_words_lp = dcache_assoc_p
-    , localparam bank_width_lp = dcache_block_width_p / dcache_assoc_p
+    , localparam block_size_in_words_lp = assoc_p
+    , localparam bank_width_lp = block_width_p / assoc_p
     , localparam num_dwords_per_bank_lp = bank_width_lp / dword_width_p
     , localparam bypass_data_mask_width_lp = (dword_width_p >> 3)
     , localparam data_mem_mask_width_lp = (bank_width_lp >> 3)
     , localparam byte_offset_width_lp = `BSG_SAFE_CLOG2(bank_width_lp>>3)
     , localparam word_offset_width_lp = `BSG_SAFE_CLOG2(block_size_in_words_lp)
     , localparam block_offset_width_lp = (word_offset_width_lp+byte_offset_width_lp)
-    , localparam index_width_lp = `BSG_SAFE_CLOG2(dcache_sets_p)
+    , localparam index_width_lp = `BSG_SAFE_CLOG2(sets_p)
     , localparam ptag_width_lp = (paddr_width_p-bp_page_offset_width_gp)
-    , localparam way_id_width_lp = `BSG_SAFE_CLOG2(dcache_assoc_p)
-    , localparam block_size_in_bytes_lp = (dcache_block_width_p / 8)
+    , localparam way_id_width_lp = `BSG_SAFE_CLOG2(assoc_p)
+    , localparam block_size_in_bytes_lp = (block_width_p / 8)
 
     , parameter timeout_max_limit_p=4
 
@@ -81,7 +85,7 @@ module bp_be_dcache_lce_req
   // casting struct
   //
   `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache);
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, dcache);
 
   bp_lce_cce_req_s lce_req;
   bp_lce_cce_resp_s lce_resp;

--- a/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
@@ -17,8 +17,8 @@ module bp_be_mem_top
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
-   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache)
-   
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache)
+
    // Generated parameters
    // D$
    , localparam block_size_in_words_lp = dcache_assoc_p // Due to cache interleaving scheme
@@ -32,8 +32,8 @@ module bp_be_mem_top
    , localparam index_width_lp         = `BSG_SAFE_CLOG2(dcache_sets_p)
    , localparam page_offset_width_lp   = (block_offset_width_lp + index_width_lp)
    , localparam way_id_width_lp=`BSG_SAFE_CLOG2(dcache_assoc_p)
-   
-   , localparam stat_info_width_lp = `bp_cache_stat_info_width(dcache_assoc_p)   
+
+   , localparam stat_info_width_lp = `bp_cache_stat_info_width(dcache_assoc_p)
 
    , localparam cfg_bus_width_lp      = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
 
@@ -82,6 +82,7 @@ module bp_be_mem_top
    , output logic                                   cache_req_metadata_v_o
 
    , input cache_req_complete_i
+   , input cache_req_critical_i
 
    // data_mem
    , input data_mem_pkt_v_i
@@ -120,7 +121,7 @@ module bp_be_mem_top
 // Not sure if this is right.
 `declare_bp_be_mmu_structs(vaddr_width_p, ptag_width_p, dcache_sets_p, dcache_block_width_p/8)
 `declare_bp_be_dcache_pkt_s(page_offset_width_lp, dword_width_p);
-`declare_bp_cache_service_if(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache);
+`declare_bp_cache_service_if(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache);
   bp_dcache_req_s cache_req_cast_o;
 
   assign cache_req_o = cache_req_cast_o;
@@ -364,7 +365,7 @@ bp_be_ptw
    ,.dcache_v_o(ptw_dcache_v)
    ,.dcache_pkt_o(ptw_dcache_pkt)
    ,.dcache_ptag_o(ptw_dcache_ptag)
-   ,.dcache_rdy_i(dcache_ready_lo) 
+   ,.dcache_rdy_i(dcache_ready_lo)
    ,.dcache_miss_i(dcache_miss_lo)
   );
 
@@ -397,6 +398,7 @@ bp_be_dcache
     // D$-LCE Interface
     ,.dcache_miss_o(dcache_miss_lo)
     ,.cache_req_complete_i(cache_req_complete_i)
+    ,.cache_req_critical_i(cache_req_critical_i)
     ,.cache_req_o(cache_req_cast_o)
     ,.cache_req_v_o(cache_req_v_o)
     ,.cache_req_ready_i(cache_req_ready_i)
@@ -530,4 +532,3 @@ always_ff @(negedge clk_i)
 // synopsys translate_on
 //
 endmodule
-

--- a/bp_be/src/v/bp_be_top.v
+++ b/bp_be/src/v/bp_be_top.v
@@ -2,7 +2,7 @@
  *
  *  Name:
  *    bp_be_top.v
- * 
+ *
  */
 
 
@@ -17,11 +17,11 @@ module bp_be_top
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_fe_be_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
-   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache)
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache)
 
-   // Default parameters 
+   // Default parameters
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
-   
+
    // VM parameters
    , localparam tlb_entry_width_lp = `bp_pte_entry_leaf_width(paddr_width_p)
    , localparam stat_info_width_lp = `bp_cache_stat_info_width(dcache_assoc_p)
@@ -59,7 +59,8 @@ module bp_be_top
    , output logic                                cache_req_metadata_v_o
 
    , input cache_req_complete_i
-   
+   , input cache_req_critical_i
+
    // data_mem
    , input data_mem_pkt_v_i
    , input [dcache_data_mem_pkt_width_lp-1:0] data_mem_pkt_i
@@ -139,7 +140,7 @@ logic wb_pkt_v;
 
 logic flush;
 // Module instantiations
-bp_be_checker_top 
+bp_be_checker_top
  #(.bp_params_p(bp_params_p))
  be_checker
   (.clk_i(clk_i)
@@ -183,7 +184,7 @@ bp_be_checker_top
    ,.wb_pkt_i(wb_pkt)
    );
 
-bp_be_calculator_top 
+bp_be_calculator_top
  #(.bp_params_p(bp_params_p))
  be_calculator
   (.clk_i(clk_i)
@@ -203,9 +204,9 @@ bp_be_calculator_top
    ,.csr_cmd_v_o(csr_cmd_v)
    ,.csr_cmd_ready_i(csr_cmd_rdy)
 
-   ,.mem_resp_i(mem_resp) 
+   ,.mem_resp_i(mem_resp)
    ,.mem_resp_v_i(mem_resp_v)
-   ,.mem_resp_ready_o(mem_resp_rdy)   
+   ,.mem_resp_ready_o(mem_resp_rdy)
 
    ,.commit_pkt_o(commit_pkt)
    ,.wb_pkt_o(wb_pkt)
@@ -234,19 +235,20 @@ bp_be_mem_top
     ,.mem_resp_o(mem_resp)
     ,.mem_resp_v_o(mem_resp_v)
     ,.mem_resp_ready_i(mem_resp_rdy)
-    
+
     ,.itlb_fill_v_o(itlb_fill_v)
     ,.itlb_fill_vaddr_o(itlb_fill_vaddr)
     ,.itlb_fill_entry_o(itlb_fill_entry)
 
-    ,.cache_req_complete_i(cache_req_complete_i)   
- 
+    ,.cache_req_complete_i(cache_req_complete_i)
+    ,.cache_req_critical_i(cache_req_critical_i)
+
     ,.cache_req_o(cache_req_o)
     ,.cache_req_metadata_o(cache_req_metadata_o)
     ,.cache_req_v_o(cache_req_v_o)
     ,.cache_req_ready_i(cache_req_ready_i)
     ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
-    
+
     ,.data_mem_pkt_v_i(data_mem_pkt_v_i)
     ,.data_mem_pkt_i(data_mem_pkt_i)
     ,.data_mem_o(data_mem_o)
@@ -274,4 +276,3 @@ bp_be_mem_top
     );
 
 endmodule
-

--- a/bp_be/syn/flist.vcs
+++ b/bp_be/syn/flist.vcs
@@ -146,8 +146,8 @@ $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter_in.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter_out.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_decoder_dor.v
-$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_input_control.v  
-$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.v 
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_input_control.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.v
 # Common files
 $BP_COMMON_DIR/src/v/bsg_fifo_1r1w_rolly.v
 $BP_COMMON_DIR/src/v/bp_pma.v
@@ -162,6 +162,7 @@ $BP_BE_DIR/src/v/bp_be_calculator/bp_be_instr_decoder.v
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_int_alu.v
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_fp.v
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_int.v
+$BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_ctrl.v
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_long.v
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_mem.v
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_mul.v

--- a/bp_be/test/tb/bp_be_dcache/wrapper.v
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.v
@@ -3,7 +3,7 @@
  * wrapper.v
  *
  */
- 
+
 module wrapper
  import bp_common_pkg::*;
  import bp_common_aviary_pkg::*;
@@ -18,7 +18,7 @@ module wrapper
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
-   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache)
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache)
 
    , parameter debug_p=0
    , parameter lock_max_limit_p=8
@@ -36,7 +36,7 @@ module wrapper
    , localparam ptag_width_lp=(paddr_width_p-bp_page_offset_width_gp)
    , localparam way_id_width_lp=`BSG_SAFE_CLOG2(dcache_assoc_p)
 
-   , localparam wg_per_cce_lp = (lce_sets_p / num_cce_p) 
+   , localparam wg_per_cce_lp = (lce_sets_p / num_cce_p)
 
    , localparam dcache_pkt_width_lp=`bp_be_dcache_pkt_width(page_offset_width_p,dword_width_p)
    , localparam tag_info_width_lp=`bp_be_dcache_tag_info_width(ptag_width_lp)
@@ -81,7 +81,7 @@ module wrapper
    // Miss, Management Interfaces
    logic cache_req_v_lo, cache_req_metadata_v_lo;
    logic cache_req_ready_lo;
-   logic cache_req_complete_lo;
+   logic cache_req_complete_lo, cache_req_critical_lo;
    logic [dcache_req_width_lp-1:0] cache_req_lo;
    logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
 
@@ -101,18 +101,18 @@ module wrapper
    bsg_fifo_1r1w_rolly
    #(.width_p(dcache_pkt_width_lp+ptag_width_lp+1)
     ,.els_p(8))
-    rolly 
+    rolly
     (.clk_i(clk_i)
     ,.reset_i(reset_i)
-    
+
     ,.roll_v_i(rollback_li)
     ,.clr_v_i(1'b0)
     ,.deq_v_i(v_o)
-    
+
     ,.data_i({uncached_i, ptag_i, dcache_pkt_i})
     ,.v_i(v_i)
     ,.ready_o(ready_o)
-    
+
     ,.data_o({rolly_uncached_lo, rolly_ptag_lo, rolly_dcache_pkt_lo})
     ,.v_o(rolly_v_lo)
     ,.yumi_i(rolly_yumi_li)
@@ -131,7 +131,7 @@ module wrapper
 
    assign rollback_li = rolly_yumi_rr & ~v_o;
    assign rolly_yumi_li = rolly_v_lo & dcache_ready_lo;
-  
+
    logic [ptag_width_lp-1:0] rolly_ptag_r;
    bsg_dff_reset
     #(.width_p(ptag_width_lp)
@@ -157,7 +157,7 @@ module wrapper
     );
 
    assign poison_li = dcache_v_rr & ~v_o;
-   
+
    logic uncached_r;
    bsg_dff_reset
    #(.width_p(1)
@@ -170,16 +170,16 @@ module wrapper
    ,.data_i(rolly_uncached_lo)
    ,.data_o(uncached_r)
    );
-  
+
    bp_be_dcache
    #(.bp_params_p(bp_params_p)
     ,.writethrough_p(writethrough_p))
    dcache
    (.clk_i(clk_i)
    ,.reset_i(reset_i)
-   
+
    ,.cfg_bus_i(cfg_bus_i)
-   
+
    ,.dcache_pkt_i(rolly_dcache_pkt_lo)
    ,.v_i(rolly_v_lo)
    ,.ready_o(dcache_ready_lo)
@@ -198,13 +198,14 @@ module wrapper
    ,.store_op_tl_o()
 
    ,.dcache_miss_o(dcache_miss_lo)
-    
+
    ,.cache_req_v_o(cache_req_v_lo)
    ,.cache_req_o(cache_req_lo)
    ,.cache_req_metadata_o(cache_req_metadata_lo)
    ,.cache_req_metadata_v_o(cache_req_metadata_v_lo)
    ,.cache_req_ready_i(cache_req_ready_lo)
    ,.cache_req_complete_i(cache_req_complete_lo)
+   ,.cache_req_critical_i(cache_req_critical_lo)
 
    ,.data_mem_pkt_v_i(data_mem_pkt_v_lo)
    ,.data_mem_pkt_i(data_mem_pkt_lo)
@@ -225,11 +226,11 @@ module wrapper
    if(uce_p == 0) begin : cce
      logic lce_req_v_lo, lce_resp_v_lo;
      logic lce_req_ready_lo, lce_resp_ready_lo;
-     logic fifo_lce_cmd_v_lo, fifo_lce_cmd_yumi_li, lce_cmd_v_lo, lce_cmd_ready_li;  
+     logic fifo_lce_cmd_v_lo, fifo_lce_cmd_yumi_li, lce_cmd_v_lo, lce_cmd_ready_li;
      logic [lce_cce_req_width_lp-1:0] lce_req_lo;
      logic [lce_cmd_width_lp-1:0] lce_cmd_lo, fifo_lce_cmd_lo;
      logic [lce_cce_resp_width_lp-1:0] lce_resp_lo;
-     
+
      logic mem_resp_ready_lo;
 
      bp_be_dcache_lce
@@ -237,7 +238,7 @@ module wrapper
      dcache_lce
      (.clk_i(clk_i)
      ,.reset_i(reset_i)
-     
+
      ,.lce_id_i('0)
 
      ,.cache_req_i(cache_req_lo)
@@ -247,6 +248,7 @@ module wrapper
      ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
 
      ,.cache_req_complete_o(cache_req_complete_lo)
+     ,.cache_req_critical_o(cache_req_critical_lo)
 
      ,.data_mem_pkt_v_o(data_mem_pkt_v_lo)
      ,.data_mem_pkt_o(data_mem_pkt_lo)
@@ -262,7 +264,7 @@ module wrapper
      ,.stat_mem_pkt_o(stat_mem_pkt_lo)
      ,.stat_mem_i(stat_mem_lo)
      ,.stat_mem_pkt_yumi_i(stat_mem_pkt_yumi_lo)
-      
+
      ,.lce_req_o(lce_req_lo)
      ,.lce_req_v_o(lce_req_v_lo)
      ,.lce_req_ready_i(lce_req_ready_lo)
@@ -270,7 +272,7 @@ module wrapper
      ,.lce_resp_o(lce_resp_lo)
      ,.lce_resp_v_o(lce_resp_v_lo)
      ,.lce_resp_ready_i(lce_resp_ready_lo)
-     
+
      ,.lce_cmd_i(fifo_lce_cmd_lo)
      ,.lce_cmd_v_i(fifo_lce_cmd_v_lo)
      ,.lce_cmd_yumi_o(fifo_lce_cmd_yumi_li)
@@ -282,11 +284,11 @@ module wrapper
      ,.credits_full_o(credits_full_lo)
      ,.credits_empty_o(credits_empty_lo)
      );
-    
+
      // lce_cmd demanding -> demanding handshake conversion
-     bsg_two_fifo 
+     bsg_two_fifo
        #(.width_p(lce_cmd_width_lp))
-       cmd_fifo 
+       cmd_fifo
        (.clk_i(clk_i)
        ,.reset_i(reset_i)
 
@@ -348,7 +350,7 @@ module wrapper
      dcache_uce
      (.clk_i(clk_i)
      ,.reset_i(reset_i)
-     
+
      ,.lce_id_i('0)
 
      ,.cache_req_i(cache_req_lo)
@@ -358,6 +360,7 @@ module wrapper
      ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
 
      ,.cache_req_complete_o(cache_req_complete_lo)
+     ,.cache_req_critical_o(cache_req_critical_lo)
 
      ,.tag_mem_pkt_o(tag_mem_pkt_lo)
      ,.tag_mem_pkt_v_o(tag_mem_pkt_v_lo)
@@ -385,7 +388,7 @@ module wrapper
      ,.mem_resp_v_i(mem_resp_v_i)
      ,.mem_resp_yumi_o(mem_resp_yumi_o)
      );
-    
+
     // We need a mem cmd fifo because we need to buffer the wt stores to
     // memory since we don't raise a miss for these stores.
     // Update: This is useful even on writebacks to successively allow the
@@ -404,7 +407,7 @@ module wrapper
       ,.data_o(mem_cmd_o)
       ,.yumi_i(mem_cmd_v_o & mem_cmd_ready_i)
       );
-    
+
    end
 
 endmodule

--- a/bp_common/src/include/bp_common_aviary_defines.vh
+++ b/bp_common/src/include/bp_common_aviary_defines.vh
@@ -133,6 +133,7 @@ typedef struct packed
   integer acache_sets;
   integer acache_assoc;
   integer acache_block_width;
+  integer acache_fill_width;
   integer cce_pc_width;
   integer ucode_cce;
 
@@ -240,6 +241,7 @@ typedef struct packed
   , localparam acache_sets_p              = proc_param_lp.acache_sets                              \
   , localparam acache_assoc_p             = proc_param_lp.acache_assoc                             \
   , localparam acache_block_width_p       = proc_param_lp.acache_block_width                       \
+  , localparam acache_fill_width_p        = proc_param_lp.acache_fill_width                        \
   , localparam lce_assoc_p                = `BSG_MAX(dcache_assoc_p,                               \
                                                      `BSG_MAX(icache_assoc_p, acache_assoc_p))     \
   , localparam lce_assoc_width_p          = `BSG_SAFE_CLOG2(lce_assoc_p)                           \
@@ -250,7 +252,6 @@ typedef struct packed
   , localparam cce_block_width_p          =  `BSG_MAX(dcache_block_width_p,                        \
                                                      `BSG_MAX(icache_block_width_p,                \
                                                        acache_block_width_p))                      \
-  , localparam lce_fill_width_p           =  `BSG_MAX(dcache_fill_width_p, icache_fill_width_p)    \
                                                                                                    \
                                                                                                    \
   , localparam cce_pc_width_p             = proc_param_lp.cce_pc_width                             \

--- a/bp_common/src/include/bp_common_aviary_defines.vh
+++ b/bp_common/src/include/bp_common_aviary_defines.vh
@@ -7,7 +7,7 @@
 `ifndef BP_COMMON_AVIARY_DEFINES_VH
 `define BP_COMMON_AVIARY_DEFINES_VH
 
-// Thoughts: 
+// Thoughts:
 // Hardcoding hartid and lceid width limits us to 8 cores for our standard configurations,
 //   but would allow the hierachical flow to reuse a single BP core for both dual-core and
 //   oct-core configurations.
@@ -125,9 +125,11 @@ typedef struct packed
   integer dcache_sets;
   integer dcache_assoc;
   integer dcache_block_width;
+  integer dcache_fill_width;
   integer icache_sets;
   integer icache_assoc;
   integer icache_block_width;
+  integer icache_fill_width;
   integer acache_sets;
   integer acache_assoc;
   integer acache_block_width;
@@ -230,9 +232,11 @@ typedef struct packed
   , localparam dcache_sets_p              = proc_param_lp.dcache_sets                              \
   , localparam dcache_assoc_p             = proc_param_lp.dcache_assoc                             \
   , localparam dcache_block_width_p       = proc_param_lp.dcache_block_width                       \
+  , localparam dcache_fill_width_p        = proc_param_lp.dcache_fill_width                        \
   , localparam icache_sets_p              = proc_param_lp.icache_sets                              \
   , localparam icache_assoc_p             = proc_param_lp.icache_assoc                             \
   , localparam icache_block_width_p       = proc_param_lp.icache_block_width                       \
+  , localparam icache_fill_width_p        = proc_param_lp.icache_fill_width                        \
   , localparam acache_sets_p              = proc_param_lp.acache_sets                              \
   , localparam acache_assoc_p             = proc_param_lp.acache_assoc                             \
   , localparam acache_block_width_p       = proc_param_lp.acache_block_width                       \
@@ -320,4 +324,3 @@ typedef struct packed
   , localparam ptag_width_p  = proc_param_lp.paddr_width - page_offset_width_p                     \
 
 `endif
-

--- a/bp_common/src/include/bp_common_aviary_defines.vh
+++ b/bp_common/src/include/bp_common_aviary_defines.vh
@@ -250,6 +250,7 @@ typedef struct packed
   , localparam cce_block_width_p          =  `BSG_MAX(dcache_block_width_p,                        \
                                                      `BSG_MAX(icache_block_width_p,                \
                                                        acache_block_width_p))                      \
+  , localparam lce_fill_width_p           =  `BSG_MAX(dcache_fill_width_p, icache_fill_width_p)    \
                                                                                                    \
                                                                                                    \
   , localparam cce_pc_width_p             = proc_param_lp.cce_pc_width                             \

--- a/bp_common/src/include/bp_common_aviary_pkg.vh
+++ b/bp_common/src/include/bp_common_aviary_pkg.vh
@@ -18,7 +18,7 @@ package bp_common_aviary_pkg;
       ,sac_x_dim : 0
       ,cacc_type : e_cacc_vdp
       ,sacc_type : e_sacc_vdp
-      
+
       ,vaddr_width: 39
       ,paddr_width: 40
       ,asid_width : 1
@@ -37,13 +37,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
-      
+
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
 
@@ -103,9 +105,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -207,7 +211,7 @@ package bp_common_aviary_pkg;
       ,io_noc_len_width     : 4
       };
 
-  localparam bp_proc_param_s bp_softcore_no_l2_cfg_p = 
+  localparam bp_proc_param_s bp_softcore_no_l2_cfg_p =
     '{cc_x_dim   : 1
       ,cc_y_dim  : 1
       ,ic_y_dim  : 1
@@ -220,13 +224,13 @@ package bp_common_aviary_pkg;
       ,vaddr_width: 39
       ,paddr_width: 40
       ,asid_width : 1
-      
+
       ,branch_metadata_fwd_width: 35
       ,btb_tag_width            : 10
       ,btb_idx_width            : 6
       ,bht_idx_width            : 9
       ,ghist_width              : 2
-      
+
       ,itlb_els             : 8
       ,dtlb_els             : 8
 
@@ -235,9 +239,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -273,7 +279,7 @@ package bp_common_aviary_pkg;
       ,io_noc_len_width     : 4
       };
 
-  localparam bp_proc_param_s bp_softcore_l1_medium_cfg_p = 
+  localparam bp_proc_param_s bp_softcore_l1_medium_cfg_p =
     '{cc_x_dim   : 1
       ,cc_y_dim  : 1
       ,ic_y_dim  : 1
@@ -286,13 +292,13 @@ package bp_common_aviary_pkg;
       ,vaddr_width: 39
       ,paddr_width: 40
       ,asid_width : 1
-      
+
       ,branch_metadata_fwd_width: 35
       ,btb_tag_width            : 10
       ,btb_idx_width            : 6
       ,bht_idx_width            : 9
       ,ghist_width              : 2
-      
+
       ,itlb_els             : 8
       ,dtlb_els             : 8
 
@@ -301,9 +307,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 4
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 4
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -339,7 +347,7 @@ package bp_common_aviary_pkg;
       ,io_noc_len_width     : 4
       };
 
-  localparam bp_proc_param_s bp_softcore_l1_small_cfg_p = 
+  localparam bp_proc_param_s bp_softcore_l1_small_cfg_p =
     '{cc_x_dim   : 1
       ,cc_y_dim  : 1
       ,ic_y_dim  : 1
@@ -352,13 +360,13 @@ package bp_common_aviary_pkg;
       ,vaddr_width: 39
       ,paddr_width: 40
       ,asid_width : 1
-      
+
       ,branch_metadata_fwd_width: 35
       ,btb_tag_width            : 10
       ,btb_idx_width            : 6
       ,bht_idx_width            : 9
       ,ghist_width              : 2
-      
+
       ,itlb_els             : 8
       ,dtlb_els             : 8
 
@@ -367,9 +375,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 2
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 2
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -405,7 +415,7 @@ package bp_common_aviary_pkg;
       ,io_noc_len_width     : 4
       };
 
-  localparam bp_proc_param_s bp_single_core_cfg_p = 
+  localparam bp_proc_param_s bp_single_core_cfg_p =
     '{cc_x_dim   : 1
       ,cc_y_dim  : 1
       ,ic_y_dim  : 1
@@ -433,9 +443,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -471,7 +483,7 @@ package bp_common_aviary_pkg;
       ,io_noc_len_width     : 4
       };
 
-  localparam bp_proc_param_s bp_single_core_no_l2_cfg_p = 
+  localparam bp_proc_param_s bp_single_core_no_l2_cfg_p =
     '{cc_x_dim   : 1
       ,cc_y_dim  : 1
       ,ic_y_dim  : 1
@@ -484,13 +496,13 @@ package bp_common_aviary_pkg;
       ,vaddr_width: 39
       ,paddr_width: 40
       ,asid_width : 1
-      
+
       ,branch_metadata_fwd_width: 35
       ,btb_tag_width            : 10
       ,btb_idx_width            : 6
       ,bht_idx_width            : 9
       ,ghist_width              : 2
-      
+
       ,itlb_els             : 8
       ,dtlb_els             : 8
 
@@ -499,9 +511,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -537,7 +551,8 @@ package bp_common_aviary_pkg;
       ,io_noc_len_width     : 4
       };
 
-  localparam bp_proc_param_s bp_single_core_l1_medium_cfg_p = 
+
+  localparam bp_proc_param_s bp_single_core_l1_medium_cfg_p =
     '{cc_x_dim   : 1
       ,cc_y_dim  : 1
       ,ic_y_dim  : 1
@@ -550,13 +565,13 @@ package bp_common_aviary_pkg;
       ,vaddr_width: 39
       ,paddr_width: 40
       ,asid_width : 1
-      
+
       ,branch_metadata_fwd_width: 35
       ,btb_tag_width            : 10
       ,btb_idx_width            : 6
       ,bht_idx_width            : 9
       ,ghist_width              : 2
-      
+
       ,itlb_els             : 8
       ,dtlb_els             : 8
 
@@ -565,9 +580,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 4
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 4
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -603,7 +620,7 @@ package bp_common_aviary_pkg;
       ,io_noc_len_width     : 4
       };
 
-  localparam bp_proc_param_s bp_single_core_l1_small_cfg_p = 
+  localparam bp_proc_param_s bp_single_core_l1_small_cfg_p =
     '{cc_x_dim   : 1
       ,cc_y_dim  : 1
       ,ic_y_dim  : 1
@@ -616,13 +633,13 @@ package bp_common_aviary_pkg;
       ,vaddr_width: 39
       ,paddr_width: 40
       ,asid_width : 1
-      
+
       ,branch_metadata_fwd_width: 35
       ,btb_tag_width            : 10
       ,btb_idx_width            : 6
       ,bht_idx_width            : 9
       ,ghist_width              : 2
-      
+
       ,itlb_els             : 8
       ,dtlb_els             : 8
 
@@ -631,9 +648,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 2
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 2
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -670,7 +689,7 @@ package bp_common_aviary_pkg;
       };
 
 
-  localparam bp_proc_param_s bp_dual_core_cfg_p = 
+  localparam bp_proc_param_s bp_dual_core_cfg_p =
     '{cc_x_dim   : 2
       ,cc_y_dim  : 1
       ,ic_y_dim  : 1
@@ -698,9 +717,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -764,9 +785,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -830,9 +853,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -896,9 +921,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -962,9 +989,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -1028,9 +1057,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -1094,9 +1125,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -1132,7 +1165,7 @@ package bp_common_aviary_pkg;
       ,io_noc_len_width     : 4
       };
 
-  localparam bp_proc_param_s bp_accelerator_single_core_cfg_p = 
+  localparam bp_proc_param_s bp_accelerator_single_core_cfg_p =
     '{cc_x_dim   : 1
       ,cc_y_dim  : 1
       ,ic_y_dim  : 1
@@ -1145,24 +1178,27 @@ package bp_common_aviary_pkg;
       ,vaddr_width: 39
       ,paddr_width: 40
       ,asid_width : 1
-      
+
       ,branch_metadata_fwd_width: 35
       ,btb_tag_width            : 10
       ,btb_idx_width            : 6
       ,bht_idx_width            : 9
       ,ghist_width              : 2
-      
+
       ,itlb_els             : 8
       ,dtlb_els             : 8
 
       ,l1_writethrough      : 0
       ,l1_coherent          : 1
+
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -1226,9 +1262,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -1292,9 +1330,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -1358,9 +1398,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -1424,9 +1466,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -1490,9 +1534,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -1556,9 +1602,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -1622,9 +1670,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -1688,9 +1738,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -1754,9 +1806,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -1820,9 +1874,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
@@ -1859,7 +1915,7 @@ package bp_common_aviary_pkg;
       };
 
 
-  typedef enum bit [lg_max_cfgs-1:0] 
+  typedef enum bit [lg_max_cfgs-1:0]
   {
     e_bp_softcore_writethrough_cfg    = 28
     ,e_bp_single_core_l1_medium_cfg   = 27
@@ -1928,4 +1984,3 @@ package bp_common_aviary_pkg;
   /* verilator lint_on WIDTH */
 
 endpackage
-

--- a/bp_common/src/include/bp_common_aviary_pkg.vh
+++ b/bp_common/src/include/bp_common_aviary_pkg.vh
@@ -45,6 +45,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -113,6 +114,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -173,12 +175,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -247,6 +252,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -315,6 +321,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -383,6 +390,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -451,6 +459,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -519,6 +528,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -588,6 +598,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -656,6 +667,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -725,6 +737,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -793,6 +806,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -861,6 +875,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -929,6 +944,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -997,6 +1013,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -1065,6 +1082,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -1133,6 +1151,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -1202,6 +1221,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -1270,6 +1290,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -1338,6 +1359,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 1
@@ -1406,6 +1428,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 1
@@ -1474,6 +1497,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 1
@@ -1542,6 +1566,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 1
@@ -1610,6 +1635,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 1
@@ -1678,6 +1704,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 1
@@ -1746,6 +1773,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 1
@@ -1814,6 +1842,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 1
@@ -1882,6 +1911,7 @@ package bp_common_aviary_pkg;
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 1

--- a/bp_common/src/include/bp_common_cache_service_if.vh
+++ b/bp_common/src/include/bp_common_cache_service_if.vh
@@ -100,18 +100,19 @@ typedef enum logic [1:0] {
 `define bp_cache_stat_mem_opcode_width $bits(bp_cache_stat_mem_opcode_e)
 
 // data mem pkt structure
-`define declare_bp_cache_data_mem_pkt_s(sets_mp, ways_mp, data_width_mp, cache_name_mp) \
-  typedef struct packed                                                                 \
-  {                                                                                     \
-    logic [`BSG_SAFE_CLOG2(sets_mp)-1:0]      index;                                    \
-    logic [`BSG_SAFE_CLOG2(ways_mp)-1:0]      way_id;                                   \
-    logic [data_width_mp-1:0]                 data;                                     \
-    bp_cache_data_mem_opcode_e                opcode;                                   \
+`define declare_bp_cache_data_mem_pkt_s(sets_mp, ways_mp, block_data_width_mp, fill_width_mp, cache_name_mp) \
+  typedef struct packed                                                                     \
+  {                                                                                         \
+    logic [`BSG_SAFE_CLOG2(sets_mp)-1:0]          index;                                    \
+    logic [`BSG_SAFE_CLOG2(ways_mp)-1:0]          way_id;                                   \
+    logic [fill_width_mp-1:0]                     data;                                     \
+    logic [block_data_width_mp/fill_width_mp-1:0] fill_mask;                                \
+    bp_cache_data_mem_opcode_e                    opcode;                                   \
   }  bp_``cache_name_mp``_data_mem_pkt_s
 
-`define bp_cache_data_mem_pkt_width(sets_mp, ways_mp, data_width_mp) \
-  (`BSG_SAFE_CLOG2(sets_mp)+`BSG_SAFE_CLOG2(ways_mp)+data_width_mp \
-   +`bp_cache_data_mem_opcode_width)
+`define bp_cache_data_mem_pkt_width(sets_mp, ways_mp, block_data_width_mp, fill_width_mp) \
+  (`BSG_SAFE_CLOG2(sets_mp)+`BSG_SAFE_CLOG2(ways_mp)+fill_width_mp \
+   +block_data_width_mp/fill_width_mp+`bp_cache_data_mem_opcode_width)
 
 // tag mem pkt structure
 `define declare_bp_cache_tag_mem_pkt_s(sets_mp, ways_mp, tag_width_mp, cache_name_mp) \
@@ -145,18 +146,18 @@ typedef enum logic [1:0] {
 `define bp_cache_stat_info_width(ways_mp) \
   (2*ways_mp-1)
 
-`define declare_bp_cache_service_if(addr_width_mp, tag_width_mp, sets_mp, ways_mp, req_data_width_mp, block_data_width_mp, cache_name_mp) \
-  `declare_bp_cache_req_s(req_data_width_mp, addr_width_mp, cache_name_mp);               \
-  `declare_bp_cache_req_metadata_s(ways_mp, cache_name_mp);                               \
-  `declare_bp_cache_data_mem_pkt_s(sets_mp, ways_mp, block_data_width_mp, cache_name_mp); \
-  `declare_bp_cache_tag_mem_pkt_s(sets_mp, ways_mp, tag_width_mp, cache_name_mp);         \
+`define declare_bp_cache_service_if(addr_width_mp, tag_width_mp, sets_mp, ways_mp, req_data_width_mp, block_data_width_mp, fill_width_mp, cache_name_mp) \
+  `declare_bp_cache_req_s(req_data_width_mp, addr_width_mp, cache_name_mp);                              \
+  `declare_bp_cache_req_metadata_s(ways_mp, cache_name_mp);                                              \
+  `declare_bp_cache_data_mem_pkt_s(sets_mp, ways_mp, block_data_width_mp, fill_width_mp, cache_name_mp); \
+  `declare_bp_cache_tag_mem_pkt_s(sets_mp, ways_mp, tag_width_mp, cache_name_mp);                        \
   `declare_bp_cache_stat_mem_pkt_s(sets_mp, ways_mp, cache_name_mp)
 
-`define declare_bp_cache_service_if_widths(addr_width_mp, tag_width_mp, sets_mp, ways_mp, req_data_width_mp, block_data_width_mp, cache_name_mp) \
-  , localparam ``cache_name_mp``_req_width_lp = `bp_cache_req_width(req_data_width_mp, addr_width_mp)                    \
-  , localparam ``cache_name_mp``_req_metadata_width_lp = `bp_cache_req_metadata_width(ways_mp)                           \
-  , localparam ``cache_name_mp``_data_mem_pkt_width_lp=`bp_cache_data_mem_pkt_width(sets_mp,ways_mp,block_data_width_mp) \
-  , localparam ``cache_name_mp``_tag_mem_pkt_width_lp=`bp_cache_tag_mem_pkt_width(sets_mp,ways_mp,tag_width_mp)          \
+`define declare_bp_cache_service_if_widths(addr_width_mp, tag_width_mp, sets_mp, ways_mp, req_data_width_mp, block_data_width_mp, fill_width_mp, cache_name_mp) \
+  , localparam ``cache_name_mp``_req_width_lp = `bp_cache_req_width(req_data_width_mp, addr_width_mp)                                  \
+  , localparam ``cache_name_mp``_req_metadata_width_lp = `bp_cache_req_metadata_width(ways_mp)                                         \
+  , localparam ``cache_name_mp``_data_mem_pkt_width_lp=`bp_cache_data_mem_pkt_width(sets_mp,ways_mp,block_data_width_mp,fill_width_mp) \
+  , localparam ``cache_name_mp``_tag_mem_pkt_width_lp=`bp_cache_tag_mem_pkt_width(sets_mp,ways_mp,tag_width_mp)                        \
   , localparam ``cache_name_mp``_stat_mem_pkt_width_lp=`bp_cache_stat_mem_pkt_width(sets_mp,ways_mp)
 
 `endif

--- a/bp_common/test/mem/hello_world.dump
+++ b/bp_common/test/mem/hello_world.dump
@@ -1,5 +1,5 @@
 
-/mnt/users/ssd0/no_backup/petrisko/pre-alpha-release/bp_common/test/mem/hello_world.riscv:     file format elf64-littleriscv
+/mnt/users/ssd3/homes/scli3/partial_fill/black-parrot/bp_common/test/mem/hello_world.riscv:     file format elf64-littleriscv
 
 
 Disassembly of section .text.init:

--- a/bp_fe/src/v/bp_fe_lce.v
+++ b/bp_fe/src/v/bp_fe_lce.v
@@ -52,6 +52,7 @@ module bp_fe_lce
     , input                                                      cache_req_metadata_v_i
 
     , output logic                                               cache_req_complete_o
+    , output logic                                               cache_req_critical_o
 
     , output logic [icache_data_mem_pkt_width_lp-1:0]            data_mem_pkt_o
     , output logic                                               data_mem_pkt_v_o
@@ -179,6 +180,7 @@ module bp_fe_lce
     ,.uncached_data_received_o(uncached_data_received)
 
     ,.cache_req_complete_o(cache_req_complete_o)
+    ,.cache_req_critical_o(cache_req_critical_o)
 
     ,.data_mem_pkt_o(data_mem_pkt)
     ,.data_mem_pkt_v_o(data_mem_pkt_v_o)

--- a/bp_fe/src/v/bp_fe_lce_req.v
+++ b/bp_fe/src/v/bp_fe_lce_req.v
@@ -18,8 +18,8 @@ module bp_fe_lce_req
   #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
-   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
-   
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache)
+
    , localparam way_id_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)
    , localparam block_size_in_words_lp=icache_assoc_p
    , localparam bank_width_lp = icache_block_width_p / icache_assoc_p
@@ -31,14 +31,14 @@ module bp_fe_lce_req
    , localparam block_offset_width_lp=(word_offset_width_lp+byte_offset_width_lp)
    , localparam ptag_width_lp=(paddr_width_p-bp_page_offset_width_gp)
    , localparam block_size_in_bytes_lp = (icache_block_width_p / 8)
-   
+
    , parameter timeout_max_limit_p=4
   )
    (input clk_i
     , input reset_i
 
     , input [lce_id_width_p-1:0] lce_id_i
- 
+
     , input [icache_req_width_lp-1:0] cache_req_i
     , input cache_req_v_i
     , output logic cache_req_ready_o
@@ -46,7 +46,7 @@ module bp_fe_lce_req
     , input cache_req_metadata_v_i
 
     , output logic [paddr_width_p-1:0] miss_addr_o
-          
+
     , input cce_data_received_i
     , input uncached_data_received_i
     , input set_tag_received_i
@@ -54,11 +54,11 @@ module bp_fe_lce_req
 
     , input coherence_blocked_i
     , input cmd_ready_i
-          
+
     , output logic [lce_cce_req_width_lp-1:0] lce_req_o
     , output logic lce_req_v_o
     , input lce_req_ready_i
-          
+
     , output logic [lce_cce_resp_width_lp-1:0] lce_resp_o
     , output logic lce_resp_v_o
     , input lce_resp_yumi_i
@@ -67,7 +67,7 @@ module bp_fe_lce_req
   // lce interface
 
   `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p);
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache);
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache);
 
   bp_lce_cce_resp_s lce_resp;
   bp_lce_cce_req_s lce_req;
@@ -94,7 +94,7 @@ module bp_fe_lce_req
      ,.data_i(cache_req_metadata_i)
      ,.data_o(cache_req_metadata_r)
      );
-  
+
   logic cache_req_metadata_v_r;
   bsg_dff_en_bypass
    #(.width_p(1))
@@ -123,7 +123,7 @@ module bp_fe_lce_req
   logic cache_req_ready;
 
   assign miss_addr_o = miss_addr_r;
-   
+
   logic [cce_id_width_p-1:0] req_cce_id_lo;
   bp_me_addr_to_cce_id
    #(.bp_params_p(bp_params_p))
@@ -186,9 +186,9 @@ module bp_fe_lce_req
     lce_resp.header.msg_type     = bp_lce_cce_resp_type_e'('0);
     lce_resp.header.addr         = miss_addr_r;
     lce_resp.data         = '0;
-  
+
     cache_req_ready = 1'b1;
-    
+
     case (state_r)
       e_lce_req_ready: begin
        cache_req_ready = 1'b1;
@@ -211,11 +211,11 @@ module bp_fe_lce_req
 
       e_lce_req_send_miss_req: begin
         lce_req_v_o        = lce_req_ready_i & cache_req_metadata_v_r;
-        
+
         cache_req_ready    = 1'b0;
-        
+
         state_n = lce_req_v_o
-          ? e_lce_req_sleep 
+          ? e_lce_req_sleep
           : e_lce_req_send_miss_req;
       end
 
@@ -233,7 +233,7 @@ module bp_fe_lce_req
         lce_req.data = '0;
 
         state_n = lce_req_v_o
-          ? e_lce_req_sleep 
+          ? e_lce_req_sleep
           : e_lce_req_send_uncached_load_req;
       end
 
@@ -271,7 +271,7 @@ module bp_fe_lce_req
           ? e_lce_req_ready
           : e_lce_req_send_coh_ack;
       end
-  
+
       // should never get in this state.
       default: begin
         state_n = e_lce_req_ready;
@@ -300,7 +300,7 @@ module bp_fe_lce_req
      ,.up_i(coherence_blocked_i)
      ,.count_o(timeout_cnt_r)
      );
-  
+
   wire timeout = (timeout_cnt_r == timeout_max_limit_p);
 
   assign cache_req_ready_o = cmd_ready_i & ~timeout & cache_req_ready;

--- a/bp_fe/src/v/bp_fe_lce_req.v
+++ b/bp_fe/src/v/bp_fe_lce_req.v
@@ -16,21 +16,26 @@ module bp_fe_lce_req
   import bp_fe_icache_pkg::*;
   import bp_common_aviary_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
+   ,parameter assoc_p = 8
+   ,parameter sets_p = 64
+   ,parameter block_width_p = 512
+   ,parameter fill_width_p = 512
+
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
-   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache)
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, icache)
 
-   , localparam way_id_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)
-   , localparam block_size_in_words_lp=icache_assoc_p
-   , localparam bank_width_lp = icache_block_width_p / icache_assoc_p
+   , localparam way_id_width_lp=`BSG_SAFE_CLOG2(assoc_p)
+   , localparam block_size_in_words_lp=assoc_p
+   , localparam bank_width_lp = block_width_p / assoc_p
    , localparam num_dwords_per_bank_lp = bank_width_lp / dword_width_p
    , localparam data_mem_mask_width_lp=(bank_width_lp >> 3)
    , localparam byte_offset_width_lp=`BSG_SAFE_CLOG2(bank_width_lp >> 3)
    , localparam word_offset_width_lp=`BSG_SAFE_CLOG2(block_size_in_words_lp)
-   , localparam index_width_lp=`BSG_SAFE_CLOG2(icache_sets_p)
+   , localparam index_width_lp=`BSG_SAFE_CLOG2(sets_p)
    , localparam block_offset_width_lp=(word_offset_width_lp+byte_offset_width_lp)
    , localparam ptag_width_lp=(paddr_width_p-bp_page_offset_width_gp)
-   , localparam block_size_in_bytes_lp = (icache_block_width_p / 8)
+   , localparam block_size_in_bytes_lp = (block_width_p / 8)
 
    , parameter timeout_max_limit_p=4
   )
@@ -67,7 +72,7 @@ module bp_fe_lce_req
   // lce interface
 
   `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p);
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache);
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, icache);
 
   bp_lce_cce_resp_s lce_resp;
   bp_lce_cce_req_s lce_req;

--- a/bp_fe/src/v/bp_fe_mem.v
+++ b/bp_fe/src/v/bp_fe_mem.v
@@ -8,8 +8,8 @@ module bp_fe_mem
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
-   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
-   
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache)
+
    , localparam way_id_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)
    , localparam block_size_in_words_lp=icache_assoc_p
    , localparam bank_width_lp = icache_block_width_p / icache_assoc_p
@@ -50,8 +50,9 @@ module bp_fe_mem
    , input                                            cache_req_ready_i
    , output logic [icache_req_metadata_width_lp-1:0]  cache_req_metadata_o
    , output logic                                     cache_req_metadata_v_o
- 
+
    , input                                            cache_req_complete_i
+   , input                                            cache_req_critical_i
 
    , input [icache_data_mem_pkt_width_lp-1:0]         data_mem_pkt_i
    , input                                            data_mem_pkt_v_i
@@ -97,12 +98,12 @@ bp_tlb
    ,.reset_i(reset_i)
    ,.flush_i(itlb_fence_v)
    ,.translation_en_i(mem_translation_en_i)
-         
+
    ,.v_i(fetch_v | itlb_fill_v)
    ,.w_i(itlb_fill_v)
    ,.vtag_i(itlb_fill_v ? mem_cmd_cast_i.operands.fill.vtag : mem_cmd_cast_i.operands.fetch.vaddr.tag)
    ,.entry_i(mem_cmd_cast_i.operands.fill.entry)
-     
+
    ,.v_o(itlb_r_v_lo)
    ,.entry_o(itlb_r_entry)
 
@@ -127,8 +128,8 @@ logic [instr_width_p-1:0] icache_data_lo;
 logic                     icache_data_v_lo;
 
 logic instr_access_fault_v, instr_page_fault_v;
-bp_fe_icache 
- #(.bp_params_p(bp_params_p)) 
+bp_fe_icache
+ #(.bp_params_p(bp_params_p))
  icache
   (.clk_i(clk_i)
    ,.reset_i(reset_i)
@@ -158,6 +159,7 @@ bp_fe_icache
    ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
 
    ,.cache_req_complete_i(cache_req_complete_i)
+   ,.cache_req_critical_i(cache_req_critical_i)
 
    ,.data_mem_pkt_i(data_mem_pkt_i)
    ,.data_mem_pkt_v_i(data_mem_pkt_v_i)

--- a/bp_fe/src/v/bp_fe_top.v
+++ b/bp_fe/src/v/bp_fe_top.v
@@ -1,5 +1,5 @@
-/*                                  
- * bp_fe_top.v 
+/*
+ * bp_fe_top.v
  */
 
 module bp_fe_top
@@ -14,8 +14,8 @@ module bp_fe_top
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_fe_be_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
-   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
-   
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache)
+
    , localparam way_id_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)
    , localparam block_size_in_words_lp=icache_assoc_p
    , localparam bank_width_lp = icache_block_width_p / icache_assoc_p
@@ -26,7 +26,7 @@ module bp_fe_top
    , localparam index_width_lp=`BSG_SAFE_CLOG2(icache_sets_p)
    , localparam block_offset_width_lp=(word_offset_width_lp+byte_offset_width_lp)
    , localparam ptag_width_lp=(paddr_width_p-bp_page_offset_width_gp)
-   
+
    , localparam stat_width_lp = `bp_cache_stat_info_width(icache_assoc_p)
 
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
@@ -51,9 +51,9 @@ module bp_fe_top
    , input                                            cache_req_ready_i
    , output logic [icache_req_metadata_width_lp-1:0]  cache_req_metadata_o
    , output logic                                     cache_req_metadata_v_o
- 
-   , input                                            cache_req_complete_i
 
+   , input                                            cache_req_complete_i
+   , input                                            cache_req_critical_i
    , input [icache_data_mem_pkt_width_lp-1:0]         data_mem_pkt_i
    , input                                            data_mem_pkt_v_i
    , output logic                                     data_mem_pkt_yumi_o
@@ -72,7 +72,7 @@ module bp_fe_top
 
 `declare_bp_fe_be_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 `declare_bp_fe_mem_structs(vaddr_width_p, icache_sets_p, icache_block_width_p, vtag_width_p, ptag_width_p)
-   
+
 bp_fe_mem_cmd_s  mem_cmd_lo;
 logic            mem_cmd_v_lo, mem_cmd_yumi_li;
 logic [rv64_priv_width_gp-1:0]  mem_priv_lo;
@@ -80,12 +80,12 @@ logic            mem_poison_lo, mem_translation_en_lo;
 bp_fe_mem_resp_s mem_resp_li;
 logic            mem_resp_v_li;
 
-bp_fe_pc_gen 
- #(.bp_params_p(bp_params_p)) 
+bp_fe_pc_gen
+ #(.bp_params_p(bp_params_p))
  pc_gen
   (.clk_i(clk_i)
    ,.reset_i(reset_i)
-               
+
    ,.mem_cmd_o(mem_cmd_lo)
    ,.mem_cmd_v_o(mem_cmd_v_lo)
    ,.mem_cmd_yumi_i(mem_cmd_yumi_li)
@@ -111,9 +111,9 @@ bp_fe_mem
  mem
   (.clk_i(clk_i)
    ,.reset_i(reset_i)
-   
+
    ,.cfg_bus_i(cfg_bus_i)
-   
+
    ,.mem_cmd_i(mem_cmd_lo)
    ,.mem_cmd_v_i(mem_cmd_v_lo)
    ,.mem_cmd_yumi_o(mem_cmd_yumi_li)
@@ -132,6 +132,7 @@ bp_fe_mem
    ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
 
    ,.cache_req_complete_i(cache_req_complete_i)
+   ,.cache_req_critical_i(cache_req_critical_i)
 
    ,.data_mem_pkt_i(data_mem_pkt_i)
    ,.data_mem_pkt_v_i(data_mem_pkt_v_i)
@@ -150,4 +151,3 @@ bp_fe_mem
    );
 
 endmodule
-

--- a/bp_fe/syn/flist.vcs
+++ b/bp_fe/syn/flist.vcs
@@ -162,6 +162,7 @@ $BP_BE_DIR/src/v/bp_be_calculator/bp_be_instr_decoder.v
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_int_alu.v
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_fp.v
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_int.v
+$BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_ctrl.v
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_long.v
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_mem.v
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_mul.v
@@ -236,7 +237,7 @@ $BP_ME_DIR/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v
 $BP_ME_DIR/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
 ## TOP
 $BP_TOP_DIR/src/v/bp_nd_socket.v
-$BP_TOP_DIR/src/v/bp_cacc_vdp.v
+# $BP_TOP_DIR/src/v/bp_cacc_vdp.v
 $BP_TOP_DIR/src/v/bp_cacc_tile.v
 $BP_TOP_DIR/src/v/bp_cacc_tile_node.v
 $BP_TOP_DIR/src/v/bp_cacc_complex.v

--- a/bp_fe/syn/flist.vcs
+++ b/bp_fe/syn/flist.vcs
@@ -146,8 +146,8 @@ $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter_in.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter_out.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_decoder_dor.v
-$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_input_control.v  
-$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.v 
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_input_control.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.v
 # Common files
 $BP_COMMON_DIR/src/v/bsg_fifo_1r1w_rolly.v
 $BP_COMMON_DIR/src/v/bp_pma.v

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.v
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.v
@@ -9,7 +9,7 @@ module wrapper
   #(parameter bp_params_e bp_params_p = BP_CFG_FLOWVAR
   , parameter uce_p = 1
   `declare_bp_proc_params(bp_params_p)
-  `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
+  `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache)
   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
   `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
 
@@ -26,8 +26,8 @@ module wrapper
   , localparam index_width_lp=`BSG_SAFE_CLOG2(icache_sets_p)
   , localparam block_offset_width_lp=(word_offset_width_lp+byte_offset_width_lp)
   , localparam ptag_width_lp=(paddr_width_p-bp_page_offset_width_gp)
-  , localparam stat_width_lp = `bp_cache_stat_info_width(icache_assoc_p) 
- 
+  , localparam stat_width_lp = `bp_cache_stat_info_width(icache_assoc_p)
+
   )
   ( input                             clk_i
   , input                             reset_i
@@ -74,7 +74,7 @@ module wrapper
   logic [icache_block_width_p-1:0] data_mem_lo;
   logic [ptag_width_lp-1:0] tag_mem_lo;
   logic [stat_width_lp-1:0] stat_mem_lo;
-  
+
   // Rolly fifo signals
   logic [ptag_width_lp-1:0] rolly_ptag_lo;
   logic [vaddr_width_p-1:0] rolly_vaddr_lo;
@@ -178,13 +178,13 @@ module wrapper
     icache
     (.clk_i(clk_i)
     ,.reset_i(reset_i)
-    
+
     ,.cfg_bus_i(cfg_bus_i)
-    
+
     ,.vaddr_i(rolly_vaddr_lo)
     ,.vaddr_v_i(rolly_v_lo)
     ,.fencei_v_i(1'b0)
-    ,.vaddr_ready_o(icache_ready_lo)    
+    ,.vaddr_ready_o(icache_ready_lo)
 
     ,.ptag_i(rolly_ptag_r)
     ,.ptag_v_i(ptag_v_r)
@@ -194,7 +194,7 @@ module wrapper
     ,.data_o(data_o)
     ,.data_v_o(data_v_o)
     ,.miss_o(icache_miss_lo)
-     
+
     ,.cache_req_ready_i(cache_req_ready_li)
     ,.cache_req_o(cache_req_lo)
     ,.cache_req_v_o(cache_req_v_lo)
@@ -202,6 +202,7 @@ module wrapper
     ,.cache_req_metadata_v_o(cache_req_metadata_v_lo)
 
     ,.cache_req_complete_i(cache_req_complete_li)
+    ,.cache_req_critical_i(cache_req_critical_li)
 
     ,.data_mem_pkt_v_i(data_mem_pkt_v_li)
     ,.data_mem_pkt_i(data_mem_pkt_li)
@@ -225,7 +226,7 @@ module wrapper
     logic [lce_cce_req_width_lp-1:0] lce_req_lo;
     logic [lce_cce_resp_width_lp-1:0] lce_resp_lo;
     logic [lce_cmd_width_lp-1:0] lce_cmd_lo, fifo_lce_cmd_lo;
-    logic mem_resp_ready_lo;    
+    logic mem_resp_ready_lo;
 
     // I-Cache LCE
     bp_fe_lce
@@ -233,7 +234,7 @@ module wrapper
       icache_lce
       (.clk_i(clk_i)
       ,.reset_i(reset_i)
-      
+
       ,.cfg_bus_i(cfg_bus_i)
 
       ,.cache_req_v_i(cache_req_v_lo)
@@ -248,7 +249,7 @@ module wrapper
       ,.data_mem_pkt_o(data_mem_pkt_li)
       ,.data_mem_pkt_v_o(data_mem_pkt_v_li)
       ,.data_mem_pkt_yumi_i(data_mem_pkt_yumi_lo)
-      
+
       ,.tag_mem_i(tag_mem_lo)
       ,.tag_mem_pkt_o(tag_mem_pkt_li)
       ,.tag_mem_pkt_v_o(tag_mem_pkt_v_li)
@@ -274,7 +275,7 @@ module wrapper
       ,.lce_cmd_o()
       ,.lce_cmd_v_o()
       ,.lce_cmd_ready_i()
-      );  
+      );
 
     // lce cmd demanding -> demanding handshake conversion
     bsg_two_fifo
@@ -282,7 +283,7 @@ module wrapper
       cmd_fifo
       (.clk_i(clk_i)
       ,.reset_i(reset_i)
-      
+
       // from CCE
       ,.v_i(lce_cmd_v_lo)
       ,.ready_o(lce_cmd_ready_li)
@@ -385,7 +386,7 @@ module wrapper
       mem_resp_fifo
       (.clk_i(clk_i)
       ,.reset_i(reset_i)
-      
+
       ,.v_i(mem_resp_v_i)
       ,.data_i(mem_resp_i)
       ,.ready_o(mem_resp_ready_lo)
@@ -397,4 +398,4 @@ module wrapper
 
     assign mem_resp_yumi_o = mem_resp_ready_lo & mem_resp_v_i;
   end
-endmodule  
+endmodule

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.v
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.v
@@ -63,7 +63,7 @@ module wrapper
   logic [icache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
   logic cache_req_metadata_v_lo;
 
-  logic cache_req_complete_li;
+  logic cache_req_complete_li, cache_req_critical_li;
 
   // Fill Interfaces
   logic data_mem_pkt_v_li, tag_mem_pkt_v_li, stat_mem_pkt_v_li;
@@ -244,6 +244,7 @@ module wrapper
       ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
 
       ,.cache_req_complete_o(cache_req_complete_li)
+      ,.cache_req_critical_o(cache_req_critical_li)
 
       ,.data_mem_i(data_mem_lo)
       ,.data_mem_pkt_o(data_mem_pkt_li)
@@ -351,6 +352,7 @@ module wrapper
       ,.cache_req_metadata_i(cache_req_metadata_lo)
       ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
       ,.cache_req_complete_o(cache_req_complete_li)
+      ,.cache_req_critical_o(cache_req_critical_li)
 
       ,.tag_mem_pkt_o(tag_mem_pkt_li)
       ,.tag_mem_pkt_v_o(tag_mem_pkt_v_li)

--- a/bp_top/src/v/bp_cacc_vdp.v
+++ b/bp_top/src/v/bp_cacc_vdp.v
@@ -6,12 +6,13 @@ module bp_cacc_vdp
  import bp_common_cfg_link_pkg::*;
  import bp_cce_pkg::*;
  import bp_me_pkg::*;
- import bp_be_dcache_pkg::*;  
+ import bp_be_dcache_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
     `declare_bp_proc_params(bp_params_p)
     `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
     `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, acache_sets_p, acache_assoc_p, dword_width_p, acache_block_width_p, cache)
+    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, acache_sets_p, acache_assoc_p, dword_width_p, acache_block_width_p, lce_fill_width_p, cache)
+
     , localparam cfg_bus_width_lp= `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
     , localparam stat_info_width_lp = `bp_cache_stat_info_width(acache_assoc_p)
     )
@@ -20,7 +21,7 @@ module bp_cacc_vdp
     , input                                   reset_i
 
     , input [lce_id_width_p-1:0]              lce_id_i
-    
+
     , output [lce_cce_req_width_lp-1:0]       lce_req_o
     , output                                  lce_req_v_o
     , input                                   lce_req_ready_i
@@ -49,8 +50,8 @@ module bp_cacc_vdp
 
  `declare_bp_be_dcache_pkt_s(bp_page_offset_width_gp, dword_width_p);
  `declare_bp_be_mmu_structs(vaddr_width_p, ptag_width_p, lce_sets_p, cce_block_width_p/8);
-   
-  bp_be_dcache_pkt_s        dcache_pkt;   
+
+  bp_be_dcache_pkt_s        dcache_pkt;
   logic                     dcache_ready, dcache_v;
   logic [dword_width_p-1:0] dcache_data;
   logic                     dcache_tlb_miss, dcache_poison;
@@ -60,22 +61,22 @@ module bp_cacc_vdp
   logic                     load_op_tl_lo, store_op_tl_lo;
   logic                     dcache_pkt_v;
   logic                     credits_full_o, credits_empty_o;
-   
+
   `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
   bp_cfg_bus_s cfg_bus_cast_i;
   assign cfg_bus_cast_i.dcache_id = lce_id_i;
-  
+
 
   assign dcache_poison = '0;
   assign dcache_tlb_miss = '0;
 
-  logic cache_req_v_o, cache_req_ready_i, cache_req_metadata_v_o, 
+  logic cache_req_v_o, cache_req_ready_i, cache_req_metadata_v_o,
   data_mem_pkt_v_i, data_mem_pkt_yumi_o,
   tag_mem_pkt_v_i, tag_mem_pkt_yumi_o,
   stat_mem_pkt_v_i, stat_mem_pkt_yumi_o,
   cache_req_complete_lo;
-   
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, acache_sets_p, acache_assoc_p, dword_width_p, acache_block_width_p, cache);
+
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, acache_sets_p, acache_assoc_p, dword_width_p, acache_block_width_p, lce_fill_width_p, cache);
 
   bp_cache_req_s cache_req_cast_o;
   bp_cache_data_mem_pkt_s data_mem_pkt_i;
@@ -84,8 +85,8 @@ module bp_cacc_vdp
   logic [ptag_width_p-1:0] tag_mem_o;
   bp_cache_stat_mem_pkt_s stat_mem_pkt_i;
   logic [stat_info_width_lp-1:0] stat_mem_o;
-  bp_cache_req_metadata_s cache_req_metadata_o; 
-   
+  bp_cache_req_metadata_s cache_req_metadata_o;
+
 bp_pma
  #(.bp_params_p(bp_params_p))
   pma
@@ -121,7 +122,7 @@ bp_be_dcache
 
     // D$-LCE Interface
     ,.dcache_miss_o(dcache_miss_v)
-    ,.cache_req_complete_i(cache_req_complete_lo) 
+    ,.cache_req_complete_i(cache_req_complete_lo)
     ,.cache_req_o(cache_req_cast_o)
     ,.cache_req_v_o(cache_req_v_o)
     ,.cache_req_ready_i(cache_req_ready_i)
@@ -141,8 +142,8 @@ bp_be_dcache
     ,.stat_mem_o(stat_mem_o)
     ,.stat_mem_pkt_yumi_o(stat_mem_pkt_yumi_o)
     );
-   
-   
+
+
 bp_be_dcache_lce
  #(.bp_params_p(bp_params_p))
   be_lce
@@ -193,24 +194,24 @@ bp_be_dcache_lce
     ,.credits_full_o(credits_full_o)
     ,.credits_empty_o(credits_empty_o)
     );
-     
+
 
   // CCE-IO interface is used for uncached requests-read/write memory mapped CSR
    `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
-   
+
   bp_cce_mem_msg_s io_resp_cast_o;
   bp_cce_mem_msg_s io_cmd_cast_i;
   bp_cce_mem_msg_header_s resp_header;
-   
+
   assign io_cmd_ready_o = 1'b1;
   assign io_cmd_cast_i = io_cmd_i;
   assign io_resp_o = io_resp_cast_o;
-   
-  logic [63:0] resp_data, start_cmd, input_a_ptr, input_b_ptr, input_len, 
+
+  logic [63:0] resp_data, start_cmd, input_a_ptr, input_b_ptr, input_len,
                res_status, res_ptr, res_len, operation, dot_product_res;
   logic [63:0] vector_a [0:7];
-  logic [63:0] vector_b [0:7]; 
-  logic [2:0] len_a_cnt, len_b_cnt; 
+  logic [63:0] vector_b [0:7];
+  logic [2:0] len_a_cnt, len_b_cnt;
   logic load, second_operand, done;
   logic [paddr_width_p-1:0]  resp_addr;
 
@@ -219,12 +220,12 @@ bp_be_dcache_lce
   logic [63:0] sum_l1 [0:3];
   logic [63:0] sum_l2 [0:1];
   logic [63:0] dot_product_temp;
-   
+
   bp_cce_mem_msg_payload_s  resp_payload;
-  bp_mem_msg_size_e         resp_size;  
+  bp_mem_msg_size_e         resp_size;
   bp_cce_mem_cmd_type_e     resp_msg;
   bp_local_addr_s          local_addr_li;
-  
+
   assign local_addr_li = io_cmd_cast_i.header.addr;
   assign resp_header   =  '{msg_type       : resp_msg
                             ,addr          : resp_addr
@@ -234,17 +235,17 @@ bp_be_dcache_lce
   assign io_resp_cast_o = '{header         : resp_header
                             ,data          : resp_data  };
 
-   
+
   bp_be_mmu_vaddr_s v_addr;
-  assign v_addr = load ? (second_operand ? (input_b_ptr+len_b_cnt*8) 
-                                         : (input_a_ptr+len_a_cnt*8)) 
+  assign v_addr = load ? (second_operand ? (input_b_ptr+len_b_cnt*8)
+                                         : (input_a_ptr+len_a_cnt*8))
                        : res_ptr;
 
-   
+
   typedef enum logic [3:0]{
     RESET
     , WAIT_START
-    , WAIT_FETCH                            
+    , WAIT_FETCH
     , FETCH
     , WAIT_DCACHE_C1
     , WAIT_DCACHE_C2
@@ -255,19 +256,19 @@ bp_be_dcache_lce
     , DONE
   } state_e;
   state_e state_r, state_n;
- 
+
   always_ff @(posedge clk_i) begin
     io_resp_v_o  <= io_cmd_v_i;
     vector_a[len_a_cnt] <= (dcache_v & load & ~second_operand) ? dcache_data : vector_a[len_a_cnt];
     len_a_cnt <= (dcache_v & load & ~second_operand) ? len_a_cnt + 1'b1 : len_a_cnt;
     vector_b[len_b_cnt]  <= (dcache_v & load & second_operand) ? dcache_data : vector_b[len_b_cnt];
     len_b_cnt <= (dcache_v & load & second_operand) ? len_b_cnt + 1'b1 : len_b_cnt;
-    
+
     if(reset_i)
       state_r <= RESET;
     else
       state_r <= state_n;
- 
+
     if (reset_i || done) begin
       start_cmd     <= '0;
       input_a_ptr   <= '0;
@@ -280,9 +281,9 @@ bp_be_dcache_lce
       len_a_cnt     <= '0;
       len_b_cnt     <= '0;
       vector_a      <= '{default:64'd0};
-      vector_b      <= '{default:64'd0}; 
-    end 
-    if (state_r == DONE) 
+      vector_b      <= '{default:64'd0};
+    end
+    if (state_r == DONE)
       start_cmd  <= '0;
     else if (io_cmd_v_i & (io_cmd_cast_i.header.msg_type == e_cce_mem_uc_wr))
     begin
@@ -290,7 +291,7 @@ bp_be_dcache_lce
       resp_payload <= io_cmd_cast_i.header.payload;
       resp_addr    <= io_cmd_cast_i.header.addr;
       resp_msg     <= io_cmd_cast_i.header.msg_type;
-      unique 
+      unique
       case (local_addr_li.addr)
         20'h00000 : input_a_ptr <= io_cmd_cast_i.data;
         20'h00040 : input_b_ptr <= io_cmd_cast_i.data;
@@ -300,32 +301,32 @@ bp_be_dcache_lce
         20'h00180 : res_len    <= io_cmd_cast_i.data;
         20'h00200 : operation  <= io_cmd_cast_i.data;
         default : begin end
-      endcase 
-    end 
+      endcase
+    end
     else if (io_cmd_v_i & (io_cmd_cast_i.header.msg_type == e_cce_mem_uc_rd))
     begin
       resp_size    <= io_cmd_cast_i.header.size;
       resp_payload <= io_cmd_cast_i.header.payload;
       resp_addr    <= io_cmd_cast_i.header.addr;
       resp_msg     <= io_cmd_cast_i.header.msg_type;
-      unique 
+      unique
       case (local_addr_li.addr)
         20'h00000 : resp_data <= input_a_ptr;
         20'h00040 : resp_data <= input_b_ptr;
         20'h00080 : resp_data <= input_len;
         20'h000c0 : resp_data <= start_cmd;
-        20'h00100 : resp_data <= res_status; 
+        20'h00100 : resp_data <= res_status;
         20'h00140 : resp_data <= res_ptr;
         20'h00180 : resp_data <= res_len;
         20'h00200 : resp_data <= operation;
         default : begin end
-      endcase 
+      endcase
     end
   end
- 
-   
+
+
   always_comb begin
-    state_n = state_r; 
+    state_n = state_r;
     case (state_r)
       RESET: begin
         state_n = reset_i ? RESET : WAIT_START;
@@ -359,7 +360,7 @@ bp_be_dcache_lce
         state_n = WAIT_DCACHE_C1;
         dcache_ptag = {(ptag_width_p-vtag_width_p)'(0), v_addr.tag};
         dcache_pkt.opcode = load ? e_dcache_opcode_ld : e_dcache_opcode_sd;
-        dcache_pkt.data = load ? '0 : dot_product_res; 
+        dcache_pkt.data = load ? '0 : dot_product_res;
         dcache_pkt.page_offset = {v_addr.index, v_addr.offset};
         res_status = '0;
         dcache_pkt_v = '1;
@@ -378,7 +379,7 @@ bp_be_dcache_lce
       WAIT_DCACHE_C2: begin
         //if load: load both input vectors
         //if store: go to DONE after store
-        state_n = dcache_miss_v ? WAIT_DCACHE_C2 : 
+        state_n = dcache_miss_v ? WAIT_DCACHE_C2 :
                   (dcache_v ? (load ? (second_operand ? CHECK_VEC2_LEN : CHECK_VEC1_LEN) : DONE)
                             : WAIT_FETCH);
         res_status = '0;
@@ -420,7 +421,7 @@ bp_be_dcache_lce
         dcache_pkt_v = '0;
         second_operand= 1;
         done = 0;
-        dot_product_res = dot_product_temp;         
+        dot_product_res = dot_product_temp;
       end
       WB_RESULT: begin
         state_n = WAIT_FETCH;
@@ -440,12 +441,12 @@ bp_be_dcache_lce
         dcache_pkt_v = '0;
         load = 0;
         second_operand= 0;
-        done = 1; 
+        done = 1;
       end
-    endcase 
+    endcase
    end // always_comb
 
-   
+
   //dot_product unit
   for (genvar i=0; i<8; i++)
   begin : product
@@ -463,6 +464,5 @@ bp_be_dcache_lce
   end
 
    assign dot_product_temp = sum_l2[0] + sum_l2[1];
-  
-endmodule
 
+endmodule

--- a/bp_top/src/v/bp_cacc_vdp.v
+++ b/bp_top/src/v/bp_cacc_vdp.v
@@ -11,7 +11,7 @@ module bp_cacc_vdp
     `declare_bp_proc_params(bp_params_p)
     `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
     `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, acache_sets_p, acache_assoc_p, dword_width_p, acache_block_width_p, lce_fill_width_p, cache)
+    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, acache_sets_p, acache_assoc_p, dword_width_p, acache_block_width_p, acache_fill_width_p, cache)
 
     , localparam cfg_bus_width_lp= `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
     , localparam stat_info_width_lp = `bp_cache_stat_info_width(acache_assoc_p)
@@ -76,7 +76,7 @@ module bp_cacc_vdp
   stat_mem_pkt_v_i, stat_mem_pkt_yumi_o,
   cache_req_complete_lo;
 
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, acache_sets_p, acache_assoc_p, dword_width_p, acache_block_width_p, lce_fill_width_p, cache);
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, acache_sets_p, acache_assoc_p, dword_width_p, acache_block_width_p, acache_fill_width_p, cache);
 
   bp_cache_req_s cache_req_cast_o;
   bp_cache_data_mem_pkt_s data_mem_pkt_i;

--- a/bp_top/src/v/bp_core.v
+++ b/bp_top/src/v/bp_core.v
@@ -17,8 +17,8 @@ module bp_core
     `declare_bp_proc_params(bp_params_p)
     `declare_bp_fe_be_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
     `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
-    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
-    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache)
+    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache)
+    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache)
 
     , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
     , localparam way_id_width_lp = `BSG_SAFE_CLOG2(lce_assoc_p)
@@ -60,8 +60,8 @@ module bp_core
     );
 
   `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache);
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache);
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache);
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache);
 
   bp_cfg_bus_s cfg_bus_cast_i;
   assign cfg_bus_cast_i = cfg_bus_i;
@@ -138,6 +138,7 @@ module bp_core
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
 
      ,.dcache_req_complete_i(dcache_req_complete_lo)
+     // ,.dcache_req_critical_i(dicache_req_critical_lo)
 
      ,.icache_req_o(icache_req_cast_lo)
      ,.icache_req_v_o(icache_req_v_lo)
@@ -146,7 +147,7 @@ module bp_core
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
 
      ,.icache_req_complete_i(icache_req_complete_lo)
-
+     // ,.icache_req_critical_i(icache_req_critical_lo)
      // response side - Interface from D$ LCE
      ,.dcache_data_mem_pkt_i(dcache_data_mem_pkt_li)
      ,.dcache_data_mem_pkt_v_i(dcache_data_mem_pkt_v_li)
@@ -284,4 +285,3 @@ module bp_core
     );
 
 endmodule
-

--- a/bp_top/src/v/bp_core.v
+++ b/bp_top/src/v/bp_core.v
@@ -77,6 +77,7 @@ module bp_core
   logic dcache_req_metadata_v_lo;
 
   logic icache_req_complete_lo, dcache_req_complete_lo;
+  logic icache_req_critical_lo, dcache_req_critical_lo;
   logic credits_full_lo, credits_empty_lo;
 
   logic [1:0] lr_hit_lo;
@@ -138,7 +139,7 @@ module bp_core
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
 
      ,.dcache_req_complete_i(dcache_req_complete_lo)
-     // ,.dcache_req_critical_i(dicache_req_critical_lo)
+     ,.dcache_req_critical_i(dcache_req_critical_lo)
 
      ,.icache_req_o(icache_req_cast_lo)
      ,.icache_req_v_o(icache_req_v_lo)
@@ -147,7 +148,7 @@ module bp_core
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
 
      ,.icache_req_complete_i(icache_req_complete_lo)
-     // ,.icache_req_critical_i(icache_req_critical_lo)
+     ,.icache_req_critical_i(icache_req_critical_lo)
      // response side - Interface from D$ LCE
      ,.dcache_data_mem_pkt_i(dcache_data_mem_pkt_li)
      ,.dcache_data_mem_pkt_v_i(dcache_data_mem_pkt_v_li)
@@ -200,6 +201,7 @@ module bp_core
      ,.cache_req_metadata_i(icache_req_metadata_lo)
      ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
      ,.cache_req_complete_o(icache_req_complete_lo)
+     ,.cache_req_critical_o(icache_req_critical_lo)
 
      ,.data_mem_pkt_o(icache_data_mem_pkt_li)
      ,.data_mem_pkt_v_o(icache_data_mem_pkt_v_li)
@@ -248,6 +250,7 @@ module bp_core
     ,.cache_req_metadata_v_i(dcache_req_metadata_v_lo)
 
     ,.cache_req_complete_o(dcache_req_complete_lo)
+    ,.cache_req_critical_o(dcache_req_critical_lo)
 
     ,.data_mem_pkt_o(dcache_data_mem_pkt_li)
     ,.data_mem_pkt_v_o(dcache_data_mem_pkt_v_li)

--- a/bp_top/src/v/bp_core.v
+++ b/bp_top/src/v/bp_core.v
@@ -188,7 +188,11 @@ module bp_core
      );
 
   bp_fe_lce
-    #(.bp_params_p(bp_params_p))
+    #(.bp_params_p(bp_params_p)
+     ,.assoc_p(icache_assoc_p)
+     ,.sets_p(icache_sets_p)
+     ,.block_width_p(icache_block_width_p)
+     ,.fill_width_p(icache_fill_width_p))
   fe_lce
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
@@ -236,7 +240,11 @@ module bp_core
      );
 
   bp_be_dcache_lce
-    #(.bp_params_p(bp_params_p))
+    #(.bp_params_p(bp_params_p)
+     ,.assoc_p(dcache_assoc_p)
+     ,.sets_p(dcache_sets_p)
+     ,.block_width_p(dcache_block_width_p)
+     ,.fill_width_p(dcache_fill_width_p))
   be_lce
     (.clk_i(clk_i)
     ,.reset_i(reset_i)

--- a/bp_top/src/v/bp_core_minimal.v
+++ b/bp_top/src/v/bp_core_minimal.v
@@ -18,16 +18,15 @@ module bp_core_minimal
     `declare_bp_proc_params(bp_params_p)
     `declare_bp_fe_be_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
     `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
-    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache)
-    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
+    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache)
+    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache)
 
     , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
 
     , localparam dcache_stat_info_width_lp = `bp_cache_stat_info_width(dcache_assoc_p)
     , localparam icache_stat_info_width_lp = `bp_cache_stat_info_width(icache_assoc_p)
     )
-   (
-    input          clk_i
+    ( input          clk_i
     , input        reset_i
 
     // Config info
@@ -48,6 +47,7 @@ module bp_core_minimal
     , output logic  dcache_req_metadata_v_o
 
     , input dcache_req_complete_i
+    , input dcache_req_critical_i
 
     , output logic [icache_req_width_lp-1:0] icache_req_o
     , output logic icache_req_v_o
@@ -56,12 +56,13 @@ module bp_core_minimal
     , output logic  icache_req_metadata_v_o
 
     , input icache_req_complete_i
+    , input icache_req_critical_i
 
     // D$ response interface
     , input [dcache_data_mem_pkt_width_lp-1:0] dcache_data_mem_pkt_i
     , input dcache_data_mem_pkt_v_i
     , output logic dcache_data_mem_pkt_yumi_o
-    , output logic [dcache_block_width_p-1:0] dcache_data_mem_o 
+    , output logic [dcache_block_width_p-1:0] dcache_data_mem_o
 
     , input [dcache_tag_mem_pkt_width_lp-1:0] dcache_tag_mem_pkt_i
     , input dcache_tag_mem_pkt_v_i
@@ -77,7 +78,7 @@ module bp_core_minimal
     , input [icache_data_mem_pkt_width_lp-1:0] icache_data_mem_pkt_i
     , input icache_data_mem_pkt_v_i
     , output logic icache_data_mem_pkt_yumi_o
-    , output logic [icache_block_width_p-1:0] icache_data_mem_o 
+    , output logic [icache_block_width_p-1:0] icache_data_mem_o
 
     , input [icache_tag_mem_pkt_width_lp-1:0] icache_tag_mem_pkt_i
     , input icache_tag_mem_pkt_v_i
@@ -128,6 +129,7 @@ module bp_core_minimal
      ,.cache_req_metadata_o(icache_req_metadata_o)
      ,.cache_req_metadata_v_o(icache_req_metadata_v_o)
      ,.cache_req_complete_i(icache_req_complete_i)
+     ,.cache_req_critical_i(icache_req_critical_i)
 
      ,.data_mem_pkt_i(icache_data_mem_pkt_i)
      ,.data_mem_pkt_v_i(icache_data_mem_pkt_v_i)
@@ -162,7 +164,7 @@ module bp_core_minimal
      ,.v_o(fe_cmd_v_lo)
      ,.yumi_i(fe_cmd_yumi_li)
      );
- 
+
   wire fe_cmd_empty_lo = ~fe_cmd_v_lo;
   wire fe_cmd_full_lo  = ~fe_cmd_ready_lo;
   wire fe_cmd_fence_li = fe_cmd_v_lo;
@@ -222,6 +224,7 @@ module bp_core_minimal
      ,.cache_req_metadata_v_o(dcache_req_metadata_v_o)
 
      ,.cache_req_complete_i(dcache_req_complete_i)
+     ,.cache_req_critical_i(dcache_req_critical_i)
 
      ,.data_mem_pkt_i(dcache_data_mem_pkt_i)
      ,.data_mem_pkt_v_i(dcache_data_mem_pkt_v_i)
@@ -247,4 +250,3 @@ module bp_core_minimal
      );
 
 endmodule
-

--- a/bp_top/src/v/bp_softcore.v
+++ b/bp_top/src/v/bp_softcore.v
@@ -14,7 +14,7 @@ module bp_softcore
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
    )
-  (input                                               clk_i
+  (  input                                               clk_i
    , input                                             reset_i
 
    // Outgoing I/O
@@ -47,8 +47,8 @@ module bp_softcore
 
   `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
 
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache);
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache);
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache);
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache);
   `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
   `declare_bp_cache_stat_info_s(dcache_assoc_p, dcache);
   `declare_bp_cache_stat_info_s(icache_assoc_p, icache);
@@ -137,6 +137,7 @@ module bp_softcore
      ,.dcache_req_metadata_o(dcache_req_metadata_lo)
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
      ,.dcache_req_complete_i(dcache_req_complete_li)
+     ,.dcache_req_critical_i(dcache_req_critical_li)
 
      ,.icache_req_o(icache_req_lo)
      ,.icache_req_v_o(icache_req_v_lo)
@@ -144,6 +145,7 @@ module bp_softcore
      ,.icache_req_metadata_o(icache_req_metadata_lo)
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
      ,.icache_req_complete_i(icache_req_complete_li)
+     ,.icache_req_critical_i(icache_req_critical_li)
 
      ,.dcache_tag_mem_pkt_i(dcache_tag_mem_pkt_li)
      ,.dcache_tag_mem_pkt_v_i(dcache_tag_mem_pkt_v_li)
@@ -189,7 +191,8 @@ module bp_softcore
     #(.bp_params_p(bp_params_p)
      ,.assoc_p(dcache_assoc_p)
      ,.sets_p(dcache_sets_p)
-     ,.block_width_p(dcache_block_width_p))
+     ,.block_width_p(dcache_block_width_p)
+     ,.fill_width_p(dcache_fill_width_p))
     dcache_uce
     (.clk_i(clk_i)
     ,.reset_i(reset_i)
@@ -218,6 +221,7 @@ module bp_softcore
     ,.stat_mem_i(dcache_stat_mem_lo)
 
     ,.cache_req_complete_o(dcache_req_complete_li)
+    ,.cache_req_critical_o(dcache_req_critical_li)
 
     ,.credits_full_o(credits_full_li[1])
     ,.credits_empty_o(credits_empty_li[1])
@@ -235,7 +239,8 @@ module bp_softcore
     #(.bp_params_p(bp_params_p)
      ,.assoc_p(icache_assoc_p)
      ,.sets_p(icache_sets_p)
-     ,.block_width_p(icache_block_width_p))
+     ,.block_width_p(icache_block_width_p)
+     ,.fill_width_p(icache_fill_width_p))
     icache_uce
     (.clk_i(clk_i)
     ,.reset_i(reset_i)
@@ -264,6 +269,7 @@ module bp_softcore
     ,.stat_mem_i(icache_stat_mem_lo)
 
     ,.cache_req_complete_o(icache_req_complete_li)
+    ,.cache_req_critical_o(icache_req_critical_li)
 
     ,.credits_full_o(credits_full_li[0])
     ,.credits_empty_o(credits_empty_li[0])
@@ -447,4 +453,3 @@ module bp_softcore
   assign cache_resp_yumi_li = |(cache_resp_match & proc_resp_yumi_lo);
 
 endmodule
-

--- a/bp_top/src/v/bp_softcore.v
+++ b/bp_top/src/v/bp_softcore.v
@@ -88,6 +88,7 @@ module bp_softcore
   bp_icache_stat_info_s icache_stat_mem_lo;
 
   logic dcache_req_complete_li, icache_req_complete_li;
+  logic dcache_req_critical_li, icache_req_critical_li;
 
   logic [1:0] credits_full_li, credits_empty_li;
   logic timer_irq_li, software_irq_li, external_irq_li;

--- a/bp_top/syn/Makefile
+++ b/bp_top/syn/Makefile
@@ -52,4 +52,3 @@ regress.list.common.run_in_parallel: $(foreach p, $(LIST_PROGS), regress.list.co
 
 regress.list.common.launch_run.%:
 	$(MAKE) run.$(_TS) PROG=$*
-

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -237,7 +237,7 @@ $BP_ME_DIR/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v
 $BP_ME_DIR/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
 ## TOP
 $BP_TOP_DIR/src/v/bp_nd_socket.v
-$BP_TOP_DIR/src/v/bp_cacc_vdp.v
+# $BP_TOP_DIR/src/v/bp_cacc_vdp.v
 $BP_TOP_DIR/src/v/bp_cacc_tile.v
 $BP_TOP_DIR/src/v/bp_cacc_tile_node.v
 $BP_TOP_DIR/src/v/bp_cacc_complex.v

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -146,8 +146,8 @@ $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter_in.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter_out.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_decoder_dor.v
-$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_input_control.v  
-$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.v 
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_input_control.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.v
 # Common files
 $BP_COMMON_DIR/src/v/bsg_fifo_1r1w_rolly.v
 $BP_COMMON_DIR/src/v/bp_pma.v
@@ -237,7 +237,7 @@ $BP_ME_DIR/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v
 $BP_ME_DIR/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
 ## TOP
 $BP_TOP_DIR/src/v/bp_nd_socket.v
-# $BP_TOP_DIR/src/v/bp_cacc_vdp.v
+$BP_TOP_DIR/src/v/bp_cacc_vdp.v
 $BP_TOP_DIR/src/v/bp_cacc_tile.v
 $BP_TOP_DIR/src/v/bp_cacc_tile_node.v
 $BP_TOP_DIR/src/v/bp_cacc_complex.v

--- a/bp_top/test/common/bp_nonsynth_if_verif.v
+++ b/bp_top/test/common/bp_nonsynth_if_verif.v
@@ -26,10 +26,10 @@ assign proc_param = all_cfgs_gp[bp_params_p];
 `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
 `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
 
-initial 
+initial
   begin
     $display("########### BP Parameters ##############");
-    //  This throws an std::length_error in Verilator 4.031 based on the length of 
+    //  This throws an std::length_error in Verilator 4.031 based on the length of
     //   this (admittedly massive) parameter
     `ifndef VERILATOR
     $display("bp_params_e %s: bp_proc_param_s %p", bp_params_p.name(), proc_param);
@@ -76,7 +76,7 @@ initial
     $warning("Warning: paddr != 40 has not been tested");
   if ((cce_block_width_p != icache_block_width_p) && (cce_block_width_p != dcache_block_width_p) && (cce_block_width_p != acache_block_width_p))
     $warning("Warning: Different cache block widths not yet supported");
-  
+  if ((icache_fill_width_p != icache_block_width_p) || (dcache_fill_width_p != dcache_block_width_p))
+    $warning("Warning: Fill width is different from block width, partial fill is not yet supported");
 
 endmodule
-


### PR DESCRIPTION
### Cache and UCE Interface modification

1. fill mask added in data_mem_pkt to indicate the banks being filled
2. Data field in data_mem_pkt is changed to fill width from data_width
3. cache_req_critical signal is added
4. In-progress registers indicating the info of the only one outstanding missed cacheline are added
5. Corresponding logic like generating writemask to SRAM based on fill mask and checking hitted bank is filled or not are added