### PR TITLE
Enable flexible LCE Request data width; fix mock LCE Verilator issue

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -20,7 +20,6 @@ module bp_be_calculator_top
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
     `declare_bp_proc_params(bp_params_p)
     `declare_bp_fe_be_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
-    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
 
    // Default parameters
    , parameter fp_en_p                  = 0

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce.v
@@ -48,7 +48,7 @@ module bp_be_dcache_lce
   import bp_be_dcache_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p) 
+   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p) 
    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache)
     
     , localparam block_size_in_words_lp = dcache_assoc_p
@@ -124,7 +124,7 @@ module bp_be_dcache_lce
 
   // casting structs
   //
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
   `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache);
  
   bp_lce_cce_req_s lce_req;

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_cmd.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_cmd.v
@@ -32,7 +32,7 @@ module bp_be_dcache_lce_cmd
     , localparam way_id_width_lp = `BSG_SAFE_CLOG2(dcache_assoc_p)
     , localparam block_size_in_bytes_lp = (dcache_block_width_p / 8)
     
-    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p) 
+    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p) 
     `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache)
 
     , localparam stat_info_width_lp=
@@ -93,8 +93,8 @@ module bp_be_dcache_lce_cmd
   );
 
   // casting structs
- `declare_bp_cache_stat_info_s(dcache_assoc_p, dcache);
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+  `declare_bp_cache_stat_info_s(dcache_assoc_p, dcache);
+  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
   `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache);
   
   bp_lce_cmd_s lce_cmd_li;

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_req.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_req.v
@@ -27,7 +27,7 @@ module bp_be_dcache_lce_req
   import bp_common_aviary_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache)
      
     , localparam cfg_bus_width_lp= `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
@@ -80,7 +80,7 @@ module bp_be_dcache_lce_req
 
   // casting struct
   //
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
   `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache);
 
   bp_lce_cce_req_s lce_req;
@@ -232,7 +232,7 @@ module bp_be_dcache_lce_req
         else if (cache_req_cast_li.msg_type == e_uc_store) begin
           lce_req_v_o = lce_req_ready_i;
 
-          lce_req.data = cache_req_cast_li.data[dword_width_p-1:0];;
+          lce_req.data[0+:dword_width_p] = cache_req_cast_li.data[0+:dword_width_p];
           lce_req.header.size = bp_mem_msg_size_e'(cache_req_cast_li.size);
           lce_req.header.addr = cache_req_cast_li.addr;
           lce_req.header.msg_type = e_lce_req_type_uc_wr;

--- a/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
@@ -16,7 +16,6 @@ module bp_be_mem_top
   import bp_be_dcache_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache)
    
    // Generated parameters

--- a/bp_be/src/v/bp_be_top.v
+++ b/bp_be/src/v/bp_be_top.v
@@ -16,7 +16,6 @@ module bp_be_top
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_fe_be_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache)
 
    // Default parameters 

--- a/bp_be/test/tb/bp_be_dcache/wrapper.v
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.v
@@ -16,7 +16,7 @@ module wrapper
   ,parameter uce_p = 1
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache)
 
    , parameter debug_p=0

--- a/bp_common/src/include/bp_common_me_if.vh
+++ b/bp_common/src/include/bp_common_me_if.vh
@@ -46,7 +46,7 @@
  *
  */
 
-`define declare_bp_lce_cce_if(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp, data_width_mp, cce_block_width_mp) \
+`define declare_bp_lce_cce_if(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp, cce_block_width_mp) \
                                                                                                          \
 /*                                                                                                       \
  * bp_lce_cce_req_s defines an LCE request sent by an LCE to a CCE on a cache miss. An LCE enters        \
@@ -59,6 +59,7 @@
  * non_exclusive indicates if the requesting cache prefers non-exclusive read-access                     \
  * addr is the cache missing address                                                                     \
  * lru_way_id indicates the way within the target set that will be used to fill the miss in to           \
+ *                                                                                                       \
  */                                                                                                      \
   typedef struct packed                                                                                  \
   {                                                                                                      \
@@ -73,7 +74,7 @@
                                                                                                          \
   typedef struct packed                                                                                  \
   {                                                                                                      \
-    logic [data_width_mp-1:0]                    data;                                                   \
+    logic [cce_block_width_mp-1:0]               data;                                                   \
     bp_lce_cce_req_header_s                      header;                                                 \
   } bp_lce_cce_req_s;                                                                                    \
                                                                                                          \
@@ -271,8 +272,8 @@ typedef enum logic [2:0]
  * Width macros for LCE-CCE Message Networks
  */
 
-`define bp_lce_cce_req_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp, data_width_mp) \
-  (`bp_lce_cce_req_header_width(cce_id_width_mp,lce_id_width_mp,paddr_width_mp,lce_assoc_mp)+data_width_mp)
+`define bp_lce_cce_req_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp, cce_block_width_mp) \
+  (`bp_lce_cce_req_header_width(cce_id_width_mp,lce_id_width_mp,paddr_width_mp,lce_assoc_mp)+cce_block_width_mp)
 
 `define bp_lce_cmd_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp, cce_block_width_mp) \
   (`bp_lce_cmd_header_width(cce_id_width_mp,lce_id_width_mp,paddr_width_mp,lce_assoc_mp)+cce_block_width_mp)
@@ -280,8 +281,9 @@ typedef enum logic [2:0]
 `define bp_lce_cce_resp_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, cce_block_width_mp) \
   (`bp_lce_cce_resp_header_width(cce_id_width_mp,lce_id_width_mp,paddr_width_mp)+cce_block_width_mp)
 
-`define declare_bp_lce_cce_if_widths(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp, data_width_mp, cce_block_width_mp)    \
-    , localparam lce_cce_req_width_lp=`bp_lce_cce_req_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp, data_width_mp) \
+`define declare_bp_lce_cce_if_widths(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp, cce_block_width_mp)    \
+    , localparam lce_cce_req_width_lp=`bp_lce_cce_req_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp, cce_block_width_mp) \
+    , localparam lce_cce_block_req_width_lp=`bp_lce_cce_req_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp, cce_block_width_mp) \
     , localparam lce_cmd_width_lp=`bp_lce_cmd_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, lce_assoc_mp, cce_block_width_mp)    \
     , localparam lce_cce_resp_width_lp=`bp_lce_cce_resp_width(cce_id_width_mp, lce_id_width_mp, paddr_width_mp, cce_block_width_mp)
 

--- a/bp_fe/src/v/bp_fe_lce.v
+++ b/bp_fe/src/v/bp_fe_lce.v
@@ -21,7 +21,7 @@ module bp_fe_lce
   import bp_common_cfg_link_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
 
    , localparam way_id_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)
@@ -87,7 +87,7 @@ module bp_fe_lce
   );
 
   `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p);
+  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
   `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache);
 
   bp_cfg_bus_s cfg_bus_cast_i;

--- a/bp_fe/src/v/bp_fe_lce_cmd.v
+++ b/bp_fe/src/v/bp_fe_lce_cmd.v
@@ -18,7 +18,7 @@ module bp_fe_lce_cmd
   import bp_common_aviary_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
    
    , localparam way_id_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)
@@ -83,7 +83,7 @@ module bp_fe_lce_cmd
   );
 
   // lce interface
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p);
+  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
   `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache);
 
   bp_lce_cmd_s lce_cmd_li;

--- a/bp_fe/src/v/bp_fe_lce_req.v
+++ b/bp_fe/src/v/bp_fe_lce_req.v
@@ -17,7 +17,7 @@ module bp_fe_lce_req
   import bp_common_aviary_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
    
    , localparam way_id_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)
@@ -66,7 +66,7 @@ module bp_fe_lce_req
 
   // lce interface
 
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p);
+  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
   `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache);
 
   bp_lce_cce_resp_s lce_resp;

--- a/bp_fe/src/v/bp_fe_mem.v
+++ b/bp_fe/src/v/bp_fe_mem.v
@@ -7,7 +7,6 @@ module bp_fe_mem
  import bp_common_rv64_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
    
    , localparam way_id_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)

--- a/bp_fe/src/v/bp_fe_top.v
+++ b/bp_fe/src/v/bp_fe_top.v
@@ -13,7 +13,6 @@ module bp_fe_top
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_fe_be_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
    
    , localparam way_id_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)

--- a/bp_fe/test/tb/bp_fe_icache/testbench.v
+++ b/bp_fe/test/tb/bp_fe_icache/testbench.v
@@ -43,7 +43,7 @@ module testbench
   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
   
   // LCE-CCE Interface Widths
-  `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+  `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
   
   // CCE-MEM Interface Widths
   `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.v
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.v
@@ -10,7 +10,7 @@ module wrapper
   , parameter uce_p = 1
   `declare_bp_proc_params(bp_params_p)
   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
-  `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+  `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
   `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
 
   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)

--- a/bp_me/src/include/v/bp_cce_pkg.v
+++ b/bp_me/src/include/v/bp_cce_pkg.v
@@ -45,4 +45,7 @@ package bp_cce_pkg;
     bp_coh_states_e          state;                \
   } dir_entry_s                                    \
 
+  `define bp_cce_dir_entry_width(tag_width_mp) \
+    ($bits(bp_coh_states_e)+tag_width_mp)
+
 endpackage : bp_cce_pkg

--- a/bp_me/src/v/cce/bp_cce.v
+++ b/bp_me/src/v/cce/bp_cce.v
@@ -33,7 +33,7 @@ module bp_cce
     // Interface Widths
     , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
     `declare_bp_lce_cce_if_header_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p)
-    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
     `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
   )
   (input                                               clk_i
@@ -91,7 +91,7 @@ module bp_cce
 
   // LCE-CCE and Mem-CCE Interface
   `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p);
+  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
 
   // Config Interface
   `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
@@ -499,9 +499,9 @@ module bp_cce
       ,.src_a_i(src_a)
       ,.alu_res_i(alu_res_lo)
 
-      ,.lce_req_i(lce_req)
-      ,.lce_resp_i(lce_resp)
-      ,.mem_resp_i(mem_resp)
+      ,.lce_req_header_i(lce_req.header)
+      ,.lce_resp_header_i(lce_resp.header)
+      ,.mem_resp_header_i(mem_resp.header)
 
       ,.pending_i(pending_lo)
 

--- a/bp_me/src/v/cce/bp_cce_dir_lru_extract.v
+++ b/bp_me/src/v/cce/bp_cce_dir_lru_extract.v
@@ -55,12 +55,9 @@ module bp_cce_dir_lru_extract
   assign lru_v_o = (row_v_i[lce_i[0]]) & ((lce_i >> 1) == row_num_i);
 
   bp_coh_states_e lru_coh_state;
-  assign lru_coh_state = (row_v_i)
-                         ? row[lce_i[0]][lru_way_i].state
-                         : e_COH_I;
+  assign lru_coh_state = row[lce_i[0]][lru_way_i].state;
   assign lru_coh_state_o = lru_coh_state;
-  assign lru_tag_o = (row_v_i)
-                     ? row[lce_i[0]][lru_way_i].tag
-                     : '0;
+  assign lru_tag_o = row[lce_i[0]][lru_way_i].tag;
+
 endmodule
 

--- a/bp_me/src/v/cce/bp_cce_dir_segment.v
+++ b/bp_me/src/v/cce/bp_cce_dir_segment.v
@@ -308,7 +308,7 @@ module bp_cce_dir_segment
         dir_ram_addr = cnt[0+:lg_rows_lp];
         dir_ram_w_mask = '1;
         dir_ram_w_data = '0;
-        cnt_clr = (cnt == (rows_lp-1));
+        cnt_clr = (cnt == counter_width_lp'(rows_lp-1));
         state_n = cnt_clr ? READY : INIT;
         cnt_inc = ~cnt_clr;
         // directory is busy and cannot accept commands
@@ -351,7 +351,7 @@ module bp_cce_dir_segment
             dir_ram_addr = set_id;
 
             // next address to read from directory
-            dir_ram_addr_n = dir_ram_addr + tag_sets_p;
+            dir_ram_addr_n = dir_ram_addr + lg_rows_lp'(tag_sets_p);
 
             // next cycle, the data coming out of the RAM will be valid
             dir_data_o_v_n =
@@ -415,18 +415,18 @@ module bp_cce_dir_segment
 
         // cnt should be shifted based on LOG2(tag_sets_per_row_lp)
         // would require tag_sets_per_row_lp to be a power of two
-        for(int i = 0; i < tag_sets_per_row_lp; i++) begin
-          sharers_hits_n[(cnt << 1) + i] = sharers_hits[i];
-          sharers_ways_n[(cnt << 1) + i] = sharers_ways[i];
-          sharers_coh_states_n[(cnt << 1) + i] = sharers_coh_states[i];
+        for(int j = 0; j < tag_sets_per_row_lp; j++) begin
+          sharers_hits_n[(cnt << 1) + j] = sharers_hits[j];
+          sharers_ways_n[(cnt << 1) + j] = sharers_ways[j];
+          sharers_coh_states_n[(cnt << 1) + j] = sharers_coh_states[j];
         end
 
         // do another read if required (num_lce_p > 2 and rows_per_set_lp >= 2)
-        if (cnt < (rows_per_set_lp-1)) begin
+        if (cnt < counter_width_lp'(rows_per_set_lp-1)) begin
           dir_ram_v = 1'b1;
           dir_ram_addr = dir_ram_addr_r;
-          dir_ram_addr_n = dir_ram_addr_r + tag_sets_p;
-          dir_data_o_v_n = (cnt == (rows_per_set_lp-2))
+          dir_ram_addr_n = dir_ram_addr_r + lg_rows_lp'(tag_sets_p);
+          dir_data_o_v_n = (cnt == counter_width_lp'(rows_per_set_lp-2))
                            ? (last_row_full_lp)
                              ? '1
                              : 2'b01

--- a/bp_me/src/v/cce/bp_cce_fsm_top.v
+++ b/bp_me/src/v/cce/bp_cce_fsm_top.v
@@ -38,7 +38,7 @@ module bp_cce_fsm_top
     , localparam wg_per_cce_lp          = (lce_sets_p / num_cce_p)
 
     // interface widths
-    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
     `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
 
   )

--- a/bp_me/src/v/cce/bp_cce_gad.v
+++ b/bp_me/src/v/cce/bp_cce_gad.v
@@ -109,15 +109,11 @@ module bp_cce_gad
     ? sharers_ways_i[req_lce_id]
     : '0;
 
-  // request type
-  logic req_wr;
-  assign req_wr = (req_type_flag_i == e_lce_req_type_wr);
-
   // Flag outputs
 
   // Upgrade from read-only to read-write
   // Requesting LCE has block cached in read-only state and request is a store-miss
-  assign upgrade_flag_o = (req_wr & req_lce_ro);
+  assign upgrade_flag_o = (req_type_flag_i & req_lce_ro);
 
   // Replace the LRU block if not doing an upgrade and the lru block might be dirty
   assign replacement_flag_o = ~upgrade_flag_o & ((lru_coh_state_i == e_COH_E)
@@ -149,6 +145,6 @@ module bp_cce_gad
   assign owner_lce_o = (gad_v_i & owner_lce_v)
                           ? {'0, owner_lce_lo} : '0;
   assign owner_way_o = (gad_v_i & owner_lce_v)
-                          ? sharers_ways_i[owner_lce_lo] : '0;
+                          ? {'0, sharers_ways_i[owner_lce_lo]} : '0;
 
 endmodule

--- a/bp_me/src/v/cce/bp_cce_msg.v
+++ b/bp_me/src/v/cce/bp_cce_msg.v
@@ -6,13 +6,13 @@
  * Description:
  *   This module handles sending and receiving of all messages in the CCE.
  *
+ * Note: all cached accesses issued to memory using mem_cmd have their address masked
+ *       and aligned by the CCE to match cce_block_width_p
+ *
  */
 
 // TODO:
-// 1. message size fields - mshr.msg_size holds size popped from LCE Req or from move inst
-// 2. address alignment and masking - does the CCE do this? or now require sender to align?
-// 3. set mem_cmd payload bits
-// 4. support globally uncached, locally cached access; locally uncached, globally cached
+// 1. support globally uncached, locally cached access; locally uncached, globally cached
 
 module bp_cce_msg
   import bp_common_pkg::*;
@@ -38,7 +38,7 @@ module bp_cce_msg
     , localparam mshr_width_lp             = `bp_cce_mshr_width(lce_id_width_p, lce_assoc_p, paddr_width_p)
     , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
     `declare_bp_lce_cce_if_header_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p)
-    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
     `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
   )
   (input                                               clk_i
@@ -116,7 +116,7 @@ module bp_cce_msg
 
   // LCE-CCE and Mem-CCE Interface
   `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p);
+  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
 
   // Config Interface
   `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
@@ -342,7 +342,6 @@ module bp_cce_msg
       end
       e_uc_ready: begin
 
-        // TODO: for now, uncached messages from memory are sent as uncached to LCE
         if (mem_resp_v_i & (mem_resp.header.msg_type == e_cce_mem_uc_rd)) begin
           // after load response is received, need to send data back to LCE
           lce_cmd_v_o = lce_cmd_ready_i;
@@ -428,7 +427,6 @@ module bp_cce_msg
       // Auto-forward mechanism
       if (auto_fwd_msg_i) begin
         if (mem_resp_v_i) begin
-          // TODO: for now, uncached messages from memory are sent as uncached to LCE
           // Uncached load response - forward data to LCE
           // This transaction does not modify the pending bits
           if (mem_resp.header.msg_type == e_cce_mem_uc_rd) begin
@@ -445,8 +443,7 @@ module bp_cce_msg
             lce_cmd.header.src_id = cfg_bus_cast.cce_id;
             lce_cmd.header.addr = mem_resp.header.addr;
             // Data is copied directly from the Mem Data Response
-            // For uncached responses, only the least significant 64-bits will be valid
-            lce_cmd.data[0+:dword_width_p] = mem_resp.data[0+:dword_width_p];
+            lce_cmd.data = mem_resp.data;
           end // uncached read response
 
           // Uncached store response - send uncached store done command on LCE Command
@@ -673,8 +670,12 @@ module bp_cce_msg
               mem_cmd.header.addr = addr_i;
               // default to size in MSHR
               mem_cmd.header.size = mshr.msg_size;
-              // uncached bit set based on bit in MSHR
-              mem_cmd.header.payload.uncached = mshr.flags[e_opd_ucf];
+
+              // set speculative bit if instruction indicates it will be written
+              if (decoded_inst_i.spec_w_v & decoded_inst_i.spec_v
+                  & decoded_inst_i.spec_bits.spec) begin
+                mem_cmd.header.payload.speculative = 1'b1;
+              end
 
               // Custom command
               if (decoded_inst_i.pushq_custom) begin
@@ -686,13 +687,20 @@ module bp_cce_msg
                 mem_cmd.header.size = decoded_inst_i.msg_size;
                 // data comes from src_a_i, as selected by the src_a field of the instruction
                 // this data is one of the GPRs
-                mem_cmd.data = {'0, src_a_i};
+                mem_cmd.data[0+:`bp_cce_inst_gpr_width] = src_a_i;
+
+                // set uncached bit based on uncached flag in MSHR
+                // this bit indicates if the LCE should receive the data as cached or uncached
+                // when it returns from memory
+                mem_cmd.header.payload.uncached = mshr.flags[e_opd_ucf];
 
               // Standard coherence command
               end else begin
                 // uncached request
                 if ((decoded_inst_i.mem_cmd == e_cce_mem_uc_rd)
                     | (decoded_inst_i.mem_cmd == e_cce_mem_uc_wr)) begin
+                  // set uncached bit
+                  mem_cmd.header.payload.uncached = 1'b1;
                   // uncached access uses the full address, no masking
                   // NOTE: address must be aligned to request size
                   mem_cmd.header.addr = addr_i;
@@ -710,25 +718,29 @@ module bp_cce_msg
                   // cached access masks the address to align to cache block
                   mem_cmd.header.addr = (addr_i & addr_mask);
 
-                  // set speculative bit if instruction indicates it will be written
-                  if (decoded_inst_i.spec_w_v & decoded_inst_i.spec_v
-                      & decoded_inst_i.spec_bits.spec) begin
-                    mem_cmd.header.payload.speculative = 1'b1;
-                  end
+                  // set uncached bit based on uncached flag in MSHR
+                  // this bit indicates if the LCE should receive the data as cached or uncached
+                  // when it returns from memory
+                  mem_cmd.header.payload.uncached = mshr.flags[e_opd_ucf];
 
                   // Writeback command - override default command fields as needed
-                  if (decoded_inst_i.mem_cmd == e_cce_mem_wr) begin
-                    mem_cmd.data = lce_resp.data;
-                    mem_cmd.header.payload.lce_id = lce_i;
-                    mem_cmd.header.payload.way_id = '0;
-                    mem_cmd.header.payload.state = e_COH_I;
-                  end else if (decoded_inst_i.mem_cmd == e_cce_mem_pre) begin
-                    mem_cmd.header.payload.prefetch = 1'b1;
-                  end else begin
-                    mem_cmd.header.payload.state = mshr.next_coh_state;
-                    mem_cmd.header.payload.way_id = way_i;
-                    mem_cmd.header.payload.lce_id = lce_i;
-                  end
+                  unique case (decoded_inst_i.mem_cmd)
+                    e_cce_mem_wr: begin
+                      mem_cmd.data = lce_resp.data;
+                      mem_cmd.header.payload.lce_id = lce_i;
+                      mem_cmd.header.payload.way_id = '0;
+                      mem_cmd.header.payload.state = e_COH_I;
+                    end
+                    e_cce_mem_pre: begin
+                      // TODO: implement prefetch functionality
+                      mem_cmd.header.payload.prefetch = 1'b1;
+                    end
+                    default: begin
+                      mem_cmd.header.payload.state = mshr.next_coh_state;
+                      mem_cmd.header.payload.way_id = way_i;
+                      mem_cmd.header.payload.lce_id = lce_i;
+                    end
+                  endcase
 
                 end // cached
 
@@ -749,23 +761,17 @@ module bp_cce_msg
                 & ((decoded_inst_i.pending_w_v & ~pending_w_v_o)
                    | ~decoded_inst_i.pending_w_v)) begin
 
-              // All commands (coherence or custom) set destination, message type, source (this CCE)
-              // and address. Custom commands set data length, while coherence commands set
-              // way ID, coherence state, target, and target way.
               lce_cmd_v_o = lce_cmd_ready_i;
               lce_cmd.header.dst_id = lce_i;
               lce_cmd.header.msg_type = decoded_inst_i.lce_cmd;
               lce_cmd.header.src_id = cfg_bus_cast.cce_id;
               lce_cmd.header.addr = addr_i;
+
               if (decoded_inst_i.pushq_custom) begin
                 lce_cmd.header.size = decoded_inst_i.msg_size;
-                lce_cmd.data = {'0, src_a_i};
+                lce_cmd.data[0+:`bp_cce_inst_gpr_width] = src_a_i;
               end else begin
                 lce_cmd.header.way_id = way_i;
-                // size is set based on message type:
-                // by default, leave as '0 equivalent size
-                // only messages that have data are data and uc_data, which are auto-forwarded
-                // for now, use pushqc to send these messages
                 if ((decoded_inst_i.lce_cmd == e_lce_cmd_st)
                     | (decoded_inst_i.lce_cmd == e_lce_cmd_st_wakeup)) begin
                   lce_cmd.header.state = coh_state_i;

--- a/bp_me/src/v/cce/bp_cce_reg.v
+++ b/bp_me/src/v/cce/bp_cce_reg.v
@@ -24,7 +24,6 @@ module bp_cce_reg
 
     // Interface Widths
     `declare_bp_lce_cce_if_header_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p)
-    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
     `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
   )
   (input                                                                   clk_i
@@ -41,9 +40,9 @@ module bp_cce_reg
    , input [`bp_cce_inst_gpr_width-1:0]                                    src_a_i
    , input [`bp_cce_inst_gpr_width-1:0]                                    alu_res_i
 
-   , input [lce_cce_req_width_lp-1:0]                                      lce_req_i
-   , input [lce_cce_resp_width_lp-1:0]                                     lce_resp_i
-   , input [cce_mem_msg_width_lp-1:0]                                      mem_resp_i
+   , input [lce_cce_req_header_width_lp-1:0]                               lce_req_header_i
+   , input [lce_cce_resp_header_width_lp-1:0]                              lce_resp_header_i
+   , input [cce_mem_msg_header_width_lp-1:0]                               mem_resp_header_i
 
    // For RDP, output state of pending bits from read operation
    , input                                                                 pending_i
@@ -80,15 +79,15 @@ module bp_cce_reg
 
   // Interface Structs
   `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p);
+  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
 
-  bp_lce_cce_req_s  lce_req;
-  bp_lce_cce_resp_s lce_resp;
-  bp_cce_mem_msg_s  mem_resp;
+  bp_lce_cce_req_header_s  lce_req_hdr;
+  bp_lce_cce_resp_header_s lce_resp_hdr;
+  bp_cce_mem_msg_header_s  mem_resp_hdr;
 
-  assign lce_req  = lce_req_i;
-  assign lce_resp = lce_resp_i;
-  assign mem_resp = mem_resp_i;
+  assign lce_req_hdr  = lce_req_header_i;
+  assign lce_resp_hdr = lce_resp_header_i;
+  assign mem_resp_hdr = mem_resp_header_i;
 
   // Registers
   `declare_bp_cce_mshr_s(lce_id_width_p, lce_assoc_p, paddr_width_p);
@@ -116,12 +115,12 @@ module bp_cce_reg
   wire queue_op      = (decoded_inst_i.op == e_op_queue);
 
   // Flag next values
-  wire lce_req_rqf   = (lce_req.header.msg_type == e_lce_req_type_wr)
-                       | (lce_req.header.msg_type == e_lce_req_type_uc_wr);
-  wire lce_req_ucf   = (lce_req.header.msg_type == e_lce_req_type_uc_rd)
-                       | (lce_req.header.msg_type == e_lce_req_type_uc_wr);
-  wire lce_resp_nwbf = (lce_resp.header.msg_type == e_lce_cce_resp_null_wb);
-  wire lce_req_nerf  = (lce_req.header.non_exclusive == e_lce_req_non_excl);
+  wire lce_req_rqf   = (lce_req_hdr.msg_type == e_lce_req_type_wr)
+                       | (lce_req_hdr.msg_type == e_lce_req_type_uc_wr);
+  wire lce_req_ucf   = (lce_req_hdr.msg_type == e_lce_req_type_uc_rd)
+                       | (lce_req_hdr.msg_type == e_lce_req_type_uc_wr);
+  wire lce_resp_nwbf = (lce_resp_hdr.msg_type == e_lce_cce_resp_null_wb);
+  wire lce_req_nerf  = (lce_req_hdr.non_exclusive == e_lce_req_non_excl);
 
   // operation writes all flags in bulk
   wire write_all_flags = ((decoded_inst_i.dst_sel == e_dst_sel_special)
@@ -174,8 +173,7 @@ module bp_cce_reg
       // paddr - from lce_req, lce_resp, mem_resp, or move
       // LRU Way ID - from lce_req or move
       // Next Coh State - from move or mem_resp.payload
-      // UC Req Size - from lce_req or move
-      // Data Length - from lce_req, lce_resp, or move
+      // Message Size - from lce_req or move
       // Way ID - from move, GAD, or mem_resp
       // Owner LCE ID - from GAD or move
       // Owner Way ID - from GAD or move
@@ -200,27 +198,27 @@ module bp_cce_reg
       if (decoded_inst_i.poph) begin
         unique case (decoded_inst_i.popq_qsel)
           e_src_q_sel_lce_req: begin
-            mshr_n.lce_id = lce_req.header.src_id;
-            mshr_n.paddr = lce_req.header.addr;
-            mshr_n.lru_way_id = lce_req.header.lru_way_id;
-            mshr_n.msg_size = lce_req.header.size;
+            mshr_n.lce_id = lce_req_hdr.src_id;
+            mshr_n.paddr = lce_req_hdr.addr;
+            mshr_n.lru_way_id = lce_req_hdr.lru_way_id;
+            mshr_n.msg_size = lce_req_hdr.size;
             mshr_n.flags[e_opd_rqf] = lce_req_rqf;
             mshr_n.flags[e_opd_ucf] = lce_req_ucf;
             mshr_n.flags[e_opd_nerf] = lce_req_nerf;
           end
           e_src_q_sel_lce_resp: begin
-            //mshr_n.lce_id = lce_resp.header.src_id;
-            //mshr_n.paddr = lce_resp.header.addr;
-            //mshr_n.msg_size = lce_resp.header.size;
+            //mshr_n.lce_id = lce_resp_hdr.src_id;
+            //mshr_n.paddr = lce_resp_hdr.addr;
+            //mshr_n.msg_size = lce_resp_hdr.size;
             mshr_n.flags[e_opd_nwbf] = lce_resp_nwbf;
           end
           e_src_q_sel_mem_resp: begin
-            //mshr_n.lce_id = mem_resp.header.payload.lce_id;
-            //mshr_n.way_id = mem_resp.header.payload.way_id;
-            //mshr_n.paddr = mem_resp.header.addr;
-            //mshr_n.next_coh_state = mem_resp.header.payload.state;
-            //mshr_n.msg_size = mem_resp.header.size;
-            mshr_n.flags[e_opd_sf] = mem_resp.header.payload.speculative;
+            //mshr_n.lce_id = mem_resp_hdr.payload.lce_id;
+            //mshr_n.way_id = mem_resp_hdr.payload.way_id;
+            //mshr_n.paddr = mem_resp_hdr.addr;
+            //mshr_n.next_coh_state = mem_resp_hdr.payload.state;
+            //mshr_n.msg_size = mem_resp_hdr.size;
+            mshr_n.flags[e_opd_sf] = mem_resp_hdr.payload.speculative;
           end
           default: begin
           end

--- a/bp_me/src/v/cce/bp_cce_src_sel.v
+++ b/bp_me/src/v/cce/bp_cce_src_sel.v
@@ -30,7 +30,7 @@ module bp_cce_src_sel
     , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
 
     `declare_bp_lce_cce_if_header_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p)
-    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
     `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
   )
   (// Select signals for src_a and src_b - from decoded instruction
@@ -78,8 +78,8 @@ module bp_cce_src_sel
 
   //synopsys translate_off
   initial begin
-    assert(`bp_cce_inst_gpr_width == dword_width_p)
-      else $error("GPR width and dword_width_p must be same in CCE");
+    assert(cce_block_width_p >= `bp_cce_inst_gpr_width)
+      else $error("CCE block width must be greater than CCE GPR width");
   end
   //synopsys translate_on
 
@@ -93,7 +93,7 @@ module bp_cce_src_sel
 
   // LCE-CCE and Mem-CCE Interface
   `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p);
+  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
 
   // Message casting
   bp_lce_cce_req_s  lce_req;
@@ -176,9 +176,9 @@ module bp_cce_src_sel
           e_opd_lce_req_v:     src_a_o[0] = lce_req_v_i;
           e_opd_lce_resp_type: src_a_o[0+:$bits(bp_lce_cce_resp_type_e)] = lce_resp.header.msg_type;
           e_opd_mem_resp_type: src_a_o[0+:$bits(bp_cce_mem_cmd_type_e)] = mem_resp.header.msg_type;
-          e_opd_lce_resp_data: src_a_o = lce_resp.data[0+:dword_width_p];
-          e_opd_mem_resp_data: src_a_o = mem_resp.data[0+:dword_width_p];
-          e_opd_lce_req_data:  src_a_o = lce_req.data[0+:dword_width_p];
+          e_opd_lce_resp_data: src_a_o = lce_resp.data[0+:`bp_cce_inst_gpr_width];
+          e_opd_mem_resp_data: src_a_o = mem_resp.data[0+:`bp_cce_inst_gpr_width];
+          e_opd_lce_req_data:  src_a_o = lce_req.data[0+:`bp_cce_inst_gpr_width];
           default:             src_a_o = '0;
         endcase
       end
@@ -266,9 +266,9 @@ module bp_cce_src_sel
           e_opd_lce_req_v:     src_b_o[0] = lce_req_v_i;
           e_opd_lce_resp_type: src_b_o[0+:$bits(bp_lce_cce_resp_type_e)] = lce_resp.header.msg_type;
           e_opd_mem_resp_type: src_b_o[0+:$bits(bp_cce_mem_cmd_type_e)] = mem_resp.header.msg_type;
-          e_opd_lce_resp_data: src_b_o = lce_resp.data[0+:dword_width_p];
-          e_opd_mem_resp_data: src_b_o = mem_resp.data[0+:dword_width_p];
-          e_opd_lce_req_data:  src_b_o = lce_req.data[0+:dword_width_p];
+          e_opd_lce_resp_data: src_b_o = lce_resp.data[0+:`bp_cce_inst_gpr_width];
+          e_opd_mem_resp_data: src_b_o = mem_resp.data[0+:`bp_cce_inst_gpr_width];
+          e_opd_lce_req_data:  src_b_o = lce_req.data[0+:`bp_cce_inst_gpr_width];
           default:             src_b_o = '0;
         endcase
       end

--- a/bp_me/src/v/cce/bp_cce_wrapper.v
+++ b/bp_me/src/v/cce/bp_cce_wrapper.v
@@ -21,7 +21,7 @@ module bp_cce_wrapper
 
     // Interface Widths
     , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
-    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
     `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
   )
   (input                                               clk_i

--- a/bp_me/src/v/cce/bp_io_cce.v
+++ b/bp_me/src/v/cce/bp_io_cce.v
@@ -6,36 +6,36 @@ module bp_io_cce
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
    `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
    )
-  (input                                clk_i
-   , input                              reset_i
+  (input                                      clk_i
+   , input                                    reset_i
 
-   , input [cce_id_width_p-1:0]         cce_id_i
+   , input [cce_id_width_p-1:0]               cce_id_i
 
-   , input [lce_cce_req_width_lp-1:0]   lce_req_i
-   , input                              lce_req_v_i
-   , output                             lce_req_yumi_o
+   , input [lce_cce_req_width_lp-1:0]         lce_req_i
+   , input                                    lce_req_v_i
+   , output                                   lce_req_yumi_o
 
-   , output [lce_cmd_width_lp-1:0]      lce_cmd_o
-   , output                             lce_cmd_v_o
-   , input                              lce_cmd_ready_i
+   , output [lce_cmd_width_lp-1:0]            lce_cmd_o
+   , output                                   lce_cmd_v_o
+   , input                                    lce_cmd_ready_i
 
-   , output [cce_mem_msg_width_lp-1:0]   io_cmd_o
-   , output                             io_cmd_v_o
-   , input                              io_cmd_ready_i
+   , output [cce_mem_msg_width_lp-1:0]        io_cmd_o
+   , output                                   io_cmd_v_o
+   , input                                    io_cmd_ready_i
 
-   , input [cce_mem_msg_width_lp-1:0]    io_resp_i
-   , input                              io_resp_v_i
-   , output                             io_resp_yumi_o
+   , input [cce_mem_msg_width_lp-1:0]         io_resp_i
+   , input                                    io_resp_v_i
+   , output                                   io_resp_yumi_o
    );
 
   `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p);
+  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
 
-  bp_lce_cce_req_s  lce_req_cast_i;
-  bp_lce_cmd_s      lce_cmd_cast_o;
+  bp_lce_cce_req_s        lce_req_cast_i;
+  bp_lce_cmd_s            lce_cmd_cast_o;
 
   bp_cce_mem_msg_s  io_cmd_cast_o;
   bp_cce_mem_msg_s  io_resp_cast_i;
@@ -49,25 +49,15 @@ module bp_io_cce
   assign lce_req_yumi_o  = lce_req_v_i & io_cmd_ready_i;
   assign io_cmd_v_o      = lce_req_yumi_o;
   wire lce_req_wr_not_rd = (lce_req_cast_i.header.msg_type == e_lce_req_type_uc_wr);
-  always_comb
-    if (lce_req_wr_not_rd)
-      begin
-        io_cmd_cast_o                       = '0;
-        io_cmd_cast_o.header.msg_type       = e_cce_mem_uc_wr;
-        io_cmd_cast_o.header.addr           = lce_req_cast_i.header.addr;
-        io_cmd_cast_o.header.size           = lce_req_cast_i.header.size;
-        io_cmd_cast_o.header.payload.lce_id = lce_req_cast_i.header.src_id;
-        io_cmd_cast_o.data                  = lce_req_cast_i.data;
-      end
-    else
-      begin
-        io_cmd_cast_o                       = '0;
-        io_cmd_cast_o.header.msg_type       = e_cce_mem_uc_rd;
-        io_cmd_cast_o.header.addr           = lce_req_cast_i.header.addr;
-        io_cmd_cast_o.header.size           = lce_req_cast_i.header.size;
-        io_cmd_cast_o.header.payload.lce_id = lce_req_cast_i.header.src_id;
-        io_cmd_cast_o.data                  = lce_req_cast_i.data;
-      end
+  always_comb begin
+    io_cmd_cast_o                         = '0;
+    io_cmd_cast_o.header.msg_type         = (lce_req_wr_not_rd) ? e_cce_mem_uc_wr : e_cce_mem_uc_rd;
+    io_cmd_cast_o.header.addr             = lce_req_cast_i.header.addr;
+    io_cmd_cast_o.header.size             = lce_req_cast_i.header.size;
+    io_cmd_cast_o.header.payload.lce_id   = lce_req_cast_i.header.src_id;
+    io_cmd_cast_o.header.payload.uncached = 1'b1;
+    io_cmd_cast_o.data                    = lce_req_cast_i.data;
+  end
 
   assign io_resp_yumi_o  = io_resp_v_i & lce_cmd_ready_i;
   assign lce_cmd_v_o     = io_resp_yumi_o;
@@ -78,6 +68,7 @@ module bp_io_cce
         lce_cmd_cast_o                 = '0;
         lce_cmd_cast_o.header.dst_id   = io_resp_cast_i.header.payload.lce_id;
         lce_cmd_cast_o.header.msg_type = e_lce_cmd_uc_st_done;
+        // no data, size is '0 equivalent
         lce_cmd_cast_o.header.addr     = io_resp_cast_i.header.addr;
         lce_cmd_cast_o.header.src_id   = cce_id_i;
       end

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_cmd.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_cmd.v
@@ -15,16 +15,17 @@ module bp_me_wormhole_packet_encode_lce_cmd
   import bp_common_aviary_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
     `declare_bp_proc_params(bp_params_p)
-    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
 
-    , localparam lce_cmd_packet_width_lp = 
+    , localparam lce_cmd_packet_width_lp =
         `bsg_wormhole_concentrator_packet_width(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cmd_width_lp)
+    , localparam lce_cmd_packet_hdr_width_lp = (lce_cmd_packet_width_lp-cce_block_width_p)
     )
    (input [lce_cmd_width_lp-1:0]           payload_i
     , output [lce_cmd_packet_width_lp-1:0] packet_o
     );
 
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
   `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cmd_width_lp, lce_cmd_packet_s);
 
   bp_lce_cmd_s payload_cast_i;
@@ -32,12 +33,26 @@ module bp_me_wormhole_packet_encode_lce_cmd
   assign payload_cast_i = payload_i;
   assign packet_o = packet_cast_o;
 
-  localparam lce_cmd_cmd_len_lp = 
-    `BSG_CDIV(lce_cmd_packet_width_lp-$bits(payload_cast_i.data), coh_noc_flit_width_p) - 1;
-  localparam lce_cmd_data_len_lp = 
-    `BSG_CDIV(lce_cmd_packet_width_lp, coh_noc_flit_width_p) - 1;
-  localparam lce_cmd_uc_data_len_lp =
-    `BSG_CDIV(lce_cmd_packet_width_lp-(cce_block_width_p-dword_width_p), coh_noc_flit_width_p) - 1;
+  // LCE Command with no data
+  localparam lce_cmd_cmd_len_lp =
+    `BSG_CDIV(lce_cmd_packet_hdr_width_lp, coh_noc_flit_width_p) - 1;
+  // LCE Commands with 1B to 128B of data
+  localparam lce_cmd_data_len_1_lp =
+    `BSG_CDIV(lce_cmd_packet_hdr_width_lp+(1*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cmd_data_len_2_lp =
+    `BSG_CDIV(lce_cmd_packet_hdr_width_lp+(2*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cmd_data_len_4_lp =
+    `BSG_CDIV(lce_cmd_packet_hdr_width_lp+(4*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cmd_data_len_8_lp =
+    `BSG_CDIV(lce_cmd_packet_hdr_width_lp+(8*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cmd_data_len_16_lp =
+    `BSG_CDIV(lce_cmd_packet_hdr_width_lp+(16*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cmd_data_len_32_lp =
+    `BSG_CDIV(lce_cmd_packet_hdr_width_lp+(32*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cmd_data_len_64_lp =
+    `BSG_CDIV(lce_cmd_packet_hdr_width_lp+(64*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cmd_data_len_128_lp =
+    `BSG_CDIV(lce_cmd_packet_hdr_width_lp+(128*8), coh_noc_flit_width_p) - 1;
 
   logic [coh_noc_cord_width_p-1:0] lce_cord_li;
   logic [coh_noc_cid_width_p-1:0]  lce_cid_li;
@@ -54,7 +69,8 @@ module bp_me_wormhole_packet_encode_lce_cmd
     packet_cast_o.cid     = lce_cid_li;
     packet_cast_o.cord    = lce_cord_li;
 
-    case (payload_cast_i.header.msg_type)
+    unique case (payload_cast_i.header.msg_type)
+      // most commands have no data
       e_lce_cmd_sync
       ,e_lce_cmd_set_clear
       ,e_lce_cmd_inv
@@ -66,8 +82,20 @@ module bp_me_wormhole_packet_encode_lce_cmd
       ,e_lce_cmd_st_tr
       ,e_lce_cmd_st_tr_wb
       ,e_lce_cmd_uc_st_done: packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_cmd_len_lp);
-      e_lce_cmd_data       : packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_data_len_lp);
-      e_lce_cmd_uc_data    : packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_uc_data_len_lp); 
+      // data and uncached data commands have data
+      e_lce_cmd_data
+      ,e_lce_cmd_uc_data:
+        unique case (payload_cast_i.header.size)
+          e_mem_msg_size_1: packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_data_len_1_lp);
+          e_mem_msg_size_2: packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_data_len_2_lp);
+          e_mem_msg_size_4: packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_data_len_4_lp);
+          e_mem_msg_size_8: packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_data_len_8_lp);
+          e_mem_msg_size_16: packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_data_len_16_lp);
+          e_mem_msg_size_32: packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_data_len_32_lp);
+          e_mem_msg_size_64: packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_data_len_64_lp);
+          e_mem_msg_size_128: packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_data_len_128_lp);
+          default: packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_cmd_len_lp);
+        endcase
       default: packet_cast_o = '0;
     endcase
   end

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_req.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_req.v
@@ -7,6 +7,7 @@
  *    packet that goes into the adapter.
  *
  *    packet = {payload, length, cord}
+ *
  */
 
 
@@ -15,16 +16,18 @@ module bp_me_wormhole_packet_encode_lce_req
   import bp_common_aviary_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
     `declare_bp_proc_params(bp_params_p)
-    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+    `declare_bp_lce_cce_if_header_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p)
+    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
 
-    , localparam lce_cce_req_packet_width_lp = 
+    , localparam lce_cce_req_packet_width_lp =
         `bsg_wormhole_concentrator_packet_width(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_req_width_lp)
+    , localparam lce_cce_req_packet_hdr_width_lp = (lce_cce_req_packet_width_lp-cce_block_width_p)
     )
    (input [lce_cce_req_width_lp-1:0]           payload_i
     , output [lce_cce_req_packet_width_lp-1:0] packet_o
     );
 
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p);
+  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
   `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_req_width_lp, lce_cce_req_packet_s);
 
   bp_lce_cce_req_s payload_cast_i;
@@ -32,13 +35,26 @@ module bp_me_wormhole_packet_encode_lce_req
   assign payload_cast_i = payload_i;
   assign packet_o = packet_cast_o;
 
-  // UC Store is header + dword_width_p = full length
+  // LCE Request with no data
   localparam lce_cce_req_req_len_lp =
-    `BSG_CDIV(lce_cce_req_packet_width_lp-$bits(payload_cast_i.data), coh_noc_flit_width_p) - 1;
-  localparam lce_cce_req_uc_wr_len_lp =
-    `BSG_CDIV(lce_cce_req_packet_width_lp, coh_noc_flit_width_p) - 1;
-  localparam lce_cce_req_uc_rd_len_lp =
-    `BSG_CDIV(lce_cce_req_packet_width_lp-$bits(payload_cast_i.data), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_req_packet_hdr_width_lp, coh_noc_flit_width_p) - 1;
+  // LCE Requests with 1B to 128B of data
+  localparam lce_cce_req_data_len_1_lp =
+    `BSG_CDIV(lce_cce_req_packet_hdr_width_lp+(1*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cce_req_data_len_2_lp =
+    `BSG_CDIV(lce_cce_req_packet_hdr_width_lp+(2*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cce_req_data_len_4_lp =
+    `BSG_CDIV(lce_cce_req_packet_hdr_width_lp+(4*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cce_req_data_len_8_lp =
+    `BSG_CDIV(lce_cce_req_packet_hdr_width_lp+(8*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cce_req_data_len_16_lp =
+    `BSG_CDIV(lce_cce_req_packet_hdr_width_lp+(16*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cce_req_data_len_32_lp =
+    `BSG_CDIV(lce_cce_req_packet_hdr_width_lp+(32*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cce_req_data_len_64_lp =
+    `BSG_CDIV(lce_cce_req_packet_hdr_width_lp+(64*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cce_req_data_len_128_lp =
+    `BSG_CDIV(lce_cce_req_packet_hdr_width_lp+(128*8), coh_noc_flit_width_p) - 1;
 
   logic [coh_noc_cord_width_p-1:0] cce_cord_li;
   logic [coh_noc_cid_width_p-1:0]  cce_cid_li;
@@ -55,11 +71,24 @@ module bp_me_wormhole_packet_encode_lce_req
     packet_cast_o.cid     = cce_cid_li;
     packet_cast_o.cord    = cce_cord_li;
 
-    case (payload_cast_i.header.msg_type)
+    unique case (payload_cast_i.header.msg_type)
+      // read, write, and uncached read requests have no data
       e_lce_req_type_rd
-      ,e_lce_req_type_wr  : packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_req_len_lp);
-      e_lce_req_type_uc_rd: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_uc_wr_len_lp);
-      e_lce_req_type_uc_wr: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_uc_wr_len_lp);
+      ,e_lce_req_type_wr
+      ,e_lce_req_type_uc_rd: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_req_len_lp);
+      // uncached write (store) has data
+      e_lce_req_type_uc_wr:
+        unique case (payload_cast_i.header.size)
+          e_mem_msg_size_1: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_data_len_1_lp);
+          e_mem_msg_size_2: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_data_len_2_lp);
+          e_mem_msg_size_4: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_data_len_4_lp);
+          e_mem_msg_size_8: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_data_len_8_lp);
+          e_mem_msg_size_16: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_data_len_16_lp);
+          e_mem_msg_size_32: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_data_len_32_lp);
+          e_mem_msg_size_64: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_data_len_64_lp);
+          e_mem_msg_size_128: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_data_len_128_lp);
+          default: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_req_len_lp);
+        endcase
       default: packet_cast_o = '0;
     endcase
   end

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_resp.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_resp.v
@@ -15,16 +15,17 @@ module bp_me_wormhole_packet_encode_lce_resp
   import bp_common_aviary_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
     `declare_bp_proc_params(bp_params_p)
-    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
 
-    , localparam lce_cce_resp_packet_width_lp = 
+    , localparam lce_cce_resp_packet_width_lp =
         `bsg_wormhole_concentrator_packet_width(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_resp_width_lp)
+    , localparam lce_cce_resp_packet_hdr_width_lp = (lce_cce_resp_packet_width_lp-cce_block_width_p)
     )
    (input [lce_cce_resp_width_lp-1:0]           payload_i
     , output [lce_cce_resp_packet_width_lp-1:0] packet_o
     );
 
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p);
+  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
   `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_resp_width_lp, lce_cce_resp_packet_s);
 
   bp_lce_cce_resp_s payload_cast_i;
@@ -32,10 +33,26 @@ module bp_me_wormhole_packet_encode_lce_resp
   assign payload_cast_i = payload_i;
   assign packet_o = packet_cast_o;
 
+  // LCE Request with no data
   localparam lce_cce_resp_ack_len_lp =
-    `BSG_CDIV(lce_cce_resp_packet_width_lp-$bits(payload_cast_i.data), coh_noc_flit_width_p) - 1;
-  localparam lce_cce_resp_wb_len_lp =
-    `BSG_CDIV(lce_cce_resp_packet_width_lp, coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_resp_packet_hdr_width_lp, coh_noc_flit_width_p) - 1;
+  // LCE Requests with 1B to 128B of data
+  localparam lce_cce_resp_data_len_1_lp =
+    `BSG_CDIV(lce_cce_resp_packet_hdr_width_lp+(1*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cce_resp_data_len_2_lp =
+    `BSG_CDIV(lce_cce_resp_packet_hdr_width_lp+(2*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cce_resp_data_len_4_lp =
+    `BSG_CDIV(lce_cce_resp_packet_hdr_width_lp+(4*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cce_resp_data_len_8_lp =
+    `BSG_CDIV(lce_cce_resp_packet_hdr_width_lp+(8*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cce_resp_data_len_16_lp =
+    `BSG_CDIV(lce_cce_resp_packet_hdr_width_lp+(16*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cce_resp_data_len_32_lp =
+    `BSG_CDIV(lce_cce_resp_packet_hdr_width_lp+(32*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cce_resp_data_len_64_lp =
+    `BSG_CDIV(lce_cce_resp_packet_hdr_width_lp+(64*8), coh_noc_flit_width_p) - 1;
+  localparam lce_cce_resp_data_len_128_lp =
+    `BSG_CDIV(lce_cce_resp_packet_hdr_width_lp+(128*8), coh_noc_flit_width_p) - 1;
 
   logic [coh_noc_cord_width_p-1:0] cce_cord_li;
   logic [coh_noc_cid_width_p-1:0]  cce_cid_li;
@@ -52,12 +69,25 @@ module bp_me_wormhole_packet_encode_lce_resp
     packet_cast_o.cid     = cce_cid_li;
     packet_cast_o.cord    = cce_cord_li;
 
-    case (payload_cast_i.header.msg_type)
+    unique case (payload_cast_i.header.msg_type)
+      // acks and null wb send no data
       e_lce_cce_sync_ack
       ,e_lce_cce_inv_ack
-      ,e_lce_cce_coh_ack    : packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_ack_len_lp);
-      e_lce_cce_resp_wb     : packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_wb_len_lp);
-      e_lce_cce_resp_null_wb: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_ack_len_lp);
+      ,e_lce_cce_coh_ack
+      ,e_lce_cce_resp_null_wb: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_ack_len_lp);
+      // writeback sends data
+      e_lce_cce_resp_wb:
+        unique case (payload_cast_i.header.size)
+          e_mem_msg_size_1: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_data_len_1_lp);
+          e_mem_msg_size_2: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_data_len_2_lp);
+          e_mem_msg_size_4: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_data_len_4_lp);
+          e_mem_msg_size_8: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_data_len_8_lp);
+          e_mem_msg_size_16: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_data_len_16_lp);
+          e_mem_msg_size_32: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_data_len_32_lp);
+          e_mem_msg_size_64: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_data_len_64_lp);
+          e_mem_msg_size_128: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_data_len_128_lp);
+          default: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_ack_len_lp);
+        endcase
       default: packet_cast_o = '0;
     endcase
   end

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v
@@ -63,6 +63,8 @@ module bp_me_wormhole_packet_encode_mem_cmd
     `BSG_CDIV(mem_cmd_packet_width_lp-$bits(mem_cmd_cast_i.data) + 8*32, mem_noc_flit_width_p) - 1;
   localparam mem_cmd_data_len_64_lp =
     `BSG_CDIV(mem_cmd_packet_width_lp-$bits(mem_cmd_cast_i.data) + 8*64, mem_noc_flit_width_p) - 1;
+  localparam mem_cmd_data_len_128_lp =
+    `BSG_CDIV(mem_cmd_packet_width_lp-$bits(mem_cmd_cast_i.data) + 8*128, mem_noc_flit_width_p) - 1;
 
   logic [len_width_p-1:0] data_cmd_len_li;
 
@@ -70,7 +72,7 @@ module bp_me_wormhole_packet_encode_mem_cmd
     packet_cast_o = '0;
 
     packet_cast_o.data       = mem_cmd_cast_i.data;
-    packet_cast_o.msg        = mem_cmd_cast_i[0+:cce_mem_msg_width_lp-cce_block_width_p];
+    packet_cast_o.msg        = mem_cmd_cast_i.header;
     packet_cast_o.src_cord   = src_cord_i;
     packet_cast_o.src_cid    = src_cid_i;
 
@@ -85,6 +87,7 @@ module bp_me_wormhole_packet_encode_mem_cmd
       e_mem_msg_size_16: data_cmd_len_li = len_width_p'(mem_cmd_data_len_16_lp);
       e_mem_msg_size_32: data_cmd_len_li = len_width_p'(mem_cmd_data_len_32_lp);
       e_mem_msg_size_64: data_cmd_len_li = len_width_p'(mem_cmd_data_len_64_lp);
+      e_mem_msg_size_128: data_cmd_len_li = len_width_p'(mem_cmd_data_len_128_lp);
       default: data_cmd_len_li = '0;
     endcase
 

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
@@ -61,6 +61,8 @@ module bp_me_wormhole_packet_encode_mem_resp
     `BSG_CDIV(mem_resp_packet_width_lp-$bits(mem_resp_cast_i.data) + 8*32, mem_noc_flit_width_p) - 1;
   localparam mem_resp_data_len_64_lp =
     `BSG_CDIV(mem_resp_packet_width_lp-$bits(mem_resp_cast_i.data) + 8*64, mem_noc_flit_width_p) - 1;
+  localparam mem_resp_data_len_128_lp =
+    `BSG_CDIV(mem_resp_packet_width_lp-$bits(mem_resp_cast_i.data) + 8*128, mem_noc_flit_width_p) - 1;
 
   logic [len_width_p-1:0] data_resp_len_li;
 
@@ -83,6 +85,7 @@ module bp_me_wormhole_packet_encode_mem_resp
       e_mem_msg_size_16: data_resp_len_li = len_width_p'(mem_resp_data_len_16_lp);
       e_mem_msg_size_32: data_resp_len_li = len_width_p'(mem_resp_data_len_32_lp);
       e_mem_msg_size_64: data_resp_len_li = len_width_p'(mem_resp_data_len_64_lp);
+      e_mem_msg_size_128: data_resp_len_li = len_width_p'(mem_resp_data_len_128_lp);
       default: data_resp_len_li = '0;
     endcase
 

--- a/bp_me/syn/flist.vcs
+++ b/bp_me/syn/flist.vcs
@@ -80,6 +80,7 @@ $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_sync_synth.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_synth.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
+$BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_banked.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v

--- a/bp_me/test/common/bp_me_nonsynth_cce_tracer.v
+++ b/bp_me/test/common/bp_me_nonsynth_cce_tracer.v
@@ -27,7 +27,7 @@ module bp_me_nonsynth_cce_tracer
     , localparam lg_cce_way_groups_lp      = `BSG_SAFE_CLOG2(cce_way_groups_p)
 
     `declare_bp_lce_cce_if_header_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p)
-    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
     `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
   )
   (input                                        clk_i
@@ -71,7 +71,7 @@ module bp_me_nonsynth_cce_tracer
 
   // LCE-CCE and Mem-CCE Interface
   `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p);
+  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
 
   bp_lce_cce_req_s           lce_req;
   bp_lce_cce_resp_s          lce_resp;
@@ -102,7 +102,7 @@ module bp_me_nonsynth_cce_tracer
       if (lce_req_v_i & lce_req_yumi_i) begin
         if (lce_req.header.msg_type == e_lce_req_type_rd | lce_req.header.msg_type == e_lce_req_type_wr) begin
         $fdisplay(file, "[%t]: CCE[%0d] REQ LCE[%0d] addr[%H] wg[%0d] wr[%0b] ne[%0b] uc[%0b] lruWay[%0d]"
-                 , $time, cce_id_i, lce_req.header.src_id, lce_req.header.addr
+                 , $time, lce_req.header.dst_id, lce_req.header.src_id, lce_req.header.addr
                  , lce_req.header.addr[lg_block_size_in_bytes_lp +: lg_cce_way_groups_lp]
                  , (lce_req.header.msg_type == e_lce_req_type_wr)
                  , lce_req.header.non_exclusive
@@ -110,12 +110,21 @@ module bp_me_nonsynth_cce_tracer
                  , lce_req.header.lru_way_id
                  );
         end
-        if (lce_req.header.msg_type == e_lce_req_type_uc_rd | lce_req.header.msg_type == e_lce_req_type_uc_wr) begin
+        if (lce_req.header.msg_type == e_lce_req_type_uc_rd) begin
         $fdisplay(file, "[%t]: CCE[%0d] REQ LCE[%0d] addr[%H] wr[%0b] ne[%0b] uc[%0b] lruWay[%0d] lruDirty[%0b]"
-                 , $time, cce_id_i, lce_req.header.src_id, lce_req.header.addr, (lce_req.header.msg_type == e_lce_req_type_uc_wr)
+                 , $time, lce_req.header.dst_id, lce_req.header.src_id, lce_req.header.addr, (lce_req.header.msg_type == e_lce_req_type_uc_wr)
                  , 1'b0
                  , 1'b1
                  , '0, '0
+                 );
+        end
+        if (lce_req.header.msg_type == e_lce_req_type_uc_wr) begin
+        $fdisplay(file, "[%t]: CCE[%0d] REQ LCE[%0d] addr[%H] wr[%0b] ne[%0b] uc[%0b] lruWay[%0d] lruDirty[%0b] %H"
+                 , $time, lce_req.header.dst_id, lce_req.header.src_id, lce_req.header.addr, (lce_req.header.msg_type == e_lce_req_type_uc_wr)
+                 , 1'b0
+                 , 1'b1
+                 , '0, '0
+                 , lce_req.data
                  );
         end
       end
@@ -124,14 +133,14 @@ module bp_me_nonsynth_cce_tracer
             | (lce_resp.header.msg_type == e_lce_cce_inv_ack)
             | (lce_resp.header.msg_type == e_lce_cce_coh_ack)) begin
         $fdisplay(file, "[%t]: CCE[%0d] RESP LCE[%0d] addr[%H] wg[%0d] ack[%4b]"
-                 , $time, cce_id_i, lce_resp.header.src_id, lce_resp.header.addr
+                 , $time, lce_resp.header.dst_id, lce_resp.header.src_id, lce_resp.header.addr
                  , lce_resp.header.addr[lg_block_size_in_bytes_lp +: lg_cce_way_groups_lp]
                  , lce_resp.header.msg_type);
         end
         if ((lce_resp.header.msg_type == e_lce_cce_resp_wb)
             | (lce_resp.header.msg_type == e_lce_cce_resp_null_wb)) begin
         $fdisplay(file, "[%t]: CCE[%0d] DATA RESP LCE[%0d] addr[%H] wg[%0d] null_wb[%0b] %H"
-                 , $time, cce_id_i, lce_resp.header.src_id, lce_resp.header.addr
+                 , $time, lce_resp.header.dst_id, lce_resp.header.src_id, lce_resp.header.addr
                  , lce_resp.header.addr[lg_block_size_in_bytes_lp +: lg_cce_way_groups_lp]
                  , (lce_resp.header.msg_type == e_lce_cce_resp_null_wb)
                  , lce_resp.data);
@@ -159,7 +168,7 @@ module bp_me_nonsynth_cce_tracer
       if (lce_cmd_v_i & lce_cmd_ready_i) begin
         if (lce_cmd.header.msg_type == e_lce_cmd_data) begin
         $fdisplay(file, "[%t]: CCE[%0d] DATA CMD LCE[%0d] cmd[%4b] addr[%H] wg[%0d] st[%3b] way[%0d] %H"
-                 , $time, cce_id_i, lce_cmd.header.dst_id, lce_cmd.header.msg_type, lce_cmd.header.addr
+                 , $time, lce_cmd.header.src_id, lce_cmd.header.dst_id, lce_cmd.header.msg_type, lce_cmd.header.addr
                  , lce_cmd.header.addr[lg_block_size_in_bytes_lp +: lg_cce_way_groups_lp]
                  , lce_cmd.header.state, lce_cmd.header.way_id
                  , lce_cmd.data
@@ -167,7 +176,7 @@ module bp_me_nonsynth_cce_tracer
         end
         else if (lce_cmd.header.msg_type == e_lce_cmd_uc_data) begin
         $fdisplay(file, "[%t]: CCE[%0d] DATA CMD LCE[%0d] cmd[%4b] addr[%H] wg[%0d] st[%3b] way[%0d] %H"
-                 , $time, cce_id_i, lce_cmd.header.dst_id, lce_cmd.header.msg_type, lce_cmd.header.addr
+                 , $time, lce_cmd.header.src_id, lce_cmd.header.dst_id, lce_cmd.header.msg_type, lce_cmd.header.addr
                  , lce_cmd.header.addr[lg_block_size_in_bytes_lp +: lg_cce_way_groups_lp]
                  , lce_cmd.header.state, lce_cmd.header.way_id
                  , lce_cmd.data
@@ -176,7 +185,7 @@ module bp_me_nonsynth_cce_tracer
 
         else begin
         $fdisplay(file, "[%t]: CCE[%0d] CMD LCE[%0d] addr[%H] wg[%0d] cmd[%4b] way[%0d] st[%3b] tgt[%0d] tgtWay[%0d]"
-                 , $time, cce_id_i, lce_cmd.header.dst_id, lce_cmd.header.addr
+                 , $time, lce_cmd.header.src_id, lce_cmd.header.dst_id, lce_cmd.header.addr
                  , lce_cmd.header.addr[lg_block_size_in_bytes_lp +: lg_cce_way_groups_lp]
                  , lce_cmd.header.msg_type, lce_cmd.header.way_id
                  , lce_cmd.header.state, lce_cmd.header.target, lce_cmd.header.target_way_id

--- a/bp_me/test/common/bp_me_nonsynth_mock_lce_tag_lookup.v
+++ b/bp_me/test/common/bp_me_nonsynth_mock_lce_tag_lookup.v
@@ -1,0 +1,55 @@
+/**
+ * bp_me_nonsynth_mock_lce_tag_lookup.v
+ *
+ *
+ */
+
+module bp_me_nonsynth_mock_lce_tag_lookup
+  import bp_common_pkg::*;
+  import bp_cce_pkg::*;
+  #(parameter assoc_p="inv"
+    , parameter ptag_width_p="inv"
+    , localparam dir_entry_width_lp=`bp_cce_dir_entry_width(ptag_width_p)
+    , localparam lg_assoc_lp=`BSG_SAFE_CLOG2(assoc_p)
+   )
+  (input [assoc_p-1:0][dir_entry_width_lp-1:0] tag_set_i
+   , input [ptag_width_p-1:0] ptag_i
+   , output logic hit_o
+   , output logic dirty_o
+   , output logic [lg_assoc_lp-1:0] way_o
+   , output bp_coh_states_e state_o
+  );
+
+  `declare_bp_cce_dir_entry_s(ptag_width_p);
+  dir_entry_s [assoc_p-1:0] tags;
+  assign tags = tag_set_i;
+
+  logic [assoc_p-1:0] hits;
+  genvar i;
+  generate
+  for (i = 0; i < assoc_p; i=i+1) begin
+    assign hits[i] = ((tags[i].tag == ptag_i) && (tags[i].state != e_COH_I));
+  end
+  endgenerate
+
+  logic way_v_lo;
+  logic [lg_assoc_lp-1:0] way_lo;
+  bsg_encode_one_hot
+    #(.width_p(assoc_p))
+  hits_to_way_id
+    (.i(hits)
+     ,.addr_o(way_lo)
+     ,.v_o(way_v_lo)
+    );
+
+  // suppress unused warning
+  wire unused0 = way_v_lo;
+
+  // hit_o is set if tag matched and coherence state was any valid state
+  assign hit_o = |hits;
+  assign way_o = way_lo;
+  assign dirty_o = (tags[way_o].state == e_COH_M);
+  assign state_o = tags[way_o].state;
+
+endmodule
+

--- a/bp_me/test/tb/bp_cce/flist.vcs
+++ b/bp_me/test/tb/bp_cce/flist.vcs
@@ -3,6 +3,7 @@ $BASEJUMP_STL_DIR/bsg_fsb/bsg_fsb_node_trace_replay.v
 $BP_ME_DIR/test/common/bp_me_nonsynth_pkg.vh
 $BP_ME_DIR/test/common/bp_me_nonsynth_cce_tracer.v
 $BP_ME_DIR/test/common/bp_me_nonsynth_lce_tracer.v
+$BP_ME_DIR/test/common/bp_me_nonsynth_mock_lce_tag_lookup.v
 $BP_ME_DIR/test/common/bp_me_nonsynth_mock_lce.v
 $BP_ME_DIR/test/common/bp_mem.v
 $BP_ME_DIR/test/common/bp_mem_transducer.v

--- a/bp_me/test/tb/bp_cce/test_bp.cpp
+++ b/bp_me/test/tb/bp_cce/test_bp.cpp
@@ -28,7 +28,7 @@ int sc_main(int argc, char **argv)
 #if VM_TRACE
   VerilatedVcdSc* wf = new VerilatedVcdSc;
   tb->trace(wf, 10);
-  wf->open("vcdplus.vpd");
+  wf->open("dump.vcd");
 #endif
 
   reset = 1;

--- a/bp_me/test/tb/bp_cce/testbench.v
+++ b/bp_me/test/tb/bp_cce/testbench.v
@@ -16,7 +16,8 @@ module testbench
    `declare_bp_proc_params(bp_params_p)
 
    // interface widths
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+   `declare_bp_lce_cce_if_header_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p)
+   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
    `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
 
    , parameter cce_trace_p = 0
@@ -62,7 +63,7 @@ module testbench
 
 `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
 `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
-`declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p);
+`declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
 
 // CFG IF
 bp_cfg_bus_s           cfg_bus_lo;
@@ -76,7 +77,7 @@ bp_cce_mem_msg_s       mem_cmd;
 logic                  mem_cmd_v, mem_cmd_ready;
 
 // LCE-CCE IF
-bp_lce_cce_req_s       lce_req, lce_req_lo;
+bp_lce_cce_req_s       lce_req_lo, lce_req_to_cce;
 logic                  lce_req_v, lce_req_v_lo, lce_req_yumi, lce_req_ready_li;
 bp_lce_cce_resp_s      lce_resp, lce_resp_lo;
 logic                  lce_resp_v, lce_resp_v_lo, lce_resp_yumi, lce_resp_ready_li;
@@ -188,7 +189,7 @@ bind bp_cce_wrapper
       ,.reset_i(reset_i)
       ,.freeze_i(cfg_bus_cast_i.freeze)
 
-      ,.cce_id_i('0)
+      ,.cce_id_i(cfg_bus_cast_i.cce_id)
 
       // To CCE
       ,.lce_req_i(lce_req_i)
@@ -226,7 +227,7 @@ lce_req_buffer
   ,.ready_o(lce_req_ready_li)
   // to CCE
   ,.v_o(lce_req_v)
-  ,.data_o(lce_req)
+  ,.data_o(lce_req_to_cce)
   ,.yumi_i(lce_req_yumi)
   );
 
@@ -262,7 +263,7 @@ wrapper
   ,.lce_cmd_v_o(lce_cmd_v)
   ,.lce_cmd_ready_i(lce_cmd_ready)
 
-  ,.lce_req_i(lce_req)
+  ,.lce_req_i(lce_req_to_cce)
   ,.lce_req_v_i(lce_req_v)
   ,.lce_req_yumi_o(lce_req_yumi)
 
@@ -375,6 +376,7 @@ bp_mem_nonsynth_tracer
    ,.mem_resp_yumi_i(mem_resp_yumi)
    );
 
+logic [coh_noc_cord_width_p-1:0] cord_li = {{coh_noc_y_cord_width_p'(1'b1)}, {coh_noc_x_cord_width_p'('0)}};
 logic cfg_resp_v_lo;
 bp_cfg
  #(.bp_params_p(bp_params_p))
@@ -393,7 +395,7 @@ bp_cfg
    ,.cfg_bus_o(cfg_bus_lo)
    ,.did_i('0)
    ,.host_did_i('0)
-   ,.cord_i('0)
+   ,.cord_i(cord_li)
    ,.irf_data_i('0)
    ,.npc_data_i('0)
    ,.csr_data_i('0)

--- a/bp_me/test/tb/bp_cce/wrapper.v
+++ b/bp_me/test/tb/bp_cce/wrapper.v
@@ -18,7 +18,7 @@ module wrapper
    `declare_bp_proc_params(bp_params_p)
 
    // interface widths
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
    `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
 

--- a/bp_top/src/v/bp_cacc_tile.v
+++ b/bp_top/src/v/bp_cacc_tile.v
@@ -11,7 +11,8 @@ module bp_cacc_tile
   
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+   `declare_bp_lce_cce_if_header_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p)
+   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
 
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam io_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(io_noc_flit_width_p)
@@ -34,9 +35,10 @@ module bp_cacc_tile
    );
 
   `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p);
+  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
 
-  `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_req_width_lp, lce_req_packet_s);
+  `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_req_header_width_lp+dword_width_p, lce_req_packet_s);
+  `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_req_width_lp, cce_lce_req_packet_s);
   `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cmd_width_lp, lce_cmd_packet_s);
   `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_resp_width_lp, lce_resp_packet_s);
    
@@ -54,7 +56,7 @@ module bp_cacc_tile
   logic cce_io_resp_v_li, cce_io_resp_yumi_lo;
 
   // accelerator-side connections network connections
-  bp_lce_cce_req_s  lce_req_lo;
+  logic [lce_cce_req_header_width_lp+dword_width_p-1:0]  lce_req_lo;
   logic             lce_req_v_lo, lce_req_ready_li;
   bp_lce_cce_resp_s lce_resp_lo;
   logic             lce_resp_v_lo, lce_resp_ready_li;
@@ -103,9 +105,11 @@ module bp_cacc_tile
 
 
 ////////////////////////////////////////////////////////////////////
-  lce_req_packet_s lce_req_packet_li, lce_req_packet_lo;
+  lce_req_packet_s lce_req_packet_lo;
+  cce_lce_req_packet_s lce_req_packet_li;
   bp_me_wormhole_packet_encode_lce_req
-   #(.bp_params_p(bp_params_p))
+   #(.bp_params_p(bp_params_p)
+     )
    req_encode
     (.payload_i(lce_req_lo)
      ,.packet_o(lce_req_packet_lo)

--- a/bp_top/src/v/bp_cacc_tile_node.v
+++ b/bp_top/src/v/bp_cacc_tile_node.v
@@ -10,8 +10,6 @@ module bp_cacc_tile_node
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
 
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
@@ -35,9 +33,6 @@ module bp_cacc_tile_node
    , output [S:W][coh_noc_ral_link_width_lp-1:0] coh_lce_resp_link_o
    );
 
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
-  `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-  
   // Declare the routing links
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, bp_coh_ready_and_link_s);
   

--- a/bp_top/src/v/bp_cacc_vdp.v
+++ b/bp_top/src/v/bp_cacc_vdp.v
@@ -9,7 +9,7 @@ module bp_cacc_vdp
  import bp_be_dcache_pkg::*;  
   #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
     `declare_bp_proc_params(bp_params_p)
-    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
     `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
     `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, acache_sets_p, acache_assoc_p, dword_width_p, acache_block_width_p, cache)
     , localparam cfg_bus_width_lp= `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)

--- a/bp_top/src/v/bp_clint_node.v
+++ b/bp_top/src/v/bp_clint_node.v
@@ -10,7 +10,6 @@ module bp_clint_node
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
 
    , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
    )
@@ -34,7 +33,6 @@ module bp_clint_node
    , output [S:W][mem_noc_ral_link_width_lp-1:0]        mem_resp_link_o
    );
 
-`declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
 `declare_bsg_ready_and_link_sif_s(mem_noc_flit_width_p, mem_noc_ral_link_s);
 
 // Core side links

--- a/bp_top/src/v/bp_core.v
+++ b/bp_top/src/v/bp_core.v
@@ -16,7 +16,7 @@ module bp_core
   #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
     `declare_bp_proc_params(bp_params_p)
     `declare_bp_fe_be_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
-    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
     `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
     `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache)
 

--- a/bp_top/src/v/bp_core_complex.v
+++ b/bp_top/src/v/bp_core_complex.v
@@ -18,8 +18,6 @@ module bp_core_complex
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
 
    , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)

--- a/bp_top/src/v/bp_core_minimal.v
+++ b/bp_top/src/v/bp_core_minimal.v
@@ -17,7 +17,6 @@ module bp_core_minimal
   #(parameter bp_params_e bp_params_p = e_bp_single_core_cfg
     `declare_bp_proc_params(bp_params_p)
     `declare_bp_fe_be_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
-    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
     `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache)
     `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
 

--- a/bp_top/src/v/bp_io_link_to_lce.v
+++ b/bp_top/src/v/bp_io_link_to_lce.v
@@ -10,7 +10,7 @@ module bp_io_link_to_lce
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
 
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
@@ -39,10 +39,8 @@ module bp_io_link_to_lce
    // No lce_resp acknowledgements for I/O (uncached) accesses
    );
 
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
   `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-  `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_req_width_lp, lce_req_packet_s);
-  `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cmd_width_lp, lce_cmd_packet_s);
 
   bp_cce_mem_msg_s io_cmd_li;
   bp_cce_mem_msg_s io_resp_lo;

--- a/bp_top/src/v/bp_io_tile.v
+++ b/bp_top/src/v/bp_io_tile.v
@@ -6,7 +6,7 @@ module bp_io_tile
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
    `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
 
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
@@ -33,7 +33,7 @@ module bp_io_tile
    );
 
   `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p);
+  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
   `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_req_width_lp, lce_req_packet_s);
   `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cmd_width_lp, lce_cmd_packet_s);
 
@@ -111,7 +111,8 @@ module bp_io_tile
 
   lce_req_packet_s lce_req_packet_li, lce_req_packet_lo;
   bp_me_wormhole_packet_encode_lce_req
-   #(.bp_params_p(bp_params_p))
+   #(.bp_params_p(bp_params_p)
+     )
    req_encode
     (.payload_i(lce_lce_req_lo)
      ,.packet_o(lce_req_packet_lo)

--- a/bp_top/src/v/bp_io_tile_node.v
+++ b/bp_top/src/v/bp_io_tile_node.v
@@ -8,8 +8,6 @@ module bp_io_tile_node
  import bsg_wormhole_router_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
 
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam io_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(io_noc_flit_width_p)
@@ -40,9 +38,6 @@ module bp_io_tile_node
    , output [E:W][io_noc_ral_link_width_lp-1:0]  io_resp_link_o
    );
 
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
-  `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-  
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, bp_coh_ready_and_link_s);
   `declare_bsg_ready_and_link_sif_s(io_noc_flit_width_p, bp_io_ready_and_link_s);
   

--- a/bp_top/src/v/bp_l2e_tile.v
+++ b/bp_top/src/v/bp_l2e_tile.v
@@ -13,7 +13,7 @@ module bp_l2e_tile
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
 
     , localparam cfg_bus_width_lp        = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
    // Wormhole parameters
@@ -45,7 +45,7 @@ module bp_l2e_tile
    );
 
 `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
-`declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+`declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
 `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
 
 // Cast the routing links

--- a/bp_top/src/v/bp_l2e_tile_node.v
+++ b/bp_top/src/v/bp_l2e_tile_node.v
@@ -11,8 +11,6 @@ module bp_l2e_tile_node
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
 
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)

--- a/bp_top/src/v/bp_mem_complex.v
+++ b/bp_top/src/v/bp_mem_complex.v
@@ -9,7 +9,6 @@ module bp_mem_complex
  import bsg_wormhole_router_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
 
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
@@ -36,8 +35,6 @@ module bp_mem_complex
    , input [mem_noc_ral_link_width_lp-1:0]                   dram_resp_link_i
    );
 
-  `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, bp_coh_ready_and_link_s);
   `declare_bsg_ready_and_link_sif_s(mem_noc_flit_width_p, bp_mem_ready_and_link_s);
 

--- a/bp_top/src/v/bp_multicore.v
+++ b/bp_top/src/v/bp_multicore.v
@@ -18,7 +18,6 @@ module bp_multicore
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
 
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
@@ -50,8 +49,6 @@ module bp_multicore
    );
 
 `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
-`declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-`declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
 `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, bp_coh_ready_and_link_s);
 `declare_bsg_ready_and_link_sif_s(io_noc_flit_width_p, bp_io_ready_and_link_s);
 `declare_bsg_ready_and_link_sif_s(mem_noc_flit_width_p, bp_mem_ready_and_link_s);

--- a/bp_top/src/v/bp_sacc_tile.v
+++ b/bp_top/src/v/bp_sacc_tile.v
@@ -11,7 +11,7 @@ module bp_sacc_tile
   
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
 
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam io_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(io_noc_flit_width_p)
@@ -31,7 +31,7 @@ module bp_sacc_tile
    );
 
   `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p);
+  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
 
   `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_req_width_lp, lce_req_packet_s);
   `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cmd_width_lp, lce_cmd_packet_s);
@@ -115,7 +115,8 @@ module bp_sacc_tile
 
   lce_req_packet_s lce_req_packet_li, lce_req_packet_lo;
   bp_me_wormhole_packet_encode_lce_req
-   #(.bp_params_p(bp_params_p))
+   #(.bp_params_p(bp_params_p)
+     )
    req_encode
     (.payload_i(lce_lce_req_lo)
      ,.packet_o(lce_req_packet_lo)

--- a/bp_top/src/v/bp_sacc_tile_node.v
+++ b/bp_top/src/v/bp_sacc_tile_node.v
@@ -10,8 +10,6 @@ module bp_sacc_tile_node
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
 
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
@@ -32,9 +30,6 @@ module bp_sacc_tile_node
    , output [S:W][coh_noc_ral_link_width_lp-1:0] coh_lce_cmd_link_o
    );
 
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
-  `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-  
   // Declare the routing links
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, bp_coh_ready_and_link_s);
   

--- a/bp_top/src/v/bp_sacc_vdp.v
+++ b/bp_top/src/v/bp_sacc_vdp.v
@@ -9,7 +9,6 @@ module bp_sacc_vdp
  import bp_be_dcache_pkg::*;  
   #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
     `declare_bp_proc_params(bp_params_p)
-    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
     `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
     , localparam cfg_bus_width_lp= `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
     )

--- a/bp_top/src/v/bp_tile.v
+++ b/bp_top/src/v/bp_tile.v
@@ -18,7 +18,8 @@ module bp_tile
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+   `declare_bp_lce_cce_if_header_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p)
+   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
 
     , localparam cfg_bus_width_lp        = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
    // Wormhole parameters
@@ -48,7 +49,7 @@ module bp_tile
    );
 
 `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
-`declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+`declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
 `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
 
 // Cast the routing links
@@ -70,6 +71,7 @@ assign lce_resp_link_o = lce_resp_link_cast_o;
 logic timer_irq_li, software_irq_li, external_irq_li;
 
 // Proc-side connections network connections
+// Proc-side LCE Requests support up to dword_width_p of data, and are passed as header+data
 bp_lce_cce_req_s  [1:0] lce_req_lo;
 logic             [1:0] lce_req_v_lo, lce_req_ready_li;
 bp_lce_cce_resp_s [1:0] lce_resp_lo;
@@ -250,7 +252,8 @@ bp_coh_ready_and_link_s cce_lce_resp_link_li, cce_lce_resp_link_lo;
 for (genvar i = 0; i < 2; i++)
   begin : lce
     bp_me_wormhole_packet_encode_lce_req
-     #(.bp_params_p(bp_params_p))
+     #(.bp_params_p(bp_params_p)
+       )
      req_encode
       (.payload_i(lce_req_lo[i])
        ,.packet_o(lce_req_packet_lo[i])

--- a/bp_top/src/v/bp_tile_node.v
+++ b/bp_top/src/v/bp_tile_node.v
@@ -16,8 +16,6 @@ module bp_tile_node
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
 
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
@@ -53,9 +51,6 @@ module bp_tile_node
    , output [mem_noc_ral_link_width_lp-1:0]      mem_resp_link_o
    );
 
-  `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
-  `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-  
   // Declare the routing links
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, bp_coh_ready_and_link_s);
   `declare_bsg_ready_and_link_sif_s(mem_noc_flit_width_p, bp_mem_ready_and_link_s);

--- a/bp_top/test/common/bp_nonsynth_if_verif.v
+++ b/bp_top/test/common/bp_nonsynth_if_verif.v
@@ -11,7 +11,7 @@ module bp_nonsynth_if_verif
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_fe_be_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
-   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
    `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
 
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
@@ -23,7 +23,7 @@ assign proc_param = all_cfgs_gp[bp_params_p];
 
 `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
 `declare_bp_fe_be_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
-`declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, dword_width_p, cce_block_width_p)
+`declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
 `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
 
 initial 


### PR DESCRIPTION
This PR adds support for larger data widths in the LCE Request message/network (Issue #404). The ME and top were updated to support these changes. The LCE Request network coming from the D$/I$ has 64-bits of data, but the CCE now supports up to cce_block_width_p of data. The I/O tiles are configured to use cce_block_width_p requests. Further changes are needed for the accelerator configurations.

This PR also provides a workaround fix for a Verilator specific issue in the mock LCE (Issue #483). It appears something in the Verilator tool itself changed regarding bit selection from a 2D vector. The mock LCE was also rewritten to use bsg_mem instances for the tag, data, and dirty bit memories, and for some general cleanup.