### PR TITLE
ITLB / I$ power optimizations

### DIFF
--- a/bp_be/test/common/bp_be_nonsynth_vm_tracer.v
+++ b/bp_be/test/common/bp_be_nonsynth_vm_tracer.v
@@ -27,15 +27,19 @@ module bp_be_nonsynth_vm_tracer
    , input                           itlb_fill_v_i
    , input [vtag_width_p-1:0]        itlb_vtag_i
    , input [itlb_entry_width_lp-1:0] itlb_entry_i
+   , input                           itlb_cam_r_v_i
 
    , input                           dtlb_clear_i
    , input                           dtlb_fill_v_i
    , input [vtag_width_p-1:0]        dtlb_vtag_i
    , input [dtlb_entry_width_lp-1:0] dtlb_entry_i
+   , input                           dtlb_cam_r_v_i
 
    //, input                           sfence_i
    //, input [rv64_priv_width_gp-1:0]  priv_i
    //, input [rv64_priv_width_gp-1:0]  shadow_priv_i
+
+   , input [num_core_p-1:0]          program_finish_i
    );
 
   `declare_bp_fe_be_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
@@ -49,6 +53,9 @@ module bp_be_nonsynth_vm_tracer
   
   integer file;
   string file_name;
+
+  logic [63:0] itlb_read_count_r;
+  logic [63:0] dtlb_read_count_r;
   
   wire delay_li = reset_i | freeze_i;
   always_ff @(negedge delay_li)
@@ -85,6 +92,26 @@ module bp_be_nonsynth_vm_tracer
                 //,dtlb_w_entry.a
                 //,dtlb_w_entry.d
                 );
+    end
+
+  // the following counters count how often itlb and dtlb are read
+  always_ff @(posedge clk_i)
+    begin
+      if (reset_i)
+        begin
+          itlb_read_count_r <= '0;
+          dtlb_read_count_r <= '0;
+        end
+      else if (program_finish_i)
+        begin
+          $fwrite(file, "[%t] Total ITLB read access count is %0d.\n", $time, itlb_read_count_r);
+          $fwrite(file, "[%t] Total DTLB read access count is %0d.\n", $time, dtlb_read_count_r);
+        end
+      else
+        begin
+          itlb_read_count_r <= itlb_cam_r_v_i + itlb_read_count_r;
+          dtlb_read_count_r <= dtlb_cam_r_v_i + dtlb_read_count_r;
+        end
     end
 
 endmodule

--- a/bp_common/src/v/bp_tlb.v
+++ b/bp_common/src/v/bp_tlb.v
@@ -48,7 +48,7 @@ bsg_dff_reset #(.width_p(vtag_width_p))
 logic tlb_bypass;
 logic tlb_bypass_r;
 logic tlb_last_read_r;
-logic r_v_lo_bypass_r;
+logic r_entry_bypass_v_r;
 bp_pte_entry_leaf_s r_entry_bypass_r;
 
 assign tlb_bypass = (vtag_i == vtag_r) & tlb_last_read_r;
@@ -106,17 +106,17 @@ bsg_dff_reset_en_bypass #(.width_p(entry_width_lp))
   );
 
 bsg_dff_reset_en_bypass #(.width_p(1))
-  r_v_lo_bypass_reg
+  r_entry_bypass_v_reg
   (.clk_i(clk_i)
    ,.reset_i(reset_i)
    ,.en_i(~tlb_bypass_r)
    ,.data_i(r_v_lo)
-   ,.data_o(r_v_lo_bypass_r)
+   ,.data_o(r_entry_bypass_v_r)
   );  
 
 assign passthrough_entry = '{ptag: vtag_r, default: '0};
 assign entry_o    = translation_en_i ? r_entry_bypass_r : passthrough_entry;
-assign v_o        = translation_en_i ? r_v_r & r_v_lo_bypass_r : r_v_r;
+assign v_o        = translation_en_i ? r_v_r & r_entry_bypass_v_r : r_v_r;
 assign miss_v_o   = r_v_r & ~v_o;
 
 endmodule

--- a/bp_common/src/v/bp_tlb.v
+++ b/bp_common/src/v/bp_tlb.v
@@ -51,7 +51,7 @@ logic tlb_last_read_r;
 logic r_entry_bypass_v_r;
 bp_pte_entry_leaf_s r_entry_bypass_r;
 
-assign tlb_bypass = (vtag_i == vtag_r) & tlb_last_read_r;
+assign tlb_bypass = (vtag_i == vtag_r) & tlb_last_read_r | ~translation_en_i;
 
 bsg_dff_reset #(.width_p(1))
   tlb_bypass_reg

--- a/bp_common/src/v/bp_tlb.v
+++ b/bp_common/src/v/bp_tlb.v
@@ -52,7 +52,7 @@ logic tlb_last_read_r;
 logic r_entry_bypass_v_r;
 bp_pte_entry_leaf_s r_entry_bypass_r;
 
-assign tlb_bypass = (vtag_i == vtag_r) & tlb_last_read_r | ~translation_en_i;
+assign tlb_bypass = ((vtag_i == vtag_r) & tlb_last_read_r) | ~translation_en_i;
 
 bsg_dff_reset #(.width_p(1))
   tlb_bypass_reg

--- a/bp_fe/src/v/bp_fe_mem.v
+++ b/bp_fe/src/v/bp_fe_mem.v
@@ -83,14 +83,13 @@ assign mem_resp_o     = mem_resp_cast_o;
 logic instr_page_fault_lo, instr_access_fault_lo, icache_miss_lo, itlb_miss_lo;
 
 logic fetch_ready;
-logic prev_fetch_vtag_v_r; //the validity of the previously fetched virtual address tag
-logic [vtag_width_p-1:0] prev_fetch_vtag_r; //previously fetched virtual address tag
+logic prev_fetch_vtag_v_r; 
+logic [vtag_width_p-1:0] prev_fetch_vtag_r; 
 
 wire itlb_fence_v 		= mem_cmd_v_i & (mem_cmd_cast_i.op == e_fe_op_tlb_fence);
 wire itlb_fill_v  		= mem_cmd_v_i & (mem_cmd_cast_i.op == e_fe_op_tlb_fill);
 wire fetch_v      		= fetch_ready & mem_cmd_v_i & (mem_cmd_cast_i.op == e_fe_op_fetch);
 wire itlb_vtag_bypass 	= (prev_fetch_vtag_r == mem_cmd_cast_i.operands.fetch.vaddr.tag) & prev_fetch_vtag_v_r & mem_cmd_v_i & ~(itlb_fence_v | itlb_fill_v);
-//wire fetch_v 			= fetch_ready & mem_cmd_v_i & (mem_cmd_cast_i.op == e_fe_op_fetch) & ~itlb_vtag_bypass;
 wire fencei_v     		= fetch_ready & mem_cmd_v_i & (mem_cmd_cast_i.op == e_fe_op_icache_fence);
 
 
@@ -98,12 +97,12 @@ wire fencei_v     		= fetch_ready & mem_cmd_v_i & (mem_cmd_cast_i.op == e_fe_op_
 always_ff @(posedge clk_i)
 	begin
 		if (reset_i) begin
-			prev_fetch_vtag_v_r  <= '0;
-			prev_fetch_vtag_r    <= '0;
+         prev_fetch_vtag_r    <= '0;
+			prev_fetch_vtag_v_r  <= 1'b0;
 		end
 
       else if (itlb_fence_v | itlb_fill_v | itlb_miss_lo) begin
-         prev_fetch_vtag_r    <= '0;
+         prev_fetch_vtag_v_r  <= 1'b0;
       end
 
 		else if (fetch_v) begin 
@@ -113,7 +112,7 @@ always_ff @(posedge clk_i)
 
 		else begin
 			prev_fetch_vtag_r 	<= prev_fetch_vtag_r;
-			prev_fetch_vtag_v_r <= prev_fetch_vtag_v_r;
+			prev_fetch_vtag_v_r  <= prev_fetch_vtag_v_r;
 		end
 	end
 
@@ -151,7 +150,7 @@ wire ptag_v_li   					      = itlb_vtag_bypass_r
 
 always_ff @(posedge clk_i) begin
 	if (reset_i) begin
-		itlb_vtag_bypass_r				   <= '0;
+		itlb_vtag_bypass_r				   <= 1'b0;
 		prev_fetch_itlb_r_entry_ptag_r	<= '0;
 	end
 

--- a/bp_fe/src/v/bp_fe_mem.v
+++ b/bp_fe/src/v/bp_fe_mem.v
@@ -97,10 +97,14 @@ wire fencei_v     		= fetch_ready & mem_cmd_v_i & (mem_cmd_cast_i.op == e_fe_op_
 //itlb bypass pre-itlb logic
 always_ff @(posedge clk_i)
 	begin
-		if (reset_i | itlb_fence_v | itlb_fill_v) begin
-			prev_fetch_vtag_v_r <= '0;
-			prev_fetch_vtag_r 	<= '0;
+		if (reset_i) begin
+			prev_fetch_vtag_v_r  <= '0;
+			prev_fetch_vtag_r    <= '0;
 		end
+
+      else if (itlb_fence_v | itlb_fill_v | itlb_miss_lo) begin
+         prev_fetch_vtag_r    <= '0;
+      end
 
 		else if (fetch_v) begin 
 			prev_fetch_vtag_r 	<= mem_cmd_cast_i.operands.fetch.vaddr.tag;

--- a/bp_fe/src/v/bp_fe_mem.v
+++ b/bp_fe/src/v/bp_fe_mem.v
@@ -83,36 +83,10 @@ assign mem_resp_o     = mem_resp_cast_o;
 logic instr_page_fault_lo, instr_access_fault_lo, icache_miss_lo, itlb_miss_lo;
 
 logic fetch_ready;
-logic prev_fetch_vtag_v_r; 
-logic [vtag_width_p-1:0] prev_fetch_vtag_r; 
-
-wire itlb_fence_v 		= mem_cmd_v_i & (mem_cmd_cast_i.op == e_fe_op_tlb_fence);
-wire itlb_fill_v  		= mem_cmd_v_i & (mem_cmd_cast_i.op == e_fe_op_tlb_fill);
-wire fetch_v      		= fetch_ready & mem_cmd_v_i & (mem_cmd_cast_i.op == e_fe_op_fetch);
-wire itlb_vtag_bypass 		= (prev_fetch_vtag_r == mem_cmd_cast_i.operands.fetch.vaddr.tag) & prev_fetch_vtag_v_r & mem_cmd_v_i & ~(itlb_fence_v | itlb_fill_v);
-wire fencei_v     		= fetch_ready & mem_cmd_v_i & (mem_cmd_cast_i.op == e_fe_op_icache_fence);
-
-//itlb bypass pre-itlb logic
-always_ff @(posedge clk_i) begin
-	if (reset_i) begin
-		prev_fetch_vtag_r    <= '0;
-		prev_fetch_vtag_v_r  <= 1'b0;
-	end
-
-	else if (itlb_fence_v | itlb_fill_v | itlb_miss_lo) begin
-        	prev_fetch_vtag_v_r  <= 1'b0;
-      	end
-
-	else if (fetch_v) begin 
-		prev_fetch_vtag_r 	<= mem_cmd_cast_i.operands.fetch.vaddr.tag;
-		prev_fetch_vtag_v_r	<= 1'b1;
-	end
-
-	else begin
-		prev_fetch_vtag_r 	<= prev_fetch_vtag_r;
-		prev_fetch_vtag_v_r  <= prev_fetch_vtag_v_r;
-	end
-end
+wire itlb_fence_v = mem_cmd_v_i & (mem_cmd_cast_i.op == e_fe_op_tlb_fence);
+wire itlb_fill_v  = mem_cmd_v_i & (mem_cmd_cast_i.op == e_fe_op_tlb_fill);
+wire fetch_v      = fetch_ready & mem_cmd_v_i & (mem_cmd_cast_i.op == e_fe_op_fetch);
+wire fencei_v     = fetch_ready & mem_cmd_v_i & (mem_cmd_cast_i.op == e_fe_op_icache_fence);
 
 bp_fe_tlb_entry_s itlb_r_entry;
 logic itlb_r_v_lo;
@@ -124,7 +98,7 @@ bp_tlb
    ,.flush_i(itlb_fence_v)
    ,.translation_en_i(mem_translation_en_i)
          
-   ,.v_i((fetch_v & ~itlb_vtag_bypass) | itlb_fill_v)
+   ,.v_i(fetch_v | itlb_fill_v)
    ,.w_i(itlb_fill_v)
    ,.vtag_i(itlb_fill_v ? mem_cmd_cast_i.operands.fill.vtag : mem_cmd_cast_i.operands.fetch.vaddr.tag)
    ,.entry_i(mem_cmd_cast_i.operands.fill.entry)
@@ -134,26 +108,8 @@ bp_tlb
    ,.entry_o(itlb_r_entry)
    );
 
-//itlb bypass post-itlb logic
-logic [ptag_width_p-1:0] prev_fetch_itlb_r_entry_ptag_r;
-logic itlb_vtag_bypass_r;
-
-wire [ptag_width_p-1:0] ptag_li = itlb_vtag_bypass_r ? prev_fetch_itlb_r_entry_ptag_r : itlb_r_entry.ptag;
-
-wire ptag_v_li = itlb_vtag_bypass_r ? 1'b1 : itlb_r_v_lo;
-
-always_ff @(posedge clk_i) begin
-	if (reset_i) begin
-		itlb_vtag_bypass_r		<= 1'b0;
-		prev_fetch_itlb_r_entry_ptag_r	<= '0;
-	end
-
-	else begin
-		itlb_vtag_bypass_r		<= itlb_vtag_bypass;
-		prev_fetch_itlb_r_entry_ptag_r 	<= (itlb_r_v_lo) ? itlb_r_entry.ptag : prev_fetch_itlb_r_entry_ptag_r;
-	end
-
-end
+wire [ptag_width_p-1:0] ptag_li     = itlb_r_entry.ptag;
+wire                    ptag_v_li   = itlb_r_v_lo;
 
 logic uncached_li;
 bp_pma

--- a/bp_fe/syn/flist.vcs
+++ b/bp_fe/syn/flist.vcs
@@ -111,6 +111,7 @@ $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_chain.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_en.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_en.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_set_clear.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_edge_detect.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_encode_one_hot.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_expand_bitmask.v

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -111,6 +111,7 @@ $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_chain.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_en.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_en.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_set_clear.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_edge_detect.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_encode_one_hot.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_expand_bitmask.v

--- a/bp_top/test/tb/bp_tethered/testbench.v
+++ b/bp_top/test/tb/bp_tethered/testbench.v
@@ -431,6 +431,10 @@ bind bp_be_top
        ,.stat_mem_pkt_v_i(stat_mem_pkt_v_i)
        ,.stat_mem_pkt_i(stat_mem_pkt_i)
        ,.stat_mem_pkt_yumi_o(stat_mem_pkt_yumi_o)
+
+       ,.tag_mem_v_i(tag_mem_v_li)
+       ,.data_mem_v_i(data_mem_v_li)
+       ,.program_finish_i(testbench.program_finish_lo)
        );
 
   bind bp_fe_icache
@@ -480,6 +484,10 @@ bind bp_be_top
        ,.stat_mem_pkt_v_i(stat_mem_pkt_v_i)
        ,.stat_mem_pkt_i(stat_mem_pkt_i)
        ,.stat_mem_pkt_yumi_o(stat_mem_pkt_yumi_o)
+
+       ,.tag_mem_v_i(tag_mem_v_li)
+       ,.data_mem_v_i(data_mem_v_li)
+       ,.program_finish_i(testbench.program_finish_lo)
        );
 
   bind bp_core_minimal
@@ -496,11 +504,15 @@ bind bp_be_top
        ,.itlb_fill_v_i(fe.mem.itlb.v_i & fe.mem.itlb.w_i)
        ,.itlb_vtag_i(fe.mem.itlb.vtag_i)
        ,.itlb_entry_i(fe.mem.itlb.entry_i)
+       ,.itlb_cam_r_v_i(fe.mem.itlb.cam.r_v_i)
 
        ,.dtlb_clear_i(be.be_mem.dtlb.flush_i)
        ,.dtlb_fill_v_i(be.be_mem.dtlb.v_i & be.be_mem.dtlb.w_i)
        ,.dtlb_vtag_i(be.be_mem.dtlb.vtag_i)
        ,.dtlb_entry_i(be.be_mem.dtlb.entry_i)
+       ,.dtlb_cam_r_v_i(be.be_mem.dtlb.cam.r_v_i)
+
+       ,.program_finish_i(testbench.program_finish_lo)
        );
 
   bp_mem_nonsynth_tracer


### PR DESCRIPTION
# I-cache power optimization
Bypass I-TLB and tag_mem when possible. In addition, select the necessary bank of data_mem.

## I-TLB:
#### 1) General Case:
When incoming vaddr tag == previously fetched valid vtag and we’re not doing itlb_fence or itlb_fill, we bypass the i-tlb
If we bypass the i-tlb, then the physical tag is always valid (ptag_v_li) and the physical tag (ptag_li) is previously stored ptag. Note itlb_r_v_lo = 0 when bypass is enabled
#### 2) Special Case 1 (itlb_fence or itlb_fill)
While we’re performing a itlb_fence or itlb_fill, we do not bypass
Furthermore, we invalidate the current vtag that’s going to be stored in the prev_fetch_vtag_r
#### 3) Special Case 2 (itlb_miss_lo)
If a fetch results in a miss, we invalidate the vtag in prev_fetch_vtag_r. Note that itlb_miss_lo is determined on the same cycle as we’re storing prev_fetch_tag

## I-Cache Tag_mem:
#### 1) General Case:
When incoming vaddr index == previous valid index and we’re not writing to or poisoning tag_mem, we bypass the tag mem
If we’re reading and we bypass the tag mem. Latch_last_read_p=1 will hold onto the previous tag_mem output
#### 2) Special Case 1 (writing to tag mem)
Turn off bypass and we invalidate the previously stored tag_mem address until we read again
#### 3) Special Case 2 (poisoning)
Turn off bypass signal

## I-Cache Data_mem:
#### 1) General Case:
If we decided to bypass tag_mem, we can use the hit_index_tl to help select the single data_mem bank that will be used. 
#### 2) Special Case 1 (ptag_i changes while tag_mem under bypass)
To solve this issue, vaddr_vtag and addr_vtag_tl were added. If the vtag changes during bypass, all banks must be enabled
