### PR TITLE
UCE FSM modification for multicycle fill/evict

### DIFF
--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_cmd.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_cmd.v
@@ -35,6 +35,7 @@ module bp_be_dcache_lce_cmd
     , localparam ptag_width_lp = (paddr_width_p-bp_page_offset_width_gp)
     , localparam way_id_width_lp = `BSG_SAFE_CLOG2(assoc_p)
     , localparam block_size_in_bytes_lp = (block_width_p / 8)
+    , localparam block_size_in_fill_lp = block_width_p/fill_width_p
 
     `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
     `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, dcache)
@@ -317,7 +318,7 @@ module bp_be_dcache_lce_cmd
               data_mem_pkt.index = miss_addr_i[block_offset_width_lp+:index_width_lp];
               data_mem_pkt.way_id = lce_cmd_li.header.way_id[0+:way_id_width_lp];
               data_mem_pkt.data = lce_cmd_li.data;
-              data_mem_pkt.fill_mask = {assoc_p{1'b1}};
+              data_mem_pkt.fill_index = {block_size_in_fill_lp{1'b1}};
               data_mem_pkt.opcode = e_cache_data_mem_uncached;
               data_mem_pkt_v_o = lce_cmd_v_i;
 
@@ -451,7 +452,7 @@ module bp_be_dcache_lce_cmd
             data_mem_pkt.index = miss_addr_i[block_offset_width_lp+:index_width_lp];
             data_mem_pkt.way_id = lce_cmd_li.header.way_id[0+:way_id_width_lp];
             data_mem_pkt.data = lce_cmd_li.data;
-            data_mem_pkt.fill_mask = {assoc_p{1'b1}};
+            data_mem_pkt.fill_index = {block_size_in_fill_lp{1'b1}};
             data_mem_pkt.opcode = e_cache_data_mem_write;
             data_mem_pkt_v_o = lce_cmd_v_i;
 
@@ -474,7 +475,7 @@ module bp_be_dcache_lce_cmd
             data_mem_pkt.index = miss_addr_i[block_offset_width_lp+:index_width_lp];
             data_mem_pkt.way_id = lce_cmd_li.header.way_id[0+:way_id_width_lp];
             data_mem_pkt.data = lce_cmd_li.data;
-            data_mem_pkt.fill_mask = {assoc_p{1'b1}};
+            data_mem_pkt.fill_index = {block_size_in_fill_lp{1'b1}};
             data_mem_pkt.opcode = e_cache_data_mem_uncached;
             data_mem_pkt_v_o = lce_cmd_v_i;
 

--- a/bp_common/src/include/bp_common_aviary_pkg.vh
+++ b/bp_common/src/include/bp_common_aviary_pkg.vh
@@ -106,11 +106,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
-      ,dcache_fill_width    : 64
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
-      ,icache_fill_width    : 64
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512

--- a/bp_common/src/include/bp_common_aviary_pkg.vh
+++ b/bp_common/src/include/bp_common_aviary_pkg.vh
@@ -106,11 +106,11 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
-      ,dcache_fill_width    : 512
+      ,dcache_fill_width    : 64
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
-      ,icache_fill_width    : 512
+      ,icache_fill_width    : 64
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512

--- a/bp_common/src/include/bp_common_cache_service_if.vh
+++ b/bp_common/src/include/bp_common_cache_service_if.vh
@@ -106,7 +106,7 @@ typedef enum logic [1:0] {
     logic [`BSG_SAFE_CLOG2(sets_mp)-1:0]          index;                                    \
     logic [`BSG_SAFE_CLOG2(ways_mp)-1:0]          way_id;                                   \
     logic [fill_width_mp-1:0]                     data;                                     \
-    logic [block_data_width_mp/fill_width_mp-1:0] fill_mask;                                \
+    logic [block_data_width_mp/fill_width_mp-1:0] fill_index;                                \
     bp_cache_data_mem_opcode_e                    opcode;                                   \
   }  bp_``cache_name_mp``_data_mem_pkt_s
 

--- a/bp_fe/src/v/bp_fe_icache.v
+++ b/bp_fe/src/v/bp_fe_icache.v
@@ -23,21 +23,21 @@ module bp_fe_icache
   #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
     `declare_bp_proc_params(bp_params_p)
     `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache)
-        
+
     , localparam way_id_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)
     , localparam block_size_in_bank_lp = icache_assoc_p
     , localparam bank_width_lp = icache_block_width_p / icache_assoc_p
     , localparam num_dwords_per_bank_lp = bank_width_lp / dword_width_p
-    , localparam data_mem_mask_width_lp=(bank_width_lp >> 3)       
-    , localparam byte_offset_width_lp=`BSG_SAFE_CLOG2(bank_width_lp >> 3) 
+    , localparam data_mem_mask_width_lp=(bank_width_lp >> 3)
+    , localparam byte_offset_width_lp=`BSG_SAFE_CLOG2(bank_width_lp >> 3)
     , localparam bank_offset_width_lp = `BSG_SAFE_CLOG2(block_size_in_bank_lp)
-    , localparam index_width_lp=`BSG_SAFE_CLOG2(icache_sets_p)                        
+    , localparam index_width_lp=`BSG_SAFE_CLOG2(icache_sets_p)
     , localparam block_offset_width_lp = (bank_offset_width_lp+byte_offset_width_lp)
-    , localparam ptag_width_lp=(paddr_width_p-bp_page_offset_width_gp) 
+    , localparam ptag_width_lp=(paddr_width_p-bp_page_offset_width_gp)
     , localparam block_size_in_fill_lp = icache_block_width_p / icache_fill_width_p
     , localparam fill_size_in_bank_lp = icache_fill_width_p / bank_width_lp
-    
-    `declare_bp_icache_widths(vaddr_width_p, ptag_width_lp, icache_assoc_p) 
+
+    `declare_bp_icache_widths(vaddr_width_p, ptag_width_lp, icache_assoc_p)
 
     , localparam stat_width_lp = `bp_cache_stat_info_width(icache_assoc_p)
     , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
@@ -57,13 +57,13 @@ module bp_fe_icache
     , input                                            ptag_v_i
     , input                                            uncached_i
     , input                                            poison_i
-    
+
     , output [instr_width_p-1:0]                       data_o
     , output                                           data_v_o
     , output                                           miss_o
 
     // LCE Interface
-    
+
     , output [icache_req_width_lp-1:0]                 cache_req_o
     , output logic                                     cache_req_v_o
     , input                                            cache_req_ready_i
@@ -101,7 +101,7 @@ module bp_fe_icache
   bp_icache_req_metadata_s cache_req_metadata_cast_lo;
   assign cache_req_o = cache_req_cast_lo;
   assign cache_req_metadata_o = cache_req_metadata_cast_lo;
-  
+
   logic [index_width_lp-1:0]            vaddr_index;
 
   logic [bank_offset_width_lp-1:0]      vaddr_offset;
@@ -115,7 +115,7 @@ module bp_fe_icache
 
   assign vaddr_index      = vaddr_i[block_offset_width_lp+:index_width_lp];
   assign vaddr_offset     = vaddr_i[byte_offset_width_lp+:bank_offset_width_lp];
-   
+
   // TL stage
   logic v_tl_r;
   logic tl_we;
@@ -202,7 +202,7 @@ module bp_fe_icache
   logic                        hit_tl;
   logic [paddr_width_p-1:0]    addr_tl;
   logic [icache_assoc_p-1:0]  way_v_tl;
-   
+
   assign addr_tl = {ptag_i, vaddr_tl_r[0+:bp_page_offset_width_gp]};
 
   assign addr_tag_tl = addr_tl[block_offset_width_lp+index_width_lp+:ptag_width_lp];
@@ -210,7 +210,7 @@ module bp_fe_icache
   for (genvar i = 0; i < icache_assoc_p; i++) begin: tag_comp_tl
     assign hit_v_tl[i]   = (tag_tl[i] == addr_tag_tl) && (state_tl[i] != e_COH_I);
     assign way_v_tl[i]   = (state_tl[i] != e_COH_I);
-  end     
+  end
 
   bsg_priority_encode #(
     .width_p(icache_assoc_p)
@@ -276,8 +276,8 @@ module bp_fe_icache
   logic [dword_width_p-1:0] uncached_load_data_r;
 
   assign uncached_req = v_tv_r & uncached_tv_r & ~uncached_load_data_v_r;
-  assign fencei_req = v_tv_r & fencei_op_tv_r; 
- 
+  assign fencei_req = v_tv_r & fencei_op_tv_r;
+
   // stat memory
   logic                                       stat_mem_v_li;
   logic                                       stat_mem_w_li;
@@ -317,7 +317,7 @@ module bp_fe_icache
     ,.v_o(invalid_exist)
     ,.addr_o(way_invalid_index)
  );
-  
+
   // LCE
   bp_icache_data_mem_pkt_s data_mem_pkt;
   assign data_mem_pkt = data_mem_pkt_i;
@@ -433,16 +433,16 @@ module bp_fe_icache
     : {icache_assoc_p{data_mem_v}};
 
   assign data_mem_w_li = data_mem_pkt_yumi_o
-    & (data_mem_pkt.opcode == e_cache_data_mem_write);   
+    & (data_mem_pkt.opcode == e_cache_data_mem_write);
 
   logic [icache_assoc_p-1:0][bank_width_lp-1:0] data_mem_write_data;
   logic [icache_assoc_p-1:0][bank_width_lp-1:0]               data_mem_pkt_data_expanded;
   logic [block_size_in_fill_lp-1:0][fill_size_in_bank_lp-1:0] data_mem_pkt_fill_mask_expanded;
-  logic [icache_assoc_p-1:0]                                  data_mem_write_bank_mask;
+  logic [icache_assoc_p-1:0]                                  data_mem_write_bank_mask, data_mem_write_mask;
 
   assign data_mem_write_bank_mask = data_mem_pkt_fill_mask_expanded;
   for (genvar i = 0; i < block_size_in_fill_lp; i++) begin
-    assign data_mem_pkt_fill_mask_expanded[i] = {fill_size_in_bank_lp{data_mem_pkt.fill_mask}};
+    assign data_mem_pkt_fill_mask_expanded[i] = {fill_size_in_bank_lp{data_mem_pkt.fill_index[i]}};
   end
 
   for (genvar i = 0; i < icache_assoc_p; i++) begin
@@ -452,8 +452,8 @@ module bp_fe_icache
 
     assign data_mem_data_li[i] = data_mem_write_data[i];
 
-    // use fill_mask to generate write_mask
-    assign data_mem_w_mask_li[i] = {data_mem_mask_width_lp{data_mem_write_bank_mask[i]}};
+    // use fill_index to generate write_mask
+    assign data_mem_w_mask_li[i] = {data_mem_mask_width_lp{data_mem_write_mask[i]}};
   end
 
   // Expand data_mem_pkt.data (fill width) to cacheline width
@@ -466,7 +466,16 @@ module bp_fe_icache
     ,.sel_i(data_mem_pkt.way_id)
     ,.data_o(data_mem_write_data)
   );
-   
+  //TODO
+  bsg_mux_butterfly #(
+    .width_p(1)
+    ,.els_p(icache_assoc_p)
+  ) write_mask_mux_butterfly (
+    .data_i(data_mem_write_bank_mask)
+    ,.sel_i(data_mem_pkt.way_id)
+    ,.data_o(data_mem_write_mask)
+  );
+
   // tag_mem
   assign tag_mem_v_li = tl_we | tag_mem_pkt_yumi_o;
   assign tag_mem_w_li = ~tl_we & tag_mem_pkt_v_i;
@@ -515,7 +524,7 @@ module bp_fe_icache
     ? ~miss_tv
     : stat_mem_pkt_yumi_o & (stat_mem_pkt.opcode != e_cache_stat_mem_read);
   assign stat_mem_addr_li = (v_tv_r & ~uncached_tv_r)
-    ? addr_index_tv 
+    ? addr_index_tv
     : stat_mem_pkt.index;
 
   logic [icache_assoc_p-2:0] lru_decode_data_lo;
@@ -538,7 +547,7 @@ module bp_fe_icache
       stat_mem_mask_li = {(icache_assoc_p-1){1'b1}};
     end
   end
-   
+
   // LCE: data mem
   logic [way_id_width_lp-1:0] data_mem_pkt_way_r;
 
@@ -583,9 +592,9 @@ module bp_fe_icache
   end
 
   // LCE: tag_mem
-  
+
   logic [way_id_width_lp-1:0] tag_mem_pkt_way_r;
-  
+
   always_ff @ (posedge clk_i) begin
     if (tag_mem_pkt_yumi_o & (tag_mem_pkt.opcode == e_cache_tag_mem_read)) begin
       tag_mem_pkt_way_r <= tag_mem_pkt.way_id;
@@ -614,5 +623,5 @@ module bp_fe_icache
     );
   end
   // synopsys translate_on
-   
+
 endmodule

--- a/bp_fe/src/v/bp_fe_lce_cmd.v
+++ b/bp_fe/src/v/bp_fe_lce_cmd.v
@@ -37,6 +37,7 @@ module bp_fe_lce_cmd
    , localparam block_offset_width_lp=(word_offset_width_lp+byte_offset_width_lp)
    , localparam ptag_width_lp=(paddr_width_p-bp_page_offset_width_gp)
    , localparam block_size_in_bytes_lp = (block_width_p / 8)
+   , localparam block_size_in_fill_lp = block_width_p/fill_width_p
 
    , localparam stat_width_lp = `bp_cache_stat_info_width(assoc_p)
 
@@ -257,7 +258,7 @@ module bp_fe_lce_cmd
             data_mem_pkt.index = miss_addr_i[block_offset_width_lp+:index_width_lp];
             data_mem_pkt.way_id = lce_cmd_li.header.way_id[0+:way_id_width_lp];
             data_mem_pkt.data = lce_cmd_li.data;
-            data_mem_pkt.fill_mask = {assoc_p{1'b1}};
+            data_mem_pkt.fill_index = {block_size_in_fill_lp{1'b1}};
             data_mem_pkt.opcode = e_cache_data_mem_uncached;
             data_mem_pkt_v_o = lce_cmd_v_i;
 
@@ -340,7 +341,7 @@ module bp_fe_lce_cmd
             data_mem_pkt.index = miss_addr_i[block_offset_width_lp+:index_width_lp];
             data_mem_pkt.way_id = lce_cmd_li.header.way_id[0+:way_id_width_lp];
             data_mem_pkt.data = lce_cmd_li.data;
-            data_mem_pkt.fill_mask = {assoc_p{1'b1}};
+            data_mem_pkt.fill_index = {block_size_in_fill_lp{1'b1}};
             data_mem_pkt.opcode = e_cache_data_mem_write;
             data_mem_pkt_v_o = lce_cmd_v_i;
 
@@ -362,7 +363,7 @@ module bp_fe_lce_cmd
             data_mem_pkt.index = miss_addr_i[block_offset_width_lp+:index_width_lp];
             data_mem_pkt.way_id = lce_cmd_li.header.way_id[0+:way_id_width_lp];
             data_mem_pkt.data = lce_cmd_li.data;
-            data_mem_pkt.fill_mask = {assoc_p{1'b1}};
+            data_mem_pkt.fill_index = {block_size_in_fill_lp{1'b1}};
             data_mem_pkt.opcode = e_cache_data_mem_uncached;
             data_mem_pkt_v_o = lce_cmd_v_i;
 

--- a/bp_me/src/v/cce/bp_uce.v
+++ b/bp_me/src/v/cce/bp_uce.v
@@ -20,14 +20,10 @@ module bp_uce
     , localparam num_dwords_per_bank_lp = bank_width_lp / dword_width_p
     , localparam byte_offset_width_lp  = `BSG_SAFE_CLOG2(bank_width_lp>>3)
     // Words per line == associativity
-    , localparam bank_offset_width_lp  = `BSG_SAFE_CLOG2(assoc_p)
-    , localparam block_offset_width_lp = (bank_offset_width_lp + byte_offset_width_lp)
+    , localparam word_offset_width_lp  = `BSG_SAFE_CLOG2(assoc_p)
+    , localparam block_offset_width_lp = (word_offset_width_lp + byte_offset_width_lp)
     , localparam index_width_lp = `BSG_SAFE_CLOG2(sets_p)
     , localparam way_width_lp = `BSG_SAFE_CLOG2(assoc_p)
-    , localparam block_size_in_fill_lp = block_width_p / fill_width_p
-    , localparam fill_size_in_bank_lp = fill_width_p / bank_width_lp
-    , localparam fill_cnt_width_lp = `BSG_SAFE_CLOG2(block_size_in_fill_lp)
-    , localparam bank_sub_offset_width_lp = `BSG_SAFE_CLOG2(fill_size_in_bank_lp)
 
     , localparam cache_req_width_lp = `bp_cache_req_width(dword_width_p, paddr_width_p)
     , localparam cache_req_metadata_width_lp = `bp_cache_req_metadata_width(assoc_p)
@@ -36,10 +32,9 @@ module bp_uce
     , localparam cache_stat_mem_pkt_width_lp = `bp_cache_stat_mem_pkt_width(sets_p, assoc_p)
 
     // Block size parameterisations -
-    , localparam is_fillwidth_512 = (fill_width_p == 512)
-    , localparam is_fillwidth_256 = (fill_width_p == 256)
-    , localparam is_fillwidth_128 = (fill_width_p == 128)
-    , localparam is_fillwidth_64  = (fill_width_p == 64)
+    , localparam is_blockwidth_512 = (block_width_p == 512)
+    , localparam is_blockwidth_256 = (block_width_p == 256)
+    , localparam is_blockwidth_128 = (block_width_p == 128)
     )
    (input                                            clk_i
     , input                                          reset_i
@@ -170,7 +165,7 @@ module bp_uce
      );
 
   // We can do a little better by sending the read_request before the writeback
-  enum logic [3:0] {e_reset, e_clear, e_flush_read, e_flush_scan, e_flush_write, e_flush_fence, e_ready, e_send_critical, e_writeback_evict, e_writeback_read_req, e_writeback_write_req, e_write_wait, e_read_req, e_uc_read_wait} state_n, state_r;
+  enum logic [3:0] {e_reset, e_clear, e_flush_read, e_flush_scan, e_flush_write, e_flush_fence, e_ready, e_send_req, e_writeback_read, e_writeback_req, e_write_wait, e_read_wait, e_uc_read_wait} state_n, state_r;
   wire is_reset         = (state_r == e_reset);
   wire is_clear         = (state_r == e_clear);
   wire is_flush_read    = (state_r == e_flush_read);
@@ -178,12 +173,11 @@ module bp_uce
   wire is_flush_write   = (state_r == e_flush_write);
   wire is_flush_fence   = (state_r == e_flush_fence);
   wire is_ready         = (state_r == e_ready);
-  wire is_send_critical = (state_r == e_send_critical);
-  wire is_writeback_evict = (state_r == e_writeback_evict); // read dirty data from cache to UCE
-  wire is_writeback_read = (state_r == e_writeback_read_req); // read data from L2 to cache
-  wire is_writeback_wb  = (state_r == e_writeback_write_req); // read dirty data in UCE
+  wire is_send_req      = (state_r == e_send_req);
+  wire is_writeback_read = (state_r == e_writeback_read);
+  wire is_writeback_req = (state_r == e_writeback_req);
   wire is_write_request = (state_r == e_write_wait);
-  wire is_read_request  = (state_r == e_read_req);
+  wire is_read_request  = (state_r == e_read_wait);
 
   // We check for uncached stores ealier than other requests, because they get sent out in ready
   wire flush_v_li         = cache_req_v_i & cache_req_cast_i.msg_type inside {e_cache_flush};
@@ -199,54 +193,6 @@ module bp_uce
   wire miss_store_v_li = cache_req_v_r & cache_req_r.msg_type inside {e_miss_store};
   wire miss_v_li       = miss_load_v_li | miss_store_v_li;
   wire uc_load_v_li    = cache_req_v_r & cache_req_r.msg_type inside {e_uc_load};
-
-  logic [fill_cnt_width_lp-1:0] fill_cnt, mem_cmd_cnt;
-  logic [block_size_in_fill_lp-1:0] fill_index_shift;
-  logic [bank_offset_width_lp-1:0] bank_index;
-  if (fill_size_in_bank_lp == 1) begin
-    assign bank_index =  mem_cmd_cnt;
-    assign fill_index_shift = mem_resp_cast_i.header.addr[byte_offset_width_lp+:bank_offset_width_lp];
-  end else begin
-    assign bank_index = mem_cmd_cnt << bank_sub_offset_width_lp;
-    assign fill_index_shift = mem_resp_cast_i.header.addr[byte_offset_width_lp+:bank_offset_width_lp] >> bank_sub_offset_width_lp;
-  end
-
-  logic fill_up, fill_cnt_hit_target, mem_cmd_up, mem_cmd_cnt_hit_target;
-  logic one_mem_cmd;
-  assign one_mem_cmd = (block_width_p == fill_width_p);
-
-
-  bsg_counter_clear_up #(
-    .max_val_p(block_size_in_fill_lp-1)
-    ,.init_val_p(0)
-    ,.disable_overflow_warning_p(1)
-    )
-  fill_counter
-    (.clk_i(clk_i)
-    ,.reset_i(reset_i)
-
-    ,.clear_i('0)
-    ,.up_i(fill_up)
-
-    ,.count_o(fill_cnt)
-    );
-  assign fill_cnt_hit_target = (fill_cnt == block_size_in_fill_lp-1);
-
-  bsg_counter_clear_up #(
-    .max_val_p(block_size_in_fill_lp-1)
-    ,.init_val_p(0)
-    ,.disable_overflow_warning_p(1)
-    )
-  mem_cmd_counter
-    (.clk_i(clk_i)
-    ,.reset_i(reset_i)
-
-    ,.clear_i('0)
-    ,.up_i(mem_cmd_up)
-
-    ,.count_o(mem_cmd_cnt)
-    );
-  assign mem_cmd_cnt_hit_target = (mem_cmd_cnt == block_size_in_fill_lp-1);
 
   logic [index_width_lp-1:0] index_cnt;
   logic index_up;
@@ -284,14 +230,6 @@ module bp_uce
      );
   wire way_done = (way_cnt == assoc_p-1);
 
-  logic mem_cmd_done_n, mem_cmd_done_r;
-  always_ff @(posedge clk_i) begin
-      if (reset_i)
-        mem_cmd_done_r <= 0;
-      else if (mem_cmd_v_o | cache_req_complete_o | way_up)
-        mem_cmd_done_r <= mem_cmd_done_n;
-  end
-
   // Outstanding Requests Counter - counts all requests, cached and uncached
   //
   logic [`BSG_WIDTH(coh_noc_max_credits_p)-1:0] credit_count_lo;
@@ -316,18 +254,6 @@ module bp_uce
   assign credits_full_o = (credit_count_lo == coh_noc_max_credits_p);
   assign credits_empty_o = (credit_count_lo == 0);
 
-  logic [fill_width_p-1:0] writeback_data;
-  logic [block_size_in_fill_lp-1:0] writeback_sel_one_hot;
-  assign writeback_sel_one_hot = 1'b1 << mem_cmd_cnt;
-  bsg_mux_one_hot #(
-    .width_p(fill_width_p)
-    ,.els_p(block_size_in_fill_lp)
-    ) writeback_mux (
-    .data_i(dirty_data_r)
-    ,.sel_one_hot_i(writeback_sel_one_hot)
-    ,.data_o(writeback_data)
-    );
-
   // We ack mem_resps for uncached stores no matter what, so mem_resp_yumi_lo is for other responses
   logic mem_resp_yumi_lo;
   assign mem_resp_yumi_o = mem_resp_yumi_lo | store_resp_v_li;
@@ -337,9 +263,6 @@ module bp_uce
 
       index_up = '0;
       way_up   = '0;
-      fill_up  = '0;
-      mem_cmd_up = '0;
-      mem_cmd_done_n ='0;
 
       tag_mem_pkt_cast_o  = '0;
       tag_mem_pkt_v_o     = '0;
@@ -395,7 +318,6 @@ module bp_uce
                 data_mem_pkt_cast_o.index  = index_cnt;
                 data_mem_pkt_cast_o.way_id = way_cnt;
                 data_mem_pkt_v_o = 1'b1;
-                data_mem_pkt_cast_o.fill_index = {block_size_in_fill_lp{1'b1}};
 
                 tag_mem_pkt_cast_o.opcode = e_cache_tag_mem_read;
                 tag_mem_pkt_cast_o.index  = index_cnt;
@@ -424,30 +346,28 @@ module bp_uce
         e_flush_write:
           begin
             mem_cmd_cast_o.header.msg_type = e_cce_mem_wr;
-            mem_cmd_cast_o.header.addr     = {dirty_tag_r, index_cnt, bank_index, byte_offset_width_lp'(0)};
-            mem_cmd_cast_o.header.size     = is_fillwidth_512
+            mem_cmd_cast_o.header.addr     = {dirty_tag_r, index_cnt, block_offset_width_lp'(0)};
+            mem_cmd_cast_o.header.size     = is_blockwidth_512
                                               ? e_mem_msg_size_64
-                                              : is_fillwidth_256
+                                              : is_blockwidth_256
                                                 ? e_mem_msg_size_32
-                                                : is_fillwidth_128
+                                                : is_blockwidth_128
                                                   ? e_mem_msg_size_16
-                                                  : is_fillwidth_64
-                                                    ? e_mem_msg_size_8
-                                                    : e_mem_msg_size_64;
+                                                  : e_mem_msg_size_64;
             mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
-            mem_cmd_cast_o.data            = writeback_data;
+            mem_cmd_cast_o.data            = dirty_data_r;
             mem_cmd_v_o = mem_cmd_ready_i;
-            mem_cmd_up = mem_cmd_v_o;
 
-            way_up = mem_cmd_cnt_hit_target & mem_cmd_v_o;
-            index_up = way_done & mem_cmd_cnt_hit_target & mem_cmd_v_o;
-            state_n = (mem_cmd_cnt_hit_target & mem_cmd_v_o & index_done & way_done)
+            way_up = mem_cmd_v_o;
+            index_up = way_done & mem_cmd_v_o;
+
+            state_n = (mem_cmd_v_o & index_done & way_done)
                       ? e_flush_fence
                       : index_up
                         ? e_flush_read
-                        : way_up
-                          ? e_flush_scan
-                          : e_flush_write;
+                          : mem_cmd_v_o
+                            ? e_flush_scan
+                            : e_flush_write;
           end
         e_flush_fence:
           begin
@@ -483,34 +403,31 @@ module bp_uce
                             ? e_flush_read
                             : clear_v_li
                               ? e_clear
-                              : e_send_critical
+                              : e_send_req
                           : e_ready;
               end
           end
-        e_send_critical:
+        e_send_req:
           if (miss_v_li)
             begin
               mem_cmd_cast_o.header.msg_type       = e_cce_mem_rd;
               mem_cmd_cast_o.header.addr           = {cache_req_r.addr[paddr_width_p-1:block_offset_width_lp], block_offset_width_lp'(0)};
-              mem_cmd_cast_o.header.size           = is_fillwidth_512
+              mem_cmd_cast_o.header.size           = is_blockwidth_512
                                                       ? e_mem_msg_size_64
-                                                      : is_fillwidth_256
+                                                      : is_blockwidth_256
                                                         ? e_mem_msg_size_32
-                                                        : is_fillwidth_128
+                                                        : is_blockwidth_128
                                                           ? e_mem_msg_size_16
-                                                          : is_fillwidth_64
-                                                            ? e_mem_msg_size_8
-                                                            : e_mem_msg_size_64;
+                                                          : e_mem_msg_size_64;
               mem_cmd_cast_o.header.payload.way_id = lce_assoc_p'(cache_req_metadata_r.repl_way);
               mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
               mem_cmd_v_o = mem_cmd_ready_i;
-              mem_cmd_up = one_mem_cmd ? 1'b0 : mem_cmd_v_o;
-              mem_cmd_done_n = one_mem_cmd;
+
               state_n = mem_cmd_v_o
                         ? cache_req_metadata_r.dirty
-                          ? e_writeback_evict
-                          : e_read_req
-                        : e_send_critical;
+                          ? e_writeback_read
+                          : e_read_wait
+                        : e_send_req;
             end
           else if (uc_load_v_li)
             begin
@@ -520,14 +437,13 @@ module bp_uce
               mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
               mem_cmd_v_o = mem_cmd_ready_i;
 
-              state_n = mem_cmd_v_o ? e_uc_read_wait : e_send_critical;
+              state_n = mem_cmd_v_o ? e_uc_read_wait : e_send_req;
             end
-        e_writeback_evict:
+        e_writeback_read:
           begin
             data_mem_pkt_cast_o.opcode = e_cache_data_mem_read;
             data_mem_pkt_cast_o.index  = cache_req_r.addr[block_offset_width_lp+:index_width_lp];
             data_mem_pkt_cast_o.way_id = cache_req_metadata_r.repl_way;
-            data_mem_pkt_cast_o.fill_index = {block_size_in_fill_lp{1'b1}};
             data_mem_pkt_v_o = 1'b1;
 
             tag_mem_pkt_cast_o.opcode  = e_cache_tag_mem_read;
@@ -540,74 +456,27 @@ module bp_uce
             stat_mem_pkt_cast_o.way_id = cache_req_metadata_r.repl_way;
             stat_mem_pkt_v_o = 1'b1;
 
-            state_n = (data_mem_pkt_yumi_i & tag_mem_pkt_yumi_i & stat_mem_pkt_yumi_i) ? e_writeback_read_req : e_writeback_evict;
+            state_n = (data_mem_pkt_yumi_i & tag_mem_pkt_yumi_i & stat_mem_pkt_yumi_i) ? e_writeback_req : e_writeback_read;
           end
-        e_writeback_read_req:
-          begin
-            // send the sub-block from L2 to cache
-            tag_mem_pkt_cast_o.opcode = e_cache_tag_mem_set_tag;
-            tag_mem_pkt_cast_o.index  = mem_resp_cast_i.header.addr[block_offset_width_lp+:index_width_lp];
-            // We fill in M because we don't want to trigger additional coherence traffic
-            tag_mem_pkt_cast_o.way_id = mem_resp_cast_i.header.payload.way_id[0+:`BSG_SAFE_CLOG2(assoc_p)];
-            tag_mem_pkt_cast_o.state  = e_COH_M;
-            tag_mem_pkt_cast_o.tag    = mem_resp_cast_i.header.addr[block_offset_width_lp+index_width_lp+:ptag_width_p];
-            tag_mem_pkt_v_o = load_resp_v_li;
-
-            data_mem_pkt_cast_o.opcode = e_cache_data_mem_write;
-            data_mem_pkt_cast_o.index  = mem_resp_cast_i.header.addr[block_offset_width_lp+:index_width_lp];
-            data_mem_pkt_cast_o.way_id = mem_resp_cast_i.header.payload.way_id[0+:`BSG_SAFE_CLOG2(assoc_p)];
-            data_mem_pkt_cast_o.data   = mem_resp_cast_i.data;
-            data_mem_pkt_cast_o.fill_index = 1'b1 << fill_index_shift;
-            data_mem_pkt_v_o = load_resp_v_li;
-
-            cache_req_critical_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
-            fill_up = one_mem_cmd ? 1'b0 : tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
-            mem_resp_yumi_lo = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
-            // request next sub-block
-            mem_cmd_cast_o.header.msg_type       = e_cce_mem_rd;
-            mem_cmd_cast_o.header.addr           = {cache_req_r.addr[paddr_width_p-1:block_offset_width_lp], bank_index, byte_offset_width_lp'(0)};
-            mem_cmd_cast_o.header.size           = is_fillwidth_512
-                                                    ? e_mem_msg_size_64
-                                                    : is_fillwidth_256
-                                                      ? e_mem_msg_size_32
-                                                      : is_fillwidth_128
-                                                        ? e_mem_msg_size_16
-                                                        : is_fillwidth_64
-                                                          ? e_mem_msg_size_8
-                                                          : e_mem_msg_size_64;
-            mem_cmd_cast_o.header.payload.way_id = lce_assoc_p'(cache_req_metadata_r.repl_way);
-            mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
-            mem_cmd_v_o = one_mem_cmd ? 1'b0 : (mem_cmd_ready_i & ~mem_cmd_done_r);
-            mem_cmd_up = mem_cmd_v_o;
-            mem_cmd_done_n = mem_cmd_cnt_hit_target & mem_cmd_v_o;
-
-            state_n = (fill_cnt_hit_target & mem_cmd_done_r & tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i) ? e_writeback_write_req : e_writeback_read_req;
-          end
-        e_writeback_write_req:
+        e_writeback_req:
           begin
             mem_cmd_cast_o.header.msg_type = e_cce_mem_wr;
-            mem_cmd_cast_o.header.addr     = {dirty_tag_r, cache_req_r.addr[block_offset_width_lp+:index_width_lp], bank_index, byte_offset_width_lp'(0)};
-            mem_cmd_cast_o.header.size     = is_fillwidth_512
+            mem_cmd_cast_o.header.addr     = {dirty_tag_r, cache_req_r.addr[block_offset_width_lp+:index_width_lp], block_offset_width_lp'(0)};
+            mem_cmd_cast_o.header.size     = is_blockwidth_512
                                               ? e_mem_msg_size_64
-                                              : is_fillwidth_256
+                                              : is_blockwidth_256
                                                 ? e_mem_msg_size_32
-                                                : is_fillwidth_128
+                                                : is_blockwidth_128
                                                   ? e_mem_msg_size_16
-                                                  : is_fillwidth_64
-                                                    ? e_mem_msg_size_8
-                                                    : e_mem_msg_size_64;
+                                                  : e_mem_msg_size_64;
             mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
-            mem_cmd_cast_o.data            = writeback_data;
+            mem_cmd_cast_o.data            = dirty_data_r;
             mem_cmd_v_o = mem_cmd_ready_i;
-            mem_cmd_v_o = mem_cmd_ready_i;
-            mem_cmd_up = mem_cmd_v_o;
 
-            cache_req_complete_o = mem_cmd_cnt_hit_target & mem_cmd_v_o;
-            state_n = cache_req_complete_o ? e_ready : e_writeback_write_req;
+            state_n = mem_cmd_v_o ? e_read_wait : e_writeback_req;
           end
-        e_read_req:
+        e_read_wait:
           begin
-            // send the sub-block from L2 to cache
             tag_mem_pkt_cast_o.opcode = e_cache_tag_mem_set_tag;
             tag_mem_pkt_cast_o.index  = mem_resp_cast_i.header.addr[block_offset_width_lp+:index_width_lp];
             // We fill in M because we don't want to trigger additional coherence traffic
@@ -620,32 +489,15 @@ module bp_uce
             data_mem_pkt_cast_o.index  = mem_resp_cast_i.header.addr[block_offset_width_lp+:index_width_lp];
             data_mem_pkt_cast_o.way_id = mem_resp_cast_i.header.payload.way_id[0+:`BSG_SAFE_CLOG2(assoc_p)];
             data_mem_pkt_cast_o.data   = mem_resp_cast_i.data;
-            data_mem_pkt_cast_o.fill_index = 1'b1 << fill_index_shift;
+            data_mem_pkt_cast_o.fill_mask = {assoc_p{1'b1}};
             data_mem_pkt_v_o = load_resp_v_li;
 
+            cache_req_complete_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
             cache_req_critical_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
-            fill_up = one_mem_cmd ? 1'b0 : tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
-            mem_resp_yumi_lo = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
-            // request next sub-block
-            mem_cmd_cast_o.header.msg_type       = e_cce_mem_rd;
-            mem_cmd_cast_o.header.addr           = {cache_req_r.addr[paddr_width_p-1:block_offset_width_lp], bank_index, byte_offset_width_lp'(0)};
-            mem_cmd_cast_o.header.size           = is_fillwidth_512
-                                                    ? e_mem_msg_size_64
-                                                    : is_fillwidth_256
-                                                      ? e_mem_msg_size_32
-                                                      : is_fillwidth_128
-                                                        ? e_mem_msg_size_16
-                                                        : is_fillwidth_64
-                                                          ? e_mem_msg_size_8
-                                                          : e_mem_msg_size_64;
-            mem_cmd_cast_o.header.payload.way_id = lce_assoc_p'(cache_req_metadata_r.repl_way);
-            mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
-            mem_cmd_v_o = one_mem_cmd ? 1'b0 : (mem_cmd_ready_i & ~mem_cmd_done_r);
-            mem_cmd_up = mem_cmd_v_o;
-            mem_cmd_done_n = mem_cmd_cnt_hit_target & mem_cmd_v_o;
+            mem_resp_yumi_lo = cache_req_complete_o;
 
-            cache_req_complete_o = fill_cnt_hit_target & mem_cmd_done_r & tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
-            state_n = cache_req_complete_o ? e_ready : e_read_req;
+
+            state_n = cache_req_complete_o ? e_ready : e_read_wait;
           end
         e_uc_read_wait:
           begin

--- a/bp_me/src/v/cce/bp_uce.v
+++ b/bp_me/src/v/cce/bp_uce.v
@@ -20,10 +20,14 @@ module bp_uce
     , localparam num_dwords_per_bank_lp = bank_width_lp / dword_width_p
     , localparam byte_offset_width_lp  = `BSG_SAFE_CLOG2(bank_width_lp>>3)
     // Words per line == associativity
-    , localparam word_offset_width_lp  = `BSG_SAFE_CLOG2(assoc_p)
-    , localparam block_offset_width_lp = (word_offset_width_lp + byte_offset_width_lp)
+    , localparam bank_offset_width_lp  = `BSG_SAFE_CLOG2(assoc_p)
+    , localparam block_offset_width_lp = (bank_offset_width_lp + byte_offset_width_lp)
     , localparam index_width_lp = `BSG_SAFE_CLOG2(sets_p)
     , localparam way_width_lp = `BSG_SAFE_CLOG2(assoc_p)
+    , localparam block_size_in_fill_lp = block_width_p / fill_width_p
+    , localparam fill_size_in_bank_lp = fill_width_p / bank_width_lp
+    , localparam fill_cnt_width_lp = `BSG_SAFE_CLOG2(block_size_in_fill_lp)
+    , localparam bank_sub_offset_width_lp = `BSG_SAFE_CLOG2(fill_size_in_bank_lp)
 
     , localparam cache_req_width_lp = `bp_cache_req_width(dword_width_p, paddr_width_p)
     , localparam cache_req_metadata_width_lp = `bp_cache_req_metadata_width(assoc_p)
@@ -32,9 +36,10 @@ module bp_uce
     , localparam cache_stat_mem_pkt_width_lp = `bp_cache_stat_mem_pkt_width(sets_p, assoc_p)
 
     // Block size parameterisations -
-    , localparam is_blockwidth_512 = (block_width_p == 512)
-    , localparam is_blockwidth_256 = (block_width_p == 256)
-    , localparam is_blockwidth_128 = (block_width_p == 128)
+    , localparam is_fillwidth_512 = (fill_width_p == 512)
+    , localparam is_fillwidth_256 = (fill_width_p == 256)
+    , localparam is_fillwidth_128 = (fill_width_p == 128)
+    , localparam is_fillwidth_64  = (fill_width_p == 64)
     )
    (input                                            clk_i
     , input                                          reset_i
@@ -165,7 +170,7 @@ module bp_uce
      );
 
   // We can do a little better by sending the read_request before the writeback
-  enum logic [3:0] {e_reset, e_clear, e_flush_read, e_flush_scan, e_flush_write, e_flush_fence, e_ready, e_send_req, e_writeback_read, e_writeback_req, e_write_wait, e_read_wait, e_uc_read_wait} state_n, state_r;
+  enum logic [3:0] {e_reset, e_clear, e_flush_read, e_flush_scan, e_flush_write, e_flush_fence, e_ready, e_send_critical, e_writeback_evict, e_writeback_read_req, e_writeback_write_req, e_write_wait, e_read_req, e_uc_read_wait} state_n, state_r;
   wire is_reset         = (state_r == e_reset);
   wire is_clear         = (state_r == e_clear);
   wire is_flush_read    = (state_r == e_flush_read);
@@ -173,11 +178,12 @@ module bp_uce
   wire is_flush_write   = (state_r == e_flush_write);
   wire is_flush_fence   = (state_r == e_flush_fence);
   wire is_ready         = (state_r == e_ready);
-  wire is_send_req      = (state_r == e_send_req);
-  wire is_writeback_read = (state_r == e_writeback_read);
-  wire is_writeback_req = (state_r == e_writeback_req);
-  wire is_write_request = (state_r == e_write_wait);
-  wire is_read_request  = (state_r == e_read_wait);
+  wire is_send_critical = (state_r == e_send_critical);
+  wire is_writeback_evict= (state_r == e_writeback_evict); // read dirty data from cache to UCE
+  wire is_writeback_read = (state_r == e_writeback_read_req); // read data from L2 to cache
+  wire is_writeback_wb   = (state_r == e_writeback_write_req); // read dirty data in UCE
+  wire is_write_request  = (state_r == e_write_wait);
+  wire is_read_request   = (state_r == e_read_req);
 
   // We check for uncached stores ealier than other requests, because they get sent out in ready
   wire flush_v_li         = cache_req_v_i & cache_req_cast_i.msg_type inside {e_cache_flush};
@@ -193,6 +199,53 @@ module bp_uce
   wire miss_store_v_li = cache_req_v_r & cache_req_r.msg_type inside {e_miss_store};
   wire miss_v_li       = miss_load_v_li | miss_store_v_li;
   wire uc_load_v_li    = cache_req_v_r & cache_req_r.msg_type inside {e_uc_load};
+
+  logic [fill_cnt_width_lp-1:0] fill_cnt, mem_cmd_cnt;
+  logic [block_size_in_fill_lp-1:0] fill_index_shift;
+  logic [bank_offset_width_lp-1:0] bank_index;
+  if (fill_size_in_bank_lp == 1) begin
+    assign bank_index =  mem_cmd_cnt;
+    assign fill_index_shift = mem_resp_cast_i.header.addr[byte_offset_width_lp+:bank_offset_width_lp];
+  end else begin
+    assign bank_index = mem_cmd_cnt << bank_sub_offset_width_lp;
+    assign fill_index_shift = mem_resp_cast_i.header.addr[byte_offset_width_lp+:bank_offset_width_lp] >> bank_sub_offset_width_lp;
+  end
+
+  logic fill_up, fill_cnt_hit_target, mem_cmd_up, mem_cmd_cnt_hit_target;
+  logic one_mem_cmd;
+  assign one_mem_cmd = (block_width_p == fill_width_p);
+
+  bsg_counter_clear_up #(
+    .max_val_p(block_size_in_fill_lp-1)
+    ,.init_val_p(0)
+    ,.disable_overflow_warning_p(1)
+    )
+  fill_counter
+    (.clk_i(clk_i)
+    ,.reset_i(reset_i)
+
+    ,.clear_i('0)
+    ,.up_i(fill_up)
+
+    ,.count_o(fill_cnt)
+    );
+  assign fill_cnt_hit_target = (fill_cnt == block_size_in_fill_lp-1);
+
+  bsg_counter_clear_up #(
+    .max_val_p(block_size_in_fill_lp-1)
+    ,.init_val_p(0)
+    ,.disable_overflow_warning_p(1)
+    )
+  mem_cmd_counter
+    (.clk_i(clk_i)
+    ,.reset_i(reset_i)
+
+    ,.clear_i('0)
+    ,.up_i(mem_cmd_up)
+
+    ,.count_o(mem_cmd_cnt)
+    );
+  assign mem_cmd_cnt_hit_target = (mem_cmd_cnt == block_size_in_fill_lp-1);
 
   logic [index_width_lp-1:0] index_cnt;
   logic index_up;
@@ -230,6 +283,14 @@ module bp_uce
      );
   wire way_done = (way_cnt == assoc_p-1);
 
+  logic mem_cmd_done_n, mem_cmd_done_r;
+  always_ff @(posedge clk_i) begin
+      if (reset_i)
+        mem_cmd_done_r <= 0;
+      else if (mem_cmd_v_o | cache_req_complete_o | way_up)
+        mem_cmd_done_r <= mem_cmd_done_n;
+  end
+
   // Outstanding Requests Counter - counts all requests, cached and uncached
   //
   logic [`BSG_WIDTH(coh_noc_max_credits_p)-1:0] credit_count_lo;
@@ -254,6 +315,18 @@ module bp_uce
   assign credits_full_o = (credit_count_lo == coh_noc_max_credits_p);
   assign credits_empty_o = (credit_count_lo == 0);
 
+  logic [fill_width_p-1:0] writeback_data;
+  logic [block_size_in_fill_lp-1:0] writeback_sel_one_hot;
+  assign writeback_sel_one_hot = 1'b1 << mem_cmd_cnt;
+  bsg_mux_one_hot #(
+    .width_p(fill_width_p)
+    ,.els_p(block_size_in_fill_lp)
+    ) writeback_mux (
+    .data_i(dirty_data_r)
+    ,.sel_one_hot_i(writeback_sel_one_hot)
+    ,.data_o(writeback_data)
+    );
+
   // We ack mem_resps for uncached stores no matter what, so mem_resp_yumi_lo is for other responses
   logic mem_resp_yumi_lo;
   assign mem_resp_yumi_o = mem_resp_yumi_lo | store_resp_v_li;
@@ -263,6 +336,9 @@ module bp_uce
 
       index_up = '0;
       way_up   = '0;
+      fill_up  = '0;
+      mem_cmd_up = '0;
+      mem_cmd_done_n ='0;
 
       tag_mem_pkt_cast_o  = '0;
       tag_mem_pkt_v_o     = '0;
@@ -318,6 +394,7 @@ module bp_uce
                 data_mem_pkt_cast_o.index  = index_cnt;
                 data_mem_pkt_cast_o.way_id = way_cnt;
                 data_mem_pkt_v_o = 1'b1;
+                data_mem_pkt_cast_o.fill_index = {block_size_in_fill_lp{1'b1}};
 
                 tag_mem_pkt_cast_o.opcode = e_cache_tag_mem_read;
                 tag_mem_pkt_cast_o.index  = index_cnt;
@@ -346,28 +423,31 @@ module bp_uce
         e_flush_write:
           begin
             mem_cmd_cast_o.header.msg_type = e_cce_mem_wr;
-            mem_cmd_cast_o.header.addr     = {dirty_tag_r, index_cnt, block_offset_width_lp'(0)};
-            mem_cmd_cast_o.header.size     = is_blockwidth_512
+            mem_cmd_cast_o.header.addr     = {dirty_tag_r, index_cnt, bank_index, byte_offset_width_lp'(0)};
+            mem_cmd_cast_o.header.size     = is_fillwidth_512
                                               ? e_mem_msg_size_64
-                                              : is_blockwidth_256
+                                              : is_fillwidth_256
                                                 ? e_mem_msg_size_32
-                                                : is_blockwidth_128
+                                                : is_fillwidth_128
                                                   ? e_mem_msg_size_16
-                                                  : e_mem_msg_size_64;
+                                                  : is_fillwidth_64
+                                                    ? e_mem_msg_size_8
+                                                    : e_mem_msg_size_64;
             mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
-            mem_cmd_cast_o.data            = dirty_data_r;
+            mem_cmd_cast_o.data                  = writeback_data;
             mem_cmd_v_o = mem_cmd_ready_i;
+            mem_cmd_up = mem_cmd_v_o;
 
-            way_up = mem_cmd_v_o;
-            index_up = way_done & mem_cmd_v_o;
+            way_up = mem_cmd_cnt_hit_target & mem_cmd_v_o;
+            index_up = way_done & mem_cmd_cnt_hit_target & mem_cmd_v_o;
 
-            state_n = (mem_cmd_v_o & index_done & way_done)
+            state_n = (mem_cmd_cnt_hit_target & mem_cmd_v_o & index_done & way_done)
                       ? e_flush_fence
                       : index_up
                         ? e_flush_read
-                          : mem_cmd_v_o
-                            ? e_flush_scan
-                            : e_flush_write;
+                        : way_up
+                          ? e_flush_scan
+                          : e_flush_write;
           end
         e_flush_fence:
           begin
@@ -403,31 +483,34 @@ module bp_uce
                             ? e_flush_read
                             : clear_v_li
                               ? e_clear
-                              : e_send_req
+                              : e_send_critical
                           : e_ready;
               end
           end
-        e_send_req:
+        e_send_critical:
           if (miss_v_li)
             begin
               mem_cmd_cast_o.header.msg_type       = e_cce_mem_rd;
               mem_cmd_cast_o.header.addr           = {cache_req_r.addr[paddr_width_p-1:block_offset_width_lp], block_offset_width_lp'(0)};
-              mem_cmd_cast_o.header.size           = is_blockwidth_512
+              mem_cmd_cast_o.header.size           = is_fillwidth_512
                                                       ? e_mem_msg_size_64
-                                                      : is_blockwidth_256
+                                                      : is_fillwidth_256
                                                         ? e_mem_msg_size_32
-                                                        : is_blockwidth_128
+                                                        : is_fillwidth_128
                                                           ? e_mem_msg_size_16
-                                                          : e_mem_msg_size_64;
+                                                          : is_fillwidth_64
+                                                            ? e_mem_msg_size_8
+                                                            : e_mem_msg_size_64;
               mem_cmd_cast_o.header.payload.way_id = lce_assoc_p'(cache_req_metadata_r.repl_way);
               mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
               mem_cmd_v_o = mem_cmd_ready_i;
-
+              mem_cmd_up = one_mem_cmd ? 1'b0 : mem_cmd_v_o;
+              mem_cmd_done_n = one_mem_cmd;
               state_n = mem_cmd_v_o
                         ? cache_req_metadata_r.dirty
-                          ? e_writeback_read
-                          : e_read_wait
-                        : e_send_req;
+                          ? e_writeback_evict
+                          : e_read_req
+                        : e_send_critical;
             end
           else if (uc_load_v_li)
             begin
@@ -437,13 +520,14 @@ module bp_uce
               mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
               mem_cmd_v_o = mem_cmd_ready_i;
 
-              state_n = mem_cmd_v_o ? e_uc_read_wait : e_send_req;
+              state_n = mem_cmd_v_o ? e_uc_read_wait : e_send_critical;
             end
-        e_writeback_read:
+        e_writeback_evict:
           begin
             data_mem_pkt_cast_o.opcode = e_cache_data_mem_read;
             data_mem_pkt_cast_o.index  = cache_req_r.addr[block_offset_width_lp+:index_width_lp];
             data_mem_pkt_cast_o.way_id = cache_req_metadata_r.repl_way;
+            data_mem_pkt_cast_o.fill_index = {block_size_in_fill_lp{1'b1}};
             data_mem_pkt_v_o = 1'b1;
 
             tag_mem_pkt_cast_o.opcode  = e_cache_tag_mem_read;
@@ -456,27 +540,11 @@ module bp_uce
             stat_mem_pkt_cast_o.way_id = cache_req_metadata_r.repl_way;
             stat_mem_pkt_v_o = 1'b1;
 
-            state_n = (data_mem_pkt_yumi_i & tag_mem_pkt_yumi_i & stat_mem_pkt_yumi_i) ? e_writeback_req : e_writeback_read;
+            state_n = (data_mem_pkt_yumi_i & tag_mem_pkt_yumi_i & stat_mem_pkt_yumi_i) ? e_writeback_read_req : e_writeback_evict;
           end
-        e_writeback_req:
+        e_writeback_read_req:
           begin
-            mem_cmd_cast_o.header.msg_type = e_cce_mem_wr;
-            mem_cmd_cast_o.header.addr     = {dirty_tag_r, cache_req_r.addr[block_offset_width_lp+:index_width_lp], block_offset_width_lp'(0)};
-            mem_cmd_cast_o.header.size     = is_blockwidth_512
-                                              ? e_mem_msg_size_64
-                                              : is_blockwidth_256
-                                                ? e_mem_msg_size_32
-                                                : is_blockwidth_128
-                                                  ? e_mem_msg_size_16
-                                                  : e_mem_msg_size_64;
-            mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
-            mem_cmd_cast_o.data            = dirty_data_r;
-            mem_cmd_v_o = mem_cmd_ready_i;
-
-            state_n = mem_cmd_v_o ? e_read_wait : e_writeback_req;
-          end
-        e_read_wait:
-          begin
+            // send the sub-block from L2 to cache
             tag_mem_pkt_cast_o.opcode = e_cache_tag_mem_set_tag;
             tag_mem_pkt_cast_o.index  = mem_resp_cast_i.header.addr[block_offset_width_lp+:index_width_lp];
             // We fill in M because we don't want to trigger additional coherence traffic
@@ -489,15 +557,94 @@ module bp_uce
             data_mem_pkt_cast_o.index  = mem_resp_cast_i.header.addr[block_offset_width_lp+:index_width_lp];
             data_mem_pkt_cast_o.way_id = mem_resp_cast_i.header.payload.way_id[0+:`BSG_SAFE_CLOG2(assoc_p)];
             data_mem_pkt_cast_o.data   = mem_resp_cast_i.data;
-            data_mem_pkt_cast_o.fill_mask = {assoc_p{1'b1}};
+            data_mem_pkt_cast_o.fill_index = 1'b1 << fill_index_shift;
             data_mem_pkt_v_o = load_resp_v_li;
 
-            cache_req_complete_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
             cache_req_critical_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
-            mem_resp_yumi_lo = cache_req_complete_o;
+            fill_up = one_mem_cmd ? 1'b0 : tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+            mem_resp_yumi_lo = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+            // request next sub-block
+            mem_cmd_cast_o.header.msg_type       = e_cce_mem_rd;
+            mem_cmd_cast_o.header.addr           = {cache_req_r.addr[paddr_width_p-1:block_offset_width_lp], bank_index, byte_offset_width_lp'(0)};
+            mem_cmd_cast_o.header.size           = is_fillwidth_512
+                                                    ? e_mem_msg_size_64
+                                                    : is_fillwidth_256
+                                                      ? e_mem_msg_size_32
+                                                      : is_fillwidth_128
+                                                        ? e_mem_msg_size_16
+                                                        : is_fillwidth_64
+                                                          ? e_mem_msg_size_8
+                                                          : e_mem_msg_size_64;
+            mem_cmd_cast_o.header.payload.way_id = lce_assoc_p'(cache_req_metadata_r.repl_way);
+            mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
+            mem_cmd_v_o = one_mem_cmd ? 1'b0 : (mem_cmd_ready_i & ~mem_cmd_done_r);
+            mem_cmd_up = mem_cmd_v_o;
+            mem_cmd_done_n = mem_cmd_cnt_hit_target & mem_cmd_v_o;
 
+            state_n = (fill_cnt_hit_target & mem_cmd_done_r & tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i) ? e_writeback_write_req : e_writeback_read_req;
+          end
+        e_writeback_write_req:
+          begin
+            mem_cmd_cast_o.header.msg_type = e_cce_mem_wr;
+            mem_cmd_cast_o.header.addr     = {dirty_tag_r, cache_req_r.addr[block_offset_width_lp+:index_width_lp], bank_index, byte_offset_width_lp'(0)};
+            mem_cmd_cast_o.header.size     = is_fillwidth_512
+                                              ? e_mem_msg_size_64
+                                              : is_fillwidth_256
+                                                ? e_mem_msg_size_32
+                                                : is_fillwidth_128
+                                                  ? e_mem_msg_size_16
+                                                  : is_fillwidth_64
+                                                    ? e_mem_msg_size_8
+                                                    : e_mem_msg_size_64;
+            mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
+            mem_cmd_cast_o.data                  = writeback_data;
+            mem_cmd_v_o = mem_cmd_ready_i;
+            mem_cmd_up = mem_cmd_v_o;
 
-            state_n = cache_req_complete_o ? e_ready : e_read_wait;
+            cache_req_complete_o = mem_cmd_cnt_hit_target & mem_cmd_v_o;
+            state_n = cache_req_complete_o ? e_ready : e_writeback_write_req;
+          end
+        e_read_req:
+          begin
+            // send the sub-block from L2 to cache
+            tag_mem_pkt_cast_o.opcode = e_cache_tag_mem_set_tag;
+            tag_mem_pkt_cast_o.index  = mem_resp_cast_i.header.addr[block_offset_width_lp+:index_width_lp];
+            // We fill in M because we don't want to trigger additional coherence traffic
+            tag_mem_pkt_cast_o.way_id = mem_resp_cast_i.header.payload.way_id[0+:`BSG_SAFE_CLOG2(assoc_p)];
+            tag_mem_pkt_cast_o.state  = e_COH_M;
+            tag_mem_pkt_cast_o.tag    = mem_resp_cast_i.header.addr[block_offset_width_lp+index_width_lp+:ptag_width_p];
+            tag_mem_pkt_v_o = load_resp_v_li;
+
+            data_mem_pkt_cast_o.opcode = e_cache_data_mem_write;
+            data_mem_pkt_cast_o.index  = mem_resp_cast_i.header.addr[block_offset_width_lp+:index_width_lp];
+            data_mem_pkt_cast_o.way_id = mem_resp_cast_i.header.payload.way_id[0+:`BSG_SAFE_CLOG2(assoc_p)];
+            data_mem_pkt_cast_o.data   = mem_resp_cast_i.data;
+            data_mem_pkt_cast_o.fill_index = 1'b1 << fill_index_shift;
+            data_mem_pkt_v_o = load_resp_v_li;
+
+            cache_req_critical_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+            fill_up = one_mem_cmd ? 1'b0 : tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+            mem_resp_yumi_lo = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+            // request next sub-block
+            mem_cmd_cast_o.header.msg_type       = e_cce_mem_rd;
+            mem_cmd_cast_o.header.addr           = {cache_req_r.addr[paddr_width_p-1:block_offset_width_lp], bank_index, byte_offset_width_lp'(0)};
+            mem_cmd_cast_o.header.size           = is_fillwidth_512
+                                                    ? e_mem_msg_size_64
+                                                    : is_fillwidth_256
+                                                      ? e_mem_msg_size_32
+                                                      : is_fillwidth_128
+                                                        ? e_mem_msg_size_16
+                                                        : is_fillwidth_64
+                                                          ? e_mem_msg_size_8
+                                                          : e_mem_msg_size_64;
+            mem_cmd_cast_o.header.payload.way_id = lce_assoc_p'(cache_req_metadata_r.repl_way);
+            mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
+            mem_cmd_v_o = one_mem_cmd ? 1'b0 : (mem_cmd_ready_i & ~mem_cmd_done_r);
+            mem_cmd_up = mem_cmd_v_o;
+            mem_cmd_done_n = mem_cmd_cnt_hit_target & mem_cmd_v_o;
+
+            cache_req_complete_o = fill_cnt_hit_target & mem_cmd_done_r & tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+            state_n = cache_req_complete_o ? e_ready : e_read_req;
           end
         e_uc_read_wait:
           begin

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -106,6 +106,7 @@ $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_chain.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_en.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_en.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_set_clear.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_edge_detect.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_encode_one_hot.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_expand_bitmask.v


### PR DESCRIPTION
UCE FSM modification for multicycle fill/evict
1. States for following func are changed:
    cache flush with dirty data (e_flush_write)
    cache miss load (e_read_req) 
    cache miss load with dirty data replacement (e_writeback_read_req, e_writeback_write_req)
2. 2 counters are added, fill_cnt and mem_cmd_cnt, to track the progress of multicycle fill/evict
3. A new register, mem_cmd_done_r is added. In multicycle fillm, this 1-bit reg indicates whether all the mem_cmd are sent. Together with this register, mem_cmds can be sent as long as L2 is ready, avoiding potential latency.