### PR TITLE
Adding CCE loopback module

### DIFF
--- a/bp_me/src/v/cce/bp_cce_loopback.v
+++ b/bp_me/src/v/cce/bp_cce_loopback.v
@@ -1,0 +1,53 @@
+
+//
+// This module is an active tie-off. That is, requests to this module will return the header
+//   with a zero payload. This is useful to not stall the network in the case of an erroneous
+//   address, or prevent deadlock at network boundaries
+module bp_cce_loopback
+  import bp_common_pkg::*;
+  import bp_common_aviary_pkg::*;
+  import bp_cce_pkg::*;
+  import bp_common_cfg_link_pkg::*;
+  import bp_me_pkg::*;
+  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
+    `declare_bp_proc_params(bp_params_p)
+    `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
+    )
+   (input                                           clk_i
+    , input                                         reset_i
+
+    , input [cce_mem_msg_width_lp-1:0]              mem_cmd_i
+    , input                                         mem_cmd_v_i
+    , output                                        mem_cmd_ready_o
+
+    , output [cce_mem_msg_width_lp-1:0]             mem_resp_o
+    , output                                        mem_resp_v_o
+    , input                                         mem_resp_yumi_i
+    );
+
+  `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
+
+  bp_cce_mem_msg_s mem_cmd_cast_i;
+  bp_cce_mem_msg_s mem_resp_cast_o;
+
+  assign mem_cmd_cast_i = mem_cmd_i;
+  assign mem_resp_o = mem_resp_cast_o;
+
+  bsg_two_fifo
+   #(.width_p($bits(mem_cmd_cast_i.header)))
+   loopback_buffer
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.data_i(mem_cmd_cast_i.header)
+     ,.v_i(mem_cmd_v_i)
+     ,.ready_o(mem_cmd_ready_o)
+
+     ,.data_o(mem_resp_cast_o.header)
+     ,.v_o(mem_resp_v_o)
+     ,.yumi_i(mem_resp_yumi_i)
+     );
+  assign mem_resp_cast_o.data = '0;
+
+endmodule
+

--- a/bp_me/src/v/cce/bp_uce.v
+++ b/bp_me/src/v/cce/bp_uce.v
@@ -373,7 +373,7 @@ module bp_uce
           end
         e_ready:
           begin
-            cache_req_ready_o = mem_cmd_ready_i;
+            cache_req_ready_o = mem_cmd_ready_i & ~credits_full_o;
             if (uc_store_v_li)
               begin
                 mem_cmd_cast_o.header.msg_type       = e_cce_mem_uc_wr;

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -225,6 +225,7 @@ $BP_ME_DIR/src/v/cce/bp_io_cce.v
 $BP_ME_DIR/src/v/cce/bp_cce_fsm.v
 $BP_ME_DIR/src/v/cce/bp_cce_wrapper.v
 # Network
+$BP_ME_DIR/src/v/cce/bp_cce_loopback.v
 $BP_ME_DIR/src/v/cce/bp_uce.v
 $BP_ME_DIR/src/v/wormhole/bp_me_addr_to_cce_id.v
 $BP_ME_DIR/src/v/wormhole/bp_me_cce_id_to_cord.v


### PR DESCRIPTION
Basically, the issue here is that local requests to in-core configuration registers will freeze the system if they don't correspond to a sink (cfg, clint, cache, etc.).

Instead, we can use this lightweight loopback module which just forwards back the request to the sender.  This makes a more robust system, since we don't have error responses in the bedrock network.