### PR TITLE
Fixing path issue for riscvdv tests

### DIFF
--- a/bp_top/test/tb/bp_tethered/Makefile.testlist
+++ b/bp_top/test/tb/bp_tethered/Makefile.testlist
@@ -433,18 +433,18 @@ MC_TESTS := \
 MC_TESTLIST := $(addprefix bp_tests@, $(MC_TESTS))
 
 RISCVDV_TESTS := \
-  riscv_arithmetic_basic_test     \
-  riscv_full_interrupt_test       \
-  riscv_illegal_instr_test        \
-  riscv_loop_test                 \
-  riscv_mmu_stress_test           \
-  riscv_no_fence_test             \
-  riscv_privileged_mode_rand_test \
-  riscv_rand_instr_test           \
-  riscv_rand_jump_test            \
-  riscv_sfence_exception_test
+  riscv_arithmetic_basic_test_0     \
+  riscv_full_interrupt_test_0       \
+  riscv_illegal_instr_test_0        \
+  riscv_loop_test_0                 \
+  riscv_mmu_stress_test_0           \
+  riscv_no_fence_test_0             \
+  riscv_privileged_mode_rand_test_0 \
+  riscv_rand_instr_test_0           \
+  riscv_rand_jump_test_0            \
+  riscv_sfence_exception_test_0
 
-RISCVDV_TESTLIST := $(addprefix riscvdv_tests@, $(RISCVDV_TESTS))
+RISCVDV_TESTLIST := $(addprefix riscvdv@, $(RISCVDV_TESTS))
 
 SPEC_TESTS := \
   175.vpr \


### PR DESCRIPTION
Minor path issue.  riscvdv tests should generate and run properly now