### PR TITLE
Dev hotfix vivado synthesis

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v
@@ -225,7 +225,7 @@ always_comb
           unique casez (instr)
             `RV64_FENCE   : 
               begin
-                decode.pipe_ctrl_v = 1'b1;
+                decode.pipe_mem_v = 1'b1;
               end
             `RV64_FENCE_I : 
               begin 

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.v
@@ -42,21 +42,16 @@ module bp_be_pipe_long
   logic [dword_width_p-1:0] op_a, op_b;
   always_comb
     begin
-      op_a = rs1_i;
-      op_b = rs2_i;
-      unique case (decode.fu_op)
-        `RV64_DIVW, `RV64_REMW:
-          begin
-            op_a = $signed(rs1_i[0+:word_width_lp]);
-            op_b = $signed(rs2_i[0+:word_width_lp]);
-          end
-        `RV64_DIVUW, `RV64_REMUW:
-          begin
-            op_a = rs1_i[0+:word_width_lp];
-            op_b = rs2_i[0+:word_width_lp];
-          end
-        default : begin end
-      endcase
+      op_a = decode.opw_v 
+             ? signed_div_li
+               ? dword_width_p'($signed(rs1_i[0+:word_width_lp]))
+               : rs1_i[0+:word_width_lp]
+             : rs1_i;
+      op_b = decode.opw_v 
+             ? signed_div_li
+               ? dword_width_p'($signed(rs2_i[0+:word_width_lp]))
+               : rs2_i[0+:word_width_lp]
+             : rs2_i;
     end
 
   // We actual could exit early here 

--- a/bp_be/src/v/bp_be_checker/bp_be_director.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.v
@@ -315,7 +315,7 @@ always_comb
       end
   end
 
-
+//synopsys translate_off
 `declare_bp_fe_branch_metadata_fwd_s(btb_tag_width_p, btb_idx_width_p, bht_idx_width_p, ghist_width_p);
 bp_fe_branch_metadata_fwd_s attaboy_md;
 bp_fe_branch_metadata_fwd_s redir_md;
@@ -332,6 +332,7 @@ always_ff @(negedge clk_i)
     else if (isd_status.isd_v)
       $display("[FETCH  ] %x   ", isd_status.isd_pc);
   end
+//synopsys translate_on
 
 endmodule
 


### PR DESCRIPTION
- Fixes bad case statement comparison
- Fences go to mem pipe, not control pipe
- //synopsys translate_off unguarded nonsynth block