### PR TITLE
Cache engine PPA fixes

### DIFF
--- a/bp_me/src/v/cce/bp_uce.v
+++ b/bp_me/src/v/cce/bp_uce.v
@@ -98,14 +98,17 @@ module bp_uce
   `bp_cast_o(bp_cce_mem_msg_s, mem_cmd);
   `bp_cast_i(bp_cce_mem_msg_s, mem_resp);
 
-  logic cache_req_v_r, dirty_data_v_r, dirty_tag_v_r, dirty_stat_v_r;
-  always_ff @(posedge clk_i)
-    begin
-      cache_req_v_r <= cache_req_v_i;
-      dirty_data_v_r <= data_mem_pkt_yumi_i & (data_mem_pkt_cast_o.opcode == e_cache_data_mem_read);
-      dirty_tag_v_r <= tag_mem_pkt_yumi_i & (tag_mem_pkt_cast_o.opcode == e_cache_tag_mem_read);
-      dirty_stat_v_r <= stat_mem_pkt_yumi_i & (stat_mem_pkt_cast_o.opcode == e_cache_stat_mem_read);
-    end
+  logic cache_req_v_r;
+  bsg_dff_reset_set_clear
+   #(.width_p(1))
+   cache_req_v_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.set_i(cache_req_v_i)
+     ,.clear_i(cache_req_complete_o)
+     ,.data_o(cache_req_v_r)
+     );
 
   bp_cache_req_s cache_req_r;
   bsg_dff_reset_en
@@ -119,8 +122,20 @@ module bp_uce
      ,.data_o(cache_req_r)
      );
 
+  logic cache_req_metadata_v_r;
+  bsg_dff_reset_set_clear
+   #(.width_p(1))
+   metadata_v_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.set_i(cache_req_metadata_v_i)
+     ,.clear_i(cache_req_v_i)
+     ,.data_o(cache_req_metadata_v_r)
+     );
+
   bp_cache_req_metadata_s cache_req_metadata_r;
-  bsg_dff_en_bypass
+  bsg_dff_en
    #(.width_p($bits(bp_cache_req_metadata_s)))
    metadata_reg
     (.clk_i(clk_i)
@@ -130,46 +145,104 @@ module bp_uce
      ,.data_o(cache_req_metadata_r)
      );
 
-  logic cache_req_metadata_v_r;
-  bsg_dff_en_bypass
+  logic dirty_data_read_en;
+  wire dirty_data_read = data_mem_pkt_yumi_i & (data_mem_pkt_cast_o.opcode == e_cache_data_mem_read);
+  bsg_dff
    #(.width_p(1))
-   metadata_v_reg
+   dirty_data_read_en_reg
     (.clk_i(clk_i)
 
-     ,.en_i(cache_req_v_i | cache_req_metadata_v_i)
-     ,.data_i(cache_req_metadata_v_i)
-     ,.data_o(cache_req_metadata_v_r)
+     ,.data_i(dirty_data_read)
+     ,.data_o(dirty_data_read_en)
+     );
+
+  logic dirty_data_v_r;
+  bsg_dff_reset_set_clear
+   #(.width_p(1))
+   dirty_data_v_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.set_i(dirty_data_read_en)
+     ,.clear_i(dirty_data_read)
+     ,.data_o(dirty_data_v_r)
      );
 
   logic [block_width_p-1:0] dirty_data_r;
-  bsg_dff_en_bypass
+  bsg_dff_en
    #(.width_p(block_width_p))
    dirty_data_reg
     (.clk_i(clk_i)
 
-    ,.en_i(dirty_data_v_r)
+    ,.en_i(dirty_data_read_en)
     ,.data_i(data_mem_i)
     ,.data_o(dirty_data_r)
     );
 
+  logic dirty_tag_read_en;
+  wire dirty_tag_read = tag_mem_pkt_yumi_i & (tag_mem_pkt_cast_o.opcode == e_cache_tag_mem_read);
+  bsg_dff
+   #(.width_p(1))
+   dirty_tag_read_en_reg
+    (.clk_i(clk_i)
+
+     ,.data_i(dirty_tag_read)
+     ,.data_o(dirty_tag_read_en)
+     );
+
+  logic dirty_tag_v_r;
+  bsg_dff_reset_set_clear
+   #(.width_p(1))
+   dirty_tag_v_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.set_i(dirty_tag_read_en)
+     ,.clear_i(dirty_tag_read)
+     ,.data_o(dirty_tag_v_r)
+     );
+
   logic [ptag_width_p-1:0] dirty_tag_r;
-  bsg_dff_en_bypass
+  bsg_dff_en
    #(.width_p(ptag_width_p))
    dirty_tag_reg
     (.clk_i(clk_i)
 
-    ,.en_i(dirty_tag_v_r)
+    ,.en_i(dirty_tag_read_en)
     ,.data_i(tag_mem_i)
     ,.data_o(dirty_tag_r)
     );
 
+  logic dirty_stat_read_en;
+  wire dirty_stat_read = stat_mem_pkt_yumi_i & (stat_mem_pkt_cast_o.opcode == e_cache_stat_mem_read);
+  bsg_dff
+   #(.width_p(1))
+   dirty_stat_read_en_reg
+    (.clk_i(clk_i)
+
+     ,.data_i(dirty_stat_read)
+     ,.data_o(dirty_stat_read_en)
+     );
+
+  logic dirty_stat_v_r;
+  bsg_dff_reset_set_clear
+   #(.width_p(1))
+   dirty_stat_v_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.set_i(dirty_stat_read_en)
+     ,.clear_i(dirty_stat_read)
+     ,.data_o(dirty_stat_v_r)
+     );
+
   bp_cache_stat_info_s dirty_stat_r;
-  bsg_dff_en_bypass
+  bsg_dff_en
    #(.width_p($bits(bp_cache_stat_info_s)))
    dirty_stat_reg
     (.clk_i(clk_i)
 
-     ,.en_i(dirty_stat_v_r)
+     ,.en_i(dirty_stat_read_en)
      ,.data_i(stat_mem_i)
      ,.data_o(dirty_stat_r)
      );
@@ -194,7 +267,6 @@ module bp_uce
   wire flush_v_li         = cache_req_v_i & cache_req_cast_i.msg_type inside {e_cache_flush};
   wire clear_v_li         = cache_req_v_i & cache_req_cast_i.msg_type inside {e_cache_clear};
   wire uc_store_v_li      = cache_req_v_i & cache_req_cast_i.msg_type inside {e_uc_store};
-
   wire wt_store_v_li      = cache_req_v_i & cache_req_cast_i.msg_type inside {e_wt_store};
 
   wire store_resp_v_li    = mem_resp_v_i & mem_resp_cast_i.header.msg_type inside {e_cce_mem_wr, e_cce_mem_uc_wr};
@@ -404,38 +476,41 @@ module bp_uce
           end
         e_flush_scan:
           begin
-            // Could check if |dirty_stat_r to skip index entirely
-            if (dirty_stat_r[way_cnt])
+            if (dirty_stat_v_r)
               begin
-                data_mem_pkt_cast_o.opcode = e_cache_data_mem_read;
-                data_mem_pkt_cast_o.index  = index_cnt;
-                data_mem_pkt_cast_o.way_id = way_cnt;
-                data_mem_pkt_v_o = 1'b1;
-                data_mem_pkt_cast_o.fill_index = {block_size_in_fill_lp{1'b1}};
+                // Could check if |dirty_stat_r to skip index entirely
+                if (dirty_stat_r[way_cnt])
+                  begin
+                    data_mem_pkt_cast_o.opcode = e_cache_data_mem_read;
+                    data_mem_pkt_cast_o.index  = index_cnt;
+                    data_mem_pkt_cast_o.way_id = way_cnt;
+                    data_mem_pkt_v_o = 1'b1;
+                    data_mem_pkt_cast_o.fill_index = {block_size_in_fill_lp{1'b1}};
 
-                tag_mem_pkt_cast_o.opcode = e_cache_tag_mem_read;
-                tag_mem_pkt_cast_o.index  = index_cnt;
-                tag_mem_pkt_cast_o.way_id = way_cnt;
-                tag_mem_pkt_v_o = 1'b1;
+                    tag_mem_pkt_cast_o.opcode = e_cache_tag_mem_read;
+                    tag_mem_pkt_cast_o.index  = index_cnt;
+                    tag_mem_pkt_cast_o.way_id = way_cnt;
+                    tag_mem_pkt_v_o = 1'b1;
 
-                stat_mem_pkt_cast_o.opcode = e_cache_stat_mem_clear_dirty;
-                stat_mem_pkt_cast_o.index  = index_cnt;
-                stat_mem_pkt_cast_o.way_id = way_cnt;
-                stat_mem_pkt_v_o = 1'b1;
+                    stat_mem_pkt_cast_o.opcode = e_cache_stat_mem_clear_dirty;
+                    stat_mem_pkt_cast_o.index  = index_cnt;
+                    stat_mem_pkt_cast_o.way_id = way_cnt;
+                    stat_mem_pkt_v_o = 1'b1;
 
-                state_n = (data_mem_pkt_yumi_i & tag_mem_pkt_yumi_i & stat_mem_pkt_yumi_i) ? e_flush_write : e_flush_scan;
-              end
-            else
-              begin
-                way_up   = 1'b1;
-                index_up = way_done;
+                    state_n = (data_mem_pkt_yumi_i & tag_mem_pkt_yumi_i & stat_mem_pkt_yumi_i) ? e_flush_write : e_flush_scan;
+                  end
+                else
+                  begin
+                    way_up   = 1'b1;
+                    index_up = way_done;
 
-                state_n = (index_done & way_done)
-                          ? e_flush_fence
-                          : way_done
-                            ? e_flush_read
-                            : e_flush_scan;
-              end
+                    state_n = (index_done & way_done)
+                              ? e_flush_fence
+                              : way_done
+                                ? e_flush_read
+                                : e_flush_scan;
+                  end
+            end
           end
         e_flush_write:
           begin
@@ -444,7 +519,7 @@ module bp_uce
             mem_cmd_cast_o.header.size     = block_msg_size_lp;
             mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
             mem_cmd_cast_o.data                  = writeback_data;
-            mem_cmd_v_o = mem_cmd_ready_i;
+            mem_cmd_v_o = mem_cmd_ready_i & dirty_data_v_r & dirty_tag_v_r;
             mem_cmd_up = mem_cmd_v_o;
 
             way_up = mem_cmd_done & mem_cmd_v_o;
@@ -504,7 +579,7 @@ module bp_uce
               mem_cmd_cast_o.header.size           = block_msg_size_lp;
               mem_cmd_cast_o.header.payload.way_id = lce_assoc_p'(cache_req_metadata_r.repl_way);
               mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
-              mem_cmd_v_o = mem_cmd_ready_i;
+              mem_cmd_v_o = mem_cmd_ready_i & cache_req_metadata_v_r;
               mem_cmd_up = mem_cmd_v_o;
               state_n = mem_cmd_v_o
                         ? cache_req_metadata_r.dirty
@@ -581,7 +656,7 @@ module bp_uce
             mem_cmd_cast_o.header.size     = block_msg_size_lp;
             mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
             mem_cmd_cast_o.data                  = writeback_data;
-            mem_cmd_v_o = mem_cmd_ready_i;
+            mem_cmd_v_o = mem_cmd_ready_i & dirty_data_v_r & dirty_tag_v_r;
             mem_cmd_up = mem_cmd_v_o;
 
             cache_req_complete_o = mem_cmd_done & mem_cmd_v_o;

--- a/bp_me/src/v/lce/bp_lce.v
+++ b/bp_me/src/v/lce/bp_lce.v
@@ -122,7 +122,7 @@ module bp_lce
   //synopsys translate_on
 
   // LCE Request Module
-  logic lce_req_cache_req_ready_lo;
+  logic req_ready_lo;
   logic uc_store_req_complete_lo;
 
   bp_lce_req
@@ -141,9 +141,10 @@ module bp_lce
       ,.lce_id_i(lce_id_i)
       ,.lce_mode_i(lce_mode_i)
 
+      ,.ready_o(req_ready_lo)
+
       ,.cache_req_i(cache_req_i)
       ,.cache_req_v_i(cache_req_v_i)
-      ,.cache_req_ready_o(lce_req_cache_req_ready_lo)
       ,.cache_req_metadata_i(cache_req_metadata_i)
       ,.cache_req_metadata_v_i(cache_req_metadata_v_i)
 
@@ -242,6 +243,6 @@ module bp_lce
   // - LCE Request module is ready (raised when in ready state and free credits exist)
   // - timout signal is low, indicating LCE isn't blocked on using data/tag/stat mem
   // - LCE Command module is ready to process commands (raised after initialization complete)
-  assign cache_req_ready_o = lce_req_cache_req_ready_lo & ~timeout & cmd_ready_lo;
+  assign cache_req_ready_o = req_ready_lo & cmd_ready_lo & ~timeout;
 
 endmodule

--- a/bp_me/src/v/lce/bp_lce_cmd.v
+++ b/bp_me/src/v/lce/bp_lce_cmd.v
@@ -131,7 +131,6 @@ module bp_lce_cmd
     ,e_wb
     ,e_wb_dirty_rd
     ,e_wb_dirty_send
-    ,e_null_wb
     ,e_coh_ack
   } lce_cmd_state_e;
   lce_cmd_state_e state_r, state_n;
@@ -147,12 +146,10 @@ module bp_lce_cmd
   bp_cache_data_mem_pkt_s data_mem_pkt;
   bp_cache_tag_mem_pkt_s tag_mem_pkt;
   bp_cache_stat_mem_pkt_s stat_mem_pkt;
-  bp_cache_stat_info_s stat_mem_cast_i;
 
   assign data_mem_pkt_o = data_mem_pkt;
   assign tag_mem_pkt_o = tag_mem_pkt;
   assign stat_mem_pkt_o = stat_mem_pkt;
-  assign stat_mem_cast_i = stat_mem_i;
 
   // sync done register - goes high when all sync command/acks complete
   logic sync_done_en, sync_done_li;
@@ -170,23 +167,70 @@ module bp_lce_cmd
   // which will capture the data into the data buffer on the next cycle (when it is guaranteed to
   // be valid on the data_mem_i port). The data will remain in the buffer until the next read
   // command is accepted and new data is latched.
-  logic data_buf_en_r;
-  always_ff @(posedge clk_i) begin
-    if (reset_i) begin
-      data_buf_en_r <= 1'b0;
-    end else begin
-      data_buf_en_r <= data_mem_pkt_yumi_i & (data_mem_pkt.opcode == e_cache_data_mem_read);
-    end
-  end
+  logic data_buf_read_en;
+  wire data_buf_read = data_mem_pkt_yumi_i & (data_mem_pkt.opcode == e_cache_data_mem_read);
+  bsg_dff
+   #(.width_p(1))
+   data_buf_read_en_reg
+    (.clk_i(clk_i)
+
+     ,.data_i(data_buf_read)
+     ,.data_o(data_buf_read_en)
+     );
+
+  logic data_buf_v_r;
+  bsg_dff_reset_set_clear
+   #(.width_p(1))
+   data_buf_v_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.set_i(data_buf_read_en)
+     ,.clear_i(data_buf_read)
+     ,.data_o(data_buf_v_r)
+     );
 
   logic [cce_block_width_p-1:0] data_buf_r;
-  bsg_dff_en_bypass
+  bsg_dff_en
     #(.width_p(cce_block_width_p))
     data_buf_reg
      (.clk_i(clk_i)
-      ,.en_i(data_buf_en_r)
+      ,.en_i(data_buf_read_en)
       ,.data_i(data_mem_i)
       ,.data_o(data_buf_r)
+      );
+
+  logic stat_buf_read_en;
+  wire stat_buf_read = stat_mem_pkt_yumi_i & (stat_mem_pkt.opcode == e_cache_stat_mem_read);
+  bsg_dff
+   #(.width_p(1))
+   stat_buf_read_en_reg
+    (.clk_i(clk_i)
+
+     ,.data_i(stat_buf_read)
+     ,.data_o(stat_buf_read_en)
+     );
+
+  logic stat_buf_v_r;
+  bsg_dff_reset_set_clear
+   #(.width_p(1))
+   stat_buf_v_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.set_i(stat_buf_read_en)
+     ,.clear_i(stat_buf_read)
+     ,.data_o(stat_buf_v_r)
+     );
+
+  bp_cache_stat_info_s stat_buf_r;
+  bsg_dff_en
+    #(.width_p($bits(bp_cache_stat_info_s)))
+    stat_buf_reg
+     (.clk_i(clk_i)
+      ,.en_i(stat_buf_read_en)
+      ,.data_i(stat_mem_i)
+      ,.data_o(stat_buf_r)
       );
 
   // common fields from LCE Command used in many states for responses or pkt fields
@@ -486,10 +530,10 @@ module bp_lce_cmd
         // handshakes
         // outbound command is ready->valid
         // inbound is valid->yumi, but only dequeue when outbound sends
-        lce_cmd_v_o = lce_cmd_ready_i;
-        lce_cmd_yumi_o = lce_cmd_ready_i & lce_cmd_v_i;
+        lce_cmd_v_o = lce_cmd_ready_i & lce_cmd_v_i & data_buf_v_r;
+        lce_cmd_yumi_o = lce_cmd_v_o;
 
-        state_n = lce_cmd_ready_i
+        state_n = lce_cmd_yumi_o
           ? e_ready
           : e_tr;
 
@@ -501,22 +545,21 @@ module bp_lce_cmd
       // Determine if the block is dirty or not.
       e_wb: begin
 
-        // try to send null writeback this cycle if not dirty, but if it doesn't send
-        // go to e_null_wb state to try again
+        // Send a null writeback if not dirty, else move to writeback
         lce_resp.data = '0;
         lce_resp.header.addr = lce_cmd.header.addr;
         lce_resp.header.msg_type = e_lce_cce_resp_null_wb;
         lce_resp.header.src_id = lce_id_i;
         lce_resp.header.dst_id = lce_cmd.header.src_id;
-        lce_resp_v_o = lce_resp_ready_i & ~stat_mem_cast_i.dirty[lce_cmd_way_id];
+        lce_resp_v_o = lce_resp_ready_i & stat_buf_v_r & ~stat_buf_r.dirty[lce_cmd_way_id];
         lce_cmd_yumi_o = lce_resp_v_o;
 
-        state_n = stat_mem_cast_i.dirty[lce_cmd_way_id]
-          ? e_wb_dirty_rd
-          : lce_resp_v_o
-            ? e_ready
-            : e_null_wb;
-
+        state_n = stat_buf_v_r & stat_buf_r.dirty[lce_cmd_way_id]
+                  ? e_wb_dirty_rd
+                  : stat_buf_v_r & lce_resp_v_o
+                    ? e_ready
+                    : e_wb;
+          
       end
 
       // Writeback dirty block - read from data memory, write to stat memory to clear dirty bit
@@ -551,30 +594,13 @@ module bp_lce_cmd
         lce_resp.header.src_id = lce_id_i;
         lce_resp.header.dst_id = lce_cmd.header.src_id;
         lce_resp.header.size = cmd_block_size_lp;
-        lce_resp_v_o = lce_resp_ready_i;
+        lce_resp_v_o = lce_resp_ready_i & data_buf_v_r;
 
         lce_cmd_yumi_o = lce_resp_v_o;
 
         state_n = lce_resp_v_o
           ? e_ready
           : e_wb_dirty_send;
-
-      end
-
-      // Null Writeback Response
-      e_null_wb: begin
-        lce_resp.data = '0;
-        lce_resp.header.addr = lce_cmd.header.addr;
-        lce_resp.header.msg_type = e_lce_cce_resp_null_wb;
-        lce_resp.header.src_id = lce_id_i;
-        lce_resp.header.dst_id = lce_cmd.header.src_id;
-        lce_resp_v_o = lce_resp_ready_i;
-
-        lce_cmd_yumi_o = lce_resp_v_o;
-
-        state_n = lce_resp_v_o
-          ? e_ready
-          : e_null_wb;
 
       end
 

--- a/bp_me/src/v/lce/bp_lce_req.v
+++ b/bp_me/src/v/lce/bp_lce_req.v
@@ -63,13 +63,15 @@ module bp_lce_req
     , input [lce_id_width_p-1:0]                     lce_id_i
     , input bp_lce_mode_e                            lce_mode_i
 
+    // LCE Req is able to sink any requests
+    , output logic                                   ready_o
+
     // Cache-LCE Interface
     // ready_o->valid_i handshake
     // metadata arrives in the same cycle as req, or any cycle after, but before the next request
     // can arrive, as indicated by the metadata_v_i signal
     , input [cache_req_width_lp-1:0]                 cache_req_i
     , input                                          cache_req_v_i
-    , output logic                                   cache_req_ready_o
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
 
@@ -108,8 +110,11 @@ module bp_lce_req
   bp_lce_cce_req_s lce_req;
   assign lce_req_o = lce_req;
 
+  bp_cache_req_s cache_req;
+  assign cache_req = cache_req_i;
+
   bp_cache_req_s cache_req_r;
-  bsg_dff_en_bypass
+  bsg_dff_en
     #(.width_p($bits(bp_cache_req_s)))
     req_reg
      (.clk_i(clk_i)
@@ -118,26 +123,27 @@ module bp_lce_req
       ,.data_o(cache_req_r)
       );
 
-  bp_cache_req_metadata_s cache_req_metadata_r;
-  bsg_dff_en_bypass
-   #(.width_p($bits(bp_cache_req_metadata_s)))
-   metadata_reg
-    (.clk_i(clk_i)
-     ,.en_i(cache_req_metadata_v_i)
-     ,.data_i(cache_req_metadata_i)
-     ,.data_o(cache_req_metadata_r)
-     );
-
   logic cache_req_metadata_v_r;
-  logic cache_req_metadata_v_en;
-  logic cache_req_metadata_v_li;
-  bsg_dff_en
+  bsg_dff_reset_set_clear
    #(.width_p(1))
    metadata_v_reg
     (.clk_i(clk_i)
-     ,.en_i(cache_req_metadata_v_en)
-     ,.data_i(cache_req_metadata_v_li)
+     ,.reset_i(reset_i)
+
+     ,.set_i(cache_req_metadata_v_i)
+     ,.clear_i(cache_req_v_i)
      ,.data_o(cache_req_metadata_v_r)
+     );
+
+  bp_cache_req_metadata_s cache_req_metadata_r;
+  bsg_dff_en
+   #(.width_p($bits(bp_cache_req_metadata_s)))
+   metadata_reg
+    (.clk_i(clk_i)
+
+     ,.en_i(cache_req_metadata_v_i)
+     ,.data_i(cache_req_metadata_i)
+     ,.data_o(cache_req_metadata_r)
      );
 
   // Outstanding request credit counter
@@ -170,10 +176,7 @@ module bp_lce_req
   always_comb begin
     state_n = state_r;
 
-    cache_req_ready_o = 1'b0;
-
-    cache_req_metadata_v_en = 1'b0;
-    cache_req_metadata_v_li = 1'b0;
+    ready_o = 1'b0;
 
     lce_req_v_o = 1'b0;
 
@@ -181,29 +184,32 @@ module bp_lce_req
     lce_req = '0;
     lce_req.header.dst_id = req_cce_id_lo;
     lce_req.header.src_id = lce_id_i;
-    lce_req.header.addr = cache_req_r.addr;
-    lce_req.header.msg_type = e_lce_req_type_rd;
 
     unique case (state_r)
 
       e_reset: begin
         state_n = e_ready;
-        // reset the metadata valid register
-        cache_req_metadata_v_en = 1'b1;
       end
 
       // Ready for new request
       e_ready: begin
         // ready for new request if LCE hasn't used all its credits
-        cache_req_ready_o = ~credits_full_o;
+        ready_o = ~credits_full_o & lce_req_ready_i;
         if (cache_req_v_i) begin
-          unique case (cache_req_r.msg_type)
+          unique case (cache_req.msg_type)
             e_miss_store
             , e_miss_load: begin
               state_n = e_send_cached_req;
             end
-            e_uc_store
-            , e_uc_load: begin
+            e_uc_store: begin
+              lce_req_v_o = lce_req_ready_i;
+
+              lce_req.data[0+:dword_width_p] = cache_req.data[0+:dword_width_p];
+              lce_req.header.size = bp_mem_msg_size_e'(cache_req.size);
+              lce_req.header.addr = cache_req.addr;
+              lce_req.header.msg_type = e_lce_req_type_uc_wr;
+            end
+            e_uc_load: begin
               state_n = e_send_uncached_req;
             end
             default: begin
@@ -217,10 +223,11 @@ module bp_lce_req
         // valid cache request arrived last cycle (or earlier) and is held in cache_req_r
 
         // send when port is ready and metadata has arrived
-        lce_req_v_o = lce_req_ready_i & (cache_req_metadata_v_i | cache_req_metadata_v_r);
+        lce_req_v_o = lce_req_ready_i & cache_req_metadata_v_r;
 
         lce_req.header.lru_way_id = lg_lce_assoc_lp'(cache_req_metadata_r.repl_way);
         lce_req.header.size = req_block_size_lp;
+        lce_req.header.addr = cache_req_r.addr;
         lce_req.header.msg_type = (cache_req_r.msg_type == e_miss_load)
           ? e_lce_req_type_rd
           : e_lce_req_type_wr;
@@ -235,11 +242,6 @@ module bp_lce_req
           ? e_ready
           : e_send_cached_req;
 
-        // cache_metadata arrives this cycle (or following cycle) into bypass DFF
-        // register is set when lce request isn't able to send, and cleared when request sends
-        cache_req_metadata_v_en = cache_req_metadata_v_i | lce_req_v_o;
-        cache_req_metadata_v_li = ~lce_req_v_o;
-
       end
 
       // Uncached Request
@@ -247,24 +249,15 @@ module bp_lce_req
         // valid cache request arrived last cycle (or earlier) and is held in cache_req_r
 
         // send when port is ready and metadata has arrived
-        lce_req_v_o = lce_req_ready_i & (cache_req_metadata_v_i | cache_req_metadata_v_r);
+        lce_req_v_o = lce_req_ready_i;
 
-        lce_req.data[0+:dword_width_p] = (cache_req_r.msg_type == e_uc_load)
-          ? '0
-          : cache_req_r.data[0+:dword_width_p];
         lce_req.header.size = bp_mem_msg_size_e'(cache_req_r.size);
-        lce_req.header.msg_type = (cache_req_r.msg_type == e_uc_load)
-          ? e_lce_req_type_uc_rd
-          : e_lce_req_type_uc_wr;
+        lce_req.header.addr = cache_req_r.addr;
+        lce_req.header.msg_type = e_lce_req_type_uc_rd;
 
         state_n = lce_req_v_o
           ? e_ready
           : e_send_uncached_req;
-
-        // cache_metadata arrives this cycle (or following cycle) into bypass DFF
-        // register is set when lce request isn't able to send, and cleared when request sends
-        cache_req_metadata_v_en = cache_req_metadata_v_i | lce_req_v_o;
-        cache_req_metadata_v_li = ~lce_req_v_o;
 
       end
 


### PR DESCRIPTION
- Uncached stores now have 1/cycle throughput in LCE
- Removing bypass paths from cache engines (these paths were critical in both unicore and multicore)
- Clarified the v_r semantics which will help with the negedge 2-cycle loads

These will cause a minor IPC regression on writebacks and flushes, but we can recover it with bypass flops using the same v_r semantics if we find the performance impact to be too great