### PR TITLE
Flush the pipeline on SATP write

### DIFF
--- a/bp_be/src/include/bp_be_internal_if_defines.vh
+++ b/bp_be/src/include/bp_be_internal_if_defines.vh
@@ -143,6 +143,7 @@
     logic                           eret;                                                          \
     logic                           fencei;                                                        \
     logic                           sfence;                                                        \
+    logic                           satp;                                                          \
   }  bp_be_trap_pkt_s;                                                                             \
                                                                                                    \
   typedef struct packed                                                                            \
@@ -204,7 +205,7 @@
    )
  
 `define bp_be_trap_pkt_width(vaddr_width_mp) \
-  (2 * vaddr_width_mp + rv64_priv_width_gp + dword_width_p + 6)
+  (2 * vaddr_width_mp + rv64_priv_width_gp + dword_width_p + 7)
 
 `define bp_be_wb_pkt_width(vaddr_width_mp) \
   (1                                                                                               \

--- a/bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v
@@ -309,7 +309,6 @@ always_comb
         decode.csr_v       = 1'b1;
         decode.serial_v    = 1'b1;
         casez (fe_exc_i)
-          e_instr_misaligned  : decode.fu_op = e_op_instr_misaligned;
           e_instr_access_fault: decode.fu_op = e_op_instr_access_fault;
           e_instr_page_fault  : decode.fu_op = e_op_instr_page_fault;
           e_itlb_miss         : decode.fu_op = e_itlb_fill;

--- a/bp_be/src/v/bp_be_checker/bp_be_director.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.v
@@ -239,7 +239,9 @@ always_comb
 
         flush_o = 1'b1;
       end
-    else if (trap_pkt.sfence)
+    // TODO: This is compliant but suboptimal, since satp is not required to flush TLBs
+    //   Should add message to fe-be interface
+    else if (trap_pkt.sfence | trap_pkt.satp)
       begin
         fe_cmd.opcode = e_op_itlb_fence;
         fe_cmd.vaddr  = commit_pkt.npc;

--- a/bp_be/src/v/bp_be_mem/bp_be_csr.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_csr.v
@@ -299,7 +299,7 @@ assign sip_wmask_li    = '{meip: 1'b0, seip: 1'b0
                             ,default: '0
                            };
 
-logic exception_v_o, interrupt_v_o, ret_v_o, sfence_v_o;
+logic exception_v_o, interrupt_v_o, ret_v_o, sfence_v_o, satp_v_o;
 // CSR data
 always_comb
   begin
@@ -339,6 +339,7 @@ always_comb
     exception_v_o    = '0;
     interrupt_v_o    = '0;
     ret_v_o          = '0;
+    satp_v_o         = '0;
     illegal_instr_o  = '0;
     csr_data_lo      = '0;
     sfence_v_o       = '0;
@@ -560,7 +561,7 @@ always_comb
               `CSR_ADDR_STVAL: stval_li = csr_data_li;
               // SIP subset of MIP
               `CSR_ADDR_SIP: mip_li = (mip_lo & ~sip_wmask_li) | (csr_data_li & sip_wmask_li);
-              `CSR_ADDR_SATP: satp_li = csr_data_li;
+              `CSR_ADDR_SATP: begin satp_li = csr_data_li; satp_v_o = 1'b1; end
               `CSR_ADDR_MVENDORID: begin end
               `CSR_ADDR_MARCHID: begin end
               `CSR_ADDR_MIMPID: begin end
@@ -674,6 +675,7 @@ assign trap_pkt_cast_o.sfence           = sfence_v_o;
 assign trap_pkt_cast_o.exception        = exception_v_o;
 assign trap_pkt_cast_o._interrupt       = interrupt_v_o;
 assign trap_pkt_cast_o.eret             = ret_v_o;
+assign trap_pkt_cast_o.satp             = satp_v_o;
 
 assign priv_mode_o      = priv_mode_r;
 assign translation_en_o = translation_en_r

--- a/bp_common/src/include/bp_common_fe_be_if.vh
+++ b/bp_common/src/include/bp_common_fe_be_if.vh
@@ -196,8 +196,8 @@ typedef enum logic
  * of why pc is redirected.
  * e_op_state_reset is used after the reset, which flushes all the states.
  * e_op_pc_redirection defines the changes of PC, which happens during the branches.
- * e_op_icache_fence happens when there is flush in the icache.
  * e_op_attaboy informs the frontend that the prediction is correct.
+ * e_op_icache_fence happens when there is flush in the icache.
  * e_op_itlb_fill_response happens when itlb populates translation.
  * e_op_itlb_fence issues a fence operation to itlb.
  */
@@ -205,11 +205,10 @@ typedef enum logic [2:0]
 {
   e_op_state_reset         = 0
   ,e_op_pc_redirection     = 1
-  ,e_op_interrupt          = 2
+  ,e_op_attaboy            = 2
   ,e_op_icache_fence       = 3
-  ,e_op_attaboy            = 4
-  ,e_op_itlb_fill_response = 5
-  ,e_op_itlb_fence         = 6
+  ,e_op_itlb_fill_response = 4
+  ,e_op_itlb_fence         = 5
 } bp_fe_command_queue_opcodes_e;
 
 /*
@@ -223,8 +222,7 @@ typedef enum logic [1:0]
 } bp_fe_misprediction_reason_e;
 
 /*
- * The exception code types. e_instr_addr_misaligned is when the instruction
- * addresses are not aligned. e_itlb_miss is when the instruction has a miss in
+ * The exception code types. e_itlb_miss is when the instruction has a miss in
  * the iTLB. ITLB misses can cause the instruction misaligned. Thus the frontend
  * detects the instruction miss first and then detect whether there is an ITLB
  * miss. e_instruction_access_fault is when the access control is violated.
@@ -232,10 +230,9 @@ typedef enum logic [1:0]
  */
 typedef enum logic [1:0]
 {
-  e_instr_misaligned    = 0
-  ,e_itlb_miss          = 1
-  ,e_instr_access_fault = 2
-  ,e_instr_page_fault   = 3
+   e_itlb_miss          = 0
+  ,e_instr_access_fault = 1
+  ,e_instr_page_fault   = 2
 } bp_fe_exception_code_e;
 
 /*
@@ -246,16 +243,16 @@ typedef enum logic [1:0]
  * e_subop_branch_mispredict is at-fault PC redirection.
  * e_subop_trap is at-fault PC redirection. It will changes the permission bits.
  * e_subop_context_switch is no-fault PC redirection. It redirect pc to a new address space.
+ * e_subop_translation_switch is no-fault PC redirection resulting from translation mode changes
 */
 typedef enum logic [2:0]
 {
-  e_subop_uret
-  ,e_subop_sret
-  ,e_subop_mret
+  e_subop_eret
   ,e_subop_interrupt
   ,e_subop_branch_mispredict
   ,e_subop_trap
   ,e_subop_context_switch
+  ,e_subop_translation_switch
 } bp_fe_command_queue_subopcodes_e;
 
 /* Declare width macros so that clients can use structs in ports before struct declaration */


### PR DESCRIPTION
The riscv-v spec dictates that SATP write must be reflected in immediately following fetches. So we flush the pipeline to force a refetch with address translation enabled