### PR TITLE
Fixing LSB of branch target to always be 0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ tools: | $(TARGET_DIRS)
 
 progs: tools
 	git submodule update --init --recursive $(BP_COMMON_DIR)/test
-	$(MAKE) -C $(BP_COMMON_DIR)/test perch bp_tests riscv_tests beebs
+	$(MAKE) -C $(BP_COMMON_DIR)/test perch bp_tests riscv_tests beebs coremark
 
 ucode: | basejump
 	$(MAKE) -C $(BP_ME_DIR)/src/asm roms

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_ctrl.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_ctrl.v
@@ -70,7 +70,7 @@ assign taken_tgt = baddr + imm_i;
 assign ntaken_tgt = pc_i + 4'd4;
 
 assign data_o   = vaddr_width_p'($signed(ntaken_tgt));
-assign br_tgt_o = btaken ? taken_tgt : ntaken_tgt;
+assign br_tgt_o = btaken ? {taken_tgt[vaddr_width_p-1:1], 1'b0} : ntaken_tgt;
 assign btaken_o = btaken;
 
 endmodule

--- a/bp_common/test/Makefile.frag
+++ b/bp_common/test/Makefile.frag
@@ -471,6 +471,10 @@ BEEBS_TESTS = \
   wikisort
 BEEBS_TESTS_RISCV := $(addprefix $(BP_TEST_MEM_DIR)/beebs/, $(addsuffix .riscv, $(BEEBS_TESTS)))
 
+COREMARK_TESTS = \
+  coremark
+COREMARK_TESTS_RISCV := $(addprefix $(BP_TEST_MEM_DIR)/coremark/, $(addsuffix .riscv, $(COREMARK_TESTS)))
+
 SPEC = \
   175.vpr \
   181.mcf \

--- a/bp_common/test/Makefile.tests
+++ b/bp_common/test/Makefile.tests
@@ -6,6 +6,7 @@ perch_dir       := $(BP_TEST_SRC_DIR)/perch
 bp_tests_dir    := $(BP_TEST_SRC_DIR)/bp_tests
 riscv_tests_dir := $(BP_TEST_SRC_DIR)/riscv-tests
 beebs_dir       := $(BP_TEST_SRC_DIR)/beebs
+coremark_dir    := $(BP_TEST_SRC_DIR)/coremark
 spec_dir        := $(BP_TEST_SRC_DIR)/spec
 riscvdv_dir     := $(BP_TEST_SRC_DIR)/riscv-dv
 
@@ -39,6 +40,9 @@ beebs_build:
 	@# TODO: We need to change to output .riscv, but the beebs makefiles are a mess
 	@find $(beebs_dir)/src -type f -executable -exec cp {} {}.riscv \;
 
+coremark_build:
+	$(MAKE) -C $(coremark_dir)/barebones
+
 spec_build:
 	$(MAKE) -C $(spec_dir)
 
@@ -56,6 +60,7 @@ $(BP_TEST_DIR)/lib/libperch.a:
 $(eval $(call submodule_test_template,bp_tests,$(bp_tests_dir)))
 $(eval $(call submodule_test_template,riscv_tests,$(riscv_tests_dir)))
 $(eval $(call submodule_test_template,beebs,$(beebs_dir)))
+$(eval $(call submodule_test_template,coremark,$(coremark_dir)))
 $(eval $(call submodule_test_template,spec,$(spec_dir)))
 $(eval $(call submodule_test_template,riscvdv,$(riscvdv_dir)))
 


### PR DESCRIPTION
RISC-V spec defines JALR to zero LSB to 0, to prevent misalignment

Fixes #400 #402 