### PR TITLE
Adding Multicore Cosimulation and Checkpointing

### DIFF
--- a/bp_top/test/common/bp_nonsynth_cosim.v
+++ b/bp_top/test/common/bp_nonsynth_cosim.v
@@ -15,6 +15,7 @@ module bp_nonsynth_cosim
     , input                                   freeze_i
     , input                                   en_i
 
+    , input [31:0]                            num_core_i
     , input [`BSG_SAFE_CLOG2(num_core_p)-1:0] mhartid_i
     , input [63:0]                            config_file_i
     , input [31:0]                            cosim_instr_i
@@ -32,23 +33,20 @@ module bp_nonsynth_cosim
     , input                                   interrupt_v_i
     , input [dword_width_p-1:0]               cause_i
 
-    , output logic [num_core_p-1:0]           finish_o
+    , output logic                            finish_o
     );
 
-import "DPI-C" context function void init_dromajo(string cfg_f_name);
+import "DPI-C" context function void dromajo_init(string cfg_f_name, int hartid, int ncpus);
 import "DPI-C" context function bit  dromajo_step(int      hart_id,
                                                   longint pc,
                                                   int insn,
                                                   longint wdata);
 import "DPI-C" context function void dromajo_trap(int hart_id, longint cause);
 
-logic finish;
-
 always_ff @(negedge reset_i)
   if (en_i)
     begin
-      $display("Running with Dromajo cosimulation");
-      init_dromajo(config_file_i);
+      dromajo_init(config_file_i, mhartid_i, num_core_i);
     end
 
   bp_be_decode_s decode_r;

--- a/bp_top/test/common/dromajo_cosim.cpp
+++ b/bp_top/test/common/dromajo_cosim.cpp
@@ -4,14 +4,20 @@
 #include "stdlib.h"
 #include <string>
 
+using namespace std;
+
 dromajo_cosim_state_t* dromajo_pointer;
 uint64_t d_address = 0;
 uint64_t d_count = 0;
 
-extern "C" void init_dromajo(char* cfg_f_name) {
-  char *argv[] = {(char*)"Variane", cfg_f_name};
+extern "C" void dromajo_init(char* cfg_f_name, int hartid, int ncpus) {
 
-  dromajo_pointer = dromajo_cosim_init(2, argv);
+  if(hartid == 0) {
+    cout << "Running with Dromajo cosimulation" << endl;
+    string ncpus_str = "--ncpus=" + to_string(ncpus);
+    char *argv[] = {(char*)"", cfg_f_name, (char*)(&ncpus_str[0])};
+    dromajo_pointer = dromajo_cosim_init(3, argv);
+  }
 }
 
 extern "C" bool dromajo_step(int      hart_id,

--- a/bp_top/test/tb/bp_tethered/Makefile.params
+++ b/bp_top/test/tb/bp_tethered/Makefile.params
@@ -17,7 +17,8 @@ export PRELOAD_MEM_P  ?= 1
 export LOAD_NBF_P     ?= 0
 export COSIM_P        ?= 0
 
-export SAMPLE_MEMSIZE   ?= 32
+export SAMPLE_MEMSIZE   ?= 256
+export SAMPLE_NCPUS     ?= 1
 export SAMPLE_START_P   ?= 0
 export SAMPLE_WARMUP_P  ?= 0
 export SAMPLE_INSTR_P   ?= 0

--- a/bp_top/test/tb/bp_tethered/Makefile.testlist
+++ b/bp_top/test/tb/bp_tethered/Makefile.testlist
@@ -501,13 +501,14 @@ run_test@%:
 	$(MAKE) sim.$(TS) SUITE=$(SUITE) PROG=$(PROG)
 
 dromajo_dump:
-	$(DROMAJO) $(BP_TEST_MEM_DIR)/$(SUITE)/$(PROG).riscv --host \
+	$(DROMAJO) $(BP_TEST_MEM_DIR)/$(SUITE)/$(PROG).riscv --host --ncpus=$(SAMPLE_NCPUS) \
 		--dump_period=$(SAMPLE_INSTR_P) --save=dromajo --memory_size=$(SAMPLE_MEMSIZE)
 
 # Run an entire benchmark in parallel
 # Important parameters:
 #   SAMPLE_INSTR_P  - instructions per sample
 #   SAMPLE_WARMUP_P - instructions to run for warmup, without statistics
+#   SAMPLE_NCPUS    - number of Dromajo cores
 #   SAMPLE_MEMSIZE  - RAM size of the sample (affects simulation startup time)
 run_psample.%: dromajo_dump
 	$(eval CHECKPOINTS := $(subst .mainram,,$(subst dromajo.,,$(shell ls dromajo.*.mainram))))

--- a/bp_top/test/tb/bp_tethered/Makefile.vcs
+++ b/bp_top/test/tb/bp_tethered/Makefile.vcs
@@ -63,7 +63,7 @@ sim_sample.v: SIM_REPORT := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).sim.$(SUITE).$(PRO
 sim_sample.v: SIM_ERROR  := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).sim.$(SUITE).$(PROG).err
 $(SIM_DIR)/run_samplev: $(SAMPLE_COLLATERAL)
 	cd $(@D); \
-		$(DROMAJO) $(@D)/prog.riscv --host --maxinsn=$(SAMPLE_START_P) --save=dromajo --memory_size=$(SAMPLE_MEMSIZE)
+		$(DROMAJO) $(@D)/prog.riscv --host --ncpus=$(SAMPLE_NCPUS) --maxinsn=$(SAMPLE_START_P) --save=dromajo --memory_size=$(SAMPLE_MEMSIZE)
 	mv $(@D)/dromajo.*.mainram $(@D)/prog.mainram
 	mv $(@D)/dromajo.*.bootram $(@D)/prog.bootram
 	mv $(@D)/dromajo.*.bp_regs $(@D)/prog.nbf

--- a/bp_top/test/tb/bp_tethered/Makefile.verilator
+++ b/bp_top/test/tb/bp_tethered/Makefile.verilator
@@ -61,7 +61,7 @@ sim_sample.sc: SIM_REPORT := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).sim.$(SUITE).$(PR
 sim_sample.sc: SIM_ERROR  := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).sim.$(SUITE).$(PROG).err
 $(SIM_DIR)/run_samplesc: $(SIM_COLLATERAL)
 	cd $(@D); \
-		$(DROMAJO) $(@D)/prog.riscv --host --maxinsn=$(SAMPLE_START_P) --save=dromajo --memory_size=$(SAMPLE_MEMSIZE)
+		$(DROMAJO) $(@D)/prog.riscv --host --ncpus=$(SAMPLE_NCPUS) --maxinsn=$(SAMPLE_START_P) --save=dromajo --memory_size=$(SAMPLE_MEMSIZE)
 	mv $(@D)/dromajo.*.mainram $(@D)/prog.mainram
 	mv $(@D)/dromajo.*.bootram $(@D)/prog.bootram
 	mv $(@D)/dromajo.*.bp_regs $(@D)/prog.nbf

--- a/bp_top/test/tb/bp_tethered/testbench.v
+++ b/bp_top/test/tb/bp_tethered/testbench.v
@@ -61,14 +61,8 @@ module testbench
 
 `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
 
-initial begin
-  if (num_core_p > 1) begin
-    assert (cosim_p == 0) else $error("cosim_p not supported for num_core_p > 1");
-  end
-end
-
 logic [num_core_p-1:0] program_finish_lo;
-logic cosim_finish_lo;
+logic [num_core_p-1:0] cosim_finish_lo;
 
 bp_cce_mem_msg_s proc_mem_cmd_lo;
 logic proc_mem_cmd_v_lo, proc_mem_cmd_ready_li;
@@ -279,7 +273,7 @@ bind bp_be_top
      ,.reset_i(reset_i)
      ,.freeze_i(be_checker.scheduler.int_regfile.cfg_bus.freeze)
 
-     ,.mhartid_i('0)
+     ,.mhartid_i(be_checker.scheduler.int_regfile.cfg_bus.core_id)
 
      ,.decode_i(be_calculator.reservation_n.decode)
 
@@ -292,43 +286,39 @@ bind bp_be_top
      ,.rd_data_i(be_checker.scheduler.wb_pkt.rd_data)
      );
 
-  if (num_core_p == 1)
-    begin : cosim
-      bind bp_be_top
-        bp_nonsynth_cosim
-         #(.bp_params_p(bp_params_p))
-          cosim
-          (.clk_i(clk_i)
-           ,.reset_i(reset_i)
-           ,.freeze_i(be_checker.scheduler.int_regfile.cfg_bus.freeze)
-           ,.en_i(testbench.cosim_p == 1)
-           ,.cosim_instr_i(testbench.cosim_instr_p)
+bind bp_be_top
+  bp_nonsynth_cosim
+   #(.bp_params_p(bp_params_p))
+   cosim
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.freeze_i(be_checker.scheduler.int_regfile.cfg_bus.freeze)
+     ,.en_i(testbench.cosim_p == 1)
+     ,.cosim_instr_i(testbench.cosim_instr_p)
 
-           ,.mhartid_i(be_checker.scheduler.int_regfile.cfg_bus.core_id)
-           // Want to pass config file as a parameter, but cannot in Verilator 4.025
-           // Parameter-resolved constants must not use dotted references
-           ,.config_file_i(testbench.cosim_cfg_file_p)
+     ,.num_core_i(testbench.num_core_p)
+     ,.mhartid_i(be_checker.scheduler.int_regfile.cfg_bus.core_id)
+     // Want to pass config file as a parameter, but cannot in Verilator 4.025
+     // Parameter-resolved constants must not use dotted references
+     ,.config_file_i(testbench.cosim_cfg_file_p)
 
-           ,.decode_i(be_calculator.reservation_n.decode)
+     ,.decode_i(be_calculator.reservation_n.decode)
 
-           ,.commit_v_i(be_calculator.commit_pkt.instret)
-           ,.commit_pc_i(be_calculator.commit_pkt.pc)
-           ,.commit_instr_i(be_calculator.commit_pkt.instr)
+     ,.commit_v_i(be_calculator.commit_pkt.instret)
+     ,.commit_pc_i(be_calculator.commit_pkt.pc)
+     ,.commit_instr_i(be_calculator.commit_pkt.instr)
 
-           ,.rd_w_v_i(be_checker.scheduler.wb_pkt.rd_w_v)
-           ,.rd_addr_i(be_checker.scheduler.wb_pkt.rd_addr)
-           ,.rd_data_i(be_checker.scheduler.wb_pkt.rd_data)
+     ,.rd_w_v_i(be_checker.scheduler.wb_pkt.rd_w_v)
+     ,.rd_addr_i(be_checker.scheduler.wb_pkt.rd_addr)
+     ,.rd_data_i(be_checker.scheduler.wb_pkt.rd_data)
 
-           ,.interrupt_v_i(be_mem.csr.trap_pkt_cast_o._interrupt)
-           ,.cause_i(be_mem.csr.trap_pkt_cast_o.cause)
+     ,.interrupt_v_i(be_mem.csr.trap_pkt_cast_o._interrupt)
+     ,.cause_i(be_mem.csr.trap_pkt_cast_o.cause)
+     // TODO: Find a way to access the finish_o signals for each core
+     ,.finish_o()
+     );
 
-           ,.finish_o(testbench.cosim_finish_lo)
-           );
-    end
-  else
-    begin : no_cosim
-      assign cosim_finish_lo = '0;
-    end
+assign cosim_finish_lo = '0;
 
 bind bp_be_top
   bp_be_nonsynth_perf


### PR DESCRIPTION
This PR adds the capability to run multicore tests with the Dromajo cosimulation and also lets us create checkpoints for these tests.
- Bumped Dromajo with multicore capability
- Initialize the Dromajo cosimulation instance using RTL parameters as input flags
- Minor testbench and Makefile changes (Added `SAMPLE_NCPUS` flag for checkpoint generation)
