### PR TITLE
Using effective addresses instead of virtual addresses in the MMU

### DIFF
--- a/bp_be/src/include/bp_be_mem_defines.vh
+++ b/bp_be/src/include/bp_be_mem_defines.vh
@@ -1,18 +1,11 @@
 `ifndef BP_BE_MEM_DEFINES_VH
 `define BP_BE_MEM_DEFINES_VH
 
-`define declare_bp_be_mmu_structs(vaddr_width_mp, ppn_width_mp, sets_mp, block_size_in_bytes_mp) \
-  typedef struct packed                                                                            \
-  {                                                                                                \
-    logic [vaddr_width_mp-`BSG_SAFE_CLOG2(sets_mp*block_size_in_bytes_mp)-1:0] tag;                \
-    logic [`BSG_SAFE_CLOG2(sets_mp)-1:0]                                       index;              \
-    logic [`BSG_SAFE_CLOG2(block_size_in_bytes_mp)-1:0]                        offset;             \
-  }  bp_be_mmu_vaddr_s;                                                                            \
-                                                                                                   \
+`define declare_bp_be_mmu_structs                                                                  \
   typedef struct packed                                                                            \
   {                                                                                                \
     bp_be_fu_op_s                      mem_op;                                                     \
-    bp_be_mmu_vaddr_s                  vaddr;                                                      \
+    logic [rv64_eaddr_width_gp-1:0]    eaddr;                                                      \
     logic [rv64_reg_data_width_gp-1:0] data;                                                       \
   }  bp_be_mmu_cmd_s;                                                                              \
                                                                                                    \
@@ -45,8 +38,8 @@
     logic v;
   }  bp_sv39_pte_s;
 
-`define bp_be_mmu_cmd_width(vaddr_width_mp) \
-  (`bp_be_fu_op_width + vaddr_width_mp + rv64_reg_data_width_gp)
+`define bp_be_mmu_cmd_width \
+  (`bp_be_fu_op_width + rv64_eaddr_width_gp + rv64_reg_data_width_gp)
 
 `define bp_be_csr_cmd_width \
   (`bp_be_fu_op_width + rv64_csr_addr_width_gp + rv64_reg_data_width_gp)

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -29,7 +29,7 @@ module bp_be_calculator_top
    , localparam cfg_bus_width_lp       = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
    , localparam calc_status_width_lp    = `bp_be_calc_status_width(vaddr_width_p)
    , localparam exception_width_lp      = `bp_be_exception_width
-   , localparam mmu_cmd_width_lp        = `bp_be_mmu_cmd_width(vaddr_width_p)
+   , localparam mmu_cmd_width_lp        = `bp_be_mmu_cmd_width
    , localparam csr_cmd_width_lp        = `bp_be_csr_cmd_width
    , localparam mem_resp_width_lp       = `bp_be_mem_resp_width(vaddr_width_p)
    , localparam dispatch_pkt_width_lp   = `bp_be_dispatch_pkt_width(vaddr_width_p)
@@ -72,7 +72,7 @@ module bp_be_calculator_top
   );
 
 // Declare parameterizable structs
-`declare_bp_be_mmu_structs(vaddr_width_p, ppn_width_p, lce_sets_p, cce_block_width_p / 8)
+`declare_bp_be_mmu_structs
 `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
 `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.v
@@ -23,6 +23,7 @@ module bp_be_pipe_mem
    , localparam mmu_cmd_width_lp       = `bp_be_mmu_cmd_width
    , localparam csr_cmd_width_lp       = `bp_be_csr_cmd_width
    , localparam mem_resp_width_lp      = `bp_be_mem_resp_width(vaddr_width_p)
+   , localparam eaddr_pad_lp           = rv64_eaddr_width_gp - vaddr_width_p
 
    // From RISC-V specifications
    , localparam reg_data_width_lp = rv64_reg_data_width_gp
@@ -110,12 +111,12 @@ wire fe_exc_v = (decode.fu_op == e_op_instr_misaligned)
                 | (decode.fu_op == e_op_instr_page_fault)
                 | (decode.fu_op == e_itlb_fill);
 
-wire pc_sigext = pc_i[38];
+wire pc_sigext = pc_i[vaddr_width_p-1];
 always_comb 
   begin
     mem1_cmd.mem_op   = decode.fu_op;
     mem1_cmd.data     = rs2_i;
-    mem1_cmd.eaddr    = fe_exc_v ? {{25{pc_sigext}}, pc_i} : (rs1_i + offset);
+    mem1_cmd.eaddr    = fe_exc_v ? {{eaddr_pad_lp{pc_sigext}}, pc_i} : (rs1_i + offset);
   end
 
 assign csr_cmd_v_o = csr_cmd_v_lo & ~kill_ex3_i;

--- a/bp_be/src/v/bp_be_mem/bp_be_csr.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_csr.v
@@ -67,7 +67,7 @@ module bp_be_csr
 // Declare parameterizable structs
 `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
 `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p); 
-`declare_bp_be_mmu_structs(vaddr_width_p, ppn_width_p, lce_sets_p, cce_block_width_p/8)
+`declare_bp_be_mmu_structs
 
 // Casting input and output ports
 bp_cfg_bus_s cfg_bus_cast_i;

--- a/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
@@ -45,6 +45,7 @@ module bp_be_mem_top
    , localparam csr_cmd_width_lp  = `bp_be_csr_cmd_width
    , localparam mem_resp_width_lp = `bp_be_mem_resp_width(vaddr_width_p)
    , localparam etag_width_lp     =  rv64_eaddr_width_gp - bp_page_offset_width_gp
+   , localparam eaddr_pad_lp      =  rv64_eaddr_width_gp - vaddr_width_p
 
    // VM
    , localparam tlb_entry_width_lp = `bp_pte_entry_leaf_width(paddr_width_p)
@@ -464,7 +465,7 @@ end
 wire data_priv_page_fault = ((priv_mode_lo == `PRIV_MODE_S) & ~mstatus_sum_lo & dtlb_r_entry.u)
                               | ((priv_mode_lo == `PRIV_MODE_U) & ~dtlb_r_entry.u);
 wire data_write_page_fault = is_store_r & (~dtlb_r_entry.w | ~dtlb_r_entry.d);
-wire eaddr_page_fault = (mmu_cmd_v_r & (mmu_cmd_r.eaddr[rv64_eaddr_width_gp-1:vaddr_width_p] != {25{mmu_cmd_r.eaddr[vaddr_width_p-1]}}));
+wire eaddr_page_fault = (mmu_cmd_v_r & (mmu_cmd_r.eaddr[rv64_eaddr_width_gp-1:vaddr_width_p] != {eaddr_pad_lp{mmu_cmd_r.eaddr[vaddr_width_p-1]}}));
 
 // This DFF is required to prevent an eaddr_page_fault from performing a page
 // table walk
@@ -504,7 +505,7 @@ always_comb
     else begin
       // We assume that mem op == dcache op
       dcache_pkt.opcode      = bp_be_dcache_opcode_e'(mmu_cmd.mem_op);
-      dcache_pkt.page_offset = mmu_cmd.eaddr[bp_page_offset_width_gp-1:0];
+      dcache_pkt.page_offset = mmu_cmd.eaddr[0+:bp_page_offset_width_gp];
       dcache_pkt.data        = mmu_cmd.data;
     end
 end
@@ -525,7 +526,7 @@ assign store_access_fault_v = store_op_tl_lo & (mode_fault_v | did_fault_v | sac
 assign dtlb_r_v     = dcache_cmd_v & ~fencei_cmd_v;
 assign dtlb_r_etag  = mmu_cmd.eaddr[rv64_eaddr_width_gp-1:bp_page_offset_width_gp];
 assign dtlb_w_v     = ptw_tlb_w_v & ~itlb_not_dtlb_resp;
-assign dtlb_w_etag  = {25'h0, ptw_tlb_w_vtag};
+assign dtlb_w_etag  = {eaddr_pad_lp'(0), ptw_tlb_w_vtag};
 assign dtlb_w_entry = ptw_tlb_w_entry;
 
 // PTW connections

--- a/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_mem_top.v
@@ -464,10 +464,10 @@ end
 wire data_priv_page_fault = ((priv_mode_lo == `PRIV_MODE_S) & ~mstatus_sum_lo & dtlb_r_entry.u)
                               | ((priv_mode_lo == `PRIV_MODE_U) & ~dtlb_r_entry.u);
 wire data_write_page_fault = is_store_r & (~dtlb_r_entry.w | ~dtlb_r_entry.d);
-wire eaddr_page_fault = (mmu_cmd.eaddr[rv64_eaddr_width_gp-1:vaddr_width_p] != {25{mmu_cmd.eaddr[vaddr_width_p-1]}});
+wire eaddr_page_fault = (mmu_cmd_r.eaddr[rv64_eaddr_width_gp-1:vaddr_width_p] != {25{mmu_cmd_r.eaddr[vaddr_width_p-1]}});
 
-assign load_page_fault_v  = (mmu_cmd_v_r & dtlb_r_v_lo & translation_en_lo & ~is_store_r & data_priv_page_fault) | (mmu_cmd_v_r & eaddr_page_fault);
-assign store_page_fault_v = (mmu_cmd_v_r & dtlb_r_v_lo & translation_en_lo & is_store_r & (data_priv_page_fault | data_write_page_fault)) | (mmu_cmd_v_r & eaddr_page_fault);
+assign load_page_fault_v  = (mmu_cmd_v_r & dtlb_r_v_lo & translation_en_lo & ~is_store_r & data_priv_page_fault) | (translation_en_lo & mmu_cmd_v_r & eaddr_page_fault);
+assign store_page_fault_v = (mmu_cmd_v_r & dtlb_r_v_lo & translation_en_lo & is_store_r & (data_priv_page_fault | data_write_page_fault)) | (translation_en_lo & mmu_cmd_v_r & eaddr_page_fault);
 
 // Decode cmd type
 assign dcache_cmd_v    = mmu_cmd_v_i;

--- a/bp_be/src/v/bp_be_top.v
+++ b/bp_be/src/v/bp_be_top.v
@@ -89,8 +89,7 @@ module bp_be_top
    );
 
 // Declare parameterized structures
-// TODO: Shouldn't the block size be in bytes and not in bits?
-`declare_bp_be_mmu_structs(vaddr_width_p, ptag_width_p, dcache_sets_p, dcache_block_width_p)
+`declare_bp_be_mmu_structs
 `declare_bp_cfg_bus_s(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p);
 `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 

--- a/bp_be/test/common/bp_be_nonsynth_vm_tracer.v
+++ b/bp_be/test/common/bp_be_nonsynth_vm_tracer.v
@@ -40,7 +40,7 @@ module bp_be_nonsynth_vm_tracer
 
   `declare_bp_fe_be_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
   `declare_bp_fe_mem_structs(vaddr_width_p, lce_sets_p, cce_block_width_p, vtag_width_p, ptag_width_p)
-  `declare_bp_be_mmu_structs(vaddr_width_p, paddr_width_p, lce_sets_p, cce_block_width_p/8)
+  `declare_bp_be_mmu_structs;
   bp_fe_tlb_entry_s   itlb_w_entry;
   bp_pte_entry_leaf_s dtlb_w_entry;
   

--- a/bp_common/src/v/bp_tlb.v
+++ b/bp_common/src/v/bp_tlb.v
@@ -2,6 +2,7 @@
 module bp_tlb
   import bp_common_pkg::*;
   import bp_common_aviary_pkg::*;
+  import bp_common_rv64_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
    ,parameter tlb_els_p       = "inv"
@@ -70,7 +71,7 @@ bsg_cam_1r1w_sync
    ,.r_v_o(r_v_lo)
    );
 
-assign passthrough_entry = '{ptag: {etag[vtag_width_p], vtag_r}, default: '0};
+assign passthrough_entry = '{ptag: {etag_i[vtag_width_p], vtag_r}, default: '0};
 assign entry_o    = translation_en_i ? r_entry : passthrough_entry;
 assign v_o        = translation_en_i ? r_v_r & r_v_lo : r_v_r;
 assign miss_v_o   = r_v_r & ~v_o;

--- a/bp_common/src/v/bp_tlb.v
+++ b/bp_common/src/v/bp_tlb.v
@@ -38,7 +38,16 @@ bsg_dff_reset #(.width_p(1))
   );
 
 logic [vtag_width_p-1:0] vtag_r, vtag_li;
+logic [etag_width_lp-1:0] etag_r;
 assign vtag_li = etag_i[vtag_width_p-1:0];
+
+bsg_dff_reset #(.width_p(etag_width_lp))
+  etag_reg
+  (.clk_i(clk_i)
+   ,.reset_i(reset_i)
+   ,.data_i(etag_i)
+   ,.data_o(etag_r)
+  );
 
 bsg_dff_reset #(.width_p(vtag_width_p))
   vtag_reg
@@ -71,7 +80,7 @@ bsg_cam_1r1w_sync
    ,.r_v_o(r_v_lo)
    );
 
-assign passthrough_entry = '{ptag: {etag_i[vtag_width_p], vtag_r}, default: '0};
+assign passthrough_entry = '{ptag: {etag_r[vtag_width_p], vtag_r}, default: '0};
 assign entry_o    = translation_en_i ? r_entry : passthrough_entry;
 assign v_o        = translation_en_i ? r_v_r & r_v_lo : r_v_r;
 assign miss_v_o   = r_v_r & ~v_o;

--- a/bp_fe/src/v/bp_fe_mem.v
+++ b/bp_fe/src/v/bp_fe_mem.v
@@ -90,6 +90,9 @@ wire fencei_v     = fetch_ready & mem_cmd_v_i & (mem_cmd_cast_i.op == e_fe_op_ic
 
 bp_fe_tlb_entry_s itlb_r_entry;
 logic itlb_r_v_lo;
+logic [24:0] fill_vtag_sigext, fetch_vtag_sigext;
+assign fill_vtag_sigext = {25{mem_cmd_cast_i.operands.fill.vtag[26]}};
+assign fetch_vtag_sigext = {25{mem_cmd_cast_i.operands.fetch.vaddr.tag[26]}};
 bp_tlb
  #(.bp_params_p(bp_params_p), .tlb_els_p(itlb_els_p))
  itlb
@@ -100,7 +103,7 @@ bp_tlb
          
    ,.v_i(fetch_v | itlb_fill_v)
    ,.w_i(itlb_fill_v)
-   ,.vtag_i(itlb_fill_v ? mem_cmd_cast_i.operands.fill.vtag : mem_cmd_cast_i.operands.fetch.vaddr.tag)
+   ,.etag_i(itlb_fill_v ? {fill_vtag_sigext, mem_cmd_cast_i.operands.fill.vtag} : {fetch_vtag_sigext, mem_cmd_cast_i.operands.fetch.vaddr.tag})
    ,.entry_i(mem_cmd_cast_i.operands.fill.entry)
      
    ,.v_o(itlb_r_v_lo)

--- a/bp_top/src/v/bp_cacc_vdp.v
+++ b/bp_top/src/v/bp_cacc_vdp.v
@@ -48,7 +48,7 @@ module bp_cacc_vdp
 
 
  `declare_bp_be_dcache_pkt_s(bp_page_offset_width_gp, dword_width_p);
- `declare_bp_be_mmu_structs(vaddr_width_p, ptag_width_p, lce_sets_p, cce_block_width_p/8);
+ `declare_bp_be_mmu_structs;
    
   bp_be_dcache_pkt_s        dcache_pkt;   
   logic                     dcache_ready, dcache_v;
@@ -235,7 +235,7 @@ bp_be_dcache_lce
                             ,data          : resp_data  };
 
    
-  bp_be_mmu_vaddr_s v_addr;
+  logic [vaddr_width_p-1:0] v_addr;
   assign v_addr = load ? (second_operand ? (input_b_ptr+len_b_cnt*8) 
                                          : (input_a_ptr+len_a_cnt*8)) 
                        : res_ptr;
@@ -357,10 +357,10 @@ bp_be_dcache_lce
       end
       FETCH: begin
         state_n = WAIT_DCACHE_C1;
-        dcache_ptag = {(ptag_width_p-vtag_width_p)'(0), v_addr.tag};
+        dcache_ptag = {(ptag_width_p-vtag_width_p)'(0), v_addr[bp_page_offset_width_gp+:vtag_width_p]};
         dcache_pkt.opcode = load ? e_dcache_opcode_ld : e_dcache_opcode_sd;
         dcache_pkt.data = load ? '0 : dot_product_res; 
-        dcache_pkt.page_offset = {v_addr.index, v_addr.offset};
+        dcache_pkt.page_offset = {v_addr[0+:bp_page_offset_width_gp]};
         res_status = '0;
         dcache_pkt_v = '1;
         done = 0;
@@ -368,9 +368,9 @@ bp_be_dcache_lce
       WAIT_DCACHE_C1: begin
         state_n = WAIT_DCACHE_C2;
         res_status = '0;
-        dcache_ptag = {(ptag_width_p-vtag_width_p)'(0), v_addr.tag};
+        dcache_ptag = {(ptag_width_p-vtag_width_p)'(0), v_addr[bp_page_offset_width_gp+:vtag_width_p]};
         dcache_pkt.opcode = load ? e_dcache_opcode_ld : e_dcache_opcode_sd;
-        dcache_pkt.page_offset = {v_addr.index, v_addr.offset};
+        dcache_pkt.page_offset = {v_addr[0+:bp_page_offset_width_gp]};
         dcache_pkt.data = load ? '0 : dot_product_res;
         dcache_pkt_v = '0;
         done = 0;
@@ -382,30 +382,30 @@ bp_be_dcache_lce
                   (dcache_v ? (load ? (second_operand ? CHECK_VEC2_LEN : CHECK_VEC1_LEN) : DONE)
                             : WAIT_FETCH);
         res_status = '0;
-        dcache_ptag = {(ptag_width_p-vtag_width_p)'(0), v_addr.tag};
+        dcache_ptag = {(ptag_width_p-vtag_width_p)'(0), v_addr[bp_page_offset_width_gp+:vtag_width_p]};
         dcache_pkt.opcode = load ? e_dcache_opcode_ld : e_dcache_opcode_sd;
         dcache_pkt.data = load ? '0 : dot_product_res;
-        dcache_pkt.page_offset = {v_addr.index, v_addr.offset};
+        dcache_pkt.page_offset = {v_addr[0+:bp_page_offset_width_gp]};
         dcache_pkt_v = '0;
         done = 0;
       end
       CHECK_VEC1_LEN: begin
         state_n = (len_a_cnt == input_len) ? FETCH_VEC2 : WAIT_FETCH;
         res_status = '0;
-        dcache_ptag = {(ptag_width_p-vtag_width_p)'(0), v_addr.tag};
+        dcache_ptag = {(ptag_width_p-vtag_width_p)'(0), v_addr[bp_page_offset_width_gp+:vtag_width_p]};
         dcache_pkt.opcode = load ? e_dcache_opcode_ld : e_dcache_opcode_sd;
         dcache_pkt.data = load ? '0 : dot_product_res;
-        dcache_pkt.page_offset = {v_addr.index, v_addr.offset};
+        dcache_pkt.page_offset = {v_addr[0+:bp_page_offset_width_gp]};
         dcache_pkt_v = '0;
         done = 0;
       end
       FETCH_VEC2: begin
         state_n = WAIT_FETCH;
         res_status = '0;
-        dcache_ptag = {(ptag_width_p-vtag_width_p)'(0), v_addr.tag};
+        dcache_ptag = {(ptag_width_p-vtag_width_p)'(0), v_addr[bp_page_offset_width_gp+:vtag_width_p]};
         dcache_pkt.opcode = load ? e_dcache_opcode_ld : e_dcache_opcode_sd;
         dcache_pkt.data = load ? '0 : dot_product_res;
-        dcache_pkt.page_offset = {v_addr.index, v_addr.offset};
+        dcache_pkt.page_offset = {v_addr[0+:bp_page_offset_width_gp]};
         dcache_pkt_v = '0;
         second_operand= 1;
         done = 0;
@@ -413,10 +413,10 @@ bp_be_dcache_lce
       CHECK_VEC2_LEN: begin
         state_n= (len_b_cnt == input_len) ? WB_RESULT : WAIT_FETCH;
         res_status = '0;
-        dcache_ptag = {(ptag_width_p-vtag_width_p)'(0), v_addr.tag};
+        dcache_ptag = {(ptag_width_p-vtag_width_p)'(0), v_addr[bp_page_offset_width_gp+:vtag_width_p]};
         dcache_pkt.opcode = load ? e_dcache_opcode_ld : e_dcache_opcode_sd;
         dcache_pkt.data = load ? '0 : dot_product_res;
-        dcache_pkt.page_offset = {v_addr.index, v_addr.offset};
+        dcache_pkt.page_offset = {v_addr[0+:bp_page_offset_width_gp]};
         dcache_pkt_v = '0;
         second_operand= 1;
         done = 0;

--- a/bp_top/src/v/bp_piton_top.v
+++ b/bp_top/src/v/bp_piton_top.v
@@ -278,6 +278,8 @@ module bp_piton_top
      ,.inst_ram_els_p(num_cce_instr_ram_els_p)
      ,.skip_ram_init_p(0)
      ,.clear_freeze_p(1)
+     // Enabling all domains for parrotpiton
+     ,.domain_mask_p(64'hff)
      )
      cfg_loader
      (.clk_i(clk_i)

--- a/bp_top/src/v/bp_softcore.v
+++ b/bp_top/src/v/bp_softcore.v
@@ -435,7 +435,7 @@ module bp_softcore
   wire is_cfg_cmd          = local_cmd_li & (device_cmd_li == cfg_dev_gp);
   wire is_clint_cmd        = local_cmd_li & (device_cmd_li == clint_dev_gp);
   wire is_io_cmd           = (local_cmd_li & (device_cmd_li == host_dev_gp)) | is_other_domain;
-  wire is_cache_cmd        = ~local_cmd_li || (local_cmd_li & (device_cmd_li == cache_dev_gp));
+  wire is_cache_cmd        = (~local_cmd_li & ~is_other_domain) || (local_cmd_li & (device_cmd_li == cache_dev_gp));
 
   assign cfg_cmd_v_li   = is_cfg_cmd   & |cmd_fifo_yumi_li;
   assign clint_cmd_v_li = is_clint_cmd & |cmd_fifo_yumi_li;

--- a/bp_top/src/v/bp_tile.v
+++ b/bp_top/src/v/bp_tile.v
@@ -479,8 +479,9 @@ for (genvar i = 0; i < 2; i++)
   assign clint_mem_cmd_li     = cce_mem_cmd_lo;
   assign clint_mem_cmd_v_li   = cce_mem_cmd_v_lo &  local_cmd_li & (device_li == clint_dev_gp);
 
+  // Cache commands are always to the same domain
   assign cache_mem_cmd_li      = cce_mem_cmd_lo;
-  assign cache_mem_cmd_v_li    = cce_mem_cmd_v_lo & ~cfg_mem_cmd_v_li & ~clint_mem_cmd_v_li;
+  assign cache_mem_cmd_v_li    = cce_mem_cmd_v_lo & ~cfg_mem_cmd_v_li & ~clint_mem_cmd_v_li & (cce_mem_cmd_lo.header.addr[paddr_width_p-1-:io_noc_did_width_p] == 0);
 
   bsg_arb_fixed
    #(.inputs_p(3)

--- a/bp_top/test/common/bp_nonsynth_host.v
+++ b/bp_top/test/common/bp_nonsynth_host.v
@@ -128,7 +128,7 @@ always_ff @(negedge clk_i)
       pop();
 
     if (io_cmd_v_i & (domain_id != '0))
-      $display("Warning: Accesing illegal domain %0h. Sending loopback message!", domain_id);
+      $display("%t Warning: Accesing illegal domain %0h. Sending loopback message!", $time, domain_id);
     for (integer i = 0; i < num_core_p; i++)
       begin
         // PASS when returned value in finish packet is zero

--- a/bp_top/test/tb/bp_tethered/testbench.v
+++ b/bp_top/test/tb/bp_tethered/testbench.v
@@ -495,12 +495,12 @@ bind bp_be_top
 
        ,.itlb_clear_i(fe.mem.itlb.flush_i)
        ,.itlb_fill_v_i(fe.mem.itlb.v_i & fe.mem.itlb.w_i)
-       ,.itlb_vtag_i(fe.mem.itlb.vtag_i)
+       ,.itlb_vtag_i(fe.mem.itlb.etag_i[0+:vtag_width_p])
        ,.itlb_entry_i(fe.mem.itlb.entry_i)
 
        ,.dtlb_clear_i(be.be_mem.dtlb.flush_i)
        ,.dtlb_fill_v_i(be.be_mem.dtlb.v_i & be.be_mem.dtlb.w_i)
-       ,.dtlb_vtag_i(be.be_mem.dtlb.vtag_i)
+       ,.dtlb_vtag_i(be.be_mem.dtlb.etag_i[0+:vtag_width_p])
        ,.dtlb_entry_i(be.be_mem.dtlb.entry_i)
        );
 


### PR DESCRIPTION
This PR introduces the fix for a bug that was found in bare metal execution where the specification is to use 64-bit effective addresses instead of 39-bit virtual addresses.

This PR also closes issues #393 and #394.