### PR TITLE
2-cycle load-use for D$

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -310,7 +310,7 @@ bp_be_pipe_mul
   
      ,.cfg_bus_i(cfg_bus_i)
 
-     ,.kill_ex1_i(exc_stage_n[1].poison_v)
+     ,.kill_ex1_i(exc_stage_r[0].poison_v)
      ,.flush_i(flush_i)
      ,.sfence_i(trap_pkt.sfence)
   

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -396,11 +396,8 @@ bp_be_pipe_mul
      ,.ptw_miss_pkt_o(ptw_miss_pkt)
      ,.ptw_fill_pkt_i(ptw_fill_pkt)
 
-     // This should actually be latched (all exceptions come from stage before)
-     // Move with 2-cycle load
-     ,.exception_i(exc_stage_n[3].exc)
-     ,.exception_pc_i(calc_stage_n[3].pc)
-     // TODO: Should be latched, somewhere when mem is moved to two cycle
+     ,.exception_i(exc_stage_r[3].exc)
+     ,.exception_pc_i(calc_stage_r[3].pc)
      ,.exception_vaddr_i(pipe_mem_vaddr_r)
      ,.commit_pkt_i(commit_pkt)
      ,.trap_pkt_o(trap_pkt)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.v
@@ -275,7 +275,7 @@ bp_be_dcache
 always_ff @(negedge clk_i) begin
   if (reset_i) begin
     is_req_mem1 <= '0;
-    is_req_mem2 <= is_req_mem1;
+    is_req_mem2 <= '0;
     is_store_mem1 <= '0;
     vaddr_mem1 <= '0;
     vaddr_mem2 <= '0;
@@ -296,12 +296,12 @@ always_ff @(negedge clk_i) begin
     vaddr_mem2 <= vaddr_mem1;
     is_fencei_mem1 <= is_fencei;
     is_fencei_mem2 <= is_fencei_mem1;
-    load_access_fault_mem2 <= load_access_fault_v & ~flush_i;
-    store_access_fault_mem2 <= store_access_fault_v & ~flush_i;
-    load_page_fault_mem2 <= load_page_fault_v & ~flush_i;
-    store_page_fault_mem2 <= store_page_fault_v & ~flush_i;
-    load_misaligned_mem2 <= load_misaligned_v & ~flush_i;
-    store_misaligned_mem2 <= store_misaligned_v & ~flush_i;
+    load_access_fault_mem2 <= load_access_fault_v;
+    store_access_fault_mem2 <= store_access_fault_v;
+    load_page_fault_mem2 <= load_page_fault_v;
+    store_page_fault_mem2 <= store_page_fault_v;
+    load_misaligned_mem2 <= load_misaligned_v;
+    store_misaligned_mem2 <= store_misaligned_v;
   end
 end
 

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.v
@@ -103,16 +103,16 @@ always_comb
 
     // Detect integer and float data hazards for EX2
     irs1_data_haz_v[1] = (isd_status_cast_i.isd_irs1_v & rs1_match_vector[1])
-                         & (dep_status_li[1].mul_iwb_v | dep_status_li[1].mem_iwb_v);
+                         & (dep_status_li[1].mul_iwb_v);
 
     irs2_data_haz_v[1] = (isd_status_cast_i.isd_irs2_v & rs2_match_vector[1])
-                         & (dep_status_li[1].mul_iwb_v | dep_status_li[1].mem_iwb_v);
+                         & (dep_status_li[1].mul_iwb_v);
 
     frs1_data_haz_v[1] = (isd_status_cast_i.isd_frs1_v & rs1_match_vector[1])
-                         & (dep_status_li[1].mem_fwb_v | dep_status_li[1].fp_fwb_v);
+                         & (dep_status_li[1].fp_fwb_v);
 
     frs2_data_haz_v[1] = (isd_status_cast_i.isd_frs2_v & rs2_match_vector[1])
-                         & (dep_status_li[1].mem_fwb_v | dep_status_li[1].fp_fwb_v);
+                         & (dep_status_li[1].fp_fwb_v);
 
     irs1_data_haz_v[2] = (isd_status_cast_i.isd_irs1_v & rs1_match_vector[2])
                          & (dep_status_li[2].mul_iwb_v);
@@ -126,7 +126,7 @@ always_comb
                          & (dep_status_li[2].fp_fwb_v);
 
     instr_in_pipe_v    = dep_status_li[0].v | dep_status_li[1].v | dep_status_li[2].v;
-    mem_in_pipe_v      = dep_status_li[0].mem_v | dep_status_li[1].mem_v | dep_status_li[2].mem_v;
+    mem_in_pipe_v      = dep_status_li[0].mem_v | dep_status_li[1].mem_v;
     fence_haz_v        = (isd_status_cast_i.isd_fence_v & (~credits_empty_i | mem_in_pipe_v))
                          | (isd_status_cast_i.isd_mem_v & credits_full_i);
     interrupt_haz_v    = interrupt_ready_i;

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -286,9 +286,9 @@ module bp_be_dcache
   logic [dword_width_p-1:0] data_tl_r;
   logic gdirty_r;
 
-  assign tl_we = v_i & cache_req_ready_i;
+  assign tl_we = v_i & ~poison_i;
   
-  always_ff @ (posedge clk_i) begin
+  always_ff @ (negedge clk_i) begin
     if (reset_i) begin
       v_tl_r <= 1'b0;
     end
@@ -330,7 +330,7 @@ module bp_be_dcache
       ,.els_p(dcache_sets_p)
     )
     tag_mem
-      (.clk_i(clk_i)
+      (.clk_i(~clk_i)
       ,.reset_i(reset_i)
       ,.v_i(tag_mem_v_li)
       ,.w_i(tag_mem_w_li)
@@ -355,7 +355,7 @@ module bp_be_dcache
         ,.els_p(dcache_sets_p*dcache_assoc_p)
         )
       data_mem
-        (.clk_i(clk_i)
+        (.clk_i(~clk_i)
         ,.reset_i(reset_i)
         ,.v_i(data_mem_v_li[i])
         ,.w_i(data_mem_w_li)
@@ -431,7 +431,7 @@ module bp_be_dcache
   // fencei does not require a ptag
   assign tv_we = v_tl_r & ~poison_i & (ptag_v_i | fencei_op_tl_r);
 
-  always_ff @ (posedge clk_i) begin
+  always_ff @(negedge clk_i) begin
     if (reset_i) begin
       v_tv_r <= 1'b0;
 
@@ -720,23 +720,23 @@ module bp_be_dcache
 
     if(load_miss_tv) begin
       cache_req_cast_o.msg_type = e_miss_load;
-      cache_req_v_o = cache_req_ready_i;
+      cache_req_v_o = cache_req_ready_i & ~poison_i;
     end
     else if(store_miss_tv | lr_miss_tv) begin
       cache_req_cast_o.msg_type = e_miss_store;
-      cache_req_v_o = cache_req_ready_i;
+      cache_req_v_o = cache_req_ready_i & ~poison_i;
     end
     else if(wt_req) begin
       cache_req_cast_o.msg_type = e_wt_store;
-      cache_req_v_o = cache_req_ready_i;
+      cache_req_v_o = cache_req_ready_i & ~poison_i;
     end
     else if(uncached_load_req) begin
       cache_req_cast_o.msg_type = e_uc_load;
-      cache_req_v_o = cache_req_ready_i;
+      cache_req_v_o = cache_req_ready_i & ~poison_i;
     end
     else if(uncached_store_req) begin
       cache_req_cast_o.msg_type = e_uc_store;
-      cache_req_v_o = cache_req_ready_i;
+      cache_req_v_o = cache_req_ready_i & ~poison_i;
     end
     else if(fencei_req) begin
       // Don't flush on fencei when coherent
@@ -765,15 +765,15 @@ module bp_be_dcache
   // output stage
   // Cache Miss Tracking logic
   logic cache_miss_r;
-  wire miss_tracker_en_li = cache_req_v_o & ~uncached_store_req & ~fencei_req & ~wt_req;
-  bsg_dff_reset_en
-   #(.width_p(1))
+  bsg_dff_reset_set_clear
+   #(.width_p(1), .clear_over_set_p(1))
    cache_miss_tracker
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.en_i(miss_tracker_en_li | cache_req_complete_i)
-     ,.data_i(cache_req_v_o)
+     // We don't wait for ack on uncached stores or writethrough requests
+     ,.set_i(cache_req_v_o & ~uncached_store_req & ~wt_req)
+     ,.clear_i(cache_req_complete_i)
      ,.data_o(cache_miss_r)
      );
   assign ready_o = cache_req_ready_i & ~cache_miss_r;
@@ -833,7 +833,7 @@ module bp_be_dcache
      ,.disable_overflow_warning_p(1)
      )
    lock_counter
-    (.clk_i(clk_i)
+    (.clk_i(~clk_i)
      ,.reset_i(reset_i)
 
      ,.clear_i(lock_clr)
@@ -1087,7 +1087,7 @@ module bp_be_dcache
 
   // stat_mem
   //
-  assign stat_mem_v_li = (v_tv_r & ~uncached_tv_r & ~fencei_op_tv_r) | stat_mem_pkt_yumi_o;
+  assign stat_mem_v_li = (v_tv_r & ~uncached_tv_r & ~fencei_op_tv_r & ~poison_i) | stat_mem_pkt_yumi_o;
   assign stat_mem_w_li = (v_tv_r & ~uncached_tv_r & ~fencei_op_tv_r)
     ? ~(load_miss_tv | store_miss_tv | lr_miss_tv)
     : stat_mem_pkt_yumi_o & (stat_mem_pkt.opcode != e_cache_stat_mem_read);
@@ -1156,10 +1156,10 @@ module bp_be_dcache
   // write buffer
   //
   if (l1_writethrough_p == 0) begin : wb_wbuf
-    assign wbuf_v_li = v_tv_r & store_op_tv_r & store_hit_tv & ~sc_fail & ~uncached_tv_r;
+    assign wbuf_v_li = v_tv_r & store_op_tv_r & store_hit_tv & ~sc_fail & ~uncached_tv_r & ~poison_i;
   end
   else begin : wt_wbuf
-    assign wbuf_v_li = v_tv_r & store_op_tv_r & store_hit_tv & ~sc_fail & ~uncached_tv_r & cache_req_ready_i;
+    assign wbuf_v_li = v_tv_r & store_op_tv_r & store_hit_tv & ~sc_fail & ~uncached_tv_r & cache_req_ready_i & ~poison_i;;
   end
   assign wbuf_yumi_li = wbuf_v_lo & ~(load_op & tl_we) & ~data_mem_pkt_yumi_o;
 
@@ -1171,7 +1171,7 @@ module bp_be_dcache
   //
   logic [lg_dcache_assoc_lp-1:0] data_mem_pkt_way_r;
 
-  always_ff @ (posedge clk_i) begin
+  always_ff @ (negedge clk_i) begin
     if (data_mem_pkt_yumi_o & (data_mem_pkt.opcode == e_cache_data_mem_read)) begin
       data_mem_pkt_way_r <= data_mem_pkt.way_id;
     end
@@ -1186,14 +1186,15 @@ module bp_be_dcache
     ,.o(data_mem_o)
   );
 
-  // As an optimization, we snoop the data_mem_pkts to see if there
-  // are any matching entries in the write buffer and disallow the
-  // data_mem_pkts to allow the write buffers to drain before we can
-  // accept the pkt in case of a match.
+  // A similar scheme could be adopted for a non-blocking version, where we snoop the bank
+  // As an optimization, we could snoop the data_mem_pkt to see if there are any matching entries
+  //   in the write buffer, so that the write buffer will only drain if it is full, or if there is
+  //   a snoop match. However, this is a critical path, so we simply drain the write buffer on
+  //   invalidations.
   // A similar scheme could be adopted for a non-blocking version, where we snoop the bank
   assign data_mem_pkt_yumi_o = (data_mem_pkt.opcode == e_cache_data_mem_uncached)
                                ? data_mem_pkt_v
-                               : ~(load_op & tl_we) & ~lce_snoop_match_lo & data_mem_pkt_v & ~wbuf_full_lo;
+                               : data_mem_pkt_v & ~(load_op & tl_we) & ~wbuf_v_lo;
 
   // load reservation logic
   always_ff @ (posedge clk_i) begin
@@ -1246,7 +1247,7 @@ module bp_be_dcache
 
   logic [lg_dcache_assoc_lp-1:0] tag_mem_pkt_way_r;
 
-  always_ff @ (posedge clk_i) begin
+  always_ff @ (negedge clk_i) begin
     if (tag_mem_pkt_yumi_o & (tag_mem_pkt.opcode == e_cache_tag_mem_read)) begin
       tag_mem_pkt_way_r <= tag_mem_pkt.way_id;
     end
@@ -1289,7 +1290,7 @@ module bp_be_dcache
         );
   end
 
-  always_ff @ (negedge clk_i) begin
+  always_ff @ (posedge clk_i) begin
     if (v_tv_r) begin
       assert($countones(load_hit_tl) <= 1)
         else $error("multiple load hit: %b. id = %0d. addr = %H", load_hit_tl, cfg_bus_cast_i.dcache_id, addr_tag_tl);

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -286,14 +286,14 @@ module bp_be_dcache
   logic [dword_width_p-1:0] data_tl_r;
   logic gdirty_r;
 
-  assign tl_we = v_i & ~poison_i;
+  assign tl_we = v_i;
   
   always_ff @ (negedge clk_i) begin
     if (reset_i) begin
       v_tl_r <= 1'b0;
     end
     else begin
-      v_tl_r <= tl_we;
+      v_tl_r <= tl_we & ~poison_i;
       if (tl_we) begin
         lr_op_tl_r <= lr_op;
         sc_op_tl_r <= sc_op;
@@ -429,7 +429,7 @@ module bp_be_dcache
   logic store_hit_tv;
 
   // fencei does not require a ptag
-  assign tv_we = v_tl_r & ~poison_i & (ptag_v_i | fencei_op_tl_r);
+  assign tv_we = v_tl_r & (ptag_v_i | fencei_op_tl_r);
 
   always_ff @(negedge clk_i) begin
     if (reset_i) begin
@@ -455,7 +455,7 @@ module bp_be_dcache
       addr_bank_offset_dec_tv_r <= '0;
     end
     else begin
-      v_tv_r <= tv_we;
+      v_tv_r <= tv_we & ~poison_i;
 
       if (tv_we) begin
         lr_op_tv_r <= lr_op_tl_r;
@@ -1023,7 +1023,7 @@ module bp_be_dcache
   // tag_mem
   //
   assign tag_mem_v_li = tl_we | tag_mem_pkt_yumi_o;
-  assign tag_mem_w_li = ~tl_we & tag_mem_pkt_v_i & (tag_mem_pkt.opcode != e_cache_tag_mem_read);
+  assign tag_mem_w_li = ~tl_we & tag_mem_pkt_yumi_o & (tag_mem_pkt.opcode != e_cache_tag_mem_read);
   assign tag_mem_addr_li = tl_we
     ? addr_index
     : tag_mem_pkt.index;

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -890,68 +890,46 @@ module bp_be_dcache
     ,.data_o(bypass_data_masked)
   );
 
-  logic [dword_width_p-1:0] final_data;
+  logic [dword_width_p-1:0] result_data;
   bsg_mux #(
     .width_p(dword_width_p)
     ,.els_p(2)
   ) final_data_mux (
     .data_i({uncached_load_data_r, bypass_data_masked})
     ,.sel_i(uncached_tv_r)
-    ,.data_o(final_data)
+    ,.data_o(result_data)
   );
 
-  if (dword_width_p == 64) begin: output64
-    logic [31:0] data_word_selected;
-    logic [15:0] data_half_selected;
-    logic [7:0] data_byte_selected;
-    logic word_sigext;
-    logic half_sigext;
-    logic byte_sigext;
+  logic [3:0][dword_width_p-1:0] final_data;
+  for (genvar i = 0; i < 4; i++)
+    begin : alignment
+      localparam slice_width_lp = 8*(2**i);
 
-    bsg_mux #(
-      .width_p(32)
-      ,.els_p(2)
-    ) word_mux (
-      .data_i(final_data)
-      ,.sel_i(paddr_tv_r[2])
-      ,.data_o(data_word_selected)
-    );
+      logic [slice_width_lp-1:0] slice_data;
+      bsg_mux #(
+        .width_p(slice_width_lp)
+        ,.els_p(dword_width_p/slice_width_lp)
+      ) align_mux (
+        .data_i(result_data)
+        ,.sel_i(paddr_tv_r[i+:`BSG_MAX(1, 3-i)])
+        ,.data_o(slice_data)
+      );
 
-    bsg_mux #(
-      .width_p(16)
-      ,.els_p(4)
-    ) half_mux (
-      .data_i(final_data)
-      ,.sel_i(paddr_tv_r[2:1])
-      ,.data_o(data_half_selected)
-    );
+      wire sigext = signed_op_tv_r & slice_data[slice_width_lp-1];
+      assign final_data[i] = {{(dword_width_p-slice_width_lp){sigext}}, slice_data};
+    end
 
-    bsg_mux #(
-      .width_p(8)
-      ,.els_p(8)
-    ) byte_mux (
-      .data_i(final_data)
-      ,.sel_i(paddr_tv_r[2:0])
-      ,.data_o(data_byte_selected)
-    );
+  logic [dword_width_p-1:0] load_data;
+  bsg_mux_one_hot #(
+    .width_p(dword_width_p)
+    ,.els_p(4)
+  ) byte_mux (
+    .data_i(final_data)
+    ,.sel_one_hot_i({double_op_tv_r, word_op_tv_r, half_op_tv_r, byte_op_tv_r})
+    ,.data_o(load_data)
+  );
 
-    assign word_sigext = signed_op_tv_r & data_word_selected[31];
-    assign half_sigext = signed_op_tv_r & data_half_selected[15];
-    assign byte_sigext = signed_op_tv_r & data_byte_selected[7];
-
-    assign data_o = load_op_tv_r
-      ? (double_op_tv_r
-        ? final_data
-        : (word_op_tv_r
-          ? {{32{word_sigext}}, data_word_selected}
-          : (half_op_tv_r
-            ? {{48{half_sigext}}, data_half_selected}
-            : {{56{byte_sigext}}, data_byte_selected})))
-      : (sc_op_tv_r & ~sc_success
-         ? 64'b1
-         : 64'b0);
-
-  end
+  assign data_o = sc_op_tv_r ? !sc_success : load_data;
 
   // ctrl logic
   //

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v
@@ -68,13 +68,13 @@ module bp_be_dcache_wbuf
   always_comb begin
     unique case (num_els_r)
       2'd0: begin
-        v_o = v_i;
+        v_o = 1'b0;
         empty_o = 1'b1;
         full_o = 1'b0;
         el0_valid = 1'b0;
         el1_valid = 1'b0;
         el0_enable = 1'b0;
-        el1_enable = v_i & ~yumi_i;
+        el1_enable = v_i;
         mux0_sel = 1'b0;
         mux1_sel = 1'b0;
       end
@@ -201,7 +201,7 @@ module bp_be_dcache_wbuf
     ,.data_o(bypass_data_n)
   );
 
-  always_ff @ (posedge clk_i) begin
+  always_ff @ (negedge clk_i) begin
     if (reset_i) begin
       bypass_mask_o <= '0;
       bypass_data_o <= '0;

--- a/bp_be/test/tb/bp_be_dcache/wrapper.v
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.v
@@ -238,6 +238,8 @@ module wrapper
         ,.block_width_p(dcache_block_width_p)
         ,.timeout_max_limit_p(4)
         ,.credits_p(coh_noc_max_credits_p)
+        ,.data_mem_negedge_p(1)
+        ,.tag_mem_negedge_p(1)
        )
      dcache_lce
      (.clk_i(clk_i)
@@ -351,6 +353,8 @@ module wrapper
      ,.assoc_p(dcache_assoc_p)
      ,.sets_p(dcache_sets_p)
      ,.block_width_p(dcache_block_width_p)
+     ,.data_mem_negedge_p(1)
+     ,.tag_mem_negedge_p(1)
      )
      dcache_uce
      (.clk_i(clk_i)

--- a/bp_fe/src/v/bp_fe_icache.v
+++ b/bp_fe/src/v/bp_fe_icache.v
@@ -594,6 +594,7 @@ module bp_fe_icache
                                : data_mem_pkt_v_i & ~tl_we;
 
   // uncached load data logic
+  //synopsys sync_set_reset "reset_i"
   always_ff @(posedge clk_i) begin
     if (reset_i) begin
       uncached_load_data_v_r <= 1'b0;

--- a/bp_me/src/v/cache/bp_me_cache_dma_to_cce.v
+++ b/bp_me/src/v/cache/bp_me_cache_dma_to_cce.v
@@ -210,6 +210,7 @@ module bp_me_cache_dma_to_cce
   
   dma_state_e dma_state_r, dma_state_n;
   
+  //synopsys sync_set_reset reset_i
   always_ff @(posedge clk_i)
     if (reset_i)
       begin

--- a/bp_me/src/v/cce/bp_cce_dir_segment.v
+++ b/bp_me/src/v/cce/bp_cce_dir_segment.v
@@ -219,6 +219,7 @@ module bp_cce_dir_segment
   logic [tag_sets_per_row_lp-1:0][lg_assoc_lp-1:0]                sharers_ways;
   bp_coh_states_e [tag_sets_per_row_lp-1:0]                       sharers_coh_states;
 
+  // synopsys sync_set_reset reset_i
   always_ff @(posedge clk_i) begin
     if (reset_i) begin
       state_r <= RESET;

--- a/bp_me/src/v/cce/bp_uce.v
+++ b/bp_me/src/v/cce/bp_uce.v
@@ -6,14 +6,17 @@ module bp_uce
   import bp_common_cfg_link_pkg::*;
   import bp_me_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
-   ,parameter assoc_p = 8
-   ,parameter sets_p = 64
-   ,parameter block_width_p = 512
-   ,parameter fill_width_p = 512
-
     `declare_bp_proc_params(bp_params_p)
     `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
+    , parameter assoc_p = 8
+    , parameter sets_p = 64
+    , parameter block_width_p = 512
+    , parameter fill_width_p = 512
     `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache)
+
+    , parameter tag_mem_negedge_p  = 0
+    , parameter data_mem_negedge_p = 0
+    , parameter stat_mem_negedge_p = 0
 
     , localparam bank_width_lp = block_width_p / assoc_p
     , localparam num_dwords_per_bank_lp = bank_width_lp / dword_width_p
@@ -140,10 +143,11 @@ module bp_uce
 
   logic dirty_data_read_en;
   wire dirty_data_read = data_mem_pkt_yumi_i & (data_mem_pkt_cast_o.opcode == e_cache_data_mem_read);
+  wire data_mem_clk = (data_mem_negedge_p ? ~clk_i : clk_i);
   bsg_dff
    #(.width_p(1))
    dirty_data_read_en_reg
-    (.clk_i(clk_i)
+    (.clk_i(data_mem_clk)
 
      ,.data_i(dirty_data_read)
      ,.data_o(dirty_data_read_en)
@@ -153,7 +157,7 @@ module bp_uce
   bsg_dff_reset_set_clear
    #(.width_p(1))
    dirty_data_v_reg
-    (.clk_i(clk_i)
+    (.clk_i(data_mem_clk)
      ,.reset_i(reset_i)
 
      ,.set_i(dirty_data_read_en)
@@ -165,19 +169,19 @@ module bp_uce
   bsg_dff_en
    #(.width_p(block_width_p))
    dirty_data_reg
-    (.clk_i(clk_i)
-
-    ,.en_i(dirty_data_read_en)
-    ,.data_i(data_mem_i)
-    ,.data_o(dirty_data_r)
-    );
+    (.clk_i(data_mem_clk)
+     ,.en_i(dirty_data_read_en)
+     ,.data_i(data_mem_i)
+     ,.data_o(dirty_data_r)
+     );
 
   logic dirty_tag_read_en;
   wire dirty_tag_read = tag_mem_pkt_yumi_i & (tag_mem_pkt_cast_o.opcode == e_cache_tag_mem_read);
+  wire tag_mem_clk = (tag_mem_negedge_p ? ~clk_i : clk_i);
   bsg_dff
    #(.width_p(1))
    dirty_tag_read_en_reg
-    (.clk_i(clk_i)
+    (.clk_i(tag_mem_clk)
 
      ,.data_i(dirty_tag_read)
      ,.data_o(dirty_tag_read_en)
@@ -187,7 +191,7 @@ module bp_uce
   bsg_dff_reset_set_clear
    #(.width_p(1))
    dirty_tag_v_reg
-    (.clk_i(clk_i)
+    (.clk_i(tag_mem_clk)
      ,.reset_i(reset_i)
 
      ,.set_i(dirty_tag_read_en)
@@ -199,7 +203,7 @@ module bp_uce
   bsg_dff_en
    #(.width_p(ptag_width_p))
    dirty_tag_reg
-    (.clk_i(clk_i)
+    (.clk_i(tag_mem_clk)
 
     ,.en_i(dirty_tag_read_en)
     ,.data_i(tag_mem_i)
@@ -208,10 +212,11 @@ module bp_uce
 
   logic dirty_stat_read_en;
   wire dirty_stat_read = stat_mem_pkt_yumi_i & (stat_mem_pkt_cast_o.opcode == e_cache_stat_mem_read);
+  wire stat_mem_clk = (stat_mem_negedge_p ? ~clk_i : clk_i);
   bsg_dff
    #(.width_p(1))
    dirty_stat_read_en_reg
-    (.clk_i(clk_i)
+    (.clk_i(stat_mem_clk)
 
      ,.data_i(dirty_stat_read)
      ,.data_o(dirty_stat_read_en)
@@ -221,7 +226,7 @@ module bp_uce
   bsg_dff_reset_set_clear
    #(.width_p(1))
    dirty_stat_v_reg
-    (.clk_i(clk_i)
+    (.clk_i(stat_mem_clk)
      ,.reset_i(reset_i)
 
      ,.set_i(dirty_stat_read_en)
@@ -233,7 +238,7 @@ module bp_uce
   bsg_dff_en
    #(.width_p($bits(bp_cache_stat_info_s)))
    dirty_stat_reg
-    (.clk_i(clk_i)
+    (.clk_i(stat_mem_clk)
 
      ,.en_i(dirty_stat_read_en)
      ,.data_i(stat_mem_i)

--- a/bp_me/src/v/cce/bp_uce.v
+++ b/bp_me/src/v/cce/bp_uce.v
@@ -14,9 +14,9 @@ module bp_uce
     , parameter fill_width_p = 512
     `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache)
 
-    , parameter tag_mem_negedge_p  = 0
-    , parameter data_mem_negedge_p = 0
-    , parameter stat_mem_negedge_p = 0
+    , parameter tag_mem_invert_clk_p  = 0
+    , parameter data_mem_invert_clk_p = 0
+    , parameter stat_mem_invert_clk_p = 0
 
     , localparam bank_width_lp = block_width_p / assoc_p
     , localparam num_dwords_per_bank_lp = bank_width_lp / dword_width_p
@@ -143,7 +143,7 @@ module bp_uce
 
   logic dirty_data_read_en;
   wire dirty_data_read = data_mem_pkt_yumi_i & (data_mem_pkt_cast_o.opcode == e_cache_data_mem_read);
-  wire data_mem_clk = (data_mem_negedge_p ? ~clk_i : clk_i);
+  wire data_mem_clk = (data_mem_invert_clk_p ? ~clk_i : clk_i);
   bsg_dff
    #(.width_p(1))
    dirty_data_read_en_reg
@@ -177,7 +177,7 @@ module bp_uce
 
   logic dirty_tag_read_en;
   wire dirty_tag_read = tag_mem_pkt_yumi_i & (tag_mem_pkt_cast_o.opcode == e_cache_tag_mem_read);
-  wire tag_mem_clk = (tag_mem_negedge_p ? ~clk_i : clk_i);
+  wire tag_mem_clk = (tag_mem_invert_clk_p ? ~clk_i : clk_i);
   bsg_dff
    #(.width_p(1))
    dirty_tag_read_en_reg
@@ -212,7 +212,7 @@ module bp_uce
 
   logic dirty_stat_read_en;
   wire dirty_stat_read = stat_mem_pkt_yumi_i & (stat_mem_pkt_cast_o.opcode == e_cache_stat_mem_read);
-  wire stat_mem_clk = (stat_mem_negedge_p ? ~clk_i : clk_i);
+  wire stat_mem_clk = (stat_mem_invert_clk_p ? ~clk_i : clk_i);
   bsg_dff
    #(.width_p(1))
    dirty_stat_read_en_reg

--- a/bp_me/src/v/lce/bp_lce.v
+++ b/bp_me/src/v/lce/bp_lce.v
@@ -19,6 +19,9 @@ module bp_lce
     , parameter sets_p = "inv"
     , parameter block_width_p = "inv"
     , parameter fill_width_p = block_width_p
+    , parameter data_mem_negedge_p = 0
+    , parameter tag_mem_negedge_p = 0
+    , parameter stat_mem_negedge_p = 0
 
     , parameter timeout_max_limit_p=4
 
@@ -124,7 +127,6 @@ module bp_lce
   // LCE Request Module
   logic req_ready_lo;
   logic uc_store_req_complete_lo;
-
   bp_lce_req
     #(.bp_params_p(bp_params_p)
       ,.assoc_p(assoc_p)
@@ -147,12 +149,12 @@ module bp_lce
       ,.cache_req_v_i(cache_req_v_i)
       ,.cache_req_metadata_i(cache_req_metadata_i)
       ,.cache_req_metadata_v_i(cache_req_metadata_v_i)
-
       ,.cache_req_complete_i(cache_req_complete_o)
-      ,.uc_store_req_complete_i(uc_store_req_complete_lo)
 
       ,.credits_full_o(credits_full_o)
       ,.credits_empty_o(credits_empty_o)
+
+      ,.uc_store_req_complete_i(uc_store_req_complete_lo)
 
       ,.lce_req_o(lce_req_o)
       ,.lce_req_v_o(lce_req_v_o)
@@ -168,6 +170,9 @@ module bp_lce
       ,.sets_p(sets_p)
       ,.block_width_p(block_width_p)
       ,.fill_width_p(fill_width_p)
+      ,.data_mem_negedge_p(data_mem_negedge_p)
+      ,.tag_mem_negedge_p(tag_mem_negedge_p)
+      ,.stat_mem_negedge_p(stat_mem_negedge_p)
       )
     command
       (.clk_i(clk_i)

--- a/bp_me/src/v/lce/bp_lce.v
+++ b/bp_me/src/v/lce/bp_lce.v
@@ -19,9 +19,9 @@ module bp_lce
     , parameter sets_p = "inv"
     , parameter block_width_p = "inv"
     , parameter fill_width_p = block_width_p
-    , parameter data_mem_negedge_p = 0
-    , parameter tag_mem_negedge_p = 0
-    , parameter stat_mem_negedge_p = 0
+    , parameter data_mem_invert_clk_p = 0
+    , parameter tag_mem_invert_clk_p = 0
+    , parameter stat_mem_invert_clk_p = 0
 
     , parameter timeout_max_limit_p=4
 
@@ -170,9 +170,9 @@ module bp_lce
       ,.sets_p(sets_p)
       ,.block_width_p(block_width_p)
       ,.fill_width_p(fill_width_p)
-      ,.data_mem_negedge_p(data_mem_negedge_p)
-      ,.tag_mem_negedge_p(tag_mem_negedge_p)
-      ,.stat_mem_negedge_p(stat_mem_negedge_p)
+      ,.data_mem_invert_clk_p(data_mem_invert_clk_p)
+      ,.tag_mem_invert_clk_p(tag_mem_invert_clk_p)
+      ,.stat_mem_invert_clk_p(stat_mem_invert_clk_p)
       )
     command
       (.clk_i(clk_i)

--- a/bp_me/src/v/lce/bp_lce_cmd.v
+++ b/bp_me/src/v/lce/bp_lce_cmd.v
@@ -25,9 +25,9 @@ module bp_lce_cmd
     , parameter sets_p = "inv"
     , parameter block_width_p = "inv"
     , parameter fill_width_p = block_width_p
-    , parameter data_mem_negedge_p = 0
-    , parameter tag_mem_negedge_p = 0
-    , parameter stat_mem_negedge_p = 0
+    , parameter data_mem_invert_clk_p = 0
+    , parameter tag_mem_invert_clk_p = 0
+    , parameter stat_mem_invert_clk_p = 0
 
     , parameter timeout_max_limit_p=4
 
@@ -172,7 +172,7 @@ module bp_lce_cmd
   // command is accepted and new data is latched.
   logic data_buf_read_en;
   wire data_buf_read = data_mem_pkt_yumi_i & (data_mem_pkt.opcode == e_cache_data_mem_read);
-  wire data_mem_clk = (data_mem_negedge_p ? ~clk_i : clk_i);
+  wire data_mem_clk = (data_mem_invert_clk_p ? ~clk_i : clk_i);
   bsg_dff
    #(.width_p(1))
    data_buf_read_en_reg
@@ -206,7 +206,7 @@ module bp_lce_cmd
 
   logic stat_buf_read_en;
   wire stat_buf_read = stat_mem_pkt_yumi_i & (stat_mem_pkt.opcode == e_cache_stat_mem_read);
-  wire stat_mem_clk = (stat_mem_negedge_p ? ~clk_i : clk_i);
+  wire stat_mem_clk = (stat_mem_invert_clk_p ? ~clk_i : clk_i);
   bsg_dff
    #(.width_p(1))
    stat_buf_read_en_reg

--- a/bp_me/src/v/lce/bp_lce_cmd.v
+++ b/bp_me/src/v/lce/bp_lce_cmd.v
@@ -565,6 +565,7 @@ module bp_lce_cmd
       // Writeback dirty block - read from data memory, write to stat memory to clear dirty bit
       e_wb_dirty_rd: begin
 
+        /* TODO: NEED TO NOT USE STAT_PKT CAST DIRECTLY */
         // read from data memory, if data read wasn't already accepted in a previous cycle
         data_mem_pkt.index = lce_cmd_addr_index;
         data_mem_pkt.way_id = lce_cmd_way_id;

--- a/bp_top/src/v/bp_core.v
+++ b/bp_top/src/v/bp_core.v
@@ -257,6 +257,8 @@ module bp_core
       ,.fill_width_p(dcache_fill_width_p)
       ,.timeout_max_limit_p(4)
       ,.credits_p(coh_noc_max_credits_p)
+      ,.data_mem_negedge_p(1)
+      ,.tag_mem_negedge_p(1)
       )
   be_lce
     (.clk_i(clk_i)

--- a/bp_top/src/v/bp_core.v
+++ b/bp_top/src/v/bp_core.v
@@ -257,8 +257,8 @@ module bp_core
       ,.fill_width_p(dcache_fill_width_p)
       ,.timeout_max_limit_p(4)
       ,.credits_p(coh_noc_max_credits_p)
-      ,.data_mem_negedge_p(1)
-      ,.tag_mem_negedge_p(1)
+      ,.data_mem_invert_clk_p(1)
+      ,.tag_mem_invert_clk_p(1)
       )
   be_lce
     (.clk_i(clk_i)

--- a/bp_top/src/v/bp_unicore.v
+++ b/bp_top/src/v/bp_unicore.v
@@ -198,7 +198,10 @@ module bp_unicore
      ,.assoc_p(dcache_assoc_p)
      ,.sets_p(dcache_sets_p)
      ,.block_width_p(dcache_block_width_p)
-     ,.fill_width_p(dcache_fill_width_p))
+     ,.fill_width_p(dcache_fill_width_p)
+     ,.data_mem_negedge_p(1)
+     ,.tag_mem_negedge_p(1)
+     )
     dcache_uce
     (.clk_i(clk_i)
     ,.reset_i(reset_i)

--- a/bp_top/src/v/bp_unicore.v
+++ b/bp_top/src/v/bp_unicore.v
@@ -199,8 +199,8 @@ module bp_unicore
      ,.sets_p(dcache_sets_p)
      ,.block_width_p(dcache_block_width_p)
      ,.fill_width_p(dcache_fill_width_p)
-     ,.data_mem_negedge_p(1)
-     ,.tag_mem_negedge_p(1)
+     ,.data_mem_invert_clk_p(1)
+     ,.tag_mem_invert_clk_p(1)
      )
     dcache_uce
     (.clk_i(clk_i)

--- a/bp_top/test/common/bp_nonsynth_core_profiler.v
+++ b/bp_top/test/common/bp_nonsynth_core_profiler.v
@@ -225,7 +225,7 @@ module bp_nonsynth_core_profiler
       stall_stage_n[3].dcache_miss       |= dcache_miss;
       stall_stage_n[3].exception         |= exception;
       stall_stage_n[3].eret              |= eret;
-      stall_stage_n[3]._interrupt         |= _interrupt;
+      stall_stage_n[3]._interrupt        |= _interrupt;
 
       // EX1
       stall_stage_n[4].mispredict        |= mispredict;
@@ -234,7 +234,7 @@ module bp_nonsynth_core_profiler
       stall_stage_n[4].long_haz          |= long_haz;
       stall_stage_n[4].exception         |= exception;
       stall_stage_n[4].eret              |= eret;
-      stall_stage_n[4]._interrupt         |= _interrupt;
+      stall_stage_n[4]._interrupt        |= _interrupt;
       stall_stage_n[4].control_haz       |= control_haz;
       stall_stage_n[4].load_dep          |= load_dep;
       stall_stage_n[4].mul_dep           |= mul_dep;

--- a/bp_top/test/tb/bp_tethered/testbench.v
+++ b/bp_top/test/tb/bp_tethered/testbench.v
@@ -548,7 +548,7 @@ bind bp_be_top
        ,.mispredict(be.director.npc_mismatch_v)
        ,.target(be.director.isd_status.isd_pc)
 
-       ,.dtlb_miss(be.calculator.pipe_mem.dtlb_miss_r)
+       ,.dtlb_miss(be.calculator.pipe_mem.dtlb_miss_v)
        ,.dcache_miss(~be.calculator.pipe_mem.dcache.ready_o)
        ,.long_haz(be.detector.long_haz_v)
        ,.exception(be.director.trap_pkt.exception)


### PR DESCRIPTION
This PR provides the data cache with a 2-cycle load-use latency. It does so by shifting the data and tag memories to a negative edge read, splitting the extra cycle into 1/2 cycle for address calculation and 1/2 cycle for data muxing. This requires some complexity in the cache engines to synchronize between the clock edges and provide a full cycle read.  Another change is to make the data muxing in the D$ more efficient to better use that 1/2 cycle.

It's been pushed through the backend flow without additional critical paths and pushed through the FPGA flow to boot linux