### PR TITLE
fix CCE and LCE tracing in bp_top and bp_me testbenches

### DIFF
--- a/bp_me/syn/Makefile
+++ b/bp_me/syn/Makefile
@@ -26,24 +26,6 @@ include $(BP_COMMON_DIR)/syn/Makefile.dc
 include $(BP_COMMON_DIR)/syn/Makefile.verilator
 include $(BP_COMMON_DIR)/syn/Makefile.vcs
 
-regress.me.sc: dirs.sc
-	$(MAKE) -j 1 build.sc sim.sc TB=bp_cce NUM_INSTR_P=$(NUM_INSTR_P) PROG=normal
-	$(MAKE) -j 1 build.sc sim.sc TB=bp_cce NUM_INSTR_P=$(NUM_INSTR_P) SKIP_INIT_P=1 PROG=uncached
-	$(MAKE) -j 1 build.sc sim.sc TB=bp_cce_fsm NUM_INSTR_P=$(NUM_INSTR_P) PROG=normal
-	$(MAKE) -j 1 build.sc sim.sc TB=bp_cce_fsm NUM_INSTR_P=$(NUM_INSTR_P) SKIP_INIT_P=1 PROG=uncached
-
-regress.me.v: dirs.v
-	$(MAKE) -j 1 build.v sim.v TB=bp_cce NUM_INSTR_P=$(NUM_INSTR_P) PROG=normal
-	$(MAKE) -j 1 build.v sim.v TB=bp_cce NUM_INSTR_P=$(NUM_INSTR_P) SKIP_INIT_P=1 PROG=uncached
-	$(MAKE) -j 1 build.v sim.v TB=bp_cce_fsm NUM_INSTR_P=$(NUM_INSTR_P) PROG=normal
-	$(MAKE) -j 1 build.v sim.v TB=bp_cce_fsm NUM_INSTR_P=$(NUM_INSTR_P) SKIP_INIT_P=1 PROG=uncached
-
-regress: regress.me
-regress.me: lint.me regress.me.sc regress.me.v
-
-regress_full.me.v:
-	./run-me.sh
-
 clean: clean.me
 clean.me:
 	rm -f *.axe

--- a/bp_me/test/tb/bp_cce/Makefile.params
+++ b/bp_me/test/tb/bp_cce/Makefile.params
@@ -1,7 +1,7 @@
-NUM_INSTR_P ?= 4096
+export NUM_INSTR_P ?= 4096
 SEED_P ?= 1
 # uncached / normal mode testing
-SKIP_INIT_P ?= 0
+export SKIP_INIT_P ?= 0
 
 # Select CCE ROM based on CFG and Coherence Protocol
 ifeq ($(CFG), e_bp_half_core_cfg)
@@ -50,24 +50,22 @@ NUMS = $(shell seq 0 `expr $(NUM_LCE_P) - 1`)
 BASE = bsg_trace_rom_
 TRACE_ROMS = $(addsuffix .v, $(addprefix $(BASE), $(NUMS)))
 
-DRAMSIM_CH_CFG  ?= DDR2_micron_16M_8b_x8_sg3E.ini
-DRAMSIM_SYS_CFG ?= system.ini
+export DRAMSIM_CH_CFG  ?= DDR2_micron_16M_8b_x8_sg3E.ini
+export DRAMSIM_SYS_CFG ?= system.ini
 
-AXE_TRACE_P ?= 0
-CCE_TRACE_P ?= 0
-LCE_TRACE_P ?= 0
-DRAM_TRACE_P ?= 0
+export AXE_TRACE_P ?= 0
+export CCE_TRACE_P ?= 0
+export LCE_TRACE_P ?= 0
+export DRAM_TRACE_P ?= 0
 
 export DUT_PARAMS =
 export TB_PARAMS  = \
-	-pvalue+axe_trace_p=$(AXE_TRACE_P) \
+    -pvalue+axe_trace_p=$(AXE_TRACE_P) \
     -pvalue+cce_trace_p=$(CCE_TRACE_P) \
     -pvalue+instr_count=$(NUM_INSTR_P) \
     -pvalue+skip_init_p=$(SKIP_INIT_P) \
     -pvalue+lce_trace_p=$(LCE_TRACE_P) \
     -pvalue+dram_trace_p=$(DRAM_TRACE_P) \
-
-export TB_PARAMS  = 
 
 export DUT_DEFINES =
 export TB_DEFINES =

--- a/bp_me/test/tb/bp_cce/testbench.v
+++ b/bp_me/test/tb/bp_cce/testbench.v
@@ -184,7 +184,7 @@ bind bp_cce_wrapper
   bp_me_nonsynth_cce_tracer
     #(.bp_params_p(bp_params_p))
     cce_tracer
-     (.clk_i(clk_i & (wrapper.cce_trace_p == 1))
+     (.clk_i(clk_i & (testbench.cce_trace_p == 1))
       ,.reset_i(reset_i)
       ,.freeze_i(cfg_bus_cast_i.freeze)
 

--- a/bp_top/test/tb/bp_tethered/testbench.v
+++ b/bp_top/test/tb/bp_tethered/testbench.v
@@ -600,6 +600,43 @@ bind bp_be_top
        ,.program_finish_i(testbench.program_finish_lo)
        );
 
+  if (cce_trace_p) begin : cce_tracer
+  bind bp_cce_wrapper
+    bp_me_nonsynth_cce_tracer
+     #(.bp_params_p(bp_params_p))
+     cce_tracer
+      (.clk_i(clk_i & (testbench.cce_trace_p == 1))
+      ,.reset_i(reset_i)
+      ,.freeze_i(cfg_bus_cast_i.freeze)
+
+      ,.cce_id_i(cfg_bus_cast_i.cce_id)
+
+      // To CCE
+      ,.lce_req_i(lce_req_i)
+      ,.lce_req_v_i(lce_req_v_i)
+      ,.lce_req_yumi_i(lce_req_yumi_o)
+      ,.lce_resp_i(lce_resp_i)
+      ,.lce_resp_v_i(lce_resp_v_i)
+      ,.lce_resp_yumi_i(lce_resp_yumi_o)
+
+      // From CCE
+      ,.lce_cmd_i(lce_cmd_o)
+      ,.lce_cmd_v_i(lce_cmd_v_o)
+      ,.lce_cmd_ready_i(lce_cmd_ready_i)
+
+      // To CCE
+      ,.mem_resp_i(mem_resp_i)
+      ,.mem_resp_v_i(mem_resp_v_i)
+      ,.mem_resp_yumi_i(mem_resp_yumi_o)
+
+      // From CCE
+      ,.mem_cmd_i(mem_cmd_o)
+      ,.mem_cmd_v_i(mem_cmd_v_o)
+      ,.mem_cmd_ready_i(mem_cmd_ready_i)
+      );
+  end
+
+
 bp_nonsynth_if_verif
  #(.bp_params_p(bp_params_p))
  if_verif


### PR DESCRIPTION
This change adds back the CCE tracer to the bp_top testbench, instantiating only if CCE_TRACE_P=1 is passed on the command line.

Setting cce_trace_p to 1 for invalid configs (e.g., softcores) results in a build error since the CCE does not exist and therefore the bind statement fails. I think this is acceptable, as the alternative is to guard the tracer instantiation by checking the provided config, which is a burden to maintain as configs are added/changed/removed.

This change also fixes up the ME bp_cce testbench to re-enable the CCE and LCE tracers.