### PR TITLE
Detecting illegal jalr

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v
@@ -173,7 +173,10 @@ always_comb
         begin
           decode.pipe_ctrl_v = 1'b1;
           decode.irf_w_v    = 1'b1;
-          decode.fu_op      = e_ctrl_op_jalr;
+          unique casez (instr)
+            `RV64_JALR: decode.fu_op = e_ctrl_op_jalr;
+            default : illegal_instr = 1'b1;
+          endcase
           decode.baddr_sel  = e_baddr_is_rs1;
         end
       `RV64_BRANCH_OP : 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2322266/81875231-d530ff80-954d-11ea-9b47-979cd13675f9.png)

RISC-V defines that funct3 for JALR == 3'b000.  In our decoder, we did not make this assertion and just checked the opcode.

```
      `RV64_JALR_OP :
        begin
          decode.pipe_ctrl_v = 1'b1;
          decode.irf_w_v    = 1'b1;
          decode.fu_op      = e_ctrl_op_jalr;
          decode.baddr_sel  = e_baddr_is_rs1;
        end
```

Fixes #497 , test added