### PR TITLE
Partial Fill / Eviction Cache Service Interface Modification

### DIFF
--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -8,13 +8,13 @@
  *    set-associative.
  *
  *    There are three different 1rw memory blocks: data_mem, tag_mem, stat_mem.
- *    
+ *
  *    data_mem is divided into 8 different banks, and cache blocks are
  *    interleaved among the banks. The governing relationship is "bank_id =
  *    word_offset + way_id" (with modular arithmetic).
- *    
+ *
  *    tag_mem contains tag and coherence state bits.
- *    
+ *
  *    stat_mem contains information about dirty bits for each cache block and
  *    LRU info about each way group. This cache uses pseudo tree-LRU
  *    algorithm.
@@ -30,7 +30,7 @@
  *
  *    Instructions from mmu arrives in the form of bp_be_dcache_pkt_s. It
  *    contains opcode, addr, data.
- *    
+ *
  *    There is write buffer which allows holding write data info that left tv stage,
  *    in forms of "bp_be_dcache_wbuf_entry_s" until data_mem becomes free from incoming
  *    load instructions. It also allows bypassing of store data when load moving
@@ -42,7 +42,7 @@
  *    used in the context of translating 'vtag' into 'ptag', and its width is
  *    fixed as defined by sv39. 'tag' width can vary with the number of sets,
  *    and it is the width of the tag that is stored inside the cache.
- *    
+ *
  *    paddr_width = ptag_width + page_offset_width = tag_width + index_width
  *    + block_offset_width
  *
@@ -50,10 +50,10 @@
  *    A load reserved acts as a normal load with the following addtional properties:
  *    1) If the block is not in an exclusive ownership state (M or E in MESI), then the cache
  *    will send an upgrade request (store miss).
- *    2) If the LR is successful, a reservation is placed on the cache line. This reservation is 
+ *    2) If the LR is successful, a reservation is placed on the cache line. This reservation is
  *    valid for the current hart only.
  *    A store conditional will succeed (return 0) if there is a valid reservation on the address of
- *    the SC. Else, it will fail (return nonzero and will not commit the store). A failing store 
+ *    the SC. Else, it will fail (return nonzero and will not commit the store). A failing store
  *    conditional will not produce a cache miss.
  *
  *    The reservation can be cleared by:
@@ -62,7 +62,7 @@
  *    address).
  *    3) An invalidate received from the LCE. This command covers all cases of losing exclusive
  *    access to the block in this hart, including eviction and a cache miss.
- 
+
  *    RISC-V guarantees forward progress for LR/SC sequences that match a set of conditions.
  *    Currently, BlackParrot makes no guarantees about these sequences, but one option to guarantee
  *    progress is to block reservation invalidates from other harts until a following SC. There is
@@ -71,7 +71,7 @@
  *
  *    LR/SC aq/rl semantics are irrelevant for BlackParrot. Since we are in-order single issue and
  *    do not use a store buffer that allows stores before cache lines have been fetched,, all
- *     memory requests are inherently ordered within a hart. 
+ *     memory requests are inherently ordered within a hart.
  */
 
 module bp_be_dcache
@@ -81,8 +81,8 @@ module bp_be_dcache
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache)
-   
-    , parameter debug_p=0 
+
+    , parameter debug_p=0
     , parameter lock_max_limit_p=8
 
     , localparam cfg_bus_width_lp= `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
@@ -90,14 +90,14 @@ module bp_be_dcache
     , localparam bank_width_lp = dcache_block_width_p / dcache_assoc_p
     , localparam num_dwords_per_bank_lp = bank_width_lp / dword_width_p
     , localparam bypass_data_mask_width_lp = (dword_width_p >> 3)
-    , localparam data_mem_mask_width_lp = (bank_width_lp >> 3) 
-    , localparam byte_offset_width_lp = `BSG_SAFE_CLOG2(bank_width_lp>>3) 
+    , localparam data_mem_mask_width_lp = (bank_width_lp >> 3)
+    , localparam byte_offset_width_lp = `BSG_SAFE_CLOG2(bank_width_lp>>3)
     , localparam word_offset_width_lp = `BSG_SAFE_CLOG2(block_size_in_words_lp)
     , localparam block_offset_width_lp=(word_offset_width_lp+byte_offset_width_lp)
     , localparam index_width_lp=`BSG_SAFE_CLOG2(dcache_sets_p)
     , localparam ptag_width_lp=(paddr_width_p-bp_page_offset_width_gp)
     , localparam way_id_width_lp=`BSG_SAFE_CLOG2(dcache_assoc_p)
-  
+
     , localparam dcache_pkt_width_lp=`bp_be_dcache_pkt_width(bp_page_offset_width_gp,dword_width_p)
     , localparam tag_info_width_lp=`bp_be_dcache_tag_info_width(ptag_width_lp)
     , localparam stat_info_width_lp=`bp_cache_stat_info_width(dcache_assoc_p)
@@ -105,7 +105,7 @@ module bp_be_dcache
   (
     input clk_i
     , input reset_i
-    
+
     , input [cfg_bus_width_lp-1:0] cfg_bus_i
 
     , input [dcache_pkt_width_lp-1:0] dcache_pkt_i
@@ -131,7 +131,7 @@ module bp_be_dcache
     // D$-LCE Interface
     // signals to LCE
     , output [dcache_req_width_lp-1:0] cache_req_o
-    , output logic cache_req_v_o 
+    , output logic cache_req_v_o
     , input cache_req_ready_i
     , output [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
     , output cache_req_metadata_v_o
@@ -168,7 +168,7 @@ module bp_be_dcache
   assign cache_req_o = cache_req_cast_o;
   assign cache_req_metadata_o = cache_req_metadata_cast_o;
 
-  
+
   // packet decoding
   //
   `declare_bp_be_dcache_pkt_s(bp_page_offset_width_gp, dword_width_p);
@@ -261,7 +261,7 @@ module bp_be_dcache
 
   assign addr_index = dcache_pkt.page_offset[block_offset_width_lp+:index_width_lp];
   assign addr_word_offset = dcache_pkt.page_offset[byte_offset_width_lp+:word_offset_width_lp];
-  
+
   // TL stage
   //
   logic v_tl_r; // valid bit
@@ -283,12 +283,12 @@ module bp_be_dcache
   logic gdirty_r;
 
   assign tl_we = v_i & cache_req_ready_i & ~fencei_req;
-  
+
   always_ff @ (posedge clk_i) begin
     if (reset_i) begin
       v_tl_r <= 1'b0;
     end
-    else begin 
+    else begin
       v_tl_r <= tl_we;
       if (tl_we) begin
         lr_op_tl_r <= lr_op;
@@ -304,13 +304,13 @@ module bp_be_dcache
         fencei_op_tl_r <= fencei_op;
         page_offset_tl_r <= dcache_pkt.page_offset;
       end
-    
+
       if (tl_we & store_op) begin
         data_tl_r <= dcache_pkt.data;
       end
     end
-  end 
- 
+  end
+
   // tag_mem
   //
   `declare_bp_be_dcache_tag_info_s(ptag_width_lp);
@@ -320,7 +320,7 @@ module bp_be_dcache
   bp_be_dcache_tag_info_s [dcache_assoc_p-1:0] tag_mem_data_li;
   bp_be_dcache_tag_info_s [dcache_assoc_p-1:0] tag_mem_mask_li;
   bp_be_dcache_tag_info_s [dcache_assoc_p-1:0] tag_mem_data_lo;
-  
+
   bsg_mem_1rw_sync_mask_write_bit
     #(.width_p(tag_info_width_lp*dcache_assoc_p)
       ,.els_p(dcache_sets_p)
@@ -344,7 +344,7 @@ module bp_be_dcache
   logic [dcache_assoc_p-1:0][bank_width_lp-1:0] data_mem_data_li;
   logic [dcache_assoc_p-1:0][data_mem_mask_width_lp-1:0] data_mem_mask_li;
   logic [dcache_assoc_p-1:0][bank_width_lp-1:0] data_mem_data_lo;
-  
+
   for (genvar i = 0; i < dcache_assoc_p; i++) begin: data_mem
     bsg_mem_1rw_sync_mask_write_byte
       #(.data_width_p(bank_width_lp)
@@ -374,7 +374,7 @@ module bp_be_dcache
   logic [dcache_assoc_p-1:0] addr_word_offset_dec_tl;
 
   assign paddr_tl = {ptag_i, page_offset_tl_r};
-  
+
   assign addr_tag_tl = paddr_tl[block_offset_width_lp+index_width_lp+:ptag_width_lp];
   assign addr_word_offset_tl = paddr_tl[byte_offset_width_lp+:word_offset_width_lp];
 
@@ -534,7 +534,7 @@ module bp_be_dcache
   // Load reserved misses if not in exclusive or modified (whether load hit or not)
   assign lr_hit_tv = v_tv_r & lr_op_tv_r & store_hit_tv;
   // Succeed if the address matches and we have a store hit
-  assign sc_success  = v_tv_r & sc_op_tv_r & store_hit_tv & load_reserved_v_r 
+  assign sc_success  = v_tv_r & sc_op_tv_r & store_hit_tv & load_reserved_v_r
                        & (load_reserved_tag_r == addr_tag_tv_r)
                        & (load_reserved_index_r == addr_index_tv);
   // Fail if we have a store conditional without success
@@ -553,10 +553,10 @@ module bp_be_dcache
   bp_be_dcache_wbuf_entry_s wbuf_entry_out;
   logic wbuf_v_lo;
   logic wbuf_yumi_li;
-  
+
   logic wbuf_empty_lo;
   logic wbuf_full_lo;
-  
+
   logic bypass_v_li;
   logic bypass_addr_li;
   logic [dword_width_p-1:0] bypass_data_lo;
@@ -585,7 +585,7 @@ module bp_be_dcache
 
       ,.empty_o(wbuf_empty_lo)
       ,.full_o(wbuf_full_lo)
-    
+      
       ,.bypass_v_i(bypass_v_li)
       ,.bypass_addr_i({ptag_i, page_offset_tl_r})
       ,.bypass_data_o(bypass_data_lo)
@@ -621,7 +621,7 @@ module bp_be_dcache
       : (half_op_tv_r
         ? {{2{paddr_tv_r[2] & paddr_tv_r[1]}}, {2{paddr_tv_r[2] & ~paddr_tv_r[1]}},
            {2{~paddr_tv_r[2] & paddr_tv_r[1]}}, {2{~paddr_tv_r[2] & ~paddr_tv_r[1]}}}
-        : {(paddr_tv_r[2] & paddr_tv_r[1] & paddr_tv_r[0]), 
+        : {(paddr_tv_r[2] & paddr_tv_r[1] & paddr_tv_r[0]),
            (paddr_tv_r[2] & paddr_tv_r[1] & ~paddr_tv_r[0]),
            (paddr_tv_r[2] & ~paddr_tv_r[1] & paddr_tv_r[0]),
            (paddr_tv_r[2] & ~paddr_tv_r[1] & ~paddr_tv_r[0]),
@@ -657,7 +657,7 @@ module bp_be_dcache
       ,.w_mask_i(stat_mem_mask_li)
       ,.data_o(stat_mem_data_lo)
       );
-  
+
   logic [way_id_width_lp-1:0] lru_encode;
 
   bsg_lru_pseudo_tree_encode #(
@@ -681,7 +681,7 @@ module bp_be_dcache
 
   // if there is invalid way, then it take prioirty over LRU way.
   wire [way_id_width_lp-1:0] lru_way_li = invalid_exist ? invalid_way : lru_encode;
- 
+
   // LCE Packet casting
   //
   bp_dcache_data_mem_pkt_s data_mem_pkt;
@@ -696,7 +696,7 @@ module bp_be_dcache
   logic stat_mem_pkt_v;
 
   wire wt_req = (wbuf_v_li & (l1_writethrough_p == 1));
-  
+
   // Assigning message types
   always_comb begin
     cache_req_v_o = 1'b0;
@@ -758,7 +758,7 @@ module bp_be_dcache
 
   assign cache_req_metadata_cast_o.repl_way = lru_way_li;
   assign cache_req_metadata_cast_o.dirty = stat_mem_data_lo.dirty[lru_way_li];
-  
+
   // output stage
   // Cache Miss Tracking logic
   logic cache_miss_r;
@@ -802,7 +802,7 @@ module bp_be_dcache
   //   2) If dirty bit is not set, we do not send a request and simply return valid flush.
   //        The CSR unit is now responsible for sending the clear request to the I$.
   wire flush_req = cache_req_v_o & (cache_req_cast_o.msg_type == e_cache_flush);
-  
+
   if(l1_writethrough_p == 1) begin : wt
     assign gdirty_r = '0;
   end
@@ -837,9 +837,9 @@ module bp_be_dcache
      ,.up_i(lock_inc)
      ,.count_o(lock_cnt_r)
      );
-  
+
   wire cache_lock = (lock_cnt_r != '0);
-  
+
   assign data_mem_pkt_v = data_mem_pkt_v_i & ~cache_lock;
   assign tag_mem_pkt_v = tag_mem_pkt_v_i & ~cache_lock;
   assign stat_mem_pkt_v = stat_mem_pkt_v_i & ~cache_lock;
@@ -903,7 +903,7 @@ module bp_be_dcache
     logic word_sigext;
     logic half_sigext;
     logic byte_sigext;
-    
+
     bsg_mux #(
       .width_p(32)
       ,.els_p(2)
@@ -912,7 +912,7 @@ module bp_be_dcache
       ,.sel_i(paddr_tv_r[2])
       ,.data_o(data_word_selected)
     );
-    
+
     bsg_mux #(
       .width_p(16)
       ,.els_p(4)
@@ -931,9 +931,9 @@ module bp_be_dcache
       ,.data_o(data_byte_selected)
     );
 
-    assign word_sigext = signed_op_tv_r & data_word_selected[31]; 
-    assign half_sigext = signed_op_tv_r & data_half_selected[15]; 
-    assign byte_sigext = signed_op_tv_r & data_byte_selected[7]; 
+    assign word_sigext = signed_op_tv_r & data_word_selected[31];
+    assign half_sigext = signed_op_tv_r & data_half_selected[15];
+    assign byte_sigext = signed_op_tv_r & data_byte_selected[7];
 
     assign data_o = load_op_tv_r
       ? (double_op_tv_r
@@ -948,7 +948,7 @@ module bp_be_dcache
          : 64'b0);
 
   end
- 
+
   // ctrl logic
   //
 
@@ -962,7 +962,7 @@ module bp_be_dcache
   ) wbuf_data_mem_v_decode (
     .i(wbuf_data_mem_offset)
     ,.o(wbuf_data_mem_v)
-  ); 
+  );
 
   logic lce_data_mem_v;
   assign lce_data_mem_v = (data_mem_pkt.opcode != e_cache_data_mem_uncached)
@@ -1001,7 +1001,7 @@ module bp_be_dcache
     assign data_mem_data_li[i] = wbuf_yumi_li
       ? {num_dwords_per_bank_lp{wbuf_entry_out.data}}
       : lce_data_mem_write_data[i];
-  
+
     assign data_mem_mask_li[i] = wbuf_yumi_li
       ? wbuf_mask
       : {data_mem_mask_width_lp{1'b1}};
@@ -1018,9 +1018,9 @@ module bp_be_dcache
 
   // tag_mem
   //
-  assign tag_mem_v_li = tl_we | tag_mem_pkt_yumi_o; 
+  assign tag_mem_v_li = tl_we | tag_mem_pkt_yumi_o;
   assign tag_mem_w_li = ~tl_we & tag_mem_pkt_v_i & (tag_mem_pkt.opcode != e_cache_tag_mem_read);
-  assign tag_mem_addr_li = tl_we 
+  assign tag_mem_addr_li = tl_we
     ? addr_index
     : tag_mem_pkt.index;
 
@@ -1040,7 +1040,7 @@ module bp_be_dcache
       end
       e_cache_tag_mem_invalidate: begin
         tag_mem_data_li = {((tag_info_width_lp)*dcache_assoc_p){1'b0}};
-        for (integer i = 0; i < dcache_assoc_p; i++) begin 
+        for (integer i = 0; i < dcache_assoc_p; i++) begin
           tag_mem_mask_li[i].coh_state = bp_coh_states_e'({$bits(bp_coh_states_e){lce_tag_mem_way_one_hot[i]}});
           tag_mem_mask_li[i].tag = {ptag_width_lp{1'b0}};
         end
@@ -1080,7 +1080,7 @@ module bp_be_dcache
     ,.data_o(lru_decode_data_lo)
     ,.mask_o(lru_decode_mask_lo)
   );
-  
+
 
   logic [way_id_width_lp-1:0] dirty_mask_way_li;
   logic dirty_mask_v_li;
@@ -1099,7 +1099,7 @@ module bp_be_dcache
       lru_decode_way_li = store_op_tv_r ? store_hit_way_tv : load_hit_way_tv;
       dirty_mask_way_li = store_hit_way_tv;
       dirty_mask_v_li = store_op_tv_r & (l1_writethrough_p == 0); // Blocks are never dirty in a writethrough cache
-      
+
       stat_mem_data_li.lru = lru_decode_data_lo;
       stat_mem_data_li.dirty = {dcache_assoc_p{1'b1}};
       stat_mem_mask_li = {lru_decode_mask_lo, dirty_mask_lo};
@@ -1162,10 +1162,10 @@ module bp_be_dcache
   // As an optimization, we snoop the data_mem_pkts to see if there
   // are any matching entries in the write buffer and disallow the
   // data_mem_pkts to allow the write buffers to drain before we can
-  // accept the pkt in case of a match. 
+  // accept the pkt in case of a match.
   // A similar scheme could be adopted for a non-blocking version, where we snoop the bank
-  assign data_mem_pkt_yumi_o = (data_mem_pkt.opcode == e_cache_data_mem_uncached) 
-                               ? data_mem_pkt_v 
+  assign data_mem_pkt_yumi_o = (data_mem_pkt.opcode == e_cache_data_mem_uncached)
+                               ? data_mem_pkt_v
                                : ~(load_op & tl_we) & ~lce_snoop_match_lo & data_mem_pkt_v & ~wbuf_full_lo;
 
   // load reservation logic
@@ -1184,7 +1184,7 @@ module bp_be_dcache
         load_reserved_v_r <= 1'b0;
       // Invalidates from other harts which match the reservation address clear the reservation
       end else if (tag_mem_pkt_v & (tag_mem_pkt.opcode == e_cache_tag_mem_invalidate)
-                  & (tag_mem_pkt.tag == load_reserved_tag_r) 
+                  & (tag_mem_pkt.tag == load_reserved_tag_r)
                   & (tag_mem_pkt.index == load_reserved_index_r)) begin
         load_reserved_v_r <= 1'b0;
       end
@@ -1214,9 +1214,9 @@ module bp_be_dcache
       end
     end
   end
-  
+
   // LCE tag_mem
-  
+
   logic [way_id_width_lp-1:0] tag_mem_pkt_way_r;
 
   always_ff @ (posedge clk_i) begin
@@ -1228,7 +1228,7 @@ module bp_be_dcache
   assign tag_mem_o =  tag_mem_data_lo[tag_mem_pkt_way_r].tag;
 
   assign tag_mem_pkt_yumi_o = ~tl_we & tag_mem_pkt_v;
-  
+
   // LCE stat_mem
   //
   assign stat_mem_pkt_yumi_o = ~(v_tv_r & ~uncached_tv_r) & stat_mem_pkt_v;

--- a/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
@@ -20,14 +20,13 @@ module bp_be_mem_top
 
    // Generated parameters
    // D$
-   , localparam block_size_in_words_lp = dcache_assoc_p // Due to cache interleaving scheme
    , localparam bank_width_lp = dcache_block_width_p / dcache_assoc_p
    , localparam num_dwords_per_bank_lp = bank_width_lp / dword_width_p
    , localparam data_mem_mask_width_lp = (bank_width_lp >> 3) // Byte mask
    , localparam bypass_data_mask_width_lp = (dword_width_p >> 3)
    , localparam byte_offset_width_lp   = `BSG_SAFE_CLOG2(bank_width_lp >> 3)
-   , localparam word_offset_width_lp   = `BSG_SAFE_CLOG2(block_size_in_words_lp)
-   , localparam block_offset_width_lp  = (word_offset_width_lp + byte_offset_width_lp)
+   , localparam bank_offset_width_lp   = `BSG_SAFE_CLOG2(dcache_assoc_p)
+   , localparam block_offset_width_lp  = (bank_offset_width_lp + byte_offset_width_lp)
    , localparam index_width_lp         = `BSG_SAFE_CLOG2(dcache_sets_p)
    , localparam page_offset_width_lp   = (block_offset_width_lp + index_width_lp)
    , localparam way_id_width_lp=`BSG_SAFE_CLOG2(dcache_assoc_p)

--- a/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
@@ -16,8 +16,8 @@ module bp_be_mem_top
   import bp_be_dcache_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache)
-   
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache)
+
    // Generated parameters
    // D$
    , localparam block_size_in_words_lp = dcache_assoc_p // Due to cache interleaving scheme
@@ -31,8 +31,8 @@ module bp_be_mem_top
    , localparam index_width_lp         = `BSG_SAFE_CLOG2(dcache_sets_p)
    , localparam page_offset_width_lp   = (block_offset_width_lp + index_width_lp)
    , localparam way_id_width_lp=`BSG_SAFE_CLOG2(dcache_assoc_p)
-   
-   , localparam stat_info_width_lp = `bp_cache_stat_info_width(dcache_assoc_p)   
+
+   , localparam stat_info_width_lp = `bp_cache_stat_info_width(dcache_assoc_p)
 
    , localparam cfg_bus_width_lp      = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
 
@@ -81,6 +81,7 @@ module bp_be_mem_top
    , output logic                                   cache_req_metadata_v_o
 
    , input cache_req_complete_i
+   , input cache_req_critical_i
 
    // data_mem
    , input data_mem_pkt_v_i
@@ -119,7 +120,7 @@ module bp_be_mem_top
 // Not sure if this is right.
 `declare_bp_be_mmu_structs(vaddr_width_p, ptag_width_p, dcache_sets_p, dcache_block_width_p/8)
 `declare_bp_be_dcache_pkt_s(page_offset_width_lp, dword_width_p);
-`declare_bp_cache_service_if(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache);
+`declare_bp_cache_service_if(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache);
   bp_dcache_req_s cache_req_cast_o;
 
   assign cache_req_o = cache_req_cast_o;
@@ -361,7 +362,7 @@ bp_be_ptw
    ,.dcache_v_o(ptw_dcache_v)
    ,.dcache_pkt_o(ptw_dcache_pkt)
    ,.dcache_ptag_o(ptw_dcache_ptag)
-   ,.dcache_rdy_i(dcache_ready_lo) 
+   ,.dcache_rdy_i(dcache_ready_lo)
    ,.dcache_miss_i(dcache_miss_lo)
   );
 
@@ -394,6 +395,7 @@ bp_be_dcache
     // D$-LCE Interface
     ,.dcache_miss_o(dcache_miss_lo)
     ,.cache_req_complete_i(cache_req_complete_i)
+    ,.cache_req_critical_i(cache_req_critical_i)
     ,.cache_req_o(cache_req_cast_o)
     ,.cache_req_v_o(cache_req_v_o)
     ,.cache_req_ready_i(cache_req_ready_i)
@@ -527,4 +529,3 @@ always_ff @(negedge clk_i)
 // synopsys translate_on
 //
 endmodule
-

--- a/bp_be/src/v/bp_be_top.v
+++ b/bp_be/src/v/bp_be_top.v
@@ -2,7 +2,7 @@
  *
  *  Name:
  *    bp_be_top.v
- * 
+ *
  */
 
 
@@ -16,11 +16,11 @@ module bp_be_top
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_fe_be_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
-   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache)
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache)
 
-   // Default parameters 
+   // Default parameters
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
-   
+
    // VM parameters
    , localparam tlb_entry_width_lp = `bp_pte_entry_leaf_width(paddr_width_p)
    , localparam stat_info_width_lp = `bp_cache_stat_info_width(dcache_assoc_p)
@@ -58,7 +58,8 @@ module bp_be_top
    , output logic                                cache_req_metadata_v_o
 
    , input cache_req_complete_i
-   
+   , input cache_req_critical_i
+
    // data_mem
    , input data_mem_pkt_v_i
    , input [dcache_data_mem_pkt_width_lp-1:0] data_mem_pkt_i
@@ -138,7 +139,7 @@ logic wb_pkt_v;
 
 logic flush;
 // Module instantiations
-bp_be_checker_top 
+bp_be_checker_top
  #(.bp_params_p(bp_params_p))
  be_checker
   (.clk_i(clk_i)
@@ -182,7 +183,7 @@ bp_be_checker_top
    ,.wb_pkt_i(wb_pkt)
    );
 
-bp_be_calculator_top 
+bp_be_calculator_top
  #(.bp_params_p(bp_params_p))
  be_calculator
   (.clk_i(clk_i)
@@ -202,9 +203,9 @@ bp_be_calculator_top
    ,.csr_cmd_v_o(csr_cmd_v)
    ,.csr_cmd_ready_i(csr_cmd_rdy)
 
-   ,.mem_resp_i(mem_resp) 
+   ,.mem_resp_i(mem_resp)
    ,.mem_resp_v_i(mem_resp_v)
-   ,.mem_resp_ready_o(mem_resp_rdy)   
+   ,.mem_resp_ready_o(mem_resp_rdy)
 
    ,.commit_pkt_o(commit_pkt)
    ,.wb_pkt_o(wb_pkt)
@@ -233,19 +234,20 @@ bp_be_mem_top
     ,.mem_resp_o(mem_resp)
     ,.mem_resp_v_o(mem_resp_v)
     ,.mem_resp_ready_i(mem_resp_rdy)
-    
+
     ,.itlb_fill_v_o(itlb_fill_v)
     ,.itlb_fill_vaddr_o(itlb_fill_vaddr)
     ,.itlb_fill_entry_o(itlb_fill_entry)
 
-    ,.cache_req_complete_i(cache_req_complete_i)   
- 
+    ,.cache_req_complete_i(cache_req_complete_i)
+    ,.cache_req_critical_i(cache_req_critical_i)
+
     ,.cache_req_o(cache_req_o)
     ,.cache_req_metadata_o(cache_req_metadata_o)
     ,.cache_req_v_o(cache_req_v_o)
     ,.cache_req_ready_i(cache_req_ready_i)
     ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
-    
+
     ,.data_mem_pkt_v_i(data_mem_pkt_v_i)
     ,.data_mem_pkt_i(data_mem_pkt_i)
     ,.data_mem_o(data_mem_o)
@@ -273,4 +275,3 @@ bp_be_mem_top
     );
 
 endmodule
-

--- a/bp_be/syn/flist.vcs
+++ b/bp_be/syn/flist.vcs
@@ -111,6 +111,7 @@ $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_chain.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_en.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_en.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_set_clear.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_edge_detect.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_encode_one_hot.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_expand_bitmask.v
@@ -154,8 +155,8 @@ $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter_in.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter_out.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_decoder_dor.v
-$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_input_control.v  
-$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.v 
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_input_control.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.v
 # Common files
 $BP_COMMON_DIR/src/v/bsg_fifo_1r1w_rolly.v
 $BP_COMMON_DIR/src/v/bp_pma.v

--- a/bp_be/test/tb/bp_be_dcache/testbench.v
+++ b/bp_be/test/tb/bp_be_dcache/testbench.v
@@ -3,7 +3,7 @@
   * testbench.v
   *
   */
-  
+
 module testbench
  import bp_common_pkg::*;
  import bp_common_aviary_pkg::*;
@@ -49,7 +49,7 @@ module testbench
    , localparam ptag_width_lp = (paddr_width_p - page_offset_width_lp)
    , localparam dcache_pkt_width_lp = `bp_be_dcache_pkt_width(page_offset_width_p, dword_width_p)
    , localparam trace_replay_data_width_lp = ptag_width_lp + dcache_pkt_width_lp + 1 // The 1 extra bit is for uncached accesses
-   , localparam trace_rom_addr_width_lp = 8 
+   , localparam trace_rom_addr_width_lp = 8
 
    , localparam yumi_min_delay_lp = 0
    , localparam yumi_max_delay_lp = 15
@@ -68,7 +68,7 @@ module testbench
   logic mem_cmd_v_lo, mem_resp_v_lo;
   logic mem_cmd_ready_lo, mem_resp_yumi_lo;
   logic [cce_mem_msg_width_lp-1:0] mem_cmd_lo, mem_resp_lo;
- 
+
   logic [trace_replay_data_width_lp-1:0] trace_data_lo;
   logic trace_v_lo;
   logic dut_ready_lo;
@@ -152,7 +152,7 @@ module testbench
       (.addr_i(trace_rom_addr_lo)
       ,.data_o(trace_rom_data_li)
       );
-           
+
   assign dcache_pkt_li = trace_data_lo[0+:dcache_pkt_width_lp];
   assign ptag_li = trace_data_lo[dcache_pkt_width_lp+:ptag_width_lp];
   assign uncached_li = trace_data_lo[(dcache_pkt_width_lp+ptag_width_lp)+:1];
@@ -179,10 +179,10 @@ module testbench
   // We need an 8 FIFO because we might be receiving all data at once rather
   // than receive data at regular intervals. This is possible a side effect of
   // our testing strategy. Open for debate.
-  bsg_fifo_1r1w_small 
+  bsg_fifo_1r1w_small
     #(.width_p(dword_width_p)
      ,.els_p(8))
-    output_fifo 
+    output_fifo
     (.clk_i(clk_i)
     ,.reset_i(reset_i)
 
@@ -205,7 +205,7 @@ module testbench
     wrapper
     (.clk_i(clk_i)
     ,.reset_i(reset_i)
-  
+
     ,.cfg_bus_i(cfg_bus_li)
 
     ,.dcache_pkt_i(dcache_pkt_li)
@@ -218,7 +218,7 @@ module testbench
     ,.ptag_i(ptag_li)
 
     ,.uncached_i(uncached_li)
- 
+
     ,.mem_resp_v_i(mem_resp_v_lo)
     ,.mem_resp_i(mem_resp_lo)
     ,.mem_resp_yumi_o(mem_resp_yumi_lo)
@@ -236,12 +236,12 @@ module testbench
     ,.mem_zero_p(mem_zero_p)
     ,.mem_file_p(mem_file_p)
     ,.mem_offset_p(mem_offset_p)
- 
+
     ,.use_max_latency_p(use_max_latency_p)
     ,.use_random_latency_p(use_random_latency_p)
     ,.use_dramsim2_latency_p(use_dramsim2_latency_p)
     ,.max_latency_p(max_latency_p)
- 
+
     ,.dram_clock_period_in_ps_p(dram_clock_period_in_ps_p)
     ,.dram_cfg_p(dram_cfg_p)
     ,.dram_sys_cfg_p(dram_sys_cfg_p)
@@ -250,11 +250,11 @@ module testbench
     mem
     (.clk_i(clk_i)
     ,.reset_i(reset_i)
- 
+
     ,.mem_cmd_i(mem_cmd_lo)
     ,.mem_cmd_v_i(mem_cmd_v_lo)
     ,.mem_cmd_ready_o(mem_cmd_ready_lo)
- 
+
     ,.mem_resp_o(mem_resp_lo)
     ,.mem_resp_v_o(mem_resp_v_lo)
     ,.mem_resp_yumi_i(mem_resp_yumi_lo)
@@ -267,11 +267,12 @@ module testbench
       ,.sets_p(dcache_sets_p)
       ,.assoc_p(dcache_assoc_p)
       ,.block_width_p(dcache_block_width_p)
+      ,.fill_width_p(dcache_fill_width_p)
       ,.trace_file_p("dcache"))
      dcache_tracer
       (.clk_i(clk_i & (testbench.dcache_trace_p == 1))
        ,.reset_i(reset_i)
-       
+
        ,.freeze_i(cfg_bus_cast_i.freeze)
        ,.mhartid_i(cfg_bus_cast_i.core_id)
 
@@ -315,10 +316,10 @@ module testbench
         bp_cce_tracer
          (.clk_i(clk_i & (testbench.cce_trace_p == 1))
           ,.reset_i(reset_i)
-          
+
           ,.freeze_i(cfg_bus_cast_i.freeze)
           ,.cce_id_i(cfg_bus_cast_i.cce_id)
-    
+
           // To CCE
           ,.lce_req_i(lce_req_i)
           ,.lce_req_v_i(lce_req_v_i)
@@ -327,17 +328,17 @@ module testbench
           ,.lce_resp_i(lce_resp_i)
           ,.lce_resp_v_i(lce_resp_v_i)
           ,.lce_resp_yumi_i(lce_resp_yumi_o)
-    
+
           // From CCE
           ,.lce_cmd_i(lce_cmd_o)
           ,.lce_cmd_v_i(lce_cmd_v_o)
           ,.lce_cmd_ready_i(lce_cmd_ready_i)
-    
+
           // To CCE
           ,.mem_resp_i(mem_resp_i)
           ,.mem_resp_v_i(mem_resp_v_i)
           ,.mem_resp_yumi_i(mem_resp_yumi_o)
-    
+
           // From CCE
           ,.mem_cmd_i(mem_cmd_o)
           ,.mem_cmd_v_i(mem_cmd_v_o)
@@ -359,7 +360,7 @@ module testbench
      ,.mem_resp_v_i(mem_resp_v_lo)
      ,.mem_resp_yumi_i(mem_resp_yumi_lo)
      );
-  
+
   // Assertions
   if(uce_p == 0 && l1_writethrough_p == 1)
     $error("Writethrough cache with CCE not yet supported");

--- a/bp_common/src/include/bp_common_aviary_defines.vh
+++ b/bp_common/src/include/bp_common_aviary_defines.vh
@@ -125,12 +125,15 @@ typedef struct packed
   integer dcache_sets;
   integer dcache_assoc;
   integer dcache_block_width;
+  integer dcache_fill_width;
   integer icache_sets;
   integer icache_assoc;
   integer icache_block_width;
+  integer icache_fill_width;
   integer acache_sets;
   integer acache_assoc;
   integer acache_block_width;
+  integer acache_fill_width;
   integer cce_pc_width;
   integer ucode_cce;
 
@@ -230,12 +233,15 @@ typedef struct packed
   , localparam dcache_sets_p              = proc_param_lp.dcache_sets                              \
   , localparam dcache_assoc_p             = proc_param_lp.dcache_assoc                             \
   , localparam dcache_block_width_p       = proc_param_lp.dcache_block_width                       \
+  , localparam dcache_fill_width_p        = proc_param_lp.dcache_fill_width                        \
   , localparam icache_sets_p              = proc_param_lp.icache_sets                              \
   , localparam icache_assoc_p             = proc_param_lp.icache_assoc                             \
   , localparam icache_block_width_p       = proc_param_lp.icache_block_width                       \
+  , localparam icache_fill_width_p        = proc_param_lp.icache_fill_width                        \
   , localparam acache_sets_p              = proc_param_lp.acache_sets                              \
   , localparam acache_assoc_p             = proc_param_lp.acache_assoc                             \
   , localparam acache_block_width_p       = proc_param_lp.acache_block_width                       \
+  , localparam acache_fill_width_p        = proc_param_lp.acache_fill_width                        \
   , localparam lce_assoc_p                = `BSG_MAX(dcache_assoc_p,                               \
                                                      `BSG_MAX(icache_assoc_p, acache_assoc_p))     \
   , localparam lce_assoc_width_p          = `BSG_SAFE_CLOG2(lce_assoc_p)                           \
@@ -320,4 +326,3 @@ typedef struct packed
   , localparam ptag_width_p  = proc_param_lp.paddr_width - page_offset_width_p                     \
 
 `endif
-

--- a/bp_common/src/include/bp_common_aviary_pkg.vh
+++ b/bp_common/src/include/bp_common_aviary_pkg.vh
@@ -37,12 +37,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -103,12 +106,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -169,12 +175,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -235,12 +244,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -301,12 +313,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 4
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 4
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -367,12 +382,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 2
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 2
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -433,12 +451,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -499,12 +520,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -565,12 +589,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 4
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 4
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -631,12 +658,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 2
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 2
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -698,12 +728,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -764,12 +797,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -830,12 +866,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -896,12 +935,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -962,12 +1004,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -1028,12 +1073,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -1094,12 +1142,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -1157,15 +1208,19 @@ package bp_common_aviary_pkg;
 
       ,l1_writethrough      : 0
       ,l1_coherent          : 1
+
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -1226,12 +1281,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 0
@@ -1292,12 +1350,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 1
@@ -1358,12 +1419,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 1
@@ -1424,12 +1488,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 1
@@ -1490,12 +1557,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 1
@@ -1556,12 +1626,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 1
@@ -1622,12 +1695,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 1
@@ -1688,12 +1764,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 1
@@ -1754,12 +1833,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 1
@@ -1820,12 +1902,15 @@ package bp_common_aviary_pkg;
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
+      ,dcache_fill_width    : 512
       ,icache_sets          : 64
       ,icache_assoc         : 8
       ,icache_block_width   : 512
+      ,icache_fill_width    : 512
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
+      ,acache_fill_width    : 512
 
       ,cce_pc_width         : 8
       ,ucode_cce            : 1
@@ -1928,4 +2013,3 @@ package bp_common_aviary_pkg;
   /* verilator lint_on WIDTH */
 
 endpackage
-

--- a/bp_common/src/include/bp_common_cache_service_if.vh
+++ b/bp_common/src/include/bp_common_cache_service_if.vh
@@ -106,13 +106,13 @@ typedef enum logic [1:0] {
     logic [`BSG_SAFE_CLOG2(sets_mp)-1:0]          index;                                    \
     logic [`BSG_SAFE_CLOG2(ways_mp)-1:0]          way_id;                                   \
     logic [fill_width_mp-1:0]                     data;                                     \
-    logic [block_data_width_mp/fill_width_mp-1:0] fill_index;                                \
+    logic [(block_data_width_mp/fill_width_mp)-1:0] fill_index;                             \
     bp_cache_data_mem_opcode_e                    opcode;                                   \
   }  bp_``cache_name_mp``_data_mem_pkt_s
 
-`define bp_cache_data_mem_pkt_width(sets_mp, ways_mp, block_data_width_mp, fill_width_mp) \
-  (`BSG_SAFE_CLOG2(sets_mp)+`BSG_SAFE_CLOG2(ways_mp)+fill_width_mp \
-   +block_data_width_mp/fill_width_mp+`bp_cache_data_mem_opcode_width)
+`define bp_cache_data_mem_pkt_width(sets_mp, ways_mp, block_data_width_mp, fill_width_mp)   \
+  (`BSG_SAFE_CLOG2(sets_mp)+`BSG_SAFE_CLOG2(ways_mp)+fill_width_mp                          \
+  +(block_data_width_mp/fill_width_mp)+`bp_cache_data_mem_opcode_width)
 
 // tag mem pkt structure
 `define declare_bp_cache_tag_mem_pkt_s(sets_mp, ways_mp, tag_width_mp, cache_name_mp) \

--- a/bp_common/src/include/bp_common_cache_service_if.vh
+++ b/bp_common/src/include/bp_common_cache_service_if.vh
@@ -100,18 +100,19 @@ typedef enum logic [1:0] {
 `define bp_cache_stat_mem_opcode_width $bits(bp_cache_stat_mem_opcode_e)
 
 // data mem pkt structure
-`define declare_bp_cache_data_mem_pkt_s(sets_mp, ways_mp, data_width_mp, cache_name_mp) \
-  typedef struct packed                                                                 \
-  {                                                                                     \
-    logic [`BSG_SAFE_CLOG2(sets_mp)-1:0]      index;                                    \
-    logic [`BSG_SAFE_CLOG2(ways_mp)-1:0]      way_id;                                   \
-    logic [data_width_mp-1:0]                 data;                                     \
-    bp_cache_data_mem_opcode_e                opcode;                                   \
+`define declare_bp_cache_data_mem_pkt_s(sets_mp, ways_mp, block_data_width_mp, fill_width_mp, cache_name_mp) \
+  typedef struct packed                                                                     \
+  {                                                                                         \
+    logic [`BSG_SAFE_CLOG2(sets_mp)-1:0]          index;                                    \
+    logic [`BSG_SAFE_CLOG2(ways_mp)-1:0]          way_id;                                   \
+    logic [fill_width_mp-1:0]                     data;                                     \
+    logic [block_data_width_mp/fill_width_mp-1:0] fill_index;                                \
+    bp_cache_data_mem_opcode_e                    opcode;                                   \
   }  bp_``cache_name_mp``_data_mem_pkt_s
 
-`define bp_cache_data_mem_pkt_width(sets_mp, ways_mp, data_width_mp) \
-  (`BSG_SAFE_CLOG2(sets_mp)+`BSG_SAFE_CLOG2(ways_mp)+data_width_mp \
-   +`bp_cache_data_mem_opcode_width)
+`define bp_cache_data_mem_pkt_width(sets_mp, ways_mp, block_data_width_mp, fill_width_mp) \
+  (`BSG_SAFE_CLOG2(sets_mp)+`BSG_SAFE_CLOG2(ways_mp)+fill_width_mp \
+   +block_data_width_mp/fill_width_mp+`bp_cache_data_mem_opcode_width)
 
 // tag mem pkt structure
 `define declare_bp_cache_tag_mem_pkt_s(sets_mp, ways_mp, tag_width_mp, cache_name_mp) \
@@ -145,18 +146,18 @@ typedef enum logic [1:0] {
 `define bp_cache_stat_info_width(ways_mp) \
   (2*ways_mp-1)
 
-`define declare_bp_cache_service_if(addr_width_mp, tag_width_mp, sets_mp, ways_mp, req_data_width_mp, block_data_width_mp, cache_name_mp) \
-  `declare_bp_cache_req_s(req_data_width_mp, addr_width_mp, cache_name_mp);               \
-  `declare_bp_cache_req_metadata_s(ways_mp, cache_name_mp);                               \
-  `declare_bp_cache_data_mem_pkt_s(sets_mp, ways_mp, block_data_width_mp, cache_name_mp); \
-  `declare_bp_cache_tag_mem_pkt_s(sets_mp, ways_mp, tag_width_mp, cache_name_mp);         \
+`define declare_bp_cache_service_if(addr_width_mp, tag_width_mp, sets_mp, ways_mp, req_data_width_mp, block_data_width_mp, fill_width_mp, cache_name_mp) \
+  `declare_bp_cache_req_s(req_data_width_mp, addr_width_mp, cache_name_mp);                              \
+  `declare_bp_cache_req_metadata_s(ways_mp, cache_name_mp);                                              \
+  `declare_bp_cache_data_mem_pkt_s(sets_mp, ways_mp, block_data_width_mp, fill_width_mp, cache_name_mp); \
+  `declare_bp_cache_tag_mem_pkt_s(sets_mp, ways_mp, tag_width_mp, cache_name_mp);                        \
   `declare_bp_cache_stat_mem_pkt_s(sets_mp, ways_mp, cache_name_mp)
 
-`define declare_bp_cache_service_if_widths(addr_width_mp, tag_width_mp, sets_mp, ways_mp, req_data_width_mp, block_data_width_mp, cache_name_mp) \
-  , localparam ``cache_name_mp``_req_width_lp = `bp_cache_req_width(req_data_width_mp, addr_width_mp)                    \
-  , localparam ``cache_name_mp``_req_metadata_width_lp = `bp_cache_req_metadata_width(ways_mp)                           \
-  , localparam ``cache_name_mp``_data_mem_pkt_width_lp=`bp_cache_data_mem_pkt_width(sets_mp,ways_mp,block_data_width_mp) \
-  , localparam ``cache_name_mp``_tag_mem_pkt_width_lp=`bp_cache_tag_mem_pkt_width(sets_mp,ways_mp,tag_width_mp)          \
+`define declare_bp_cache_service_if_widths(addr_width_mp, tag_width_mp, sets_mp, ways_mp, req_data_width_mp, block_data_width_mp, fill_width_mp, cache_name_mp) \
+  , localparam ``cache_name_mp``_req_width_lp = `bp_cache_req_width(req_data_width_mp, addr_width_mp)                                  \
+  , localparam ``cache_name_mp``_req_metadata_width_lp = `bp_cache_req_metadata_width(ways_mp)                                         \
+  , localparam ``cache_name_mp``_data_mem_pkt_width_lp=`bp_cache_data_mem_pkt_width(sets_mp,ways_mp,block_data_width_mp,fill_width_mp) \
+  , localparam ``cache_name_mp``_tag_mem_pkt_width_lp=`bp_cache_tag_mem_pkt_width(sets_mp,ways_mp,tag_width_mp)                        \
   , localparam ``cache_name_mp``_stat_mem_pkt_width_lp=`bp_cache_stat_mem_pkt_width(sets_mp,ways_mp)
 
 `endif

--- a/bp_fe/src/v/bp_fe_icache.v
+++ b/bp_fe/src/v/bp_fe_icache.v
@@ -22,20 +22,22 @@ module bp_fe_icache
   import bp_fe_icache_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
     `declare_bp_proc_params(bp_params_p)
-    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
-        
+    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache)
+
     , localparam way_id_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)
-    , localparam block_size_in_words_lp=icache_assoc_p
+    , localparam block_size_in_bank_lp = icache_assoc_p
     , localparam bank_width_lp = icache_block_width_p / icache_assoc_p
     , localparam num_dwords_per_bank_lp = bank_width_lp / dword_width_p
-    , localparam data_mem_mask_width_lp=(bank_width_lp >> 3)       
-    , localparam byte_offset_width_lp=`BSG_SAFE_CLOG2(bank_width_lp >> 3) 
-    , localparam word_offset_width_lp=`BSG_SAFE_CLOG2(block_size_in_words_lp)      
-    , localparam index_width_lp=`BSG_SAFE_CLOG2(icache_sets_p)                        
-    , localparam block_offset_width_lp=(word_offset_width_lp+byte_offset_width_lp) 
-    , localparam ptag_width_lp=(paddr_width_p-bp_page_offset_width_gp) 
-    
-    `declare_bp_icache_widths(vaddr_width_p, ptag_width_lp, icache_assoc_p) 
+    , localparam data_mem_mask_width_lp=(bank_width_lp >> 3)
+    , localparam byte_offset_width_lp=`BSG_SAFE_CLOG2(bank_width_lp >> 3)
+    , localparam bank_offset_width_lp = `BSG_SAFE_CLOG2(block_size_in_bank_lp)
+    , localparam index_width_lp=`BSG_SAFE_CLOG2(icache_sets_p)
+    , localparam block_offset_width_lp = (bank_offset_width_lp+byte_offset_width_lp)
+    , localparam ptag_width_lp=(paddr_width_p-bp_page_offset_width_gp)
+    , localparam block_size_in_fill_lp = icache_block_width_p / icache_fill_width_p
+    , localparam fill_size_in_bank_lp = icache_fill_width_p / bank_width_lp
+
+    `declare_bp_icache_widths(vaddr_width_p, ptag_width_lp, icache_assoc_p)
 
     , localparam stat_width_lp = `bp_cache_stat_info_width(icache_assoc_p)
     , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
@@ -55,13 +57,13 @@ module bp_fe_icache
     , input                                            ptag_v_i
     , input                                            uncached_i
     , input                                            poison_i
-    
+
     , output [instr_width_p-1:0]                       data_o
     , output                                           data_v_o
     , output                                           miss_o
 
     // LCE Interface
-    
+
     , output [icache_req_width_lp-1:0]                 cache_req_o
     , output logic                                     cache_req_v_o
     , input                                            cache_req_ready_i
@@ -69,6 +71,7 @@ module bp_fe_icache
     , output                                           cache_req_metadata_v_o
 
     , input                                            cache_req_complete_i
+    , input                                            cache_req_critical_i
 
     // data_mem
     , input data_mem_pkt_v_i
@@ -93,15 +96,15 @@ module bp_fe_icache
   bp_cfg_bus_s cfg_bus_cast_i;
   assign cfg_bus_cast_i = cfg_bus_i;
 
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache);
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache);
   bp_icache_req_s cache_req_cast_lo;
   bp_icache_req_metadata_s cache_req_metadata_cast_lo;
   assign cache_req_o = cache_req_cast_lo;
   assign cache_req_metadata_o = cache_req_metadata_cast_lo;
-  
+
   logic [index_width_lp-1:0]            vaddr_index;
 
-  logic [word_offset_width_lp-1:0] vaddr_offset;
+  logic [bank_offset_width_lp-1:0]      vaddr_offset;
 
   logic [icache_assoc_p-1:0]            way_v_tv_r; // valid bits of each way
   logic [way_id_width_lp-1:0]           way_invalid_index; // first invalid way
@@ -110,9 +113,9 @@ module bp_fe_icache
   logic uncached_req;
   logic fencei_req;
 
-  assign vaddr_index      = vaddr_i[word_offset_width_lp+byte_offset_width_lp+:index_width_lp];
-  assign vaddr_offset     = vaddr_i[byte_offset_width_lp+:word_offset_width_lp];
-   
+  assign vaddr_index      = vaddr_i[block_offset_width_lp+:index_width_lp];
+  assign vaddr_offset     = vaddr_i[byte_offset_width_lp+:bank_offset_width_lp];
+
   // TL stage
   logic v_tl_r;
   logic tl_we;
@@ -170,7 +173,7 @@ module bp_fe_icache
   // data memory
   logic [icache_assoc_p-1:0]                                           data_mem_v_li;
   logic                                                                data_mem_w_li;
-  logic [icache_assoc_p-1:0][index_width_lp+word_offset_width_lp-1:0]  data_mem_addr_li;
+  logic [icache_assoc_p-1:0][index_width_lp+bank_offset_width_lp-1:0]  data_mem_addr_li;
   logic [icache_assoc_p-1:0][bank_width_lp-1:0]                        data_mem_data_li;
   logic [icache_assoc_p-1:0][data_mem_mask_width_lp-1:0]               data_mem_w_mask_li;
   logic [icache_assoc_p-1:0][bank_width_lp-1:0]                        data_mem_data_lo;
@@ -194,27 +197,27 @@ module bp_fe_icache
   end
 
   logic [ptag_width_lp-1:0]        addr_tag_tl;
-  logic [word_offset_width_lp-1:0] addr_word_offset_tl;
-  logic [icache_assoc_p-1:0]       addr_word_offset_dec_tl;
+  logic [bank_offset_width_lp-1:0] addr_bank_offset_tl;
+  logic [icache_assoc_p-1:0]       addr_bank_offset_dec_tl;
   logic [icache_assoc_p-1:0]       hit_v_tl;
   logic [paddr_width_p-1:0]        addr_tl;
   logic [icache_assoc_p-1:0]       way_v_tl;
-   
+
   assign addr_tl = {ptag_i, vaddr_tl_r[0+:bp_page_offset_width_gp]};
 
   assign addr_tag_tl = addr_tl[block_offset_width_lp+index_width_lp+:ptag_width_lp];
-  assign addr_word_offset_tl = addr_tl[byte_offset_width_lp+:word_offset_width_lp];
+  assign addr_bank_offset_tl = addr_tl[byte_offset_width_lp+:bank_offset_width_lp];
 
   for (genvar i = 0; i < icache_assoc_p; i++) begin: tag_comp_tl
     assign hit_v_tl[i]   = (tag_tl[i] == addr_tag_tl) && (state_tl[i] != e_COH_I);
     assign way_v_tl[i]   = (state_tl[i] != e_COH_I);
-  end     
+  end
 
   bsg_decode
    #(.num_out_p(icache_assoc_p))
    offset_decode
-    (.i(addr_word_offset_tl)
-     ,.o(addr_word_offset_dec_tl)
+    (.i(addr_bank_offset_tl)
+     ,.o(addr_bank_offset_dec_tl)
      );
 
   // TV stage
@@ -227,10 +230,11 @@ module bp_fe_icache
   logic [icache_assoc_p-1:0][$bits(bp_coh_states_e)-1:0]     state_tv_r;
   logic [icache_assoc_p-1:0][bank_width_lp-1:0]              ld_data_tv_r;
   logic [ptag_width_lp-1:0]                                  addr_tag_tv_r;
-  logic [icache_assoc_p-1:0]                                 addr_word_offset_dec_tv_r;
+  logic [icache_assoc_p-1:0]                                 addr_bank_offset_dec_tv_r;
   logic [index_width_lp-1:0]                                 addr_index_tv;
   logic                                                      fencei_op_tv_r;
   logic [icache_assoc_p-1:0]                                 hit_v_tv_r;
+
 
   // Flush ops are non-speculative and so cannot be poisoned
   assign tv_we = v_tl_r & ((~poison_i & ptag_v_i) | fencei_op_tl_r) & ~fencei_req;
@@ -253,7 +257,7 @@ module bp_fe_icache
         fencei_op_tv_r <= fencei_op_tl_r;
         hit_v_tv_r     <= hit_v_tl;
         addr_tag_tv_r  <= addr_tag_tl;
-        addr_word_offset_dec_tv_r <= addr_word_offset_dec_tl;
+        addr_bank_offset_dec_tv_r <= addr_bank_offset_dec_tl;
         way_v_tv_r     <= way_v_tl;
       end
     end
@@ -269,8 +273,8 @@ module bp_fe_icache
   logic [dword_width_p-1:0] uncached_load_data_r;
 
   assign uncached_req = v_tv_r & uncached_tv_r & ~uncached_load_data_v_r;
-  assign fencei_req = v_tv_r & fencei_op_tv_r; 
- 
+  assign fencei_req = v_tv_r & fencei_op_tv_r;
+
   // stat memory
   logic                                       stat_mem_v_li;
   logic                                       stat_mem_w_li;
@@ -310,7 +314,7 @@ module bp_fe_icache
     ,.v_o(invalid_exist)
     ,.addr_o(way_invalid_index)
  );
-  
+
   // LCE
   bp_icache_data_mem_pkt_s data_mem_pkt;
   assign data_mem_pkt = data_mem_pkt_i;
@@ -384,7 +388,7 @@ module bp_fe_icache
    #(.width_p(icache_assoc_p))
    select_adder
     (.a_i(hit_v_tv_r)
-     ,.b_i(addr_word_offset_dec_tv_r)
+     ,.b_i(addr_bank_offset_dec_tv_r)
      ,.o(ld_data_way_select)
      );
 
@@ -426,8 +430,11 @@ module bp_fe_icache
     : final_data[instr_width_p-1:0];
 
   // data mem
+  logic                                                       data_mem_v;
+  logic [icache_assoc_p-1:0]                                  data_mem_write_bank_mask;
+  logic [icache_assoc_p-1:0][bank_width_lp-1:0]               data_mem_pkt_data_expanded;
+  logic [block_size_in_fill_lp-1:0][fill_size_in_bank_lp-1:0] data_mem_pkt_fill_mask_expanded;
 
-  logic data_mem_v;
   assign data_mem_v = (data_mem_pkt.opcode != e_cache_data_mem_uncached)
     & data_mem_pkt_yumi_o;
 
@@ -436,25 +443,42 @@ module bp_fe_icache
     : {icache_assoc_p{data_mem_v}};
 
   assign data_mem_w_li = data_mem_pkt_yumi_o
-    & (data_mem_pkt.opcode == e_cache_data_mem_write);   
+    & (data_mem_pkt.opcode == e_cache_data_mem_write);
 
   for (genvar i = 0; i < icache_assoc_p; i++) begin : rof1
-    wire [word_offset_width_lp-1:0] data_mem_pkt_offset = (word_offset_width_lp'(i) - data_mem_pkt.way_id);
+    wire [bank_offset_width_lp-1:0] data_mem_pkt_offset = (bank_offset_width_lp'(i) - data_mem_pkt.way_id);
 
     assign data_mem_addr_li[i] = tl_we
       ? {vaddr_index, vaddr_offset}
       : {data_mem_pkt.index, data_mem_pkt_offset};
 
-    assign data_mem_w_mask_li[i] = {data_mem_mask_width_lp{1'b1}};
+    // use fill_index to generate write_mask
+    assign data_mem_w_mask_li[i] = {data_mem_mask_width_lp{data_mem_write_bank_mask[i]}};
   end
+
+  // Expand data_mem_pkt.data (fill width) to cacheline width
+  assign data_mem_pkt_data_expanded = {block_size_in_fill_lp{data_mem_pkt.data}};
 
   wire [`BSG_SAFE_CLOG2(icache_block_width_p)-1:0] write_data_rot_li = data_mem_pkt.way_id*bank_width_lp;
   bsg_rotate_left #(
     .width_p(icache_block_width_p)
   ) write_data_rotate (
-    .data_i(data_mem_pkt.data)
+    .data_i(data_mem_pkt_data_expanded)
     ,.rot_i(write_data_rot_li)
     ,.o(data_mem_data_li)
+  );
+
+  for (genvar i = 0; i < block_size_in_fill_lp; i++) begin
+    assign data_mem_pkt_fill_mask_expanded[i] = {fill_size_in_bank_lp{data_mem_pkt.fill_index[i]}};
+  end
+
+  wire [`BSG_SAFE_CLOG2(icache_assoc_p)-1:0] write_mask_rot_li = data_mem_pkt.way_id;
+  bsg_rotate_left #(
+    .width_p(icache_assoc_p)
+  ) write_mask_rotate (
+    .data_i(data_mem_pkt_fill_mask_expanded)
+    ,.rot_i(write_mask_rot_li)
+    ,.o(data_mem_write_bank_mask)
   );
 
   // tag_mem
@@ -505,7 +529,7 @@ module bp_fe_icache
     ? ~miss_tv
     : stat_mem_pkt_yumi_o & (stat_mem_pkt.opcode != e_cache_stat_mem_read);
   assign stat_mem_addr_li = (v_tv_r & ~uncached_tv_r)
-    ? addr_index_tv 
+    ? addr_index_tv
     : stat_mem_pkt.index;
 
   logic [icache_assoc_p-2:0] lru_decode_data_lo;
@@ -539,7 +563,7 @@ module bp_fe_icache
       stat_mem_mask_li = {(icache_assoc_p-1){1'b1}};
     end
   end
-   
+
   // LCE: data mem
   logic [way_id_width_lp-1:0] data_mem_pkt_way_r;
 
@@ -584,9 +608,9 @@ module bp_fe_icache
   end
 
   // LCE: tag_mem
-  
+
   logic [way_id_width_lp-1:0] tag_mem_pkt_way_r;
-  
+
   always_ff @ (posedge clk_i) begin
     if (tag_mem_pkt_yumi_o & (tag_mem_pkt.opcode == e_cache_tag_mem_read)) begin
       tag_mem_pkt_way_r <= tag_mem_pkt.way_id;
@@ -615,5 +639,5 @@ module bp_fe_icache
     );
   end
   // synopsys translate_on
-   
+
 endmodule

--- a/bp_fe/src/v/bp_fe_mem.v
+++ b/bp_fe/src/v/bp_fe_mem.v
@@ -7,8 +7,8 @@ module bp_fe_mem
  import bp_common_rv64_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
-   
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache)
+
    , localparam way_id_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)
    , localparam block_size_in_words_lp=icache_assoc_p
    , localparam bank_width_lp = icache_block_width_p / icache_assoc_p
@@ -49,8 +49,9 @@ module bp_fe_mem
    , input                                            cache_req_ready_i
    , output logic [icache_req_metadata_width_lp-1:0]  cache_req_metadata_o
    , output logic                                     cache_req_metadata_v_o
- 
+
    , input                                            cache_req_complete_i
+   , input                                            cache_req_critical_i
 
    , input [icache_data_mem_pkt_width_lp-1:0]         data_mem_pkt_i
    , input                                            data_mem_pkt_v_i
@@ -96,12 +97,12 @@ bp_tlb
    ,.reset_i(reset_i)
    ,.flush_i(itlb_fence_v)
    ,.translation_en_i(mem_translation_en_i)
-         
+
    ,.v_i(fetch_v | itlb_fill_v)
    ,.w_i(itlb_fill_v)
    ,.vtag_i(itlb_fill_v ? mem_cmd_cast_i.operands.fill.vtag : mem_cmd_cast_i.operands.fetch.vaddr.tag)
    ,.entry_i(mem_cmd_cast_i.operands.fill.entry)
-     
+
    ,.v_o(itlb_r_v_lo)
    ,.miss_v_o(itlb_miss_lo)
    ,.entry_o(itlb_r_entry)
@@ -124,8 +125,8 @@ logic [instr_width_p-1:0] icache_data_lo;
 logic                     icache_data_v_lo;
 
 logic instr_access_fault_v, instr_page_fault_v;
-bp_fe_icache 
- #(.bp_params_p(bp_params_p)) 
+bp_fe_icache
+ #(.bp_params_p(bp_params_p))
  icache
   (.clk_i(clk_i)
    ,.reset_i(reset_i)
@@ -155,6 +156,7 @@ bp_fe_icache
    ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
 
    ,.cache_req_complete_i(cache_req_complete_i)
+   ,.cache_req_critical_i(cache_req_critical_i)
 
    ,.data_mem_pkt_i(data_mem_pkt_i)
    ,.data_mem_pkt_v_i(data_mem_pkt_v_i)

--- a/bp_fe/src/v/bp_fe_mem.v
+++ b/bp_fe/src/v/bp_fe_mem.v
@@ -10,14 +10,13 @@ module bp_fe_mem
    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache)
 
    , localparam way_id_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)
-   , localparam block_size_in_words_lp=icache_assoc_p
    , localparam bank_width_lp = icache_block_width_p / icache_assoc_p
    , localparam num_dwords_per_bank_lp = bank_width_lp / dword_width_p
    , localparam data_mem_mask_width_lp=(bank_width_lp >> 3)
    , localparam byte_offset_width_lp=`BSG_SAFE_CLOG2(bank_width_lp >> 3)
-   , localparam word_offset_width_lp=`BSG_SAFE_CLOG2(block_size_in_words_lp)
+   , localparam bank_offset_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)
    , localparam index_width_lp=`BSG_SAFE_CLOG2(icache_sets_p)
-   , localparam block_offset_width_lp=(word_offset_width_lp+byte_offset_width_lp)
+   , localparam block_offset_width_lp=(bank_offset_width_lp+byte_offset_width_lp)
    , localparam ptag_width_lp=(paddr_width_p-bp_page_offset_width_gp)
 
    , localparam stat_width_lp = `bp_cache_stat_info_width(icache_assoc_p)

--- a/bp_fe/src/v/bp_fe_pc_gen.v
+++ b/bp_fe/src/v/bp_fe_pc_gen.v
@@ -21,7 +21,7 @@ module bp_fe_pc_gen
    )
   (input                                             clk_i
    , input                                           reset_i
- 
+
    , output [mem_cmd_width_lp-1:0]                   mem_cmd_o
    , output                                          mem_cmd_v_o
    , input                                           mem_cmd_yumi_i
@@ -85,7 +85,7 @@ wire [vaddr_width_p-1:0] pc_if2 = pc_gen_stage_r[1].pc;
 
 // Flags for valid FE commands
 wire fetch_v          = mem_cmd_yumi_i & (mem_cmd_cast_o.op == e_fe_op_fetch);
-wire state_reset_v    = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_state_reset); 
+wire state_reset_v    = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_state_reset);
 wire pc_redirect_v    = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_pc_redirection);
 wire itlb_fill_v      = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_itlb_fill_response);
 wire icache_fence_v   = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_icache_fence);
@@ -117,7 +117,7 @@ bsg_dff_reset_en
    ,.data_i(shadow_priv_n)
    ,.data_o(shadow_priv_r)
    );
-   
+
 logic shadow_translation_en_n, shadow_translation_en_r;
 wire shadow_translation_en_w = state_reset_v | trap_v | itlb_fence_v;
 assign shadow_translation_en_n = fe_cmd_cast_i.operands.pc_redirect_operands.translation_enabled;
@@ -176,15 +176,15 @@ always_comb
     // Stall until we can start valid fetch
     e_stall: state_n = pc_gen_stage_n[0].v ? e_run : e_stall;
     // Run state -- PCs are actually being fetched
-    // Stay in run if there's an incoming cmd, the next pc will automatically be valid 
+    // Stay in run if there's an incoming cmd, the next pc will automatically be valid
     // Transition to wait if there's a TLB miss while we wait for fill
     // Transition to stall if we don't successfully complete the fetch for whatever reason
-    e_run  : state_n = cmd_nonattaboy_v 
-                       ? e_run 
-                       : fetch_fail 
-                         ? e_stall 
-                         : fe_exception_v 
-                           ? e_wait 
+    e_run  : state_n = cmd_nonattaboy_v
+                       ? e_run
+                       : fetch_fail
+                         ? e_stall
+                         : fe_exception_v
+                           ? e_wait
                            : e_run;
     default: state_n = e_wait;
   endcase
@@ -194,7 +194,7 @@ always_ff @(posedge clk_i)
   if (reset_i)
       state_r <= e_wait;
   else
-    begin 
+    begin
       state_r <= state_n;
     end
 
@@ -298,7 +298,7 @@ always_ff @(posedge clk_i)
   end
 
 bp_fe_branch_metadata_fwd_s fe_queue_cast_o_branch_metadata;
-assign fe_queue_cast_o_branch_metadata = 
+assign fe_queue_cast_o_branch_metadata =
   '{pred_taken: pc_gen_stage_r[1].taken | is_jalr // We can't predict target, but jalr are always taken
     ,src_btb  : pc_gen_stage_r[1].btb
     ,src_ret  : pc_gen_stage_r[1].ret
@@ -337,7 +337,7 @@ bp_fe_btb
    ,.w_v_i(fe_cmd_yumi_o & btb_incorrect)
    ,.w_clr_i(br_miss_nonbr)
    ,.w_jmp_i(br_res_jmp)
-   ,.w_tag_i(fe_cmd_branch_metadata.btb_tag) 
+   ,.w_tag_i(fe_cmd_branch_metadata.btb_tag)
    ,.w_idx_i(fe_cmd_branch_metadata.btb_idx)
    ,.br_tgt_i(fe_cmd_cast_i.vaddr)
    );
@@ -366,7 +366,7 @@ bp_fe_bht
 
 `declare_bp_fe_instr_scan_s(vaddr_width_p)
 bp_fe_instr_scan_s scan_instr;
-bp_fe_instr_scan 
+bp_fe_instr_scan
  #(.bp_params_p(bp_params_p))
  instr_scan
   (.instr_i(mem_resp_cast_i.data)
@@ -401,7 +401,7 @@ bsg_dff_reset_en
 // We wait until both the FE queue and I$ are ready, but flushes invalidate the fetch.
 // The next PC is valid during a FE cmd, since it is a non-speculative
 //   command and we must accept it immediately.
-// This may cause us to fetch during an I$ miss or a with a full queue.  
+// This may cause us to fetch during an I$ miss or a with a full queue.
 // FE cmds normally flush the queue, so we don't expect this to affect
 //   power much in practice.
 assign mem_cmd_v_o = cmd_nonattaboy_v || (~is_wait & fe_queue_ready_i & ~flush);
@@ -456,7 +456,7 @@ always_comb
                                                          ? e_instr_page_fault
                                                          : e_instr_access_fault;
       end
-    else 
+    else
       begin
         fe_queue_cast_o.msg_type                      = e_fe_fetch;
         fe_queue_cast_o.msg.fetch.pc                  = pc_if2;
@@ -466,4 +466,3 @@ always_comb
   end
 
 endmodule
-

--- a/bp_fe/src/v/bp_fe_top.v
+++ b/bp_fe/src/v/bp_fe_top.v
@@ -16,14 +16,13 @@ module bp_fe_top
    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache)
 
    , localparam way_id_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)
-   , localparam block_size_in_words_lp=icache_assoc_p
    , localparam bank_width_lp = icache_block_width_p / icache_assoc_p
    , localparam num_dwords_per_bank_lp = bank_width_lp / dword_width_p
    , localparam data_mem_mask_width_lp=(bank_width_lp >> 3)
    , localparam byte_offset_width_lp=`BSG_SAFE_CLOG2(bank_width_lp >> 3)
-   , localparam word_offset_width_lp=`BSG_SAFE_CLOG2(block_size_in_words_lp)
+   , localparam bank_offset_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)
    , localparam index_width_lp=`BSG_SAFE_CLOG2(icache_sets_p)
-   , localparam block_offset_width_lp=(word_offset_width_lp+byte_offset_width_lp)
+   , localparam block_offset_width_lp=(bank_offset_width_lp+byte_offset_width_lp)
    , localparam ptag_width_lp=(paddr_width_p-bp_page_offset_width_gp)
 
    , localparam stat_width_lp = `bp_cache_stat_info_width(icache_assoc_p)

--- a/bp_fe/src/v/bp_fe_top.v
+++ b/bp_fe/src/v/bp_fe_top.v
@@ -1,5 +1,5 @@
-/*                                  
- * bp_fe_top.v 
+/*
+ * bp_fe_top.v
  */
 
 module bp_fe_top
@@ -13,8 +13,8 @@ module bp_fe_top
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_fe_be_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
-   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
-   
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache)
+
    , localparam way_id_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)
    , localparam block_size_in_words_lp=icache_assoc_p
    , localparam bank_width_lp = icache_block_width_p / icache_assoc_p
@@ -25,7 +25,7 @@ module bp_fe_top
    , localparam index_width_lp=`BSG_SAFE_CLOG2(icache_sets_p)
    , localparam block_offset_width_lp=(word_offset_width_lp+byte_offset_width_lp)
    , localparam ptag_width_lp=(paddr_width_p-bp_page_offset_width_gp)
-   
+
    , localparam stat_width_lp = `bp_cache_stat_info_width(icache_assoc_p)
 
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
@@ -50,9 +50,9 @@ module bp_fe_top
    , input                                            cache_req_ready_i
    , output logic [icache_req_metadata_width_lp-1:0]  cache_req_metadata_o
    , output logic                                     cache_req_metadata_v_o
- 
-   , input                                            cache_req_complete_i
 
+   , input                                            cache_req_complete_i
+   , input                                            cache_req_critical_i
    , input [icache_data_mem_pkt_width_lp-1:0]         data_mem_pkt_i
    , input                                            data_mem_pkt_v_i
    , output logic                                     data_mem_pkt_yumi_o
@@ -71,7 +71,7 @@ module bp_fe_top
 
 `declare_bp_fe_be_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 `declare_bp_fe_mem_structs(vaddr_width_p, icache_sets_p, icache_block_width_p, vtag_width_p, ptag_width_p)
-   
+
 bp_fe_mem_cmd_s  mem_cmd_lo;
 logic            mem_cmd_v_lo, mem_cmd_yumi_li;
 logic [rv64_priv_width_gp-1:0]  mem_priv_lo;
@@ -79,12 +79,12 @@ logic            mem_poison_lo, mem_translation_en_lo;
 bp_fe_mem_resp_s mem_resp_li;
 logic            mem_resp_v_li;
 
-bp_fe_pc_gen 
- #(.bp_params_p(bp_params_p)) 
+bp_fe_pc_gen
+ #(.bp_params_p(bp_params_p))
  pc_gen
   (.clk_i(clk_i)
    ,.reset_i(reset_i)
-               
+
    ,.mem_cmd_o(mem_cmd_lo)
    ,.mem_cmd_v_o(mem_cmd_v_lo)
    ,.mem_cmd_yumi_i(mem_cmd_yumi_li)
@@ -110,9 +110,9 @@ bp_fe_mem
  mem
   (.clk_i(clk_i)
    ,.reset_i(reset_i)
-   
+
    ,.cfg_bus_i(cfg_bus_i)
-   
+
    ,.mem_cmd_i(mem_cmd_lo)
    ,.mem_cmd_v_i(mem_cmd_v_lo)
    ,.mem_cmd_yumi_o(mem_cmd_yumi_li)
@@ -131,6 +131,7 @@ bp_fe_mem
    ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
 
    ,.cache_req_complete_i(cache_req_complete_i)
+   ,.cache_req_critical_i(cache_req_critical_i)
 
    ,.data_mem_pkt_i(data_mem_pkt_i)
    ,.data_mem_pkt_v_i(data_mem_pkt_v_i)
@@ -149,4 +150,3 @@ bp_fe_mem
    );
 
 endmodule
-

--- a/bp_fe/syn/flist.vcs
+++ b/bp_fe/syn/flist.vcs
@@ -111,6 +111,7 @@ $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_chain.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_en.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_en.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_set_clear.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_edge_detect.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_encode_one_hot.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_expand_bitmask.v
@@ -241,7 +242,7 @@ $BP_ME_DIR/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v
 $BP_ME_DIR/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
 ## TOP
 $BP_TOP_DIR/src/v/bp_nd_socket.v
-# $BP_TOP_DIR/src/v/bp_cacc_vdp.v
+$BP_TOP_DIR/src/v/bp_cacc_vdp.v
 $BP_TOP_DIR/src/v/bp_cacc_tile.v
 $BP_TOP_DIR/src/v/bp_cacc_tile_node.v
 $BP_TOP_DIR/src/v/bp_cacc_complex.v

--- a/bp_fe/syn/flist.vcs
+++ b/bp_fe/syn/flist.vcs
@@ -154,8 +154,8 @@ $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter_in.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter_out.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_decoder_dor.v
-$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_input_control.v  
-$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.v 
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_input_control.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.v
 # Common files
 $BP_COMMON_DIR/src/v/bsg_fifo_1r1w_rolly.v
 $BP_COMMON_DIR/src/v/bp_pma.v
@@ -241,7 +241,7 @@ $BP_ME_DIR/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v
 $BP_ME_DIR/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
 ## TOP
 $BP_TOP_DIR/src/v/bp_nd_socket.v
-$BP_TOP_DIR/src/v/bp_cacc_vdp.v
+# $BP_TOP_DIR/src/v/bp_cacc_vdp.v
 $BP_TOP_DIR/src/v/bp_cacc_tile.v
 $BP_TOP_DIR/src/v/bp_cacc_tile_node.v
 $BP_TOP_DIR/src/v/bp_cacc_complex.v

--- a/bp_fe/test/tb/bp_fe_icache/testbench.v
+++ b/bp_fe/test/tb/bp_fe_icache/testbench.v
@@ -39,7 +39,7 @@ module testbench
    , parameter dram_capacity_p           = 16384
 
   // I-Cache Widths
-  `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
+  `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache)
 
   // LCE-CCE Interface Widths
   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)

--- a/bp_fe/test/tb/bp_fe_icache/testbench.v
+++ b/bp_fe/test/tb/bp_fe_icache/testbench.v
@@ -30,9 +30,9 @@ module testbench
    , parameter use_max_latency_p      = 0
    , parameter use_random_latency_p   = 1
    , parameter use_dramsim2_latency_p = 0
-   
+
    , parameter max_latency_p = 15
-   
+
    , parameter dram_clock_period_in_ps_p = 1000
    , parameter dram_cfg_p                = "dram_ch.ini"
    , parameter dram_sys_cfg_p            = "dram_sys.ini"
@@ -40,13 +40,13 @@ module testbench
 
   // I-Cache Widths
   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
-  
+
   // LCE-CCE Interface Widths
   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
-  
+
   // CCE-MEM Interface Widths
   `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-  
+
   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
   , localparam page_offset_width_lp = bp_page_offset_width_gp
   , localparam ptag_width_lp = (paddr_width_p - page_offset_width_lp)
@@ -70,7 +70,7 @@ module testbench
   logic mem_cmd_v_lo, mem_resp_v_lo;
   logic mem_cmd_ready_lo, mem_resp_yumi_li;
   logic [cce_mem_msg_width_lp-1:0] mem_cmd_lo, mem_resp_lo;
- 
+
   logic [trace_replay_data_width_lp-1:0] trace_data_lo;
   logic trace_v_lo;
   logic dut_ready_lo;
@@ -97,7 +97,7 @@ module testbench
     cfg_bus_cast_li.icache_mode = e_lce_mode_normal;
     cfg_bus_cast_li.cce_mode = e_cce_mode_normal;
   end
- 
+
   assign ptag_li = trace_data_lo[0+:(ptag_width_lp)];
   assign vaddr_li = trace_data_lo[ptag_width_lp+:vaddr_width_p];
   assign uncached_li = trace_data_lo[(ptag_width_lp+vaddr_width_p)+:1];
@@ -168,11 +168,11 @@ module testbench
 
   // This fifo has 16 elements since maximum number of streaming hits is 16
   // Probably a side effect of the testing strategy.  Open for debate
-  bsg_fifo_1r1w_small 
+  bsg_fifo_1r1w_small
     #(.width_p(instr_width_p)
      ,.els_p(16)
     )
-    output_fifo 
+    output_fifo
     (.clk_i(clk_i)
     ,.reset_i(reset_i)
 
@@ -197,11 +197,11 @@ module testbench
      ,.reset_i(reset_i)
 
      ,.cfg_bus_i(cfg_bus_li)
-     
+
      ,.vaddr_i(vaddr_li)
      ,.vaddr_v_i(trace_v_lo)
      ,.vaddr_ready_o(dut_ready_lo)
-     
+
      ,.ptag_i(ptag_li)
      ,.ptag_v_i(trace_v_lo)
 
@@ -226,12 +226,12 @@ module testbench
      ,.mem_zero_p(mem_zero_p)
      ,.mem_file_p(mem_file_p)
      ,.mem_offset_p(mem_offset_p)
-   
+
      ,.use_max_latency_p(use_max_latency_p)
      ,.use_random_latency_p(use_random_latency_p)
      ,.use_dramsim2_latency_p(use_dramsim2_latency_p)
      ,.max_latency_p(max_latency_p)
-   
+
      ,.dram_clock_period_in_ps_p(dram_clock_period_in_ps_p)
      ,.dram_cfg_p(dram_cfg_p)
      ,.dram_sys_cfg_p(dram_sys_cfg_p)
@@ -240,11 +240,11 @@ module testbench
     mem
     (.clk_i(clk_i)
     ,.reset_i(reset_i)
- 
+
     ,.mem_cmd_i(mem_cmd_lo)
     ,.mem_cmd_v_i(mem_cmd_v_lo)
     ,.mem_cmd_ready_o(mem_cmd_ready_lo)
- 
+
     ,.mem_resp_o(mem_resp_lo)
     ,.mem_resp_v_o(mem_resp_v_lo)
     ,.mem_resp_yumi_i(mem_resp_yumi_li)
@@ -257,14 +257,15 @@ module testbench
      ,.assoc_p(icache_assoc_p)
      ,.sets_p(icache_sets_p)
      ,.block_width_p(icache_block_width_p)
+     ,.fill_width_p(icache_fill_width_p)
      ,.trace_file_p("icache"))
     icache_tracer
       (.clk_i(clk_i)
       ,.reset_i(reset_i)
-      
+
       ,.freeze_i(cfg_bus_cast_i.freeze)
       ,.mhartid_i(cfg_bus_cast_i.core_id)
-      
+
       ,.v_tl_r(v_tl_r)
 
       ,.v_tv_r(v_tv_r)
@@ -280,7 +281,7 @@ module testbench
       ,.cache_req_complete_i(cache_req_complete_i)
 
       ,.wt_req()
-      
+
       ,.v_o(data_v_o)
       ,.load_data(dword_width_p'(data_o))
       ,.store_data(dword_width_p'(0))

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.v
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.v
@@ -9,8 +9,8 @@ module wrapper
   #(parameter bp_params_e bp_params_p = BP_CFG_FLOWVAR
   , parameter uce_p = 1
   `declare_bp_proc_params(bp_params_p)
-  `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
   `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
+  `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache)
   `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
 
   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
@@ -26,8 +26,8 @@ module wrapper
   , localparam index_width_lp=`BSG_SAFE_CLOG2(icache_sets_p)
   , localparam block_offset_width_lp=(word_offset_width_lp+byte_offset_width_lp)
   , localparam ptag_width_lp=(paddr_width_p-bp_page_offset_width_gp)
-  , localparam stat_width_lp = `bp_cache_stat_info_width(icache_assoc_p) 
- 
+  , localparam stat_width_lp = `bp_cache_stat_info_width(icache_assoc_p)
+
   )
   ( input                             clk_i
   , input                             reset_i
@@ -67,7 +67,7 @@ module wrapper
   logic [icache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
   logic cache_req_metadata_v_lo;
 
-  logic cache_req_complete_li;
+  logic cache_req_complete_li, cache_req_critical_li;
 
   // Fill Interfaces
   logic data_mem_pkt_v_li, tag_mem_pkt_v_li, stat_mem_pkt_v_li;
@@ -78,7 +78,7 @@ module wrapper
   logic [icache_block_width_p-1:0] data_mem_lo;
   logic [ptag_width_lp-1:0] tag_mem_lo;
   logic [stat_width_lp-1:0] stat_mem_lo;
-  
+
   // Rolly fifo signals
   logic [ptag_width_lp-1:0] rolly_ptag_lo;
   logic [vaddr_width_p-1:0] rolly_vaddr_lo;
@@ -182,13 +182,13 @@ module wrapper
     icache
     (.clk_i(clk_i)
     ,.reset_i(reset_i)
-    
+
     ,.cfg_bus_i(cfg_bus_i)
-    
+
     ,.vaddr_i(rolly_vaddr_lo)
     ,.vaddr_v_i(rolly_v_lo)
     ,.fencei_v_i(1'b0)
-    ,.vaddr_ready_o(icache_ready_lo)    
+    ,.vaddr_ready_o(icache_ready_lo)
 
     ,.ptag_i(rolly_ptag_r)
     ,.ptag_v_i(ptag_v_r)
@@ -198,7 +198,7 @@ module wrapper
     ,.data_o(data_o)
     ,.data_v_o(data_v_o)
     ,.miss_o(icache_miss_lo)
-     
+
     ,.cache_req_ready_i(cache_req_ready_li)
     ,.cache_req_o(cache_req_lo)
     ,.cache_req_v_o(cache_req_v_lo)
@@ -206,6 +206,7 @@ module wrapper
     ,.cache_req_metadata_v_o(cache_req_metadata_v_lo)
 
     ,.cache_req_complete_i(cache_req_complete_li)
+    ,.cache_req_critical_i(cache_req_critical_li)
 
     ,.data_mem_pkt_v_i(data_mem_pkt_v_li)
     ,.data_mem_pkt_i(data_mem_pkt_li)
@@ -229,7 +230,7 @@ module wrapper
     logic [lce_cce_req_width_lp-1:0] lce_req_lo;
     logic [lce_cce_resp_width_lp-1:0] lce_resp_lo;
     logic [lce_cmd_width_lp-1:0] lce_cmd_lo, fifo_lce_cmd_lo;
-    logic mem_resp_ready_lo;    
+    logic mem_resp_ready_lo;
 
     // I-Cache LCE
     bp_lce
@@ -244,7 +245,7 @@ module wrapper
       icache_lce
       (.clk_i(clk_i)
       ,.reset_i(reset_i)
-      
+
       ,.lce_id_i(cfg_bus_cast_i.icache_id)
       ,.lce_mode_i(cfg_bus_cast_i.icache_mode)
 
@@ -255,12 +256,13 @@ module wrapper
       ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
 
       ,.cache_req_complete_o(cache_req_complete_li)
+      ,.cache_req_critical_o(cache_req_critical_li)
 
       ,.data_mem_i(data_mem_lo)
       ,.data_mem_pkt_o(data_mem_pkt_li)
       ,.data_mem_pkt_v_o(data_mem_pkt_v_li)
       ,.data_mem_pkt_yumi_i(data_mem_pkt_yumi_lo)
-      
+
       ,.tag_mem_i(tag_mem_lo)
       ,.tag_mem_pkt_o(tag_mem_pkt_li)
       ,.tag_mem_pkt_v_o(tag_mem_pkt_v_li)
@@ -289,7 +291,8 @@ module wrapper
 
       ,.credits_full_o()
       ,.credits_empty_o()
-      );  
+      );
+
 
     // lce cmd demanding -> demanding handshake conversion
     bsg_two_fifo
@@ -297,7 +300,7 @@ module wrapper
       cmd_fifo
       (.clk_i(clk_i)
       ,.reset_i(reset_i)
-      
+
       // from CCE
       ,.v_i(lce_cmd_v_lo)
       ,.ready_o(lce_cmd_ready_li)
@@ -365,6 +368,7 @@ module wrapper
       ,.cache_req_metadata_i(cache_req_metadata_lo)
       ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
       ,.cache_req_complete_o(cache_req_complete_li)
+      ,.cache_req_critical_o(cache_req_critical_li)
 
       ,.tag_mem_pkt_o(tag_mem_pkt_li)
       ,.tag_mem_pkt_v_o(tag_mem_pkt_v_li)
@@ -400,7 +404,7 @@ module wrapper
       mem_resp_fifo
       (.clk_i(clk_i)
       ,.reset_i(reset_i)
-      
+
       ,.v_i(mem_resp_v_i)
       ,.data_i(mem_resp_i)
       ,.ready_o(mem_resp_ready_lo)
@@ -412,4 +416,4 @@ module wrapper
 
     assign mem_resp_yumi_o = mem_resp_ready_lo & mem_resp_v_i;
   end
-endmodule  
+endmodule

--- a/bp_me/src/v/cce/bp_uce.v
+++ b/bp_me/src/v/cce/bp_uce.v
@@ -9,6 +9,8 @@ module bp_uce
    ,parameter assoc_p = 8
    ,parameter sets_p = 64
    ,parameter block_width_p = 512
+   ,parameter fill_width_p = 512
+
     `declare_bp_proc_params(bp_params_p)
     `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
 
@@ -18,21 +20,31 @@ module bp_uce
     , localparam num_dwords_per_bank_lp = bank_width_lp / dword_width_p
     , localparam byte_offset_width_lp  = `BSG_SAFE_CLOG2(bank_width_lp>>3)
     // Words per line == associativity
-    , localparam word_offset_width_lp  = `BSG_SAFE_CLOG2(assoc_p)
-    , localparam block_offset_width_lp = (word_offset_width_lp + byte_offset_width_lp)
+    , localparam bank_offset_width_lp  = `BSG_SAFE_CLOG2(assoc_p)
+    , localparam block_offset_width_lp = (bank_offset_width_lp + byte_offset_width_lp)
     , localparam index_width_lp = `BSG_SAFE_CLOG2(sets_p)
     , localparam way_width_lp = `BSG_SAFE_CLOG2(assoc_p)
+    , localparam block_size_in_fill_lp = block_width_p / fill_width_p
+    , localparam fill_size_in_bank_lp = fill_width_p / bank_width_lp
+    , localparam fill_cnt_width_lp = `BSG_SAFE_CLOG2(block_size_in_fill_lp)
+    , localparam bank_sub_offset_width_lp = `BSG_SAFE_CLOG2(fill_size_in_bank_lp)
 
-    , localparam cache_req_width_lp = `bp_cache_req_width(dword_width_p, paddr_width_p) 
+    , localparam cache_req_width_lp = `bp_cache_req_width(dword_width_p, paddr_width_p)
     , localparam cache_req_metadata_width_lp = `bp_cache_req_metadata_width(assoc_p)
     , localparam cache_tag_mem_pkt_width_lp = `bp_cache_tag_mem_pkt_width(sets_p, assoc_p, ptag_width_p)
-    , localparam cache_data_mem_pkt_width_lp = `bp_cache_data_mem_pkt_width(sets_p, assoc_p, block_width_p)
+    , localparam cache_data_mem_pkt_width_lp = `bp_cache_data_mem_pkt_width(sets_p, assoc_p, block_width_p, fill_width_p)
     , localparam cache_stat_mem_pkt_width_lp = `bp_cache_stat_mem_pkt_width(sets_p, assoc_p)
 
-    // Block size parameterisations - 
-    , localparam is_blockwidth_512 = (block_width_p == 512)
-    , localparam is_blockwidth_256 = (block_width_p == 256)
-    , localparam is_blockwidth_128 = (block_width_p == 128)
+    // Fill size parameterisations -
+    , localparam bp_mem_msg_size_e block_msg_size_lp = (fill_width_p == 512)
+                                                      ? e_mem_msg_size_64
+                                                      : (fill_width_p == 256)
+                                                        ? e_mem_msg_size_32
+                                                        : (fill_width_p == 128)
+                                                          ? e_mem_msg_size_16
+                                                          : (fill_width_p == 64)
+                                                            ? e_mem_msg_size_8
+                                                            : e_mem_msg_size_64
     )
    (input                                            clk_i
     , input                                          reset_i
@@ -45,6 +57,7 @@ module bp_uce
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
     , output logic                                   cache_req_complete_o
+    , output logic                                   cache_req_critical_o
 
     , output logic [cache_tag_mem_pkt_width_lp-1:0]  tag_mem_pkt_o
     , output logic                                   tag_mem_pkt_v_o
@@ -74,7 +87,7 @@ module bp_uce
     );
 
   `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, sets_p, assoc_p, dword_width_p, block_width_p, cache);
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache);
   `declare_bp_cache_stat_info_s(assoc_p, cache);
 
   `bp_cast_i(bp_cache_req_s, cache_req);
@@ -105,7 +118,7 @@ module bp_uce
      ,.data_i(cache_req_cast_i)
      ,.data_o(cache_req_r)
      );
- 
+
   bp_cache_req_metadata_s cache_req_metadata_r;
   bsg_dff_en_bypass
    #(.width_p($bits(bp_cache_req_metadata_s)))
@@ -162,7 +175,7 @@ module bp_uce
      );
 
   // We can do a little better by sending the read_request before the writeback
-  enum logic [3:0] {e_reset, e_clear, e_flush_read, e_flush_scan, e_flush_write, e_flush_fence, e_ready, e_send_req, e_writeback_read, e_writeback_req, e_write_wait, e_read_wait, e_uc_read_wait} state_n, state_r;
+  enum logic [3:0] {e_reset, e_clear, e_flush_read, e_flush_scan, e_flush_write, e_flush_fence, e_ready, e_send_critical, e_writeback_evict, e_writeback_read_req, e_writeback_write_req, e_write_wait, e_read_req, e_uc_read_wait} state_n, state_r;
   wire is_reset         = (state_r == e_reset);
   wire is_clear         = (state_r == e_clear);
   wire is_flush_read    = (state_r == e_flush_read);
@@ -170,11 +183,12 @@ module bp_uce
   wire is_flush_write   = (state_r == e_flush_write);
   wire is_flush_fence   = (state_r == e_flush_fence);
   wire is_ready         = (state_r == e_ready);
-  wire is_send_req      = (state_r == e_send_req);
-  wire is_writeback_read = (state_r == e_writeback_read);
-  wire is_writeback_req = (state_r == e_writeback_req);
-  wire is_write_request = (state_r == e_write_wait);
-  wire is_read_request  = (state_r == e_read_wait);
+  wire is_send_critical = (state_r == e_send_critical);
+  wire is_writeback_evict = (state_r == e_writeback_evict); // read dirty data from cache to UCE
+  wire is_writeback_read = (state_r == e_writeback_read_req); // read data from L2 to cache
+  wire is_writeback_wb   = (state_r == e_writeback_write_req); // send dirty data from UCE to L2
+  wire is_write_request  = (state_r == e_write_wait);
+  wire is_read_request   = (state_r == e_read_req);
 
   // We check for uncached stores ealier than other requests, because they get sent out in ready
   wire flush_v_li         = cache_req_v_i & cache_req_cast_i.msg_type inside {e_cache_flush};
@@ -182,7 +196,7 @@ module bp_uce
   wire uc_store_v_li      = cache_req_v_i & cache_req_cast_i.msg_type inside {e_uc_store};
 
   wire wt_store_v_li      = cache_req_v_i & cache_req_cast_i.msg_type inside {e_wt_store};
-  
+
   wire store_resp_v_li    = mem_resp_v_i & mem_resp_cast_i.header.msg_type inside {e_cce_mem_wr, e_cce_mem_uc_wr};
   wire load_resp_v_li     = mem_resp_v_i & mem_resp_cast_i.header.msg_type inside {e_cce_mem_rd, e_cce_mem_uc_rd};
 
@@ -191,41 +205,111 @@ module bp_uce
   wire miss_v_li       = miss_load_v_li | miss_store_v_li;
   wire uc_load_v_li    = cache_req_v_r & cache_req_r.msg_type inside {e_uc_load};
 
+  // When fill_width_p < block_width_p, multicycle fill and writeback is implemented in cache flush write,
+  // cache miss load with and without dirty data writeback.
+  // To track the progress of these multicycle opeation, two counters, fill_cnt and mem_cmd_cnt are added
+  // In addition, mem_cmd_cnt is used to generated the addr in mem_cmd_o to request data from L2 and
+  // to write back dirty data to L2 in the size of fill_width.
+  logic [fill_cnt_width_lp-1:0] mem_cmd_cnt;
+  logic [block_size_in_fill_lp-1:0] fill_index_shift;
+  logic [bank_offset_width_lp-1:0] bank_index;
+  if (fill_size_in_bank_lp == 1)
+    begin
+      assign bank_index =  mem_cmd_cnt;
+      assign fill_index_shift = mem_resp_cast_i.header.addr[byte_offset_width_lp+:bank_offset_width_lp];
+    end
+  else
+    begin
+      assign bank_index = mem_cmd_cnt << bank_sub_offset_width_lp;
+      assign fill_index_shift = mem_resp_cast_i.header.addr[byte_offset_width_lp+:bank_offset_width_lp] >> bank_sub_offset_width_lp;
+    end
+
+  logic fill_up, fill_done, mem_cmd_up, mem_cmd_done;
+  if (fill_width_p == block_width_p)
+    begin
+      assign mem_cmd_cnt = 1'b0;
+      assign fill_done = 1'b1;
+      assign mem_cmd_done = 1'b1;
+    end
+  else
+    begin
+      logic [fill_cnt_width_lp-1:0] fill_cnt;
+      bsg_counter_clear_up
+       #(.max_val_p(block_size_in_fill_lp-1)
+        ,.init_val_p(0)
+        ,.disable_overflow_warning_p(1))
+      fill_counter
+        (.clk_i(clk_i)
+        ,.reset_i(reset_i)
+
+        ,.clear_i('0)
+        ,.up_i(fill_up)
+
+        ,.count_o(fill_cnt)
+        );
+      assign fill_done = (fill_cnt == block_size_in_fill_lp-1);
+
+      bsg_counter_clear_up
+       #(.max_val_p(block_size_in_fill_lp-1)
+        ,.init_val_p(0)
+        ,.disable_overflow_warning_p(1))
+       mem_cmd_counter
+        (.clk_i(clk_i)
+        ,.reset_i(reset_i)
+
+        ,.clear_i('0)
+        ,.up_i(mem_cmd_up)
+
+        ,.count_o(mem_cmd_cnt)
+        );
+      assign mem_cmd_done = (mem_cmd_cnt == block_size_in_fill_lp-1);
+    end
+
   logic [index_width_lp-1:0] index_cnt;
   logic index_up;
   bsg_counter_clear_up
    #(.max_val_p(sets_p-1)
-     ,.init_val_p(0)
-     ,.disable_overflow_warning_p(1)
-     )
+    ,.init_val_p(0)
+    ,.disable_overflow_warning_p(1))
    index_counter
     (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+    ,.reset_i(reset_i)
 
-     ,.clear_i('0)
-     ,.up_i(index_up)
+    ,.clear_i('0)
+    ,.up_i(index_up)
 
-     ,.count_o(index_cnt)
-     );
+    ,.count_o(index_cnt)
+    );
   wire index_done = (index_cnt == sets_p-1);
 
   logic [way_width_lp-1:0] way_cnt;
   logic way_up;
   bsg_counter_clear_up
    #(.max_val_p(assoc_p-1)
-     ,.init_val_p(0)
-     ,.disable_overflow_warning_p(1)
-     )
+    ,.init_val_p(0)
+    ,.disable_overflow_warning_p(1))
    way_counter
     (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+    ,.reset_i(reset_i)
 
-     ,.clear_i('0)
-     ,.up_i(way_up)
+    ,.clear_i('0)
+    ,.up_i(way_up)
 
-     ,.count_o(way_cnt)
-     );
+    ,.count_o(way_cnt)
+    );
   wire way_done = (way_cnt == assoc_p-1);
+
+  logic mem_cmd_done_r;
+  bsg_dff_reset_set_clear
+   #(.width_p(1)
+    ,.clear_over_set_p(1)) // if 1, clear overrides set.
+   mem_cmd_done_reg
+    (.clk_i(clk_i)
+    ,.reset_i(reset_i)
+    ,.set_i(mem_cmd_done & mem_cmd_v_o)
+    ,.clear_i(cache_req_complete_o | way_up)
+    ,.data_o(mem_cmd_done_r)
+    );
 
   // Outstanding Requests Counter - counts all requests, cached and uncached
   //
@@ -251,7 +335,17 @@ module bp_uce
   assign credits_full_o = (credit_count_lo == coh_noc_max_credits_p);
   assign credits_empty_o = (credit_count_lo == 0);
 
-  // We ack mem_resps for uncached stores no matter what, so mem_resp_yumi_lo is for other responses 
+  logic [fill_width_p-1:0] writeback_data;
+  bsg_mux
+   #(.width_p(fill_width_p)
+    ,.els_p(block_size_in_fill_lp))
+   writeback_mux
+    (.data_i(dirty_data_r)
+    ,.sel_i(mem_cmd_cnt)
+    ,.data_o(writeback_data)
+    );
+
+  // We ack mem_resps for uncached stores no matter what, so mem_resp_yumi_lo is for other responses
   logic mem_resp_yumi_lo;
   assign mem_resp_yumi_o = mem_resp_yumi_lo | store_resp_v_li;
   always_comb
@@ -260,6 +354,8 @@ module bp_uce
 
       index_up = '0;
       way_up   = '0;
+      fill_up  = '0;
+      mem_cmd_up = '0;
 
       tag_mem_pkt_cast_o  = '0;
       tag_mem_pkt_v_o     = '0;
@@ -269,6 +365,7 @@ module bp_uce
       stat_mem_pkt_v_o    = '0;
 
       cache_req_complete_o = '0;
+      cache_req_critical_o = '0;
 
       mem_cmd_cast_o   = '0;
       mem_cmd_v_o      = '0;
@@ -314,6 +411,7 @@ module bp_uce
                 data_mem_pkt_cast_o.index  = index_cnt;
                 data_mem_pkt_cast_o.way_id = way_cnt;
                 data_mem_pkt_v_o = 1'b1;
+                data_mem_pkt_cast_o.fill_index = {block_size_in_fill_lp{1'b1}};
 
                 tag_mem_pkt_cast_o.opcode = e_cache_tag_mem_read;
                 tag_mem_pkt_cast_o.index  = index_cnt;
@@ -334,36 +432,31 @@ module bp_uce
 
                 state_n = (index_done & way_done)
                           ? e_flush_fence
-                          : way_done 
-                            ? e_flush_read 
+                          : way_done
+                            ? e_flush_read
                             : e_flush_scan;
               end
           end
         e_flush_write:
           begin
             mem_cmd_cast_o.header.msg_type = e_cce_mem_wr;
-            mem_cmd_cast_o.header.addr     = {dirty_tag_r, index_cnt, block_offset_width_lp'(0)};
-            mem_cmd_cast_o.header.size     = is_blockwidth_512
-                                              ? e_mem_msg_size_64
-                                              : is_blockwidth_256
-                                                ? e_mem_msg_size_32
-                                                : is_blockwidth_128
-                                                  ? e_mem_msg_size_16
-                                                  : e_mem_msg_size_64;
+            mem_cmd_cast_o.header.addr     = {dirty_tag_r, index_cnt, bank_index, byte_offset_width_lp'(0)};
+            mem_cmd_cast_o.header.size     = block_msg_size_lp;
             mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
-            mem_cmd_cast_o.data            = dirty_data_r;
+            mem_cmd_cast_o.data                  = writeback_data;
             mem_cmd_v_o = mem_cmd_ready_i;
+            mem_cmd_up = mem_cmd_v_o;
 
-            way_up = mem_cmd_v_o;
-            index_up = way_done & mem_cmd_v_o;
+            way_up = mem_cmd_done & mem_cmd_v_o;
+            index_up = way_done & mem_cmd_done & mem_cmd_v_o;
 
-            state_n = (mem_cmd_v_o & index_done & way_done)
+            state_n = (mem_cmd_done & mem_cmd_v_o & index_done & way_done)
                       ? e_flush_fence
                       : index_up
                         ? e_flush_read
-                          : mem_cmd_v_o
-                            ? e_flush_scan
-                            : e_flush_write;
+                        : way_up
+                          ? e_flush_scan
+                          : e_flush_write;
           end
         e_flush_fence:
           begin
@@ -383,7 +476,7 @@ module bp_uce
                 mem_cmd_cast_o.data                  = cache_req_cast_i.data;
                 mem_cmd_v_o = mem_cmd_ready_i;
               end
-            else if (wt_store_v_li) 
+            else if (wt_store_v_li)
               begin
                 mem_cmd_cast_o.header.msg_type       = e_cce_mem_wr;
                 mem_cmd_cast_o.header.addr           = cache_req_cast_i.addr;
@@ -399,31 +492,25 @@ module bp_uce
                             ? e_flush_read
                             : clear_v_li
                               ? e_clear
-                              : e_send_req
+                              : e_send_critical
                           : e_ready;
               end
           end
-        e_send_req:
+        e_send_critical:
           if (miss_v_li)
             begin
               mem_cmd_cast_o.header.msg_type       = e_cce_mem_rd;
               mem_cmd_cast_o.header.addr           = {cache_req_r.addr[paddr_width_p-1:block_offset_width_lp], block_offset_width_lp'(0)};
-              mem_cmd_cast_o.header.size           = is_blockwidth_512
-                                                      ? e_mem_msg_size_64
-                                                      : is_blockwidth_256
-                                                        ? e_mem_msg_size_32
-                                                        : is_blockwidth_128
-                                                          ? e_mem_msg_size_16
-                                                          : e_mem_msg_size_64;
+              mem_cmd_cast_o.header.size           = block_msg_size_lp;
               mem_cmd_cast_o.header.payload.way_id = lce_assoc_p'(cache_req_metadata_r.repl_way);
               mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
               mem_cmd_v_o = mem_cmd_ready_i;
-
-              state_n = mem_cmd_v_o 
-                        ? cache_req_metadata_r.dirty 
-                          ? e_writeback_read
-                          : e_read_wait 
-                        : e_send_req;
+              mem_cmd_up = mem_cmd_v_o;
+              state_n = mem_cmd_v_o
+                        ? cache_req_metadata_r.dirty
+                          ? e_writeback_evict
+                          : e_read_req
+                        : e_send_critical;
             end
           else if (uc_load_v_li)
             begin
@@ -433,13 +520,14 @@ module bp_uce
               mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
               mem_cmd_v_o = mem_cmd_ready_i;
 
-              state_n = mem_cmd_v_o ? e_uc_read_wait : e_send_req;
+              state_n = mem_cmd_v_o ? e_uc_read_wait : e_send_critical;
             end
-        e_writeback_read:
+        e_writeback_evict:
           begin
             data_mem_pkt_cast_o.opcode = e_cache_data_mem_read;
             data_mem_pkt_cast_o.index  = cache_req_r.addr[block_offset_width_lp+:index_width_lp];
             data_mem_pkt_cast_o.way_id = cache_req_metadata_r.repl_way;
+            data_mem_pkt_cast_o.fill_index = {block_size_in_fill_lp{1'b1}};
             data_mem_pkt_v_o = 1'b1;
 
             tag_mem_pkt_cast_o.opcode  = e_cache_tag_mem_read;
@@ -452,27 +540,11 @@ module bp_uce
             stat_mem_pkt_cast_o.way_id = cache_req_metadata_r.repl_way;
             stat_mem_pkt_v_o = 1'b1;
 
-            state_n = (data_mem_pkt_yumi_i & tag_mem_pkt_yumi_i & stat_mem_pkt_yumi_i) ? e_writeback_req : e_writeback_read;
+            state_n = (data_mem_pkt_yumi_i & tag_mem_pkt_yumi_i & stat_mem_pkt_yumi_i) ? e_writeback_read_req : e_writeback_evict;
           end
-        e_writeback_req:
+        e_writeback_read_req:
           begin
-            mem_cmd_cast_o.header.msg_type = e_cce_mem_wr;
-            mem_cmd_cast_o.header.addr     = {dirty_tag_r, cache_req_r.addr[block_offset_width_lp+:index_width_lp], block_offset_width_lp'(0)};
-            mem_cmd_cast_o.header.size     = is_blockwidth_512
-                                              ? e_mem_msg_size_64
-                                              : is_blockwidth_256
-                                                ? e_mem_msg_size_32
-                                                : is_blockwidth_128
-                                                  ? e_mem_msg_size_16
-                                                  : e_mem_msg_size_64;
-            mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
-            mem_cmd_cast_o.data            = dirty_data_r;
-            mem_cmd_v_o = mem_cmd_ready_i;
-
-            state_n = mem_cmd_v_o ? e_read_wait : e_writeback_req;
-          end
-        e_read_wait:
-          begin
+            // send the sub-block from L2 to cache
             tag_mem_pkt_cast_o.opcode = e_cache_tag_mem_set_tag;
             tag_mem_pkt_cast_o.index  = mem_resp_cast_i.header.addr[block_offset_width_lp+:index_width_lp];
             // We fill in M because we don't want to trigger additional coherence traffic
@@ -485,12 +557,68 @@ module bp_uce
             data_mem_pkt_cast_o.index  = mem_resp_cast_i.header.addr[block_offset_width_lp+:index_width_lp];
             data_mem_pkt_cast_o.way_id = mem_resp_cast_i.header.payload.way_id[0+:`BSG_SAFE_CLOG2(assoc_p)];
             data_mem_pkt_cast_o.data   = mem_resp_cast_i.data;
+            data_mem_pkt_cast_o.fill_index = 1'b1 << fill_index_shift;
             data_mem_pkt_v_o = load_resp_v_li;
 
-            cache_req_complete_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
-            mem_resp_yumi_lo = cache_req_complete_o; 
+            cache_req_critical_o = '0;
+            fill_up = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+            mem_resp_yumi_lo = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+            // request next sub-block
+            mem_cmd_cast_o.header.msg_type       = e_cce_mem_rd;
+            mem_cmd_cast_o.header.addr           = {cache_req_r.addr[paddr_width_p-1:block_offset_width_lp], bank_index, byte_offset_width_lp'(0)};
+            mem_cmd_cast_o.header.size           = block_msg_size_lp;
+            mem_cmd_cast_o.header.payload.way_id = lce_assoc_p'(cache_req_metadata_r.repl_way);
+            mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
+            mem_cmd_v_o = mem_cmd_ready_i & ~mem_cmd_done_r;
+            mem_cmd_up = mem_cmd_v_o;
 
-            state_n = cache_req_complete_o ? e_ready : e_read_wait;
+            state_n = (fill_done & mem_cmd_done_r & tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i) ? e_writeback_write_req : e_writeback_read_req;
+          end
+        e_writeback_write_req:
+          begin
+            mem_cmd_cast_o.header.msg_type = e_cce_mem_wr;
+            mem_cmd_cast_o.header.addr     = {dirty_tag_r, cache_req_r.addr[block_offset_width_lp+:index_width_lp], bank_index, byte_offset_width_lp'(0)};
+            mem_cmd_cast_o.header.size     = block_msg_size_lp;
+            mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
+            mem_cmd_cast_o.data                  = writeback_data;
+            mem_cmd_v_o = mem_cmd_ready_i;
+            mem_cmd_up = mem_cmd_v_o;
+
+            cache_req_complete_o = mem_cmd_done & mem_cmd_v_o;
+            state_n = cache_req_complete_o ? e_ready : e_writeback_write_req;
+          end
+        e_read_req:
+          begin
+            // send the sub-block from L2 to cache
+            tag_mem_pkt_cast_o.opcode = e_cache_tag_mem_set_tag;
+            tag_mem_pkt_cast_o.index  = mem_resp_cast_i.header.addr[block_offset_width_lp+:index_width_lp];
+            // We fill in M because we don't want to trigger additional coherence traffic
+            tag_mem_pkt_cast_o.way_id = mem_resp_cast_i.header.payload.way_id[0+:`BSG_SAFE_CLOG2(assoc_p)];
+            tag_mem_pkt_cast_o.state  = e_COH_M;
+            tag_mem_pkt_cast_o.tag    = mem_resp_cast_i.header.addr[block_offset_width_lp+index_width_lp+:ptag_width_p];
+            tag_mem_pkt_v_o = load_resp_v_li;
+
+            data_mem_pkt_cast_o.opcode = e_cache_data_mem_write;
+            data_mem_pkt_cast_o.index  = mem_resp_cast_i.header.addr[block_offset_width_lp+:index_width_lp];
+            data_mem_pkt_cast_o.way_id = mem_resp_cast_i.header.payload.way_id[0+:`BSG_SAFE_CLOG2(assoc_p)];
+            data_mem_pkt_cast_o.data   = mem_resp_cast_i.data;
+            data_mem_pkt_cast_o.fill_index = 1'b1 << fill_index_shift;
+            data_mem_pkt_v_o = load_resp_v_li;
+
+            cache_req_critical_o = '0;
+            fill_up = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+            mem_resp_yumi_lo = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+            // request next sub-block
+            mem_cmd_cast_o.header.msg_type       = e_cce_mem_rd;
+            mem_cmd_cast_o.header.addr           = {cache_req_r.addr[paddr_width_p-1:block_offset_width_lp], bank_index, byte_offset_width_lp'(0)};
+            mem_cmd_cast_o.header.size           = block_msg_size_lp;
+            mem_cmd_cast_o.header.payload.way_id = lce_assoc_p'(cache_req_metadata_r.repl_way);
+            mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
+            mem_cmd_v_o = mem_cmd_ready_i & ~mem_cmd_done_r;
+            mem_cmd_up = mem_cmd_v_o;
+
+            cache_req_complete_o = fill_done & mem_cmd_done_r & tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+            state_n = cache_req_complete_o ? e_ready : e_read_req;
           end
         e_uc_read_wait:
           begin
@@ -523,4 +651,3 @@ module bp_uce
 ////synopsys translate_off
 
 endmodule
-

--- a/bp_me/src/v/lce/bp_lce.v
+++ b/bp_me/src/v/lce/bp_lce.v
@@ -114,7 +114,7 @@ module bp_lce
       $error("LCE block width must be a whole number of bytes and power of two");
     assert(block_width_p <= 1024) else
       $error("LCE block width must be no greater than 128 bytes");
-    assert(fill_width_p != block_width_p) else
+    assert(fill_width_p == block_width_p) else
       $error("LCE block width must be equal to fill width. Partial fill is not supported");
     assert(`BSG_IS_POW2(assoc_p)) else
       $error("LCE assoc must be power of two");

--- a/bp_me/src/v/lce/bp_lce.v
+++ b/bp_me/src/v/lce/bp_lce.v
@@ -18,6 +18,7 @@ module bp_lce
     , parameter assoc_p = "inv"
     , parameter sets_p = "inv"
     , parameter block_width_p = "inv"
+    , parameter fill_width_p = block_width_p
 
     , parameter timeout_max_limit_p=4
 
@@ -34,7 +35,7 @@ module bp_lce
 
    `declare_bp_lce_cce_if_header_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p)
    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
-   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_lp, sets_p, assoc_p, dword_width_p, block_width_p, cache)
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_lp, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache)
 
     , localparam stat_info_width_lp = `bp_cache_stat_info_width(assoc_p)
   )
@@ -79,6 +80,7 @@ module bp_lce
     , output logic                                   credits_empty_o
 
     , output logic                                   cache_req_complete_o
+    , output logic                                   cache_req_critical_o
 
     // LCE-CCE interface
     // Req: ready->valid
@@ -112,6 +114,8 @@ module bp_lce
       $error("LCE block width must be a whole number of bytes and power of two");
     assert(block_width_p <= 1024) else
       $error("LCE block width must be no greater than 128 bytes");
+    assert(fill_width_p != block_width_p) else
+      $error("LCE block width must be equal to fill width. Partial fill is not supported");
     assert(`BSG_IS_POW2(assoc_p)) else
       $error("LCE assoc must be power of two");
   end
@@ -126,6 +130,7 @@ module bp_lce
       ,.assoc_p(assoc_p)
       ,.sets_p(sets_p)
       ,.block_width_p(block_width_p)
+      ,.fill_width_p(fill_width_p)
       ,.credits_p(credits_p)
       ,.non_excl_reads_p(non_excl_reads_p)
       )
@@ -161,6 +166,7 @@ module bp_lce
       ,.assoc_p(assoc_p)
       ,.sets_p(sets_p)
       ,.block_width_p(block_width_p)
+      ,.fill_width_p(fill_width_p)
       )
     command
       (.clk_i(clk_i)
@@ -172,6 +178,7 @@ module bp_lce
       ,.ready_o(cmd_ready_lo)
       ,.sync_done_o(cmd_sync_done_lo)
       ,.cache_req_complete_o(cache_req_complete_o)
+      ,.cache_req_critical_o(cache_req_critical_o)
       ,.uc_store_req_complete_o(uc_store_req_complete_lo)
 
       ,.data_mem_pkt_o(data_mem_pkt_o)
@@ -238,4 +245,3 @@ module bp_lce
   assign cache_req_ready_o = lce_req_cache_req_ready_lo & ~timeout & cmd_ready_lo;
 
 endmodule
-

--- a/bp_me/src/v/lce/bp_lce_cmd.v
+++ b/bp_me/src/v/lce/bp_lce_cmd.v
@@ -24,6 +24,8 @@ module bp_lce_cmd
     , parameter assoc_p = "inv"
     , parameter sets_p = "inv"
     , parameter block_width_p = "inv"
+    , parameter fill_width_p = block_width_p
+
     , parameter timeout_max_limit_p=4
 
     , localparam block_size_in_bytes_lp = (block_width_p/8)
@@ -34,7 +36,7 @@ module bp_lce_cmd
 
    `declare_bp_lce_cce_if_header_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p)
    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
-   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_lp, sets_p, assoc_p, dword_width_p, block_width_p, cache)
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_lp, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache)
 
     , localparam stat_info_width_lp = `bp_cache_stat_info_width(assoc_p)
 
@@ -90,6 +92,7 @@ module bp_lce_cmd
     // cached requests and uncached loads block in the caches, but uncached stores do not
     // cache_req_complete_o is routed to the cache to indicate a blocking request is complete
     , output logic                                   cache_req_complete_o
+    , output logic                                   cache_req_critical_o
     // uncached store request complete is used by the LCE to decrement the request credit counter
     // when an uncached store complete, but is not routed to the cache because the caches do not
     // block (miss) on uncached stores
@@ -115,7 +118,7 @@ module bp_lce_cmd
   );
 
   `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_lp, sets_p, assoc_p, dword_width_p, block_width_p, cache);
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_lp, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache);
   `declare_bp_cache_stat_info_s(assoc_p, cache);
 
   // FSM states
@@ -216,6 +219,7 @@ module bp_lce_cmd
     state_n = state_r;
 
     cache_req_complete_o = 1'b0;
+    cache_req_critical_o = 1'b0;  //TODO partial fill is not supported now
     uc_store_req_complete_o = 1'b0;
 
     // LCE-CCE Interface signals

--- a/bp_me/src/v/lce/bp_lce_cmd.v
+++ b/bp_me/src/v/lce/bp_lce_cmd.v
@@ -57,6 +57,7 @@ module bp_lce_cmd
             ? e_mem_msg_size_16
             : e_mem_msg_size_8
 
+    , localparam block_size_in_fill_lp = block_width_p/fill_width_p
   )
   (
     input                                            clk_i
@@ -392,6 +393,7 @@ module bp_lce_cmd
               data_mem_pkt.index = lce_cmd_addr_index;
               data_mem_pkt.way_id = lce_cmd_way_id;
               data_mem_pkt.data = lce_cmd.data;
+              data_mem_pkt.fill_index = {block_size_in_fill_lp{1'b1}};
               data_mem_pkt.opcode = e_cache_data_mem_write;
               data_mem_pkt_v_o = lce_cmd_v_i;
 
@@ -414,6 +416,7 @@ module bp_lce_cmd
             e_lce_cmd_uc_data: begin
               data_mem_pkt.index = lce_cmd_addr_index;
               data_mem_pkt.data = lce_cmd.data;
+              data_mem_pkt.fill_index = {block_size_in_fill_lp{1'b1}};
               data_mem_pkt.opcode = e_cache_data_mem_uncached;
               data_mem_pkt_v_o = lce_cmd_v_i;
 

--- a/bp_me/src/v/lce/bp_lce_req.v
+++ b/bp_me/src/v/lce/bp_lce_req.v
@@ -21,6 +21,8 @@ module bp_lce_req
     , parameter assoc_p = "inv"
     , parameter sets_p = "inv"
     , parameter block_width_p = "inv"
+    , parameter fill_width_p = block_width_p
+
 
     // maximum number of outstanding transactions
     , parameter credits_p = coh_noc_max_credits_p
@@ -36,7 +38,7 @@ module bp_lce_req
 
    `declare_bp_lce_cce_if_header_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p)
    `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
-   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_lp, sets_p, assoc_p, dword_width_p, block_width_p, cache)
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_lp, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache)
 
     , localparam stat_info_width_lp = `bp_cache_stat_info_width(assoc_p)
 
@@ -92,7 +94,7 @@ module bp_lce_req
   );
 
   `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_lp, sets_p, assoc_p, dword_width_p, block_width_p, cache);
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_lp, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache);
 
   // FSM states
   typedef enum logic [2:0] {

--- a/bp_top/src/v/bp_cacc_vdp.v
+++ b/bp_top/src/v/bp_cacc_vdp.v
@@ -6,12 +6,13 @@ module bp_cacc_vdp
  import bp_common_cfg_link_pkg::*;
  import bp_cce_pkg::*;
  import bp_me_pkg::*;
- import bp_be_dcache_pkg::*;  
+ import bp_be_dcache_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
     `declare_bp_proc_params(bp_params_p)
     `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
     `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
-    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, acache_sets_p, acache_assoc_p, dword_width_p, acache_block_width_p, cache)
+    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, acache_sets_p, acache_assoc_p, dword_width_p, acache_block_width_p, acache_fill_width_p, cache)
+
     , localparam cfg_bus_width_lp= `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
     , localparam stat_info_width_lp = `bp_cache_stat_info_width(acache_assoc_p)
     )
@@ -20,7 +21,7 @@ module bp_cacc_vdp
     , input                                   reset_i
 
     , input [lce_id_width_p-1:0]              lce_id_i
-    
+
     , output [lce_cce_req_width_lp-1:0]       lce_req_o
     , output                                  lce_req_v_o
     , input                                   lce_req_ready_i
@@ -49,8 +50,8 @@ module bp_cacc_vdp
 
  `declare_bp_be_dcache_pkt_s(bp_page_offset_width_gp, dword_width_p);
  `declare_bp_be_mmu_structs(vaddr_width_p, ptag_width_p, lce_sets_p, cce_block_width_p/8);
-   
-  bp_be_dcache_pkt_s        dcache_pkt;   
+
+  bp_be_dcache_pkt_s        dcache_pkt;
   logic                     dcache_ready, dcache_v;
   logic [dword_width_p-1:0] dcache_data;
   logic                     dcache_tlb_miss, dcache_poison;
@@ -60,22 +61,22 @@ module bp_cacc_vdp
   logic                     load_op_tl_lo, store_op_tl_lo;
   logic                     dcache_pkt_v;
   logic                     credits_full_o, credits_empty_o;
-   
+
   `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
   bp_cfg_bus_s cfg_bus_cast_i;
   assign cfg_bus_cast_i.dcache_id = lce_id_i;
-  
+
 
   assign dcache_poison = '0;
   assign dcache_tlb_miss = '0;
 
-  logic cache_req_v_o, cache_req_ready_i, cache_req_metadata_v_o, 
+  logic cache_req_v_o, cache_req_ready_i, cache_req_metadata_v_o,
   data_mem_pkt_v_i, data_mem_pkt_yumi_o,
   tag_mem_pkt_v_i, tag_mem_pkt_yumi_o,
   stat_mem_pkt_v_i, stat_mem_pkt_yumi_o,
   cache_req_complete_lo;
-   
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, acache_sets_p, acache_assoc_p, dword_width_p, acache_block_width_p, cache);
+
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, acache_sets_p, acache_assoc_p, dword_width_p, acache_block_width_p, acache_fill_width_p, cache);
 
   bp_cache_req_s cache_req_cast_o;
   bp_cache_data_mem_pkt_s data_mem_pkt_i;
@@ -84,8 +85,8 @@ module bp_cacc_vdp
   logic [ptag_width_p-1:0] tag_mem_o;
   bp_cache_stat_mem_pkt_s stat_mem_pkt_i;
   logic [stat_info_width_lp-1:0] stat_mem_o;
-  bp_cache_req_metadata_s cache_req_metadata_o; 
-   
+  bp_cache_req_metadata_s cache_req_metadata_o;
+
 bp_pma
  #(.bp_params_p(bp_params_p))
   pma
@@ -121,7 +122,7 @@ bp_be_dcache
 
     // D$-LCE Interface
     ,.dcache_miss_o(dcache_miss_v)
-    ,.cache_req_complete_i(cache_req_complete_lo) 
+    ,.cache_req_complete_i(cache_req_complete_lo)
     ,.cache_req_o(cache_req_cast_o)
     ,.cache_req_v_o(cache_req_v_o)
     ,.cache_req_ready_i(cache_req_ready_i)
@@ -141,8 +142,8 @@ bp_be_dcache
     ,.stat_mem_o(stat_mem_o)
     ,.stat_mem_pkt_yumi_o(stat_mem_pkt_yumi_o)
     );
-   
-   
+
+
 bp_be_dcache_lce
  #(.bp_params_p(bp_params_p))
   be_lce
@@ -193,24 +194,24 @@ bp_be_dcache_lce
     ,.credits_full_o(credits_full_o)
     ,.credits_empty_o(credits_empty_o)
     );
-     
+
 
   // CCE-IO interface is used for uncached requests-read/write memory mapped CSR
    `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
-   
+
   bp_cce_mem_msg_s io_resp_cast_o;
   bp_cce_mem_msg_s io_cmd_cast_i;
   bp_cce_mem_msg_header_s resp_header;
-   
+
   assign io_cmd_ready_o = 1'b1;
   assign io_cmd_cast_i = io_cmd_i;
   assign io_resp_o = io_resp_cast_o;
-   
-  logic [63:0] resp_data, start_cmd, input_a_ptr, input_b_ptr, input_len, 
+
+  logic [63:0] resp_data, start_cmd, input_a_ptr, input_b_ptr, input_len,
                res_status, res_ptr, res_len, operation, dot_product_res;
   logic [63:0] vector_a [0:7];
-  logic [63:0] vector_b [0:7]; 
-  logic [2:0] len_a_cnt, len_b_cnt; 
+  logic [63:0] vector_b [0:7];
+  logic [2:0] len_a_cnt, len_b_cnt;
   logic load, second_operand, done;
   logic [paddr_width_p-1:0]  resp_addr;
 
@@ -219,12 +220,12 @@ bp_be_dcache_lce
   logic [63:0] sum_l1 [0:3];
   logic [63:0] sum_l2 [0:1];
   logic [63:0] dot_product_temp;
-   
+
   bp_cce_mem_msg_payload_s  resp_payload;
-  bp_mem_msg_size_e         resp_size;  
+  bp_mem_msg_size_e         resp_size;
   bp_cce_mem_cmd_type_e     resp_msg;
   bp_local_addr_s          local_addr_li;
-  
+
   assign local_addr_li = io_cmd_cast_i.header.addr;
   assign resp_header   =  '{msg_type       : resp_msg
                             ,addr          : resp_addr
@@ -234,17 +235,17 @@ bp_be_dcache_lce
   assign io_resp_cast_o = '{header         : resp_header
                             ,data          : resp_data  };
 
-   
+
   bp_be_mmu_vaddr_s v_addr;
-  assign v_addr = load ? (second_operand ? (input_b_ptr+len_b_cnt*8) 
-                                         : (input_a_ptr+len_a_cnt*8)) 
+  assign v_addr = load ? (second_operand ? (input_b_ptr+len_b_cnt*8)
+                                         : (input_a_ptr+len_a_cnt*8))
                        : res_ptr;
 
-   
+
   typedef enum logic [3:0]{
     RESET
     , WAIT_START
-    , WAIT_FETCH                            
+    , WAIT_FETCH
     , FETCH
     , WAIT_DCACHE_C1
     , WAIT_DCACHE_C2
@@ -255,19 +256,19 @@ bp_be_dcache_lce
     , DONE
   } state_e;
   state_e state_r, state_n;
- 
+
   always_ff @(posedge clk_i) begin
     io_resp_v_o  <= io_cmd_v_i;
     vector_a[len_a_cnt] <= (dcache_v & load & ~second_operand) ? dcache_data : vector_a[len_a_cnt];
     len_a_cnt <= (dcache_v & load & ~second_operand) ? len_a_cnt + 1'b1 : len_a_cnt;
     vector_b[len_b_cnt]  <= (dcache_v & load & second_operand) ? dcache_data : vector_b[len_b_cnt];
     len_b_cnt <= (dcache_v & load & second_operand) ? len_b_cnt + 1'b1 : len_b_cnt;
-    
+
     if(reset_i)
       state_r <= RESET;
     else
       state_r <= state_n;
- 
+
     if (reset_i || done) begin
       start_cmd     <= '0;
       input_a_ptr   <= '0;
@@ -280,9 +281,9 @@ bp_be_dcache_lce
       len_a_cnt     <= '0;
       len_b_cnt     <= '0;
       vector_a      <= '{default:64'd0};
-      vector_b      <= '{default:64'd0}; 
-    end 
-    if (state_r == DONE) 
+      vector_b      <= '{default:64'd0};
+    end
+    if (state_r == DONE)
       start_cmd  <= '0;
     else if (io_cmd_v_i & (io_cmd_cast_i.header.msg_type == e_cce_mem_uc_wr))
     begin
@@ -290,7 +291,7 @@ bp_be_dcache_lce
       resp_payload <= io_cmd_cast_i.header.payload;
       resp_addr    <= io_cmd_cast_i.header.addr;
       resp_msg     <= io_cmd_cast_i.header.msg_type;
-      unique 
+      unique
       case (local_addr_li.addr)
         20'h00000 : input_a_ptr <= io_cmd_cast_i.data;
         20'h00040 : input_b_ptr <= io_cmd_cast_i.data;
@@ -300,32 +301,32 @@ bp_be_dcache_lce
         20'h00180 : res_len    <= io_cmd_cast_i.data;
         20'h00200 : operation  <= io_cmd_cast_i.data;
         default : begin end
-      endcase 
-    end 
+      endcase
+    end
     else if (io_cmd_v_i & (io_cmd_cast_i.header.msg_type == e_cce_mem_uc_rd))
     begin
       resp_size    <= io_cmd_cast_i.header.size;
       resp_payload <= io_cmd_cast_i.header.payload;
       resp_addr    <= io_cmd_cast_i.header.addr;
       resp_msg     <= io_cmd_cast_i.header.msg_type;
-      unique 
+      unique
       case (local_addr_li.addr)
         20'h00000 : resp_data <= input_a_ptr;
         20'h00040 : resp_data <= input_b_ptr;
         20'h00080 : resp_data <= input_len;
         20'h000c0 : resp_data <= start_cmd;
-        20'h00100 : resp_data <= res_status; 
+        20'h00100 : resp_data <= res_status;
         20'h00140 : resp_data <= res_ptr;
         20'h00180 : resp_data <= res_len;
         20'h00200 : resp_data <= operation;
         default : begin end
-      endcase 
+      endcase
     end
   end
- 
-   
+
+
   always_comb begin
-    state_n = state_r; 
+    state_n = state_r;
     case (state_r)
       RESET: begin
         state_n = reset_i ? RESET : WAIT_START;
@@ -359,7 +360,7 @@ bp_be_dcache_lce
         state_n = WAIT_DCACHE_C1;
         dcache_ptag = {(ptag_width_p-vtag_width_p)'(0), v_addr.tag};
         dcache_pkt.opcode = load ? e_dcache_opcode_ld : e_dcache_opcode_sd;
-        dcache_pkt.data = load ? '0 : dot_product_res; 
+        dcache_pkt.data = load ? '0 : dot_product_res;
         dcache_pkt.page_offset = {v_addr.index, v_addr.offset};
         res_status = '0;
         dcache_pkt_v = '1;
@@ -378,7 +379,7 @@ bp_be_dcache_lce
       WAIT_DCACHE_C2: begin
         //if load: load both input vectors
         //if store: go to DONE after store
-        state_n = dcache_miss_v ? WAIT_DCACHE_C2 : 
+        state_n = dcache_miss_v ? WAIT_DCACHE_C2 :
                   (dcache_v ? (load ? (second_operand ? CHECK_VEC2_LEN : CHECK_VEC1_LEN) : DONE)
                             : WAIT_FETCH);
         res_status = '0;
@@ -420,7 +421,7 @@ bp_be_dcache_lce
         dcache_pkt_v = '0;
         second_operand= 1;
         done = 0;
-        dot_product_res = dot_product_temp;         
+        dot_product_res = dot_product_temp;
       end
       WB_RESULT: begin
         state_n = WAIT_FETCH;
@@ -440,12 +441,12 @@ bp_be_dcache_lce
         dcache_pkt_v = '0;
         load = 0;
         second_operand= 0;
-        done = 1; 
+        done = 1;
       end
-    endcase 
+    endcase
    end // always_comb
 
-   
+
   //dot_product unit
   for (genvar i=0; i<8; i++)
   begin : product
@@ -463,6 +464,5 @@ bp_be_dcache_lce
   end
 
    assign dot_product_temp = sum_l2[0] + sum_l2[1];
-  
-endmodule
 
+endmodule

--- a/bp_top/src/v/bp_core.v
+++ b/bp_top/src/v/bp_core.v
@@ -17,8 +17,8 @@ module bp_core
     `declare_bp_proc_params(bp_params_p)
     `declare_bp_fe_be_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
     `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
-    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
-    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache)
+    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache)
+    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache)
 
     , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
     , localparam way_id_width_lp = `BSG_SAFE_CLOG2(lce_assoc_p)
@@ -60,8 +60,8 @@ module bp_core
     );
 
   `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache);
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache);
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache);
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache);
 
   bp_cfg_bus_s cfg_bus_cast_i;
   assign cfg_bus_cast_i = cfg_bus_i;
@@ -77,6 +77,7 @@ module bp_core
   logic dcache_req_metadata_v_lo;
 
   logic icache_req_complete_lo, dcache_req_complete_lo;
+  logic icache_req_critical_lo, dcache_req_critical_lo;
   logic dcache_credits_full_lo, dcache_credits_empty_lo;
 
   logic [1:0] lr_hit_lo;
@@ -138,6 +139,7 @@ module bp_core
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
 
      ,.dcache_req_complete_i(dcache_req_complete_lo)
+     ,.dcache_req_critical_i(dcache_req_critical_lo)
 
      ,.icache_req_o(icache_req_cast_lo)
      ,.icache_req_v_o(icache_req_v_lo)
@@ -146,7 +148,7 @@ module bp_core
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
 
      ,.icache_req_complete_i(icache_req_complete_lo)
-
+     ,.icache_req_critical_i(icache_req_critical_lo)
      // response side - Interface from D$ LCE
      ,.dcache_data_mem_pkt_i(dcache_data_mem_pkt_li)
      ,.dcache_data_mem_pkt_v_i(dcache_data_mem_pkt_v_li)
@@ -192,6 +194,7 @@ module bp_core
       ,.assoc_p(icache_assoc_p)
       ,.sets_p(icache_sets_p)
       ,.block_width_p(icache_block_width_p)
+      ,.fill_width_p(icache_fill_width_p)
       ,.timeout_max_limit_p(4)
       ,.credits_p(coh_noc_max_credits_p)
       ,.non_excl_reads_p(1)
@@ -210,6 +213,7 @@ module bp_core
      ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
 
      ,.cache_req_complete_o(icache_req_complete_lo)
+     ,.cache_req_critical_o(icache_req_critical_lo)
 
      ,.data_mem_pkt_o(icache_data_mem_pkt_li)
      ,.data_mem_pkt_v_o(icache_data_mem_pkt_v_li)
@@ -253,6 +257,7 @@ module bp_core
       ,.assoc_p(dcache_assoc_p)
       ,.sets_p(dcache_sets_p)
       ,.block_width_p(dcache_block_width_p)
+      ,.fill_width_p(dcache_fill_width_p)
       ,.timeout_max_limit_p(4)
       ,.credits_p(coh_noc_max_credits_p)
       )
@@ -270,6 +275,7 @@ module bp_core
      ,.cache_req_metadata_v_i(dcache_req_metadata_v_lo)
 
      ,.cache_req_complete_o(dcache_req_complete_lo)
+     ,.cache_req_critical_o(dcache_req_critical_lo)
 
      ,.data_mem_pkt_o(dcache_data_mem_pkt_li)
      ,.data_mem_pkt_v_o(dcache_data_mem_pkt_v_li)
@@ -307,4 +313,3 @@ module bp_core
      );
 
 endmodule
-

--- a/bp_top/src/v/bp_core_minimal.v
+++ b/bp_top/src/v/bp_core_minimal.v
@@ -17,16 +17,15 @@ module bp_core_minimal
   #(parameter bp_params_e bp_params_p = e_bp_single_core_cfg
     `declare_bp_proc_params(bp_params_p)
     `declare_bp_fe_be_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
-    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache)
-    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache)
+    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache)
+    `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache)
 
     , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
 
     , localparam dcache_stat_info_width_lp = `bp_cache_stat_info_width(dcache_assoc_p)
     , localparam icache_stat_info_width_lp = `bp_cache_stat_info_width(icache_assoc_p)
     )
-   (
-    input          clk_i
+    ( input          clk_i
     , input        reset_i
 
     // Config info
@@ -47,6 +46,7 @@ module bp_core_minimal
     , output logic  dcache_req_metadata_v_o
 
     , input dcache_req_complete_i
+    , input dcache_req_critical_i
 
     , output logic [icache_req_width_lp-1:0] icache_req_o
     , output logic icache_req_v_o
@@ -55,12 +55,13 @@ module bp_core_minimal
     , output logic  icache_req_metadata_v_o
 
     , input icache_req_complete_i
+    , input icache_req_critical_i
 
     // D$ response interface
     , input [dcache_data_mem_pkt_width_lp-1:0] dcache_data_mem_pkt_i
     , input dcache_data_mem_pkt_v_i
     , output logic dcache_data_mem_pkt_yumi_o
-    , output logic [dcache_block_width_p-1:0] dcache_data_mem_o 
+    , output logic [dcache_block_width_p-1:0] dcache_data_mem_o
 
     , input [dcache_tag_mem_pkt_width_lp-1:0] dcache_tag_mem_pkt_i
     , input dcache_tag_mem_pkt_v_i
@@ -76,7 +77,7 @@ module bp_core_minimal
     , input [icache_data_mem_pkt_width_lp-1:0] icache_data_mem_pkt_i
     , input icache_data_mem_pkt_v_i
     , output logic icache_data_mem_pkt_yumi_o
-    , output logic [icache_block_width_p-1:0] icache_data_mem_o 
+    , output logic [icache_block_width_p-1:0] icache_data_mem_o
 
     , input [icache_tag_mem_pkt_width_lp-1:0] icache_tag_mem_pkt_i
     , input icache_tag_mem_pkt_v_i
@@ -127,6 +128,7 @@ module bp_core_minimal
      ,.cache_req_metadata_o(icache_req_metadata_o)
      ,.cache_req_metadata_v_o(icache_req_metadata_v_o)
      ,.cache_req_complete_i(icache_req_complete_i)
+     ,.cache_req_critical_i(icache_req_critical_i)
 
      ,.data_mem_pkt_i(icache_data_mem_pkt_i)
      ,.data_mem_pkt_v_i(icache_data_mem_pkt_v_i)
@@ -161,7 +163,7 @@ module bp_core_minimal
      ,.v_o(fe_cmd_v_lo)
      ,.yumi_i(fe_cmd_yumi_li)
      );
- 
+
   wire fe_cmd_empty_lo = ~fe_cmd_v_lo;
   wire fe_cmd_full_lo  = ~fe_cmd_ready_lo;
   wire fe_cmd_fence_li = fe_cmd_v_lo;
@@ -221,6 +223,7 @@ module bp_core_minimal
      ,.cache_req_metadata_v_o(dcache_req_metadata_v_o)
 
      ,.cache_req_complete_i(dcache_req_complete_i)
+     ,.cache_req_critical_i(dcache_req_critical_i)
 
      ,.data_mem_pkt_i(dcache_data_mem_pkt_i)
      ,.data_mem_pkt_v_i(dcache_data_mem_pkt_v_i)
@@ -246,4 +249,3 @@ module bp_core_minimal
      );
 
 endmodule
-

--- a/bp_top/src/v/bp_unicore.v
+++ b/bp_top/src/v/bp_unicore.v
@@ -14,7 +14,7 @@ module bp_unicore
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
    )
-  (input                                               clk_i
+  (  input                                               clk_i
    , input                                             reset_i
 
    // Outgoing I/O
@@ -47,8 +47,8 @@ module bp_unicore
 
   `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
 
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache);
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache);
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_p, dcache_block_width_p, dcache_fill_width_p, dcache);
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache);
   `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
   `declare_bp_cache_stat_info_s(dcache_assoc_p, dcache);
   `declare_bp_cache_stat_info_s(icache_assoc_p, icache);
@@ -88,6 +88,7 @@ module bp_unicore
   bp_icache_stat_info_s icache_stat_mem_lo;
 
   logic dcache_req_complete_li, icache_req_complete_li;
+  logic dcache_req_critical_li, icache_req_critical_li;
 
   logic [1:0] credits_full_li, credits_empty_li;
   logic timer_irq_li, software_irq_li, external_irq_li;
@@ -142,6 +143,7 @@ module bp_unicore
      ,.dcache_req_metadata_o(dcache_req_metadata_lo)
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
      ,.dcache_req_complete_i(dcache_req_complete_li)
+     ,.dcache_req_critical_i(dcache_req_critical_li)
 
      ,.icache_req_o(icache_req_lo)
      ,.icache_req_v_o(icache_req_v_lo)
@@ -149,6 +151,7 @@ module bp_unicore
      ,.icache_req_metadata_o(icache_req_metadata_lo)
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
      ,.icache_req_complete_i(icache_req_complete_li)
+     ,.icache_req_critical_i(icache_req_critical_li)
 
      ,.dcache_tag_mem_pkt_i(dcache_tag_mem_pkt_li)
      ,.dcache_tag_mem_pkt_v_i(dcache_tag_mem_pkt_v_li)
@@ -194,7 +197,8 @@ module bp_unicore
     #(.bp_params_p(bp_params_p)
      ,.assoc_p(dcache_assoc_p)
      ,.sets_p(dcache_sets_p)
-     ,.block_width_p(dcache_block_width_p))
+     ,.block_width_p(dcache_block_width_p)
+     ,.fill_width_p(dcache_fill_width_p))
     dcache_uce
     (.clk_i(clk_i)
     ,.reset_i(reset_i)
@@ -223,6 +227,7 @@ module bp_unicore
     ,.stat_mem_i(dcache_stat_mem_lo)
 
     ,.cache_req_complete_o(dcache_req_complete_li)
+    ,.cache_req_critical_o(dcache_req_critical_li)
 
     ,.credits_full_o(credits_full_li[1])
     ,.credits_empty_o(credits_empty_li[1])
@@ -240,7 +245,8 @@ module bp_unicore
     #(.bp_params_p(bp_params_p)
      ,.assoc_p(icache_assoc_p)
      ,.sets_p(icache_sets_p)
-     ,.block_width_p(icache_block_width_p))
+     ,.block_width_p(icache_block_width_p)
+     ,.fill_width_p(icache_fill_width_p))
     icache_uce
     (.clk_i(clk_i)
     ,.reset_i(reset_i)
@@ -269,6 +275,7 @@ module bp_unicore
     ,.stat_mem_i(icache_stat_mem_lo)
 
     ,.cache_req_complete_o(icache_req_complete_li)
+    ,.cache_req_critical_o(icache_req_critical_li)
 
     ,.credits_full_o(credits_full_li[0])
     ,.credits_empty_o(credits_empty_li[0])
@@ -496,4 +503,3 @@ module bp_unicore
     end
 
 endmodule
-

--- a/bp_top/syn/Makefile
+++ b/bp_top/syn/Makefile
@@ -25,4 +25,3 @@ include $(BP_COMMON_DIR)/syn/Makefile.dc
 include $(BP_COMMON_DIR)/syn/Makefile.sv2v
 include $(BP_COMMON_DIR)/syn/Makefile.verilator
 include $(BP_COMMON_DIR)/syn/Makefile.vcs
-

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -111,6 +111,7 @@ $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_chain.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_en.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_en.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_set_clear.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_edge_detect.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_encode_one_hot.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_expand_bitmask.v
@@ -154,8 +155,8 @@ $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter_in.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter_out.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_decoder_dor.v
-$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_input_control.v  
-$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.v 
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_input_control.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.v
 # Common files
 $BP_COMMON_DIR/src/v/bsg_fifo_1r1w_rolly.v
 $BP_COMMON_DIR/src/v/bp_pma.v

--- a/bp_top/test/common/bp_nonsynth_if_verif.v
+++ b/bp_top/test/common/bp_nonsynth_if_verif.v
@@ -26,10 +26,10 @@ assign proc_param = all_cfgs_gp[bp_params_p];
 `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
 `declare_bp_me_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p);
 
-initial 
+initial
   begin
     $display("########### BP Parameters ##############");
-    //  This throws an std::length_error in Verilator 4.031 based on the length of 
+    //  This throws an std::length_error in Verilator 4.031 based on the length of
     //   this (admittedly massive) parameter
     `ifndef VERILATOR
     $display("bp_params_e %s: bp_proc_param_s %p", bp_params_p.name(), proc_param);
@@ -76,7 +76,7 @@ initial
     $warning("Warning: paddr != 40 has not been tested");
   if ((cce_block_width_p != icache_block_width_p) && (cce_block_width_p != dcache_block_width_p) && (cce_block_width_p != acache_block_width_p))
     $warning("Warning: Different cache block widths not yet supported");
-  
+  if ((icache_fill_width_p != icache_block_width_p) || (dcache_fill_width_p != dcache_block_width_p))
+    $warning("Warning: Fill width is different from block width, partial fill is not yet supported");
 
 endmodule
-

--- a/bp_top/test/common/bp_nonsynth_if_verif.v
+++ b/bp_top/test/common/bp_nonsynth_if_verif.v
@@ -69,6 +69,10 @@ initial
     $fatal("Error: We can't maintain 64-bit dwords with a 128-bit cache block size and 4-way or 8-way cache associativity");
   if ((l1_writethrough_p == 1) && (l1_coherent_p == 1))
     $fatal("Error: Writethrough with coherent_l1 is unsupported");
+  if ((icache_fill_width_p > icache_block_width_p) || (dcache_fill_width_p > dcache_block_width_p))
+    $fatal("Error: Cache fill width should be less or equal to L1 cache block width");
+  if ((icache_fill_width_p % (icache_block_width_p/icache_assoc_p) != 0) || (dcache_fill_width_p % (dcache_block_width_p / dcache_assoc_p) != 0))
+    $fatal("Error: Cache fill width should be a multiple of cache bank width");
 
   if (vaddr_width_p != 39)
     $warning("Warning: VM will not work without 39 bit vaddr");
@@ -76,7 +80,5 @@ initial
     $warning("Warning: paddr != 40 has not been tested");
   if ((cce_block_width_p != icache_block_width_p) && (cce_block_width_p != dcache_block_width_p) && (cce_block_width_p != acache_block_width_p))
     $warning("Warning: Different cache block widths not yet supported");
-  if ((icache_fill_width_p != icache_block_width_p) || (dcache_fill_width_p != dcache_block_width_p))
-    $warning("Warning: Fill width is different from block width, partial fill is not yet supported");
 
 endmodule

--- a/bp_top/test/tb/bp_tethered/testbench.v
+++ b/bp_top/test/tb/bp_tethered/testbench.v
@@ -3,7 +3,7 @@
   * testbench.v
   *
   */
-  
+
 `include "bsg_noc_links.vh"
 
 module testbench
@@ -139,12 +139,12 @@ bp_mem
    ,.mem_zero_p(mem_zero_p)
    ,.mem_file_p(mem_file_p)
    ,.mem_offset_p(mem_offset_p)
- 
+
    ,.use_max_latency_p(use_max_latency_p)
    ,.use_random_latency_p(use_random_latency_p)
    ,.use_dramsim2_latency_p(use_dramsim2_latency_p)
    ,.max_latency_p(max_latency_p)
- 
+
    ,.dram_clock_period_in_ps_p(dram_clock_period_in_ps_p)
    ,.dram_cfg_p(dram_cfg_p)
    ,.dram_sys_cfg_p(dram_sys_cfg_p)
@@ -153,11 +153,11 @@ bp_mem
  mem
   (.clk_i(clk_i)
    ,.reset_i(reset_i)
- 
+
    ,.mem_cmd_i(proc_mem_cmd_lo)
    ,.mem_cmd_v_i(proc_mem_cmd_ready_li & proc_mem_cmd_v_lo)
    ,.mem_cmd_ready_o(proc_mem_cmd_ready_li)
- 
+
    ,.mem_resp_o(proc_mem_resp_li)
    ,.mem_resp_v_o(proc_mem_resp_v_li)
    ,.mem_resp_yumi_i(proc_mem_resp_yumi_lo)
@@ -171,17 +171,17 @@ if (load_nbf_p)
      nbf_loader
       (.clk_i(clk_i)
        ,.reset_i(reset_i | ~cfg_done_lo)
-    
+
        ,.lce_id_i(lce_id_width_p'('b10))
-    
+
        ,.io_cmd_o(nbf_cmd_lo)
        ,.io_cmd_v_o(nbf_cmd_v_lo)
        ,.io_cmd_yumi_i(nbf_cmd_yumi_li)
-    
+
        ,.io_resp_i(nbf_resp_li)
        ,.io_resp_v_i(nbf_resp_v_li)
        ,.io_resp_ready_o(nbf_resp_ready_lo)
-    
+
        ,.done_o(nbf_done_lo)
        );
   end
@@ -208,7 +208,7 @@ bp_cce_mmio_cfg_loader
    ,.reset_i(reset_i)
 
    ,.lce_id_i(lce_id_width_p'('b10))
-    
+
    ,.io_cmd_o(cfg_cmd_lo)
    ,.io_cmd_v_o(cfg_cmd_v_lo)
    ,.io_cmd_yumi_i(cfg_cmd_yumi_li)
@@ -227,7 +227,7 @@ always_comb
       load_cmd_lo = cfg_cmd_lo;
       load_cmd_v_lo = cfg_cmd_v_lo;
 
-      nbf_cmd_yumi_li = '0; 
+      nbf_cmd_yumi_li = '0;
       cfg_cmd_yumi_li = load_cmd_yumi_li;
 
       load_resp_ready_lo = cfg_resp_ready_lo;
@@ -243,7 +243,7 @@ always_comb
       load_cmd_lo = nbf_cmd_lo;
       load_cmd_v_lo = nbf_cmd_v_lo;
 
-      nbf_cmd_yumi_li = load_cmd_yumi_li; 
+      nbf_cmd_yumi_li = load_cmd_yumi_li;
       cfg_cmd_yumi_li = '0;
 
       load_resp_ready_lo = nbf_resp_ready_lo;
@@ -391,6 +391,7 @@ bind bp_be_top
       ,.assoc_p(dcache_assoc_p)
       ,.sets_p(dcache_sets_p)
       ,.block_width_p(dcache_block_width_p)
+      ,.fill_width_p(dcache_fill_width_p)
       ,.trace_file_p("dcache"))
      dcache_tracer
       (.clk_i(clk_i & (testbench.dcache_trace_p == 1))
@@ -400,19 +401,19 @@ bind bp_be_top
        ,.mhartid_i(cfg_bus_cast_i.core_id)
 
        ,.v_tl_r(v_tl_r)
-       
+
        ,.v_tv_r(v_tv_r)
        ,.addr_tv_r(paddr_tv_r)
        ,.lr_miss_tv(lr_miss_tv)
        ,.sc_op_tv_r(sc_op_tv_r)
        ,.sc_success(sc_success)
-        
+
        ,.cache_req_v_o(cache_req_v_o)
        ,.cache_req_o(cache_req_o)
 
        ,.cache_req_metadata_o(cache_req_metadata_o)
        ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
-        
+
        ,.cache_req_complete_i(cache_req_complete_i)
 
        ,.v_o(v_o)
@@ -424,7 +425,7 @@ bind bp_be_top
        ,.data_mem_pkt_v_i(data_mem_pkt_v_i)
        ,.data_mem_pkt_i(data_mem_pkt_i)
        ,.data_mem_pkt_yumi_o(data_mem_pkt_yumi_o)
-       
+
        ,.tag_mem_pkt_v_i(tag_mem_pkt_v_i)
        ,.tag_mem_pkt_i(tag_mem_pkt_i)
        ,.tag_mem_pkt_yumi_o(tag_mem_pkt_yumi_o)
@@ -440,28 +441,29 @@ bind bp_be_top
       ,.assoc_p(icache_assoc_p)
       ,.sets_p(icache_sets_p)
       ,.block_width_p(icache_block_width_p)
+      ,.fill_width_p(icache_fill_width_p)
       ,.trace_file_p("icache"))
      icache_tracer
       (.clk_i(clk_i & (testbench.icache_trace_p == 1))
        ,.reset_i(reset_i)
-       
+
        ,.freeze_i(cfg_bus_cast_i.freeze)
        ,.mhartid_i(cfg_bus_cast_i.core_id)
 
        ,.v_tl_r(v_tl_r)
-       
+
        ,.v_tv_r(v_tv_r)
        ,.addr_tv_r(addr_tv_r)
        ,.lr_miss_tv(1'b0)
        ,.sc_op_tv_r(1'b0)
        ,.sc_success(1'b0)
-        
+
        ,.cache_req_v_o(cache_req_v_o)
        ,.cache_req_o(cache_req_o)
 
        ,.cache_req_metadata_o(cache_req_metadata_o)
        ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
-        
+
        ,.cache_req_complete_i(cache_req_complete_i)
 
        ,.v_o(data_v_o)
@@ -473,7 +475,7 @@ bind bp_be_top
        ,.data_mem_pkt_v_i(data_mem_pkt_v_i)
        ,.data_mem_pkt_i(data_mem_pkt_i)
        ,.data_mem_pkt_yumi_o(data_mem_pkt_yumi_o)
-       
+
        ,.tag_mem_pkt_v_i(tag_mem_pkt_v_i)
        ,.tag_mem_pkt_i(tag_mem_pkt_i)
        ,.tag_mem_pkt_yumi_o(tag_mem_pkt_yumi_o)
@@ -671,4 +673,3 @@ bp_nonsynth_if_verif
   ();
 
 endmodule
-


### PR DESCRIPTION
Rebase the work of IF modification for partial fill and UCE FSM modification for multi-cycle fill/eviction to me_dev. Tested on unicore with multicycle-fill, and on single core with full cache block fill.