### PR TITLE
Enabling option to boot from synthesizable bootrom 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,8 +24,8 @@
 
 [submodule "external/basejump_stl"]
   path = external/basejump_stl
-  url = https://github.com/black-parrot/basejump_stl.git
-  branch = blackparrot_mods
+  url = https://github.com/bespoke-silicon-group/basejump_stl.git
+  branch = master
   ignore = dirty
 
 [submodule "external/DRAMSim2"]

--- a/bp_common/test/Makefile.tests
+++ b/bp_common/test/Makefile.tests
@@ -3,6 +3,7 @@ TOP ?= $(shell git rev-parse --show-toplevel)
 include $(TOP)/Makefile.common
 
 perch_dir       := $(BP_TEST_SRC_DIR)/perch
+bootrom_dir     := $(BP_TEST_SRC_DIR)/bootrom
 bp_tests_dir    := $(BP_TEST_SRC_DIR)/bp_tests
 riscv_tests_dir := $(BP_TEST_SRC_DIR)/riscv-tests
 beebs_dir       := $(BP_TEST_SRC_DIR)/beebs
@@ -58,6 +59,11 @@ $(BP_TEST_DIR)/lib/libperch.a:
 	cp $(BP_TEST_DIR)/src/perch/libperch.a $(BP_TEST_DIR)/lib
 	cp $(BP_TEST_DIR)/src/perch/*.h $(BP_TEST_DIR)/include
 
+bootrom: $(BP_TEST_DIR)/mem/bootrom.riscv
+$(BP_TEST_DIR)/mem/bootrom.riscv:
+	$(MAKE) -C $(bootrom_dir)
+	cp $(BP_TEST_DIR)/src/bootrom/bootrom.riscv $(BP_TEST_MEM_DIR)/bootrom.riscv
+
 demos:
 	$(MAKE) -C $(demos_dir)
 	mkdir -p $(BP_TEST_MEM_DIR)/demos
@@ -80,7 +86,7 @@ DROMAJO       ?= dromajo
 	$(RISCV_OBJCOPY) -O verilog $*.riscv $@
 
 %.bin: %.riscv
-	$(RISCV_OBJCOPY) -O binary $*.riscv $@
+	$(RISCV_OBJCOPY) -O binary --reverse-bytes=4 $*.riscv $@
 
 %.dump: %.riscv
 	$(RISCV_OBJDUMP) $*.riscv > $@

--- a/bp_common/test/src/bootrom/Makefile
+++ b/bp_common/test/src/bootrom/Makefile
@@ -1,0 +1,8 @@
+
+RISCV_GCC = $(CROSS_COMPILE)gcc -fPIC -march=rv64im -mabi=lp64 -mcmodel=medany -static -nostdlib -nostartfiles
+
+build:
+	$(RISCV_GCC) bootrom.S -o bootrom.riscv -Tlink.ld -static -Wl,--no-gc-sections
+
+
+

--- a/bp_common/test/src/bootrom/bootrom.S
+++ b/bp_common/test/src/bootrom/bootrom.S
@@ -1,0 +1,41 @@
+
+.section .text.start
+.globl _start
+_start:
+    li x0, 0
+    li x1, 0
+    li x2, 0
+    li x3, 0
+    li x4, 0
+    li x5, 0
+    li x6, 0
+    li x7, 0
+    li x8, 0
+    li x9, 0
+    li x10, 0
+    li x11, 0
+    li x12, 0
+    li x13, 0
+    li x14, 0
+    li x15, 0
+    li x16, 0
+    li x17, 0
+    li x18, 0
+    li x19, 0
+    li x20, 0
+    li x21, 0
+    li x22, 0
+    li x23, 0
+    li x24, 0
+    li x25, 0
+    li x26, 0
+    li x27, 0
+    li x28, 0
+    li x29, 0
+    li x30, 0
+    li x31, 0
+    
+    li x31, 0x80000000
+    jr x31
+halt:
+    j halt

--- a/bp_common/test/src/bootrom/link.ld
+++ b/bp_common/test/src/bootrom/link.ld
@@ -1,0 +1,5 @@
+SECTIONS
+{
+    . = 0x0000;
+    .text.start : { *(.text.start) }
+}

--- a/bp_fe/src/v/bp_fe_icache.v
+++ b/bp_fe/src/v/bp_fe_icache.v
@@ -594,6 +594,7 @@ module bp_fe_icache
                                : data_mem_pkt_v_i & ~tl_we;
 
   // uncached load data logic
+  //synopsys sync_set_reset "reset_i"
   always_ff @(posedge clk_i) begin
     if (reset_i) begin
       uncached_load_data_v_r <= 1'b0;

--- a/bp_fe/src/v/bp_fe_mem.v
+++ b/bp_fe/src/v/bp_fe_mem.v
@@ -205,10 +205,8 @@ wire is_uncached_mode = (cfg_bus_cast_i.icache_mode == e_lce_mode_uncached);
 wire mode_fault_v = (is_uncached_mode & ~uncached_li);
 // TODO: Enable other domains by setting enabled dids with cfg_bus
 wire did_fault_v = (ptag_li[ptag_width_p-1-:io_noc_did_width_p] != '0);
-// Don't allow speculative access to local tile memory
-wire local_fault_v = (ptag_li < (dram_base_addr_gp >> page_offset_width_p));
 
-assign instr_access_fault_v = fetch_v_r & (mode_fault_v | did_fault_v | local_fault_v);
+assign instr_access_fault_v = fetch_v_r & (mode_fault_v | did_fault_v);
 assign instr_page_fault_v   = fetch_v_r & itlb_r_v_lo & mem_translation_en_i & (instr_priv_page_fault | instr_exe_page_fault);
 
 assign mem_cmd_yumi_o = itlb_fence_v | itlb_fill_v | fetch_v | fencei_v;

--- a/bp_fe/src/v/bp_fe_pc_gen.v
+++ b/bp_fe/src/v/bp_fe_pc_gen.v
@@ -432,7 +432,7 @@ always_comb
       end
   end
 
-assign mem_poison_o         = ~pc_gen_stage_n[1].v;
+assign mem_poison_o         = flush;
 assign mem_priv_o           = shadow_priv_w ? shadow_priv_n : shadow_priv_r;
 assign mem_translation_en_o = shadow_translation_en_w ? shadow_translation_en_n : shadow_translation_en_r;
 

--- a/bp_me/src/v/cache/bp_me_cache_dma_to_cce.v
+++ b/bp_me/src/v/cache/bp_me_cache_dma_to_cce.v
@@ -210,6 +210,7 @@ module bp_me_cache_dma_to_cce
   
   dma_state_e dma_state_r, dma_state_n;
   
+  //synopsys sync_set_reset reset_i
   always_ff @(posedge clk_i)
     if (reset_i)
       begin

--- a/bp_me/src/v/cce/bp_cce_dir_segment.v
+++ b/bp_me/src/v/cce/bp_cce_dir_segment.v
@@ -219,6 +219,7 @@ module bp_cce_dir_segment
   logic [tag_sets_per_row_lp-1:0][lg_assoc_lp-1:0]                sharers_ways;
   bp_coh_states_e [tag_sets_per_row_lp-1:0]                       sharers_coh_states;
 
+  // synopsys sync_set_reset reset_i
   always_ff @(posedge clk_i) begin
     if (reset_i) begin
       state_r <= RESET;

--- a/bp_me/src/v/cce/bp_uce.v
+++ b/bp_me/src/v/cce/bp_uce.v
@@ -516,7 +516,7 @@ module bp_uce
             begin
               mem_cmd_cast_o.header.msg_type       = e_cce_mem_uc_rd;
               mem_cmd_cast_o.header.addr           = cache_req_r.addr;
-              mem_cmd_cast_o.header.size           = e_mem_msg_size_8;
+              mem_cmd_cast_o.header.size           = bp_mem_msg_size_e'(cache_req_r.size);
               mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
               mem_cmd_v_o = mem_cmd_ready_i;
 

--- a/bp_me/src/v/wormhole/bp_me_addr_to_cce_id.v
+++ b/bp_me/src/v/wormhole/bp_me_addr_to_cce_id.v
@@ -64,7 +64,7 @@ always_comb begin
     cce_id_o[0+:lg_num_cce_lp] = cce_dst_id_lo;
   else
     cce_id_o = (num_sacc_p > 1)
-               ? max_cac_cce_lp + paddr_i[paddr_width_p-io_noc_did_width_p-1-:`BSG_SAFE_CLOG2(num_sacc_p)]
+               ? max_cac_cce_lp + paddr_i[paddr_width_p-io_noc_did_width_p-1-: (num_sacc_p > 1 ? `BSG_SAFE_CLOG2(num_sacc_p) : 1)]
                : max_cac_cce_lp;
      
    

--- a/bp_top/test/common/bp_nonsynth_host.v
+++ b/bp_top/test/common/bp_nonsynth_host.v
@@ -11,6 +11,8 @@ module bp_nonsynth_host
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
+
+   , parameter host_max_outstanding_p = 32
    )
   (input clk_i
    , input reset_i
@@ -50,28 +52,53 @@ end
 localparam getchar_base_addr_gp = paddr_width_p'(64'h0010_0000);
 localparam putchar_base_addr_gp = paddr_width_p'(64'h0010_1000);
 localparam finish_base_addr_gp  = paddr_width_p'(64'h0010_2???);
+localparam bootrom_base_addr_gp = paddr_width_p'(64'h0010_3???);
 
-bp_cce_mem_msg_s  io_cmd_cast_i;
+bp_cce_mem_msg_s io_cmd_li, io_cmd_lo;
+bp_cce_mem_msg_s io_resp_cast_o;
 
-assign io_cmd_cast_i = io_cmd_i;
+assign io_cmd_li = io_cmd_i;
+assign io_resp_o = io_resp_cast_o;
 
 localparam lg_num_core_lp = `BSG_SAFE_CLOG2(num_core_p);
+
+logic io_cmd_v_lo, io_cmd_yumi_li;
+bsg_fifo_1r1w_small
+ #(.width_p($bits(bp_cce_mem_msg_s)), .els_p(host_max_outstanding_p))
+ small_fifo
+  (.clk_i(clk_i)
+   ,.reset_i(reset_i)
+
+   ,.data_i(io_cmd_li)
+   ,.v_i(io_cmd_v_i)
+   ,.ready_o(io_cmd_ready_o)
+
+   ,.data_o(io_cmd_lo)
+   ,.v_o(io_cmd_v_lo)
+   ,.yumi_i(io_cmd_yumi_li)
+   );
+ assign io_resp_v_o = io_cmd_v_lo;
+ assign io_cmd_yumi_li = io_resp_yumi_i;
+
 
 logic putchar_data_cmd_v;
 logic getchar_data_cmd_v;
 logic finish_data_cmd_v;
+logic bootrom_data_cmd_v;
 
 always_comb
   begin
     putchar_data_cmd_v = 1'b0;
     getchar_data_cmd_v = 1'b0;
     finish_data_cmd_v = 1'b0;
+    bootrom_data_cmd_v = 1'b0;
 
     unique
-    casez (io_cmd_cast_i.header.addr)
-      putchar_base_addr_gp: putchar_data_cmd_v = io_cmd_v_i; 
-      getchar_base_addr_gp: getchar_data_cmd_v = io_cmd_v_i;
-      finish_base_addr_gp: finish_data_cmd_v = io_cmd_v_i;
+    casez (io_cmd_lo.header.addr)
+      putchar_base_addr_gp: putchar_data_cmd_v = io_cmd_v_lo;
+      getchar_base_addr_gp: getchar_data_cmd_v = io_cmd_v_lo;
+      finish_base_addr_gp : finish_data_cmd_v = io_cmd_v_lo;
+      bootrom_base_addr_gp: bootrom_data_cmd_v = io_cmd_v_lo;
       default: begin end
     endcase
   end
@@ -81,7 +108,7 @@ logic [num_core_p-1:0] finish_w_v_li;
 // Memory-mapped I/O is 64 bit aligned
 localparam byte_offset_width_lp = 3;
 wire [lg_num_core_lp-1:0] io_cmd_core_enc =
-  io_cmd_cast_i.header.addr[byte_offset_width_lp+:lg_num_core_lp];
+  io_cmd_lo.header.addr[byte_offset_width_lp+:lg_num_core_lp];
 
 bsg_decode_with_v
  #(.num_out_p(num_core_p))
@@ -118,21 +145,21 @@ assign program_finish_o = finish_r;
 
 always_ff @(negedge clk_i)
   begin
-    if (putchar_data_cmd_v & io_cmd_v_i) begin
-      $write("%c", io_cmd_cast_i.data[0+:8]);
+    if (putchar_data_cmd_v) begin
+      $write("%c", io_cmd_lo.data[0+:8]);
       $fflush(32'h8000_0001);
     end
-    if (getchar_data_cmd_v & io_cmd_v_i)
+    if (getchar_data_cmd_v)
       pop();
     for (integer i = 0; i < num_core_p; i++)
       begin
         // PASS when returned value in finish packet is zero
-        if (finish_w_v_li[i] & io_cmd_v_i &
-          (io_cmd_cast_i.data[0+:8] == 8'(0)))
+        if (finish_w_v_li[i] &
+          (io_cmd_lo.data[0+:8] == 8'(0)))
           $display("[CORE%0x FSH] PASS", i);
         // FAIL when returned value in finish packet is non-zero
-        if (finish_w_v_li[i] & io_cmd_v_i &
-          (io_cmd_cast_i.data[0+:8] != 8'(0)))
+        if (finish_w_v_li[i] &
+          (io_cmd_lo.data[0+:8] != 8'(0)))
           $display("[CORE%0x FSH] FAIL", i);
       end
 
@@ -143,30 +170,24 @@ always_ff @(negedge clk_i)
       end
   end
 
-bp_cce_mem_msg_s io_resp_lo;
-bsg_two_fifo
- #(.width_p($bits(bp_cce_mem_msg_s)))
- io_resp_buffer
-  (.clk_i(clk_i)
-   ,.reset_i(reset_i)
+  parameter bootrom_els_p  = 64;
+  parameter bootrom_addr_width_lp = `BSG_SAFE_CLOG2(bootrom_els_p);
+  logic [bootrom_addr_width_lp-1:0] bootrom_addr_li;
+  logic [instr_width_p-1:0] bootrom_data_lo;
+  assign bootrom_addr_li = io_cmd_lo.header.addr[2+:bootrom_addr_width_lp];
+  bp_bootrom
+   #(.addr_width_p(bootrom_addr_width_lp)
+     ,.width_p(instr_width_p)
+     )
+   bootrom
+    (.addr_i(bootrom_addr_li)
+     ,.data_o(bootrom_data_lo)
+     );
 
-   ,.data_i(io_resp_lo)
-   ,.v_i(io_cmd_v_i)
-   ,.ready_o(io_cmd_ready_o)
-
-   ,.data_o(io_resp_o)
-   ,.v_o(io_resp_v_o)
-   ,.yumi_i(io_resp_yumi_i)
-   );
-
-assign io_resp_lo =
-  '{header: '{msg_type       : io_cmd_cast_i.header.msg_type
-              ,addr          : io_cmd_cast_i.header.addr
-              ,payload       : io_cmd_cast_i.header.payload
-              ,size          : io_cmd_cast_i.header.size
-              }
-    ,data : ch
-    };
+  assign io_resp_cast_o =
+    '{header: io_cmd_lo.header
+      ,data : bootrom_data_cmd_v ? bootrom_data_lo : ch
+      };
 
 endmodule
 

--- a/bp_top/test/tb/bp_tethered/Makefile.vcs
+++ b/bp_top/test/tb/bp_tethered/Makefile.vcs
@@ -7,6 +7,7 @@ $(LINT_DIR)/flist.vcs:
 	@echo wrapper.v                              >> $@ 
 	@echo testbench.v                            >> $@ 
 	@echo test_bp.v                              >> $@ 
+	@echo bp_bootrom.v							 >> $@
 	@echo "$(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_reset_gen.v" >> $@
 	@echo "$(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_clock_gen.v" >> $@
 
@@ -20,11 +21,24 @@ $(BUILD_DIR)/flist.vcs:
 	@grep -v -e "^\#" $(TB_PATH)/$(TB)/flist.vcs >> $@ 
 	@echo wrapper.v                              >> $@ 
 	@echo testbench.v                            >> $@ 
-	@echo test_bp.v                              >> $@ 
+	@echo test_bp.v                              >> $@
+	@echo bp_bootrom.v							 >> $@
 	@echo "$(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_reset_gen.v" >> $@
 	@echo "$(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_clock_gen.v" >> $@
 
-BUILD_COLLATERAL = $(addprefix $(BUILD_DIR)/, flist.vcs wrapper.v testbench.v test_bp.v)
+$(BUILD_DIR)/bootrom.riscv: $(BP_TEST_MEM_DIR)/bootrom.riscv
+	cp $^ $@
+
+XXD ?= xxd
+AWK ?= awk
+$(BUILD_DIR)/bootrom.txt: $(BUILD_DIR)/bootrom.bin
+	$(XXD) -b -c 4 $< | $(AWK) '{print $$2$$3$$4$$5}' > $@
+
+$(BUILD_DIR)/bp_bootrom.v: $(BUILD_DIR)/bootrom.txt
+	$(PYTHON) $(BASEJUMP_STL_DIR)/bsg_mem/bsg_ascii_to_rom.py $< bp_bootrom > $@
+
+BUILD_COLLATERAL  = $(addprefix $(BUILD_DIR)/, flist.vcs wrapper.v testbench.v test_bp.v)
+BUILD_COLLATERAL += $(addprefix $(BUILD_DIR)/, bootrom.riscv bootrom.bin bootrom.dump bp_bootrom.v)
 
 $(SIM_DIR)/simv $(SIM_DIR)/simv.daidir: $(BUILD_DIR)/simv $(BUILD_DIR)/simv.daidir
 	@ln -nsf $(<D)/$(@F) $@


### PR DESCRIPTION
This is the first step in enabling execution-driven debug mode.  This PR enables program execution from uncached regions and adds a boot rom flow, which can be used to add arbitrary code execution to the boot flow, before loading the actual program in DRAM