### PR TITLE
Redirect basejump to upstream master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,8 +24,8 @@
 
 [submodule "external/basejump_stl"]
   path = external/basejump_stl
-  url = https://github.com/black-parrot/basejump_stl.git
-  branch = blackparrot_mods
+  url = https://github.com/bespoke-silicon-group/basejump_stl.git
+  branch = master
   ignore = dirty
 
 [submodule "external/DRAMSim2"]

--- a/bp_me/src/v/wormhole/bp_me_addr_to_cce_id.v
+++ b/bp_me/src/v/wormhole/bp_me_addr_to_cce_id.v
@@ -64,7 +64,7 @@ always_comb begin
     cce_id_o[0+:lg_num_cce_lp] = cce_dst_id_lo;
   else
     cce_id_o = (num_sacc_p > 1)
-               ? max_cac_cce_lp + paddr_i[paddr_width_p-io_noc_did_width_p-1-:`BSG_SAFE_CLOG2(num_sacc_p)]
+               ? max_cac_cce_lp + paddr_i[paddr_width_p-io_noc_did_width_p-1-: (num_sacc_p > 1 ? `BSG_SAFE_CLOG2(num_sacc_p) : 1)]
                : max_cac_cce_lp;
      
    


### PR DESCRIPTION
To solve integration issues with other projects using basejump stl, our new policy is to track master as closely as possible.  Leaving the BlackParrot basejump fork up for legacy builds