### PR TITLE
Fix poison condition for long latency instructions

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -311,7 +311,7 @@ bp_be_pipe_mem
      ,.instr_i(reservation_r.instr)
      ,.rs1_i(reservation_r.rs1)
      ,.rs2_i(reservation_r.rs2)
-     ,.v_i(reservation_r.v & reservation_r.decode.pipe_long_v & ~reservation_r.poison)
+     ,.v_i(reservation_r.v & reservation_r.decode.pipe_long_v & ~exc_stage_r[0].poison_v)
      ,.ready_o(pipe_long_ready_lo)
 
      ,.flush_i(flush_i)


### PR DESCRIPTION
This caused issues where things wouldn't quite be flushed in some situations, leading to a spurious long instruction writing back.  Interestingly, cosim had a hard time finding it, because the writeback happens out of band, so the commits looked fine.