### PR TITLE
Adding ability to boot from bootrom

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -47,8 +47,6 @@ module bp_be_calculator_top
   , input                               reset_i
 
   , input [cfg_bus_width_lp-1:0]        cfg_bus_i
-  , output [dword_width_p-1:0]          cfg_csr_data_o
-  , output [1:0]                        cfg_priv_data_o
    
   // Calculator - Checker interface   
   , input [dispatch_pkt_width_lp-1:0]   dispatch_pkt_i
@@ -379,8 +377,6 @@ bp_be_pipe_mul
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
      ,.cfg_bus_i(cfg_bus_i)
-     ,.cfg_csr_data_o(cfg_csr_data_o)
-     ,.cfg_priv_data_o(cfg_priv_data_o)
 
      ,.kill_ex1_i(exc_stage_n[1].poison_v)
      ,.kill_ex2_i(exc_stage_n[2].poison_v)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.v
@@ -31,8 +31,6 @@ module bp_be_pipe_sys
    , input                                reset_i
 
    , input [cfg_bus_width_lp-1:0]         cfg_bus_i
-   , output [dword_width_p-1:0]           cfg_csr_data_o
-   , output [1:0]                         cfg_priv_data_o
 
    , input [decode_width_lp-1:0]          decode_i
    , input [vaddr_width_p-1:0]            pc_i
@@ -177,8 +175,6 @@ always_comb
      ,.reset_i(reset_i)
   
      ,.cfg_bus_i(cfg_bus_i)
-     ,.cfg_csr_data_o(cfg_csr_data_o)
-     ,.cfg_priv_data_o(cfg_priv_data_o)
   
      ,.csr_cmd_i(csr_cmd_lo)
      ,.csr_cmd_v_i(csr_cmd_v_lo & ~kill_ex3_i)

--- a/bp_be/src/v/bp_be_checker/bp_be_director.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.v
@@ -39,7 +39,6 @@ module bp_be_director
    , input                            reset_i
 
    , input [cfg_bus_width_lp-1:0]     cfg_bus_i
-   , output [vaddr_width_p-1:0]       cfg_npc_data_o
 
    // Dependency information
    , input [isd_status_width_lp-1:0]  isd_status_i
@@ -99,8 +98,7 @@ logic [vaddr_width_p-1:0] roll_mux_o;
 
 // Module instantiations
 // Update the NPC on a valid instruction in ex1 or a cache miss or a tlb miss
-assign npc_w_v = cfg_bus_cast_i.npc_w_v
-                 | calc_status.ex1_instr_v
+assign npc_w_v = calc_status.ex1_instr_v
                  | (trap_pkt.rollback | trap_pkt.exception | trap_pkt._interrupt | trap_pkt.eret);
 bsg_dff_reset_en 
  #(.width_p(vaddr_width_p), .reset_val_p(32'h0010_3000))
@@ -112,7 +110,6 @@ bsg_dff_reset_en
    ,.data_i(npc_n)
    ,.data_o(npc_r)
    );
-assign cfg_npc_data_o = npc_r;
 
 bsg_mux
  #(.width_p(vaddr_width_p)

--- a/bp_be/src/v/bp_be_checker/bp_be_director.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.v
@@ -95,7 +95,7 @@ enum logic [1:0] {e_reset, e_boot, e_run, e_fence} state_n, state_r;
 // Control signals
 logic npc_w_v, btaken_pending, attaboy_pending;
 
-logic [vaddr_width_p-1:0] roll_mux_o, trap_mux_o;
+logic [vaddr_width_p-1:0] roll_mux_o;
 
 // Module instantiations
 // Update the NPC on a valid instruction in ex1 or a cache miss or a tlb miss
@@ -103,7 +103,7 @@ assign npc_w_v = cfg_bus_cast_i.npc_w_v
                  | calc_status.ex1_instr_v
                  | (trap_pkt.rollback | trap_pkt.exception | trap_pkt._interrupt | trap_pkt.eret);
 bsg_dff_reset_en 
- #(.width_p(vaddr_width_p), .reset_val_p(dram_base_addr_gp))
+ #(.width_p(vaddr_width_p), .reset_val_p(32'h0010_3000))
  npc
   (.clk_i(clk_i)
    ,.reset_i(reset_i)
@@ -114,17 +114,6 @@ bsg_dff_reset_en
    );
 assign cfg_npc_data_o = npc_r;
 
-// NPC calculation
-bsg_mux 
- #(.width_p(vaddr_width_p)
-   ,.els_p(2)   
-   )
- init_mux
-  (.data_i({cfg_bus_cast_i.npc, trap_mux_o})
-   ,.sel_i(cfg_bus_cast_i.npc_w_v)
-   ,.data_o(npc_n)
-   );
-
 bsg_mux
  #(.width_p(vaddr_width_p)
    ,.els_p(2)
@@ -132,7 +121,7 @@ bsg_mux
  trap_mux
   (.data_i({trap_pkt.npc, calc_status.ex1_npc})
    ,.sel_i(trap_pkt.rollback | trap_pkt.exception | trap_pkt._interrupt | trap_pkt.eret)
-   ,.data_o(trap_mux_o)
+   ,.data_o(npc_n)
    );
 
 assign npc_mismatch_v = isd_status.isd_v & (expected_npc_o != isd_status.isd_pc);

--- a/bp_be/src/v/bp_be_checker/bp_be_director.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.v
@@ -101,7 +101,7 @@ logic [vaddr_width_p-1:0] roll_mux_o;
 assign npc_w_v = calc_status.ex1_instr_v
                  | (trap_pkt.rollback | trap_pkt.exception | trap_pkt._interrupt | trap_pkt.eret);
 bsg_dff_reset_en 
- #(.width_p(vaddr_width_p), .reset_val_p(32'h0010_3000))
+ #(.width_p(vaddr_width_p), .reset_val_p(bootrom_base_addr_gp))
  npc
   (.clk_i(clk_i)
    ,.reset_i(reset_i)

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.v
@@ -34,7 +34,6 @@ module bp_be_scheduler
 
   // Slow inputs
   , input [cfg_bus_width_lp-1:0]       cfg_bus_i
-  , output [dword_width_p-1:0]         cfg_irf_data_o
 
   , output [isd_status_width_lp-1:0]   isd_status_o
   , input [vaddr_width_p-1:0]          expected_npc_i
@@ -193,9 +192,6 @@ bp_be_regfile
  int_regfile
   (.clk_i(clk_i)
    ,.reset_i(reset_i)
-
-   ,.cfg_bus_i(cfg_bus_i)
-   ,.cfg_data_o(cfg_irf_data_o)
 
    ,.rd_w_v_i(wb_pkt.rd_w_v)
    ,.rd_addr_i(wb_pkt.rd_addr)

--- a/bp_be/src/v/bp_be_mem/bp_be_csr.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_csr.v
@@ -227,7 +227,7 @@ always_comb
 
 logic [vaddr_width_p-1:0] apc_n, apc_r;
 bsg_dff_reset
- #(.width_p(vaddr_width_p), .reset_val_p(dram_base_addr_gp))
+ #(.width_p(vaddr_width_p), .reset_val_p(bootrom_base_addr_gp))
  apc
   (.clk_i(clk_i)
    ,.reset_i(reset_i)

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -858,6 +858,7 @@ module bp_be_dcache
 
   logic [bank_width_lp-1:0] ld_data_way_picked;
   logic [dword_width_p-1:0] ld_data_dword_picked;
+  logic [dword_width_p-1:0] ld_data_final;
   logic [dword_width_p-1:0] bypass_data_masked;
   logic [dcache_assoc_p-1:0] ld_data_way_select;
 
@@ -878,21 +879,29 @@ module bp_be_dcache
     ,.data_o(ld_data_way_picked)
   );
 
-  bsg_mux
-    #(.width_p(dword_width_p)
+  bsg_mux #(
+    .width_p(dword_width_p)
     ,.els_p(num_dwords_per_bank_lp)
-    )
-    dword_mux
-    (.data_i(ld_data_way_picked)
+  ) dword_mux (
+    .data_i(ld_data_way_picked)
     ,.sel_i(paddr_tv_r[3+:`BSG_CDIV(num_dwords_per_bank_lp, 2)])
     ,.data_o(ld_data_dword_picked)
     );
+
+  bsg_mux #(
+     .width_p(dword_width_p)
+     ,.els_p(2)
+   ) uncached_mux (
+     .data_i({uncached_load_data_r, ld_data_dword_picked})
+     ,.sel_i(uncached_tv_r)
+     ,.data_o(ld_data_final)
+   );
 
   bsg_mux_segmented #(
     .segments_p(bypass_data_mask_width_lp)
     ,.segment_width_p(8)
   ) bypass_mux_segmented (
-    .data0_i(ld_data_dword_picked)
+    .data0_i(ld_data_final)
     ,.data1_i(bypass_data_lo)
     ,.sel_i(bypass_mask_lo)
     ,.data_o(bypass_data_masked)

--- a/bp_be/src/v/bp_be_top.v
+++ b/bp_be/src/v/bp_be_top.v
@@ -29,10 +29,6 @@ module bp_be_top
 
    // Processor configuration
    , input [cfg_bus_width_lp-1:0]                    cfg_bus_i
-   , output [dword_width_p-1:0]                      cfg_irf_data_o
-   , output [vaddr_width_p-1:0]                      cfg_npc_data_o
-   , output [dword_width_p-1:0]                      cfg_csr_data_o
-   , output [1:0]                                    cfg_priv_data_o
 
    // FE queue interface
    , input [fe_queue_width_lp-1:0]                   fe_queue_i
@@ -122,7 +118,6 @@ bp_be_director
    ,.reset_i(reset_i)
 
    ,.cfg_bus_i(cfg_bus_i)
-   ,.cfg_npc_data_o(cfg_npc_data_o)
 
    ,.isd_status_i(isd_status)
    ,.calc_status_i(calc_status) 
@@ -168,7 +163,6 @@ bp_be_scheduler
    ,.reset_i(reset_i)
 
    ,.cfg_bus_i(cfg_bus_i)
-   ,.cfg_irf_data_o(cfg_irf_data_o)
 
    ,.isd_status_o(isd_status)
    ,.expected_npc_i(expected_npc_lo)
@@ -199,8 +193,6 @@ bp_be_calculator_top
    ,.reset_i(reset_i)
 
    ,.cfg_bus_i(cfg_bus_i)
-   ,.cfg_csr_data_o(cfg_csr_data_o)
-   ,.cfg_priv_data_o(cfg_priv_data_o)
 
    ,.dispatch_pkt_i(dispatch_pkt)
 

--- a/bp_common/software/py/nbf.py
+++ b/bp_common/software/py/nbf.py
@@ -166,7 +166,7 @@ class NBF:
     self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_dcache_mode, 1)
     self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_cce_mode, 1)
     # Write PC to the DRAM base
-    self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_npc, 0x80000000)
+    self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_npc, 0x103000)
 
     # Write checkpoint
     if self.checkpoint_file:

--- a/bp_common/src/include/bp_common_aviary_defines.vh
+++ b/bp_common/src/include/bp_common_aviary_defines.vh
@@ -45,28 +45,10 @@ typedef enum logic [15:0]{
     logic [core_id_width_mp-1:0]             core_id;                                              \
     logic [lce_id_width_mp-1:0]              icache_id;                                            \
     bp_lce_mode_e                            icache_mode;                                          \
-    logic                                    npc_w_v;                                              \
-    logic                                    npc_r_v;                                              \
-    logic [vaddr_width_mp-1:0]               npc;                                                  \
     logic [lce_id_width_mp-1:0]              dcache_id;                                            \
     bp_lce_mode_e                            dcache_mode;                                          \
     logic [cce_id_width_mp-1:0]              cce_id;                                               \
     bp_cce_mode_e                            cce_mode;                                             \
-    logic                                    cce_ucode_w_v;                                        \
-    logic                                    cce_ucode_r_v;                                        \
-    logic [cce_pc_width_mp-1:0]              cce_ucode_addr;                                       \
-    logic [cce_instr_width_mp-1:0]           cce_ucode_data;                                       \
-    logic                                    irf_w_v;                                              \
-    logic                                    irf_r_v;                                              \
-    logic [reg_addr_width_p-1:0]             irf_addr;                                             \
-    logic [dword_width_p-1:0]                irf_data;                                             \
-    logic                                    csr_w_v;                                              \
-    logic                                    csr_r_v;                                              \
-    logic [csr_addr_width_p-1:0]             csr_addr;                                             \
-    logic [dword_width_p-1:0]                csr_data;                                             \
-    logic                                    priv_w_v;                                             \
-    logic                                    priv_r_v;                                             \
-    logic [1:0]                              priv_data;                                            \
   }  bp_cfg_bus_s
 
 `define bp_cfg_bus_width(vaddr_width_mp, core_id_width_mp, cce_id_width_mp, lce_id_width_mp, cce_pc_width_mp, cce_instr_width_mp) \
@@ -74,24 +56,10 @@ typedef enum logic [15:0]{
    + core_id_width_mp               \
    + lce_id_width_mp                \
    + $bits(bp_lce_mode_e)           \
-   + 1                              \
-   + 1                              \
-   + vaddr_width_mp                 \
    + lce_id_width_mp                \
    + $bits(bp_lce_mode_e)           \
    + cce_id_width_mp                \
    + $bits(bp_cce_mode_e)           \
-   + 2                              \
-   + cce_pc_width_mp                \
-   + cce_instr_width_mp             \
-   + 2                              \
-   + reg_addr_width_p               \
-   + dword_width_p                  \
-   + 2                              \
-   + csr_addr_width_p               \
-   + dword_width_p                  \
-   + 2                              \
-   + 2                              \
    )
 
 

--- a/bp_common/src/include/bp_common_cfg_link_pkg.vh
+++ b/bp_common/src/include/bp_common_cfg_link_pkg.vh
@@ -27,18 +27,11 @@ package bp_common_cfg_link_pkg;
   localparam bp_cfg_reg_host_did_gp       = 'h0008;
   localparam bp_cfg_reg_icache_id_gp      = 'h0021;
   localparam bp_cfg_reg_icache_mode_gp    = 'h0022;
-  localparam bp_cfg_reg_npc_gp            = 'h0040;
   localparam bp_cfg_reg_dcache_id_gp      = 'h0042;
   localparam bp_cfg_reg_dcache_mode_gp    = 'h0043;
-  localparam bp_cfg_reg_priv_gp           = 'h0044;
-  localparam bp_cfg_reg_irf_x0_gp         = 'h0050;
-  /* ... */
-  localparam bp_cfg_reg_irf_x31_gp        = 'h006f;
   localparam bp_cfg_reg_cce_id_gp         = 'h0080;
   localparam bp_cfg_reg_cce_mode_gp       = 'h0081;
   localparam bp_cfg_reg_num_lce_gp        = 'h0082;
-  localparam bp_cfg_reg_csr_begin_gp      = 'h6000;
-  localparam bp_cfg_reg_csr_end_gp        = 'h6fff;
   localparam bp_cfg_mem_base_cce_ucode_gp = 'h8000;
 
 endpackage

--- a/bp_common/src/include/bp_common_pkg.vh
+++ b/bp_common/src/include/bp_common_pkg.vh
@@ -36,12 +36,14 @@ package bp_common_pkg;
   parameter bp_page_size_in_bytes_gp = 4096;
   parameter bp_page_offset_width_gp = `BSG_SAFE_CLOG2(bp_page_size_in_bytes_gp);
 
+  localparam boot_dev_gp  = 0;
   localparam host_dev_gp  = 1;
   localparam cfg_dev_gp   = 2;
   localparam clint_dev_gp = 3;
   localparam cache_dev_gp = 4;
 
                              // 0x00_0(nnnN)(D)(A_AAAA)
+  localparam boot_dev_base_addr_gp     = 32'h0000_0000;
   localparam host_dev_base_addr_gp     = 32'h0010_0000;
   localparam cfg_dev_base_addr_gp      = 32'h0020_0000;
   localparam clint_dev_base_addr_gp    = 32'h0030_0000;
@@ -54,6 +56,7 @@ package bp_common_pkg;
 
   localparam cache_tagfl_base_addr_gp  = 20'h0_0000;
 
+  localparam bootrom_base_addr_gp      = 40'h00_0001_0000;
   localparam dram_base_addr_gp         = 40'h00_8000_0000;
   localparam coproc_base_addr_gp       = 40'h10_0000_0000;
   localparam global_base_addr_gp       = 40'h20_0000_0000;

--- a/bp_common/test/Makefile.tests
+++ b/bp_common/test/Makefile.tests
@@ -4,6 +4,7 @@ include $(TOP)/Makefile.common
 include $(BP_TEST_DIR)/Makefile.linux
 
 perch_dir       := $(BP_TEST_SRC_DIR)/perch
+bootrom_dir     := $(BP_TEST_SRC_DIR)/bootrom
 bp_tests_dir    := $(BP_TEST_SRC_DIR)/bp_tests
 riscv_tests_dir := $(BP_TEST_SRC_DIR)/riscv-tests
 beebs_dir       := $(BP_TEST_SRC_DIR)/beebs
@@ -62,6 +63,11 @@ $(BP_TEST_DIR)/lib/libperch.a:
 	cp $(BP_TEST_DIR)/src/perch/libperch.a $(BP_TEST_DIR)/lib
 	cp $(BP_TEST_DIR)/src/perch/*.h $(BP_TEST_DIR)/include
 
+bootrom: $(BP_TEST_DIR)/mem/bootrom.riscv
+$(BP_TEST_DIR)/mem/bootrom.riscv:
+	$(MAKE) -C $(bootrom_dir)
+	cp $(BP_TEST_DIR)/src/bootrom/bootrom.riscv $(BP_TEST_MEM_DIR)/bootrom.riscv
+
 demos:
 	$(MAKE) -C $(demos_dir)
 	mkdir -p $(BP_TEST_MEM_DIR)/demos
@@ -83,7 +89,7 @@ DROMAJO       ?= dromajo
 	$(RISCV_OBJCOPY) -O verilog $*.riscv $@
 
 %.bin: %.riscv
-	$(RISCV_OBJCOPY) -O binary $*.riscv $@
+	$(RISCV_OBJCOPY) -O binary --reverse-bytes=4 $*.riscv $@
 
 %.dump: %.riscv
 	$(RISCV_OBJDUMP) $*.riscv > $@

--- a/bp_common/test/Makefile.tests
+++ b/bp_common/test/Makefile.tests
@@ -89,7 +89,7 @@ DROMAJO       ?= dromajo
 	$(RISCV_OBJCOPY) -O verilog $*.riscv $@
 
 %.bin: %.riscv
-	$(RISCV_OBJCOPY) -O binary --reverse-bytes=4 $*.riscv $@
+	$(RISCV_OBJCOPY) -O binary $*.riscv $@
 
 %.dump: %.riscv
 	$(RISCV_OBJDUMP) $*.riscv > $@

--- a/bp_common/test/src/bootrom/Makefile
+++ b/bp_common/test/src/bootrom/Makefile
@@ -1,0 +1,8 @@
+
+RISCV_GCC = $(CROSS_COMPILE)gcc -fPIC -march=rv64im -mabi=lp64 -mcmodel=medany -static -nostdlib -nostartfiles
+
+build:
+	$(RISCV_GCC) bootrom.S -o bootrom.riscv -Tlink.ld -static -Wl,--no-gc-sections
+
+
+

--- a/bp_common/test/src/bootrom/bootrom.S
+++ b/bp_common/test/src/bootrom/bootrom.S
@@ -36,6 +36,8 @@ _start:
     li x31, 0
     
     li x31, 0x80000000
-    jr x31
+    csrw dpc, x31
+    csrwi dcsr, 0x3
+    dret
 halt:
     j halt

--- a/bp_common/test/src/bootrom/bootrom.S
+++ b/bp_common/test/src/bootrom/bootrom.S
@@ -1,0 +1,41 @@
+
+.section .text.start
+.globl _start
+_start:
+    li x0, 0
+    li x1, 0
+    li x2, 0
+    li x3, 0
+    li x4, 0
+    li x5, 0
+    li x6, 0
+    li x7, 0
+    li x8, 0
+    li x9, 0
+    li x10, 0
+    li x11, 0
+    li x12, 0
+    li x13, 0
+    li x14, 0
+    li x15, 0
+    li x16, 0
+    li x17, 0
+    li x18, 0
+    li x19, 0
+    li x20, 0
+    li x21, 0
+    li x22, 0
+    li x23, 0
+    li x24, 0
+    li x25, 0
+    li x26, 0
+    li x27, 0
+    li x28, 0
+    li x29, 0
+    li x30, 0
+    li x31, 0
+    
+    li x31, 0x80000000
+    jr x31
+halt:
+    j halt

--- a/bp_common/test/src/bootrom/link.ld
+++ b/bp_common/test/src/bootrom/link.ld
@@ -1,0 +1,5 @@
+SECTIONS
+{
+    . = 0x0000;
+    .text.start : { *(.text.start) }
+}

--- a/bp_fe/src/v/bp_fe_icache.v
+++ b/bp_fe/src/v/bp_fe_icache.v
@@ -282,7 +282,7 @@ module bp_fe_icache
 
   // uncached request
   logic uncached_load_data_v_r;
-  logic [dword_width_p-1:0] uncached_load_data_r;
+  logic [instr_width_p-1:0] uncached_load_data_r;
 
   assign uncached_req = v_tv_r & uncached_tv_r & ~uncached_load_data_v_r;
   assign fencei_req = v_tv_r & fencei_op_tv_r;
@@ -424,22 +424,17 @@ module bp_fe_icache
      ,.data_o(ld_data_dword_picked)
      );
 
-  logic [dword_width_p-1:0] final_data;
+  logic [instr_width_p-1:0] final_data;
   bsg_mux #(
-    .width_p(dword_width_p)
+    .width_p(instr_width_p)
     ,.els_p(2)
   ) final_data_mux (
-    .data_i({uncached_load_data_r, ld_data_dword_picked})
-    ,.sel_i(uncached_tv_r)
+    .data_i(ld_data_dword_picked)
+    ,.sel_i(addr_tv_r[2])
     ,.data_o(final_data)
   );
 
-  logic lower_upper_sel;
-
-  assign lower_upper_sel             = addr_tv_r[2]; // Select upper/lower 32 bits
-  assign data_o = lower_upper_sel
-    ? final_data[instr_width_p+:instr_width_p]
-    : final_data[instr_width_p-1:0];
+  assign data_o = uncached_tv_r ? uncached_load_data_r : final_data;
 
   // data mem
   logic                                                       data_mem_v;
@@ -655,7 +650,7 @@ module bp_fe_icache
     end
     else begin
       if (data_mem_pkt_yumi_o & (data_mem_pkt.opcode == e_cache_data_mem_uncached)) begin
-        uncached_load_data_r <= data_mem_pkt.data[0+:dword_width_p];
+        uncached_load_data_r <= data_mem_pkt.data[0+:instr_width_p];
         uncached_load_data_v_r <= 1'b1;
       end
       else if (poison_i)

--- a/bp_fe/src/v/bp_fe_mem.v
+++ b/bp_fe/src/v/bp_fe_mem.v
@@ -206,10 +206,8 @@ wire is_uncached_mode = (cfg_bus_cast_i.icache_mode == e_lce_mode_uncached);
 wire mode_fault_v = (is_uncached_mode & ~uncached_li);
 // TODO: Enable other domains by setting enabled dids with cfg_bus
 wire did_fault_v = (ptag_li[ptag_width_p-1-:io_noc_did_width_p] != '0);
-// Don't allow speculative access to local tile memory
-wire local_fault_v = (ptag_li < (dram_base_addr_gp >> page_offset_width_p));
 
-assign instr_access_fault_v = fetch_v_r & (mode_fault_v | did_fault_v | local_fault_v);
+assign instr_access_fault_v = fetch_v_r & (mode_fault_v | did_fault_v);
 assign instr_page_fault_v   = fetch_v_r & itlb_r_v_lo & mem_translation_en_i & (instr_priv_page_fault | instr_exe_page_fault);
 
 assign mem_cmd_yumi_o = itlb_fence_v | itlb_fill_v | fetch_v | fencei_v;

--- a/bp_fe/src/v/bp_fe_pc_gen.v
+++ b/bp_fe/src/v/bp_fe_pc_gen.v
@@ -436,7 +436,7 @@ always_comb
       end
   end
 
-assign mem_poison_o         = ~pc_gen_stage_n[1].v;
+assign mem_poison_o         = flush | ovr_taken | ovr_ret;
 assign mem_priv_o           = shadow_priv_w ? shadow_priv_n : shadow_priv_r;
 assign mem_translation_en_o = shadow_translation_en_w ? shadow_translation_en_n : shadow_translation_en_r;
 

--- a/bp_me/src/v/cce/bp_cce.v
+++ b/bp_me/src/v/cce/bp_cce.v
@@ -41,7 +41,13 @@ module bp_cce
 
    // Configuration Interface
    , input [cfg_bus_width_lp-1:0]                      cfg_bus_i
-   , output [cce_instr_width_p-1:0]                    cfg_cce_ucode_data_o
+
+   // ucode programming interface, synchronous read, direct connection to RAM
+   , input                                             ucode_v_i
+   , input                                             ucode_w_i
+   , input [cce_pc_width_p-1:0]                        ucode_addr_i
+   , input [cce_instr_width_p-1:0]                     ucode_data_i
+   , output [cce_instr_width_p-1:0]                    ucode_data_o
 
    // LCE-CCE Interface
    , input [lce_cce_req_width_lp-1:0]                  lce_req_i
@@ -235,7 +241,13 @@ module bp_cce
     inst_ram
      (.clk_i(clk_i)
       ,.reset_i(reset_i)
-      ,.cfg_bus_i(cfg_bus_i)
+
+      ,.ucode_v_i(ucode_v_i)
+      ,.ucode_w_i(ucode_w_i)
+      ,.ucode_addr_i(ucode_addr_i)
+      ,.ucode_data_i(ucode_data_i)
+      ,.ucode_data_o(ucode_data_o)
+
       ,.predicted_fetch_pc_i(predicted_fetch_pc_lo)
       ,.branch_resolution_pc_i(branch_resolution_pc_lo)
       ,.stall_i(stall_lo)
@@ -244,9 +256,6 @@ module bp_cce
       ,.inst_o(fetch_inst_lo)
       ,.inst_v_o(fetch_inst_v_lo)
       );
-
-  // Configuration Bus Microcode Data output
-  assign cfg_cce_ucode_data_o = fetch_inst_lo;
 
   // Inst Pre-decode
   bp_cce_inst_predecode

--- a/bp_me/src/v/cce/bp_cce_fsm.v
+++ b/bp_me/src/v/cce/bp_cce_fsm.v
@@ -74,9 +74,6 @@ module bp_cce_fsm
    , input                                             mem_cmd_ready_i
   );
 
-  // stub cfg ucode output, since FSM CCE has no ucode
-  assign cfg_cce_ucode_data_o = '0;
-
   //synopsys translate_off
   initial begin
     assert (lce_sets_p > 1) else $error("Number of LCE sets must be greater than 1");

--- a/bp_me/src/v/cce/bp_cce_fsm.v
+++ b/bp_me/src/v/cce/bp_cce_fsm.v
@@ -48,7 +48,6 @@ module bp_cce_fsm
 
    // Config channel
    , input [cfg_bus_width_lp-1:0]                      cfg_bus_i
-   , output [cce_instr_width_p-1:0]                    cfg_cce_ucode_data_o
 
    // LCE-CCE Interface
    , input [lce_cce_req_width_lp-1:0]                  lce_req_i

--- a/bp_me/src/v/cce/bp_cce_inst_ram.v
+++ b/bp_me/src/v/cce/bp_cce_inst_ram.v
@@ -30,6 +30,13 @@ module bp_cce_inst_ram
    // Configuration Interface
    , input [cfg_bus_width_lp-1:0]                cfg_bus_i
 
+   // ucode programming interface, synchronous read, direct connection to RAM
+   , input                                       ucode_v_i
+   , input                                       ucode_w_i
+   , input [cce_pc_width_p-1:0]                  ucode_addr_i
+   , input [cce_instr_width_p-1:0]               ucode_data_i
+   , output [cce_instr_width_p-1:0]              ucode_data_o
+
    , input [cce_pc_width_p-1:0]                  predicted_fetch_pc_i
    , input [cce_pc_width_p-1:0]                  branch_resolution_pc_i
 
@@ -69,12 +76,16 @@ module bp_cce_inst_ram
     inst_ram
      (.clk_i(clk_i)
       ,.reset_i(reset_i)
-      ,.v_i((cfg_bus_cast_i.cce_ucode_w_v | cfg_bus_cast_i.cce_ucode_r_v) | ram_v_li)
-      ,.data_i(cfg_bus_cast_i.cce_ucode_data[0+:cce_instr_width_p])
-      ,.addr_i((cfg_bus_cast_i.cce_ucode_w_v | cfg_bus_cast_i.cce_ucode_r_v) ? cfg_bus_cast_i.cce_ucode_addr : fetch_pc_n)
-      ,.w_i(cfg_bus_cast_i.cce_ucode_w_v)
+      ,.v_i(ucode_v_i | ram_v_li)
+      ,.data_i(ucode_data_i)
+      ,.addr_i(ucode_v_i ? ucode_addr_i : fetch_pc_n)
+      ,.w_i(ucode_w_i)
       ,.data_o(inst_o)
       );
+
+  // Configuration Bus Microcode Data output
+  assign ucode_data_o = inst_o;
+
 
   typedef enum logic [1:0] {
     RESET

--- a/bp_me/src/v/cce/bp_cce_wrapper.v
+++ b/bp_me/src/v/cce/bp_cce_wrapper.v
@@ -29,7 +29,13 @@ module bp_cce_wrapper
 
    // Configuration Interface
    , input [cfg_bus_width_lp-1:0]                      cfg_bus_i
-   , output [cce_instr_width_p-1:0]                    cfg_cce_ucode_data_o
+
+   // ucode programming interface, synchronous read, direct connection to RAM
+   , input                                             ucode_v_i
+   , input                                             ucode_w_i
+   , input [cce_pc_width_p-1:0]                        ucode_addr_i
+   , input [cce_instr_width_p-1:0]                     ucode_data_i
+   , output [cce_instr_width_p-1:0]                    ucode_data_o
 
    // LCE-CCE Interface
    , input [lce_cce_req_width_lp-1:0]                  lce_req_i

--- a/bp_me/src/v/cce/bp_uce.v
+++ b/bp_me/src/v/cce/bp_uce.v
@@ -588,7 +588,7 @@ module bp_uce
             begin
               mem_cmd_cast_o.header.msg_type       = e_cce_mem_uc_rd;
               mem_cmd_cast_o.header.addr           = cache_req_r.addr;
-              mem_cmd_cast_o.header.size           = e_mem_msg_size_8;
+              mem_cmd_cast_o.header.size           = bp_mem_msg_size_e'(cache_req_r.size);
               mem_cmd_cast_o.header.payload.lce_id = lce_id_i;
               mem_cmd_v_o = mem_cmd_ready_i;
 
@@ -695,7 +695,8 @@ module bp_uce
         e_uc_read_wait:
           begin
             data_mem_pkt_cast_o.opcode = e_cache_data_mem_uncached;
-            data_mem_pkt_cast_o.data = mem_resp_cast_i.data;
+            // TODO: Alignment should be handled via replication
+            data_mem_pkt_cast_o.data = mem_resp_cast_i.data >> 8*cache_req_r.addr[0+:3];
             data_mem_pkt_v_o = load_resp_v_li;
 
             cache_req_complete_o = data_mem_pkt_yumi_i;

--- a/bp_me/test/common/bp_cce_mmio_cfg_loader.v
+++ b/bp_me/test/common/bp_cce_mmio_cfg_loader.v
@@ -26,7 +26,7 @@ module bp_cce_mmio_cfg_loader
     , parameter skip_ram_init_p       = 0
     , parameter clear_freeze_p        = 0
 
-    , localparam bp_pc_entry_point_gp=39'h00_8000_0000
+    , localparam bp_pc_entry_point_gp=39'h10_3000
     )
   (input                                             clk_i
    , input                                           reset_i

--- a/bp_top/src/v/bp_cfg.v
+++ b/bp_top/src/v/bp_cfg.v
@@ -30,10 +30,12 @@ module bp_cfg
    , input [io_noc_did_width_p-1:0]     did_i
    , input [io_noc_did_width_p-1:0]     host_did_i
    , input [coh_noc_cord_width_p-1:0]   cord_i
-   , input [dword_width_p-1:0]          irf_data_i
-   , input [vaddr_width_p-1:0]          npc_data_i
-   , input [dword_width_p-1:0]          csr_data_i
-   , input [1:0]                        priv_data_i
+
+   // ucode programming interface, synchronous read, direct connection to RAM
+   , output                             cce_ucode_v_o
+   , output                             cce_ucode_w_o
+   , output [cce_pc_width_p-1:0]        cce_ucode_addr_o
+   , output [cce_instr_width_p-1:0]     cce_ucode_data_o
    , input [cce_instr_width_p-1:0]      cce_ucode_data_i
    );
 
@@ -97,39 +99,10 @@ wire did_r_v_li       = cfg_r_v_li & (cfg_addr_li == bp_cfg_reg_did_gp);
 wire host_did_r_v_li  = cfg_r_v_li & (cfg_addr_li == bp_cfg_reg_host_did_gp);
 wire cord_r_v_li      = cfg_r_v_li & (cfg_addr_li == bp_cfg_reg_cord_gp);
 
-wire cce_ucode_w_v_li = cfg_w_v_li & (cfg_addr_li >= 16'h8000);
-wire cce_ucode_r_v_li = cfg_r_v_li & (cfg_addr_li >= 16'h8000);
-wire [cce_pc_width_p-1:0] cce_ucode_addr_li = cfg_addr_li[0+:cce_pc_width_p];
-wire [cce_instr_width_p-1:0] cce_ucode_data_li = cfg_data_li[0+:cce_instr_width_p];
-
-wire npc_w_v_li = cfg_w_v_li & (cfg_addr_li == bp_cfg_reg_npc_gp);
-wire npc_r_v_li = cfg_r_v_li & (cfg_addr_li == bp_cfg_reg_npc_gp);
-wire [vaddr_width_p-1:0] npc_li = cfg_data_li[0+:vaddr_width_p];
-
-// Need to delay reads by 1 cycle here, to align with other synchronous reads
-logic [dword_width_p-1:0] npc_data_r;
-always_ff @(posedge clk_i)
-  npc_data_r <= csr_data_i;
-
-wire irf_w_v_li = cfg_w_v_li & (cfg_addr_li >= bp_cfg_reg_irf_x0_gp && cfg_addr_li <= bp_cfg_reg_irf_x31_gp);
-wire irf_r_v_li = cfg_r_v_li & (cfg_addr_li >= bp_cfg_reg_irf_x0_gp && cfg_addr_li <= bp_cfg_reg_irf_x31_gp);
-// TODO: we could get rid of this subtraction with intellignent address map
-wire [reg_addr_width_p-1:0] irf_addr_li = (cfg_addr_li - bp_cfg_reg_irf_x0_gp);
-wire [dword_width_p-1:0] irf_data_li = cfg_data_li;
-
-wire csr_w_v_li = cfg_w_v_li & (cfg_addr_li >= bp_cfg_reg_csr_begin_gp && cfg_addr_li <= bp_cfg_reg_csr_end_gp);
-wire csr_r_v_li = cfg_r_v_li & (cfg_addr_li >= bp_cfg_reg_csr_begin_gp && cfg_addr_li <= bp_cfg_reg_csr_end_gp);
-wire [rv64_csr_addr_width_gp-1:0] csr_addr_li = (cfg_addr_li - bp_cfg_reg_csr_begin_gp);
-wire [dword_width_p-1:0] csr_data_li = cfg_data_li;
-
-// Need to delay reads by 1 cycle here, to align with other synchronous reads
-logic [dword_width_p-1:0] csr_data_r;
-always_ff @(posedge clk_i)
-  csr_data_r <= csr_data_i;
-
-wire priv_w_v_li = cfg_w_v_li & (cfg_addr_li == bp_cfg_reg_priv_gp);
-wire priv_r_v_li = cfg_r_v_li & (cfg_addr_li == bp_cfg_reg_priv_gp);
-wire [1:0] priv_data_li = cfg_data_li[1:0];
+assign cce_ucode_v_o    = (cfg_r_v_li | cfg_w_v_li) & (cfg_addr_li >= 16'h8000);
+assign cce_ucode_w_o    = cfg_w_v_li;
+assign cce_ucode_addr_o = cfg_addr_li[0+:cce_pc_width_p];
+assign cce_ucode_data_o = cfg_data_li[0+:cce_instr_width_p];
 
 logic [core_id_width_p-1:0] core_id_li;
 logic [cce_id_width_p-1:0]  cce_id_li;
@@ -148,28 +121,10 @@ assign cfg_bus_cast_o = '{freeze: freeze_r
                           ,core_id: core_id_li
                           ,icache_id: icache_id_li
                           ,icache_mode: icache_mode_r
-                          ,npc_w_v: npc_w_v_li
-                          ,npc_r_v: npc_r_v_li
-                          ,npc: npc_li
                           ,dcache_id: dcache_id_li
                           ,dcache_mode: dcache_mode_r
                           ,cce_id: cce_id_li
                           ,cce_mode: cce_mode_r
-                          ,cce_ucode_w_v: cce_ucode_w_v_li
-                          ,cce_ucode_r_v: cce_ucode_r_v_li
-                          ,cce_ucode_addr: cce_ucode_addr_li
-                          ,cce_ucode_data: cce_ucode_data_li
-                          ,irf_w_v: irf_w_v_li
-                          ,irf_r_v: irf_r_v_li
-                          ,irf_addr: irf_addr_li
-                          ,irf_data: irf_data_li
-                          ,csr_w_v: csr_w_v_li
-                          ,csr_r_v: csr_r_v_li
-                          ,csr_addr: csr_addr_li
-                          ,csr_data: csr_data_li
-                          ,priv_w_v: priv_w_v_li
-                          ,priv_r_v: priv_r_v_li
-                          ,priv_data: priv_data_li
                           };
 
   logic rdata_v_r;
@@ -183,27 +138,23 @@ assign cfg_bus_cast_o = '{freeze: freeze_r
      ,.data_o(rdata_v_r)
      );
 
-  logic [7:0] read_sel_one_hot_r;
+  logic [3:0] read_sel_one_hot_r;
   bsg_dff_reset_en
-   #(.width_p(8))
+   #(.width_p(4))
    read_reg_one_hot
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
      ,.en_i(mem_cmd_v_lo)
 
-     ,.data_i({irf_r_v_li, npc_r_v_li, csr_r_v_li, priv_r_v_li, host_did_r_v_li, did_r_v_li, cord_r_v_li, cce_ucode_r_v_li})
+     ,.data_i({host_did_r_v_li, did_r_v_li, cord_r_v_li, cce_ucode_v_o})
      ,.data_o(read_sel_one_hot_r)
      );
 
   logic [dword_width_p-1:0] read_data;
   bsg_mux_one_hot
-   #(.width_p(dword_width_p), .els_p(8))
+   #(.width_p(dword_width_p), .els_p(4))
    read_mux_one_hot
-    (.data_i({dword_width_p'(irf_data_i)
-              ,dword_width_p'(npc_data_r)
-              ,dword_width_p'(csr_data_r)
-              ,dword_width_p'(priv_data_i)
-              ,dword_width_p'(host_did_i)
+    (.data_i({dword_width_p'(host_did_i)
               ,dword_width_p'(did_i)
               ,dword_width_p'(cord_i)
               ,dword_width_p'(cce_ucode_data_i)

--- a/bp_top/src/v/bp_core.v
+++ b/bp_top/src/v/bp_core.v
@@ -28,10 +28,6 @@ module bp_core
     , input                                        reset_i
 
     , input [cfg_bus_width_lp-1:0]                 cfg_bus_i
-    , output [vaddr_width_p-1:0]                   cfg_npc_data_o
-    , output [dword_width_p-1:0]                   cfg_irf_data_o
-    , output [dword_width_p-1:0]                   cfg_csr_data_o
-    , output [1:0]                                 cfg_priv_data_o
 
     // LCE-CCE interface
     , output [1:0][lce_cce_req_width_lp-1:0]       lce_req_o
@@ -120,10 +116,6 @@ module bp_core
 
      // Config info
      ,.cfg_bus_i(cfg_bus_i)
-     ,.cfg_npc_data_o(cfg_npc_data_o)
-     ,.cfg_irf_data_o(cfg_irf_data_o)
-     ,.cfg_csr_data_o(cfg_csr_data_o)
-     ,.cfg_priv_data_o(cfg_priv_data_o)
 
      // BP request side - Interface to LCE
      ,.credits_full_i(dcache_credits_full_lo)

--- a/bp_top/src/v/bp_core_minimal.v
+++ b/bp_top/src/v/bp_core_minimal.v
@@ -27,10 +27,6 @@ module bp_core_minimal
 
     // Config info
     , input [cfg_bus_width_lp-1:0] cfg_bus_i
-    , output [vaddr_width_p-1:0] cfg_npc_data_o
-    , output [dword_width_p-1:0] cfg_irf_data_o
-    , output [dword_width_p-1:0] cfg_csr_data_o
-    , output [1:0] cfg_priv_data_o
 
     // BP request side - Interface to LCE
     , input credits_full_i
@@ -195,10 +191,6 @@ module bp_core_minimal
      ,.reset_i(reset_i)
 
      ,.cfg_bus_i(cfg_bus_i)
-     ,.cfg_npc_data_o(cfg_npc_data_o)
-     ,.cfg_irf_data_o(cfg_irf_data_o)
-     ,.cfg_csr_data_o(cfg_csr_data_o)
-     ,.cfg_priv_data_o(cfg_priv_data_o)
 
      ,.fe_queue_clr_o(fe_queue_clr_li)
      ,.fe_queue_deq_o(fe_queue_deq_li)

--- a/bp_top/src/v/bp_io_tile.v
+++ b/bp_top/src/v/bp_io_tile.v
@@ -181,7 +181,7 @@ module bp_io_tile
   assign global_addr_lo = cce_io_cmd_lo.header.addr;
   assign local_addr_lo  = cce_io_cmd_lo.header.addr;
 
-  wire is_host_addr  = (~local_addr_lo.nonlocal && (local_addr_lo.dev == host_dev_gp));
+  wire is_host_addr  = (~local_addr_lo.nonlocal && (local_addr_lo.dev inside {boot_dev_gp, host_dev_gp}));
   assign dst_did_lo  = is_host_addr ? host_did_i : global_addr_lo.did;
   assign dst_cord_lo = dst_did_lo;
 

--- a/bp_top/src/v/bp_tile.v
+++ b/bp_top/src/v/bp_tile.v
@@ -120,11 +120,10 @@ always_ff @(posedge clk_i)
   reset_r <= reset_i;
 
 bp_cfg_bus_s cfg_bus_lo;
-logic [dword_width_p-1:0] cfg_irf_data_li;
-logic [vaddr_width_p-1:0] cfg_npc_data_li;
-logic [dword_width_p-1:0] cfg_csr_data_li;
-logic [1:0]               cfg_priv_data_li;
-logic [cce_instr_width_p-1:0] cfg_cce_ucode_data_li;
+logic cce_ucode_v_lo;
+logic cce_ucode_w_lo;
+logic [cce_pc_width_p-1:0] cce_ucode_addr_lo;
+logic [cce_instr_width_p-1:0] cce_ucode_data_lo, cce_ucode_data_li;
 bp_cfg
  #(.bp_params_p(bp_params_p))
  cfg
@@ -143,11 +142,12 @@ bp_cfg
    ,.did_i(my_did_i)
    ,.host_did_i(host_did_i)
    ,.cord_i(my_cord_i)
-   ,.irf_data_i(cfg_irf_data_li)
-   ,.npc_data_i(cfg_npc_data_li)
-   ,.csr_data_i(cfg_csr_data_li)
-   ,.priv_data_i(cfg_priv_data_li)
-   ,.cce_ucode_data_i(cfg_cce_ucode_data_li)
+
+   ,.cce_ucode_v_o(cce_ucode_v_lo)
+   ,.cce_ucode_w_o(cce_ucode_w_lo)
+   ,.cce_ucode_addr_o(cce_ucode_addr_lo)
+   ,.cce_ucode_data_o(cce_ucode_data_lo)
+   ,.cce_ucode_data_i(cce_ucode_data_li)
    );
 
 bp_clint_slice
@@ -177,10 +177,6 @@ bp_core
    ,.reset_i(reset_r)
 
    ,.cfg_bus_i(cfg_bus_lo)
-   ,.cfg_irf_data_o(cfg_irf_data_li)
-   ,.cfg_npc_data_o(cfg_npc_data_li)
-   ,.cfg_csr_data_o(cfg_csr_data_li)
-   ,.cfg_priv_data_o(cfg_priv_data_li)
 
    ,.lce_req_o(lce_req_lo)
    ,.lce_req_v_o(lce_req_v_lo)
@@ -210,7 +206,12 @@ bp_cce_wrapper
    ,.reset_i(reset_r)
 
    ,.cfg_bus_i(cfg_bus_lo)
-   ,.cfg_cce_ucode_data_o(cfg_cce_ucode_data_li)
+
+   ,.ucode_v_i(cce_ucode_v_lo)
+   ,.ucode_w_i(cce_ucode_w_lo)
+   ,.ucode_addr_i(cce_ucode_addr_lo)
+   ,.ucode_data_i(cce_ucode_data_lo)
+   ,.ucode_data_o(cce_ucode_data_li)
 
    ,.lce_req_i(cce_lce_req_li)
    ,.lce_req_v_i(cce_lce_req_v_li)

--- a/bp_top/src/v/bp_unicore.v
+++ b/bp_top/src/v/bp_unicore.v
@@ -323,6 +323,11 @@ module bp_unicore
      ,.did_i('0)
      ,.host_did_i('0)
      ,.cord_i({coh_noc_y_cord_width_p'(1), coh_noc_x_cord_width_p'(0)})
+
+     ,.cce_ucode_v_o()
+     ,.cce_ucode_w_o()
+     ,.cce_ucode_addr_o()
+     ,.cce_ucode_data_o()
      ,.cce_ucode_data_i('0)
      );
 

--- a/bp_top/src/v/bp_unicore.v
+++ b/bp_top/src/v/bp_unicore.v
@@ -130,10 +130,6 @@ module bp_unicore
      ,.reset_i(reset_i)
 
      ,.cfg_bus_i(cfg_bus_lo)
-     ,.cfg_npc_data_o(cfg_npc_data_li)
-     ,.cfg_irf_data_o(cfg_irf_data_li)
-     ,.cfg_csr_data_o(cfg_csr_data_li)
-     ,.cfg_priv_data_o(cfg_priv_data_li)
 
      ,.dcache_req_o(dcache_req_lo)
      ,.dcache_req_v_o(dcache_req_v_lo)
@@ -327,10 +323,6 @@ module bp_unicore
      ,.did_i('0)
      ,.host_did_i('0)
      ,.cord_i({coh_noc_y_cord_width_p'(1), coh_noc_x_cord_width_p'(0)})
-     ,.irf_data_i(cfg_irf_data_li)
-     ,.npc_data_i(cfg_npc_data_li)
-     ,.csr_data_i(cfg_csr_data_li)
-     ,.priv_data_i(cfg_priv_data_li)
      ,.cce_ucode_data_i('0)
      );
 

--- a/bp_top/src/v/bp_unicore.v
+++ b/bp_top/src/v/bp_unicore.v
@@ -437,7 +437,7 @@ module bp_unicore
   wire [3:0] device_cmd_li = cmd_fifo_selected_lo.header.addr[20+:4];
   wire is_cfg_cmd          = local_cmd_li & (device_cmd_li == cfg_dev_gp);
   wire is_clint_cmd        = local_cmd_li & (device_cmd_li == clint_dev_gp);
-  wire is_io_cmd           = local_cmd_li & (device_cmd_li == host_dev_gp);
+  wire is_io_cmd           = local_cmd_li & (device_cmd_li inside {boot_dev_gp, host_dev_gp});
   wire is_cache_cmd        = ~local_cmd_li || (local_cmd_li & (device_cmd_li == cache_dev_gp));
   wire is_loopback_cmd     = local_cmd_li & ~is_cfg_cmd & ~is_clint_cmd & ~is_io_cmd & ~is_cache_cmd;
 

--- a/bp_top/syn/Makefile
+++ b/bp_top/syn/Makefile
@@ -26,3 +26,4 @@ export TAG   ?= none
 -include $(BP_COMMON_DIR)/syn/Makefile.sv2v
 -include $(BP_COMMON_DIR)/syn/Makefile.verilator
 -include $(BP_COMMON_DIR)/syn/Makefile.vcs
+

--- a/bp_top/test/common/bp_nonsynth_cosim.v
+++ b/bp_top/test/common/bp_nonsynth_cosim.v
@@ -39,7 +39,7 @@ module bp_nonsynth_cosim
     );
 
 import "DPI-C" context function void dromajo_init(string cfg_f_name, int hartid, int ncpus, int memory_size, bit checkpoint);
-import "DPI-C" context function bit  dromajo_step(int      hart_id,
+import "DPI-C" context function bit  dromajo_step(int hart_id,
                                                   longint pc,
                                                   int insn,
                                                   longint wdata);

--- a/bp_top/test/common/bp_nonsynth_host.v
+++ b/bp_top/test/common/bp_nonsynth_host.v
@@ -170,14 +170,16 @@ always_ff @(negedge clk_i)
       end
   end
 
-  parameter bootrom_els_p  = 64;
-  parameter bootrom_addr_width_lp = `BSG_SAFE_CLOG2(bootrom_els_p);
-  logic [bootrom_addr_width_lp-1:0] bootrom_addr_li;
+  localparam bootrom_els_p = 64;
+  localparam lg_bootrom_els_lp = `BSG_SAFE_CLOG2(bootrom_els_p);
+  logic [lg_bootrom_els_lp-1:0] bootrom_addr_li;
   logic [instr_width_p-1:0] bootrom_data_lo;
-  assign bootrom_addr_li = io_cmd_lo.header.addr[2+:bootrom_addr_width_lp];
-  bp_bootrom
-   #(.addr_width_p(bootrom_addr_width_lp)
-     ,.width_p(instr_width_p)
+  assign bootrom_addr_li = io_cmd_lo.header.addr[2+:lg_bootrom_els_lp];
+  bsg_nonsynth_test_rom
+   #(.filename_p("bootrom.mem")
+     ,.data_width_p(instr_width_p)
+     ,.addr_width_p(lg_bootrom_els_lp)
+     ,.hex_not_bin_p(1)
      )
    bootrom
     (.addr_i(bootrom_addr_li)

--- a/bp_top/test/common/bp_nonsynth_host.v
+++ b/bp_top/test/common/bp_nonsynth_host.v
@@ -186,7 +186,7 @@ always_ff @(negedge clk_i)
 
   assign io_resp_cast_o =
     '{header: io_cmd_lo.header
-      ,data : bootrom_data_cmd_v ? bootrom_data_lo : ch
+      ,data : bootrom_data_cmd_v ? {bootrom_data_lo, bootrom_data_lo} : ch
       };
 
 endmodule

--- a/bp_top/test/common/bp_nonsynth_host.v
+++ b/bp_top/test/common/bp_nonsynth_host.v
@@ -49,10 +49,10 @@ end
 // Host I/O mappings (arbitrarily decided for now)
 //   Overall host controls 32'h0300_0000-32'h03FF_FFFF
 
+localparam bootrom_base_addr_gp = paddr_width_p'(64'h0001_????);
 localparam getchar_base_addr_gp = paddr_width_p'(64'h0010_0000);
 localparam putchar_base_addr_gp = paddr_width_p'(64'h0010_1000);
 localparam finish_base_addr_gp  = paddr_width_p'(64'h0010_2???);
-localparam bootrom_base_addr_gp = paddr_width_p'(64'h0010_3???);
 
 bp_cce_mem_msg_s io_cmd_li, io_cmd_lo;
 bp_cce_mem_msg_s io_resp_cast_o;

--- a/bp_top/test/common/bp_nonsynth_host.v
+++ b/bp_top/test/common/bp_nonsynth_host.v
@@ -11,6 +11,8 @@ module bp_nonsynth_host
  #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_me_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p)
+
+   , parameter host_max_outstanding_p = 32
    )
   (input clk_i
    , input reset_i
@@ -50,28 +52,53 @@ end
 localparam getchar_base_addr_gp = paddr_width_p'(64'h0010_0000);
 localparam putchar_base_addr_gp = paddr_width_p'(64'h0010_1000);
 localparam finish_base_addr_gp  = paddr_width_p'(64'h0010_2???);
+localparam bootrom_base_addr_gp = paddr_width_p'(64'h0010_3???);
 
-bp_cce_mem_msg_s  io_cmd_cast_i;
+bp_cce_mem_msg_s io_cmd_li, io_cmd_lo;
+bp_cce_mem_msg_s io_resp_cast_o;
 
-assign io_cmd_cast_i = io_cmd_i;
+assign io_cmd_li = io_cmd_i;
+assign io_resp_o = io_resp_cast_o;
 
 localparam lg_num_core_lp = `BSG_SAFE_CLOG2(num_core_p);
+
+logic io_cmd_v_lo, io_cmd_yumi_li;
+bsg_fifo_1r1w_small
+ #(.width_p($bits(bp_cce_mem_msg_s)), .els_p(host_max_outstanding_p))
+ small_fifo
+  (.clk_i(clk_i)
+   ,.reset_i(reset_i)
+
+   ,.data_i(io_cmd_li)
+   ,.v_i(io_cmd_v_i)
+   ,.ready_o(io_cmd_ready_o)
+
+   ,.data_o(io_cmd_lo)
+   ,.v_o(io_cmd_v_lo)
+   ,.yumi_i(io_cmd_yumi_li)
+   );
+ assign io_resp_v_o = io_cmd_v_lo;
+ assign io_cmd_yumi_li = io_resp_yumi_i;
+
 
 logic putchar_data_cmd_v;
 logic getchar_data_cmd_v;
 logic finish_data_cmd_v;
+logic bootrom_data_cmd_v;
 
 always_comb
   begin
     putchar_data_cmd_v = 1'b0;
     getchar_data_cmd_v = 1'b0;
     finish_data_cmd_v = 1'b0;
+    bootrom_data_cmd_v = 1'b0;
 
     unique
-    casez (io_cmd_cast_i.header.addr)
-      putchar_base_addr_gp: putchar_data_cmd_v = io_cmd_v_i; 
-      getchar_base_addr_gp: getchar_data_cmd_v = io_cmd_v_i;
-      finish_base_addr_gp: finish_data_cmd_v = io_cmd_v_i;
+    casez (io_cmd_lo.header.addr)
+      putchar_base_addr_gp: putchar_data_cmd_v = io_cmd_v_lo;
+      getchar_base_addr_gp: getchar_data_cmd_v = io_cmd_v_lo;
+      finish_base_addr_gp : finish_data_cmd_v = io_cmd_v_lo;
+      bootrom_base_addr_gp: bootrom_data_cmd_v = io_cmd_v_lo;
       default: begin end
     endcase
   end
@@ -81,7 +108,7 @@ logic [num_core_p-1:0] finish_w_v_li;
 // Memory-mapped I/O is 64 bit aligned
 localparam byte_offset_width_lp = 3;
 wire [lg_num_core_lp-1:0] io_cmd_core_enc =
-  io_cmd_cast_i.header.addr[byte_offset_width_lp+:lg_num_core_lp];
+  io_cmd_lo.header.addr[byte_offset_width_lp+:lg_num_core_lp];
 
 bsg_decode_with_v
  #(.num_out_p(num_core_p))
@@ -118,21 +145,21 @@ assign program_finish_o = finish_r;
 
 always_ff @(negedge clk_i)
   begin
-    if (putchar_data_cmd_v & io_cmd_v_i) begin
-      $write("%c", io_cmd_cast_i.data[0+:8]);
+    if (putchar_data_cmd_v) begin
+      $write("%c", io_cmd_lo.data[0+:8]);
       $fflush(32'h8000_0001);
     end
-    if (getchar_data_cmd_v & io_cmd_v_i)
+    if (getchar_data_cmd_v)
       pop();
     for (integer i = 0; i < num_core_p; i++)
       begin
         // PASS when returned value in finish packet is zero
-        if (finish_w_v_li[i] & io_cmd_v_i &
-          (io_cmd_cast_i.data[0+:8] == 8'(0)))
+        if (finish_w_v_li[i] &
+          (io_cmd_lo.data[0+:8] == 8'(0)))
           $display("[CORE%0x FSH] PASS", i);
         // FAIL when returned value in finish packet is non-zero
-        if (finish_w_v_li[i] & io_cmd_v_i &
-          (io_cmd_cast_i.data[0+:8] != 8'(0)))
+        if (finish_w_v_li[i] &
+          (io_cmd_lo.data[0+:8] != 8'(0)))
           $display("[CORE%0x FSH] FAIL", i);
       end
 
@@ -143,30 +170,24 @@ always_ff @(negedge clk_i)
       end
   end
 
-bp_cce_mem_msg_s io_resp_lo;
-bsg_two_fifo
- #(.width_p($bits(bp_cce_mem_msg_s)))
- io_resp_buffer
-  (.clk_i(clk_i)
-   ,.reset_i(reset_i)
+  parameter bootrom_els_p  = 64;
+  parameter bootrom_addr_width_lp = `BSG_SAFE_CLOG2(bootrom_els_p);
+  logic [bootrom_addr_width_lp-1:0] bootrom_addr_li;
+  logic [instr_width_p-1:0] bootrom_data_lo;
+  assign bootrom_addr_li = io_cmd_lo.header.addr[2+:bootrom_addr_width_lp];
+  bp_bootrom
+   #(.addr_width_p(bootrom_addr_width_lp)
+     ,.width_p(instr_width_p)
+     )
+   bootrom
+    (.addr_i(bootrom_addr_li)
+     ,.data_o(bootrom_data_lo)
+     );
 
-   ,.data_i(io_resp_lo)
-   ,.v_i(io_cmd_v_i)
-   ,.ready_o(io_cmd_ready_o)
-
-   ,.data_o(io_resp_o)
-   ,.v_o(io_resp_v_o)
-   ,.yumi_i(io_resp_yumi_i)
-   );
-
-assign io_resp_lo =
-  '{header: '{msg_type       : io_cmd_cast_i.header.msg_type
-              ,addr          : io_cmd_cast_i.header.addr
-              ,payload       : io_cmd_cast_i.header.payload
-              ,size          : io_cmd_cast_i.header.size
-              }
-    ,data : ch
-    };
+  assign io_resp_cast_o =
+    '{header: io_cmd_lo.header
+      ,data : bootrom_data_cmd_v ? bootrom_data_lo : ch
+      };
 
 endmodule
 

--- a/bp_top/test/common/dromajo_cosim.cpp
+++ b/bp_top/test/common/dromajo_cosim.cpp
@@ -19,14 +19,15 @@ extern "C" void dromajo_init(char* cfg_f_name, int hartid, int ncpus, int memory
     string memsize_str = "--memory_size=" + to_string(memory_size);
     string mmio_str = "--mmio_range=0x20000:0x80000000";
     char* load_str = "--load=prog";
+    char* bootrom_str = "--bootrom=bootrom.bin";
 
     if(checkpoint) {
       char* argv[] = {"dromajo", (char*)(&ncpus_str[0]), (char*)(&memsize_str[0]), (char*)(&mmio_str[0]), load_str, "prog.elf"};
       dromajo_pointer = dromajo_cosim_init(6, argv);
     }
     else {
-      char* argv[] = {"dromajo", (char*)(&ncpus_str[0]), (char*)(&memsize_str[0]), (char*)(&mmio_str[0]), "prog.elf"};
-      dromajo_pointer = dromajo_cosim_init(5, argv);
+      char* argv[] = {"dromajo", (char*)(&ncpus_str[0]), (char*)(&memsize_str[0]), (char*)(&mmio_str[0]), bootrom_str, "prog.elf"};
+      dromajo_pointer = dromajo_cosim_init(6, argv);
     }
   }
 }

--- a/bp_top/test/tb/bp_tethered/Makefile.vcs
+++ b/bp_top/test/tb/bp_tethered/Makefile.vcs
@@ -7,10 +7,23 @@ $(LINT_DIR)/flist.vcs:
 	@echo wrapper.v                              >> $@ 
 	@echo testbench.v                            >> $@ 
 	@echo test_bp.v                              >> $@ 
+	@echo bp_bootrom.v							 >> $@
 	@echo "$(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_reset_gen.v" >> $@
 	@echo "$(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_clock_gen.v" >> $@
 
-LINT_COLLATERAL = $(addprefix $(LINT_DIR)/, flist.vcs wrapper.v testbench.v test_bp.v)
+$(LINT_DIR)/bootrom.riscv: $(BP_TEST_MEM_DIR)/bootrom.riscv
+	cp $^ $@
+
+XXD ?= xxd
+AWK ?= awk
+$(LINT_DIR)/bootrom.txt: $(LINT_DIR)/bootrom.bin
+	$(XXD) -b -c 4 $< | $(AWK) '{print $$2$$3$$4$$5}' > $@
+
+$(LINT_DIR)/bp_bootrom.v: $(LINT_DIR)/bootrom.txt
+	$(PYTHON) $(BASEJUMP_STL_DIR)/bsg_mem/bsg_ascii_to_rom.py $< bp_bootrom > $@
+
+LINT_COLLATERAL  = $(addprefix $(LINT_DIR)/, flist.vcs wrapper.v testbench.v test_bp.v)
+LINT_COLLATERAL += $(addprefix $(LINT_DIR)/, bootrom.riscv bootrom.bin bootrom.dump bp_bootrom.v)
 
 $(BUILD_DIR)/testbench.v $(BUILD_DIR)/wrapper.v $(BUILD_DIR)/test_bp.v:
 	@sed "s/BP_CFG_FLOWVAR/$(CFG)/g" $(TB_PATH)/$(TB)/$(@F) > $@
@@ -20,11 +33,24 @@ $(BUILD_DIR)/flist.vcs:
 	@grep -v -e "^\#" $(TB_PATH)/$(TB)/flist.vcs >> $@ 
 	@echo wrapper.v                              >> $@ 
 	@echo testbench.v                            >> $@ 
-	@echo test_bp.v                              >> $@ 
+	@echo test_bp.v                              >> $@
+	@echo bp_bootrom.v							 >> $@
 	@echo "$(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_reset_gen.v" >> $@
 	@echo "$(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_clock_gen.v" >> $@
 
-BUILD_COLLATERAL = $(addprefix $(BUILD_DIR)/, flist.vcs wrapper.v testbench.v test_bp.v)
+$(BUILD_DIR)/bootrom.riscv: $(BP_TEST_MEM_DIR)/bootrom.riscv
+	cp $^ $@
+
+XXD ?= xxd
+AWK ?= awk
+$(BUILD_DIR)/bootrom.txt: $(BUILD_DIR)/bootrom.bin
+	$(XXD) -b -c 4 $< | $(AWK) '{print $$2$$3$$4$$5}' > $@
+
+$(BUILD_DIR)/bp_bootrom.v: $(BUILD_DIR)/bootrom.txt
+	$(PYTHON) $(BASEJUMP_STL_DIR)/bsg_mem/bsg_ascii_to_rom.py $< bp_bootrom > $@
+
+BUILD_COLLATERAL  = $(addprefix $(BUILD_DIR)/, flist.vcs wrapper.v testbench.v test_bp.v)
+BUILD_COLLATERAL += $(addprefix $(BUILD_DIR)/, bootrom.riscv bootrom.bin bootrom.dump bp_bootrom.v)
 
 $(SIM_DIR)/simv $(SIM_DIR)/simv.daidir: $(BUILD_DIR)/simv $(BUILD_DIR)/simv.daidir
 	@ln -nsf $(<D)/$(@F) $@

--- a/bp_top/test/tb/bp_tethered/Makefile.vcs
+++ b/bp_top/test/tb/bp_tethered/Makefile.vcs
@@ -46,7 +46,7 @@ $(SIM_DIR)/bootrom.riscv: $(BP_TEST_MEM_DIR)/bootrom.riscv
 	cp $^ $@
 
 $(SIM_DIR)/bootrom.mem: $(SIM_DIR)/bootrom.bin
-	$(RISCV_OBJCOPY) -I binary $< -O verilog --verilog-data-width=4 $@
+	$(RISCV_OBJCOPY) -I binary $< -O verilog --reverse-bytes=4 --verilog-data-width=4 $@
 
 NBF_INPUTS = $(NCPUS)
 NBF_INPUTS += cce_ucode.mem

--- a/bp_top/test/tb/bp_tethered/Makefile.vcs
+++ b/bp_top/test/tb/bp_tethered/Makefile.vcs
@@ -7,23 +7,10 @@ $(LINT_DIR)/flist.vcs:
 	@echo wrapper.v                              >> $@ 
 	@echo testbench.v                            >> $@ 
 	@echo test_bp.v                              >> $@ 
-	@echo bp_bootrom.v							 >> $@
 	@echo "$(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_reset_gen.v" >> $@
 	@echo "$(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_clock_gen.v" >> $@
 
-$(LINT_DIR)/bootrom.riscv: $(BP_TEST_MEM_DIR)/bootrom.riscv
-	cp $^ $@
-
-XXD ?= xxd
-AWK ?= awk
-$(LINT_DIR)/bootrom.txt: $(LINT_DIR)/bootrom.bin
-	$(XXD) -b -c 4 $< | $(AWK) '{print $$2$$3$$4$$5}' > $@
-
-$(LINT_DIR)/bp_bootrom.v: $(LINT_DIR)/bootrom.txt
-	$(PYTHON) $(BASEJUMP_STL_DIR)/bsg_mem/bsg_ascii_to_rom.py $< bp_bootrom > $@
-
 LINT_COLLATERAL  = $(addprefix $(LINT_DIR)/, flist.vcs wrapper.v testbench.v test_bp.v)
-LINT_COLLATERAL += $(addprefix $(LINT_DIR)/, bootrom.riscv bootrom.bin bootrom.dump bp_bootrom.v)
 
 $(BUILD_DIR)/testbench.v $(BUILD_DIR)/wrapper.v $(BUILD_DIR)/test_bp.v:
 	@sed "s/BP_CFG_FLOWVAR/$(CFG)/g" $(TB_PATH)/$(TB)/$(@F) > $@
@@ -34,23 +21,10 @@ $(BUILD_DIR)/flist.vcs:
 	@echo wrapper.v                              >> $@ 
 	@echo testbench.v                            >> $@ 
 	@echo test_bp.v                              >> $@
-	@echo bp_bootrom.v							 >> $@
 	@echo "$(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_reset_gen.v" >> $@
 	@echo "$(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_clock_gen.v" >> $@
 
-$(BUILD_DIR)/bootrom.riscv: $(BP_TEST_MEM_DIR)/bootrom.riscv
-	cp $^ $@
-
-XXD ?= xxd
-AWK ?= awk
-$(BUILD_DIR)/bootrom.txt: $(BUILD_DIR)/bootrom.bin
-	$(XXD) -b -c 4 $< | $(AWK) '{print $$2$$3$$4$$5}' > $@
-
-$(BUILD_DIR)/bp_bootrom.v: $(BUILD_DIR)/bootrom.txt
-	$(PYTHON) $(BASEJUMP_STL_DIR)/bsg_mem/bsg_ascii_to_rom.py $< bp_bootrom > $@
-
 BUILD_COLLATERAL  = $(addprefix $(BUILD_DIR)/, flist.vcs wrapper.v testbench.v test_bp.v)
-BUILD_COLLATERAL += $(addprefix $(BUILD_DIR)/, bootrom.riscv bootrom.bin bootrom.dump bp_bootrom.v)
 
 $(SIM_DIR)/simv $(SIM_DIR)/simv.daidir: $(BUILD_DIR)/simv $(BUILD_DIR)/simv.daidir
 	@ln -nsf $(<D)/$(@F) $@
@@ -74,6 +48,12 @@ ifeq ($(PRELOAD_MEM_P), 0)
 	NBF_INPUTS += --mem=prog.mem
 endif
 
+$(SIM_DIR)/bootrom.riscv: $(BP_TEST_MEM_DIR)/bootrom.riscv
+	cp $^ $@
+
+$(SIM_DIR)/bootrom.mem: $(SIM_DIR)/bootrom.bin
+	$(RISCV_OBJCOPY) -I binary $< -O verilog --verilog-data-width=4 $@
+
 $(SIM_DIR)/prog.nbf: $(SIM_DIR)/cce_ucode.mem $(SIM_DIR)/prog.mem
 	cd $(@D); python $(MEM2NBF) $(NBF_INPUTS) > $@
 
@@ -81,6 +61,7 @@ SIM_COLLATERAL  = $(addprefix $(SIM_DIR)/, simv simv.daidir)
 SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, prog.riscv prog.elf prog.mem prog.nbf prog.dump)
 SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, cce_ucode.mem)
 SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, dram_ch.ini dram_sys.ini)
+SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, bootrom.riscv bootrom.bin bootrom.mem bootrom.dump)
 
 SAMPLE_COLLATERAL  = $(addprefix $(SIM_DIR)/, simv simv.daidir)
 SAMPLE_COLLATERAL += $(addprefix $(SIM_DIR)/, prog.riscv prog.elf prog.dump)

--- a/bp_top/test/tb/bp_tethered/Makefile.vcs
+++ b/bp_top/test/tb/bp_tethered/Makefile.vcs
@@ -42,17 +42,17 @@ $(SIM_DIR)/dram_ch.ini $(SIM_DIR)/dram_sys.ini:
 	@cp $(BP_COMMON_DIR)/test/cfg/$(DRAMSIM_CH_CFG) $(@D)/dram_ch.ini
 	@cp $(BP_COMMON_DIR)/test/cfg/$(DRAMSIM_SYS_CFG) $(@D)/dram_sys.ini
 
-NBF_INPUTS = $(NCPUS)
-NBF_INPUTS += cce_ucode.mem
-ifeq ($(PRELOAD_MEM_P), 0)
-	NBF_INPUTS += --mem=prog.mem
-endif
-
 $(SIM_DIR)/bootrom.riscv: $(BP_TEST_MEM_DIR)/bootrom.riscv
 	cp $^ $@
 
 $(SIM_DIR)/bootrom.mem: $(SIM_DIR)/bootrom.bin
 	$(RISCV_OBJCOPY) -I binary $< -O verilog --verilog-data-width=4 $@
+
+NBF_INPUTS = $(NCPUS)
+NBF_INPUTS += cce_ucode.mem
+ifeq ($(PRELOAD_MEM_P), 0)
+NBF_INPUTS += --mem=prog.mem
+endif
 
 $(SIM_DIR)/prog.nbf: $(SIM_DIR)/cce_ucode.mem $(SIM_DIR)/prog.mem
 	cd $(@D); python $(MEM2NBF) $(NBF_INPUTS) > $@
@@ -82,6 +82,7 @@ $(SIM_DIR)/run_samplev: $(SAMPLE_COLLATERAL)
 	$(RISCV_OBJCOPY) --change-addresses 0x80000000 -I binary -O elf64-littleriscv -B riscv \
 		$(@D)/prog.mainram $(@D)/prog.riscv
 	$(RISCV_OBJCOPY) -O verilog $(@D)/prog.riscv $(@D)/prog.mem
+	$(RISCV_OBJCOPY) -I binary -O verilog --verilog-data-width=4 $(@D)/prog.bootram $(@D)/bootrom.mem
 	cd $(@D); \
 		python $(MEM2NBF) $(NBF_INPUTS) --checkpoint=prog.bp_regs > prog.nbf
 	cd $(@D); \

--- a/bp_top/test/tb/bp_tethered/Makefile.verilator
+++ b/bp_top/test/tb/bp_tethered/Makefile.verilator
@@ -78,10 +78,17 @@ endif
 $(SIM_DIR)/prog.nbf: $(SIM_DIR)/cce_ucode.mem $(SIM_DIR)/prog.mem
 	cd $(@D); python $(MEM2NBF) $(NBF_INPUTS) > $@
 
+$(SIM_DIR)/bootrom.riscv: $(BP_TEST_MEM_DIR)/bootrom.riscv
+	cp $^ $@
+
+$(SIM_DIR)/bootrom.mem: $(SIM_DIR)/bootrom.bin
+	$(RISCV_OBJCOPY) -I binary $< -O verilog --verilog-data-width=4 $@
+
 SIM_COLLATERAL  = $(addprefix $(SIM_DIR)/, simsc)
 SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, prog.riscv prog.elf prog.mem prog.nbf prog.dump)
 SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, cce_ucode.mem)
 SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, dram_ch.ini dram_sys.ini)
+SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, bootrom.riscv bootrom.bin bootrom.mem bootrom.dump)
 
 sim_sample.sc: build.sc
 sim_sample.sc: $(SIM_DIR)/run_samplesc

--- a/bp_top/test/tb/bp_tethered/Makefile.verilator
+++ b/bp_top/test/tb/bp_tethered/Makefile.verilator
@@ -14,16 +14,7 @@ $(LINT_DIR)/config.vlt:
 $(LINT_DIR)/bootrom.riscv: $(BP_TEST_MEM_DIR)/bootrom.riscv
 	cp $^ $@
 
-XXD ?= xxd
-AWK ?= awk
-$(LINT_DIR)/bootrom.txt: $(LINT_DIR)/bootrom.bin
-	$(XXD) -b -c 4 $< | $(AWK) '{print $$2$$3$$4$$5}' > $@
-
-$(LINT_DIR)/bp_bootrom.v: $(LINT_DIR)/bootrom.txt
-	$(PYTHON) $(BASEJUMP_STL_DIR)/bsg_mem/bsg_ascii_to_rom.py $< bp_bootrom > $@
-
 LINT_COLLATERAL  = $(addprefix $(LINT_DIR)/, config.vlt flist.vcs wrapper.v testbench.v test_bp.cpp)
-LINT_COLLATERAL += $(addprefix $(LINT_DIR)/, bootrom.riscv bootrom.bin bootrom.dump bp_bootrom.v)
 
 $(BUILD_DIR)/testbench.v $(BUILD_DIR)/wrapper.v $(BUILD_DIR)/test_bp.cpp:
 	@sed "s/BP_CFG_FLOWVAR/$(CFG)/g" $(TB_PATH)/$(TB)/$(@F) > $@
@@ -49,9 +40,7 @@ $(BUILD_DIR)/bootrom.txt: $(BUILD_DIR)/bootrom.bin
 $(BUILD_DIR)/bp_bootrom.v: $(BUILD_DIR)/bootrom.txt
 	$(PYTHON) $(BASEJUMP_STL_DIR)/bsg_mem/bsg_ascii_to_rom.py $< bp_bootrom > $@
 
-VBUILD_COLLATERAL  = $(addprefix $(BUILD_DIR)/, config.vlt flist.vcs wrapper.v testbench.v test_bp.cpp)
-VBUILD_COLLATERAL += $(addprefix $(BUILD_DIR)/, bootrom.riscv bootrom.bin bootrom.dump bp_bootrom.v)
-CBUILD_COLLATERAL = none
+VBUILD_COLLATERAL = $(addprefix $(BUILD_DIR)/, config.vlt flist.vcs wrapper.v testbench.v test_bp.cpp)
 
 $(SIM_DIR)/simsc: $(BUILD_DIR)/obj_dir
 	@ln -nsf $</simsc $@
@@ -82,7 +71,7 @@ $(SIM_DIR)/bootrom.riscv: $(BP_TEST_MEM_DIR)/bootrom.riscv
 	cp $^ $@
 
 $(SIM_DIR)/bootrom.mem: $(SIM_DIR)/bootrom.bin
-	$(RISCV_OBJCOPY) -I binary $< -O verilog --verilog-data-width=4 $@
+	$(RISCV_OBJCOPY) -I binary $< -O verilog --reverse-bytes=4 --verilog-data-width=4 $@
 
 SIM_COLLATERAL  = $(addprefix $(SIM_DIR)/, simsc)
 SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, prog.riscv prog.elf prog.mem prog.nbf prog.dump)

--- a/bp_top/test/tb/bp_tethered/Makefile.verilator
+++ b/bp_top/test/tb/bp_tethered/Makefile.verilator
@@ -11,9 +11,6 @@ $(LINT_DIR)/flist.vcs:
 $(LINT_DIR)/config.vlt:
 	cat $(SYN_PATH)/lint_settings.verilator | envsubst > $@
 
-$(LINT_DIR)/bootrom.riscv: $(BP_TEST_MEM_DIR)/bootrom.riscv
-	cp $^ $@
-
 LINT_COLLATERAL  = $(addprefix $(LINT_DIR)/, config.vlt flist.vcs wrapper.v testbench.v test_bp.cpp)
 
 $(BUILD_DIR)/testbench.v $(BUILD_DIR)/wrapper.v $(BUILD_DIR)/test_bp.cpp:
@@ -28,17 +25,6 @@ $(BUILD_DIR)/flist.vcs:
 
 $(BUILD_DIR)/config.vlt:
 	cat $(SYN_PATH)/lint_settings.verilator | envsubst > $@
-
-$(BUILD_DIR)/bootrom.riscv: $(BP_TEST_MEM_DIR)/bootrom.riscv
-	cp $^ $@
-
-XXD ?= xxd
-AWK ?= awk
-$(BUILD_DIR)/bootrom.txt: $(BUILD_DIR)/bootrom.bin
-	$(XXD) -b -c 4 $< | $(AWK) '{print $$2$$3$$4$$5}' > $@
-
-$(BUILD_DIR)/bp_bootrom.v: $(BUILD_DIR)/bootrom.txt
-	$(PYTHON) $(BASEJUMP_STL_DIR)/bsg_mem/bsg_ascii_to_rom.py $< bp_bootrom > $@
 
 VBUILD_COLLATERAL = $(addprefix $(BUILD_DIR)/, config.vlt flist.vcs wrapper.v testbench.v test_bp.cpp)
 

--- a/bp_top/test/tb/bp_tethered/Makefile.verilator
+++ b/bp_top/test/tb/bp_tethered/Makefile.verilator
@@ -104,6 +104,7 @@ $(SIM_DIR)/run_samplesc: $(SIM_COLLATERAL)
 	$(RISCV_OBJCOPY) --change-addresses 0x80000000 -I binary -O elf64-littleriscv -B riscv \
 		$(@D)/prog.mainram $(@D)/prog.riscv
 	$(RISCV_OBJCOPY) -O verilog $(@D)/prog.riscv $(@D)/prog.mem
+	$(RISCV_OBJCOPY) -I binary -O verilog --verilog-data-width=4 $(@D)/prog.bootram $(@D)/bootrom.mem
 	cd $(@D); \
 		python $(MEM2NBF) $(NBF_INPUTS) --checkpoint=prog.bp_regs > prog.nbf
 	cd $(@D); \

--- a/bp_top/test/tb/bp_tethered/Makefile.verilator
+++ b/bp_top/test/tb/bp_tethered/Makefile.verilator
@@ -11,7 +11,19 @@ $(LINT_DIR)/flist.vcs:
 $(LINT_DIR)/config.vlt:
 	cat $(SYN_PATH)/lint_settings.verilator | envsubst > $@
 
-LINT_COLLATERAL = $(addprefix $(LINT_DIR)/, config.vlt flist.vcs wrapper.v testbench.v test_bp.cpp)
+$(LINT_DIR)/bootrom.riscv: $(BP_TEST_MEM_DIR)/bootrom.riscv
+	cp $^ $@
+
+XXD ?= xxd
+AWK ?= awk
+$(LINT_DIR)/bootrom.txt: $(LINT_DIR)/bootrom.bin
+	$(XXD) -b -c 4 $< | $(AWK) '{print $$2$$3$$4$$5}' > $@
+
+$(LINT_DIR)/bp_bootrom.v: $(LINT_DIR)/bootrom.txt
+	$(PYTHON) $(BASEJUMP_STL_DIR)/bsg_mem/bsg_ascii_to_rom.py $< bp_bootrom > $@
+
+LINT_COLLATERAL  = $(addprefix $(LINT_DIR)/, config.vlt flist.vcs wrapper.v testbench.v test_bp.cpp)
+LINT_COLLATERAL += $(addprefix $(LINT_DIR)/, bootrom.riscv bootrom.bin bootrom.dump bp_bootrom.v)
 
 $(BUILD_DIR)/testbench.v $(BUILD_DIR)/wrapper.v $(BUILD_DIR)/test_bp.cpp:
 	@sed "s/BP_CFG_FLOWVAR/$(CFG)/g" $(TB_PATH)/$(TB)/$(@F) > $@
@@ -26,7 +38,19 @@ $(BUILD_DIR)/flist.vcs:
 $(BUILD_DIR)/config.vlt:
 	cat $(SYN_PATH)/lint_settings.verilator | envsubst > $@
 
-VBUILD_COLLATERAL = $(addprefix $(BUILD_DIR)/, config.vlt flist.vcs wrapper.v testbench.v test_bp.cpp)
+$(BUILD_DIR)/bootrom.riscv: $(BP_TEST_MEM_DIR)/bootrom.riscv
+	cp $^ $@
+
+XXD ?= xxd
+AWK ?= awk
+$(BUILD_DIR)/bootrom.txt: $(BUILD_DIR)/bootrom.bin
+	$(XXD) -b -c 4 $< | $(AWK) '{print $$2$$3$$4$$5}' > $@
+
+$(BUILD_DIR)/bp_bootrom.v: $(BUILD_DIR)/bootrom.txt
+	$(PYTHON) $(BASEJUMP_STL_DIR)/bsg_mem/bsg_ascii_to_rom.py $< bp_bootrom > $@
+
+VBUILD_COLLATERAL  = $(addprefix $(BUILD_DIR)/, config.vlt flist.vcs wrapper.v testbench.v test_bp.cpp)
+VBUILD_COLLATERAL += $(addprefix $(BUILD_DIR)/, bootrom.riscv bootrom.bin bootrom.dump bp_bootrom.v)
 CBUILD_COLLATERAL = none
 
 $(SIM_DIR)/simsc: $(BUILD_DIR)/obj_dir

--- a/bp_top/test/tb/bp_tethered/flist.vcs
+++ b/bp_top/test/tb/bp_tethered/flist.vcs
@@ -10,7 +10,6 @@ $BP_ME_DIR/test/common/bp_mem.v
 $BP_ME_DIR/test/common/bp_mem_transducer.v
 $BP_ME_DIR/test/common/bp_mem_delay_model.v
 $BP_ME_DIR/test/common/bp_mem_storage_sync.v
-$BP_ME_DIR/test/common/bp_cce_mmio_cfg_loader.v
 $BP_ME_DIR/test/common/dramsim2_wrapper.cpp
 $BP_ME_DIR/test/common/bp_mem_utils.cpp
 $BP_ME_DIR/test/common/bp_me_nonsynth_cce_tracer.v

--- a/bp_top/test/tb/bp_tethered/flist.vcs
+++ b/bp_top/test/tb/bp_tethered/flist.vcs
@@ -1,5 +1,6 @@
 # bsg_ip_cores files
 $BASEJUMP_STL_DIR/bsg_fsb/bsg_fsb_node_trace_replay.v
+$BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_test_rom.v
 # be files
 $BP_BE_DIR/test/common/bp_be_nonsynth_perf.v
 $BP_BE_DIR/test/common/bp_be_nonsynth_npc_tracer.v

--- a/bp_top/test/tb/bp_tethered/testbench.v
+++ b/bp_top/test/tb/bp_tethered/testbench.v
@@ -187,9 +187,9 @@ bind bp_be_top
    commit_tracer
     (.clk_i(clk_i & (testbench.cmt_trace_p == 1))
      ,.reset_i(reset_i)
-     ,.freeze_i(scheduler.int_regfile.cfg_bus.freeze)
+     ,.freeze_i(calculator.pipe_sys.csr.cfg_bus_cast_i.freeze)
 
-     ,.mhartid_i(scheduler.int_regfile.cfg_bus.core_id)
+     ,.mhartid_i(calculator.pipe_sys.csr.cfg_bus_cast_i.core_id)
 
      ,.decode_i(calculator.reservation_n.decode)
 
@@ -208,14 +208,14 @@ bind bp_be_top
    cosim
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
-     ,.freeze_i(scheduler.int_regfile.cfg_bus.freeze)
+     ,.freeze_i(calculator.pipe_sys.csr.cfg_bus_cast_i.freeze)
 
      // We want to pass these values as parameters, but cannot in Verilator 4.025
      // Parameter-resolved constants must not use dotted references
      ,.en_i(testbench.cosim_p == 1)
      ,.checkpoint_i(testbench.checkpoint_p == 1)
      ,.num_core_i(testbench.num_core_p)
-     ,.mhartid_i(scheduler.int_regfile.cfg_bus.core_id)
+     ,.mhartid_i(calculator.pipe_sys.csr.cfg_bus_cast_i.core_id)
      ,.config_file_i(testbench.cosim_cfg_file_p)
      ,.instr_cap_i(testbench.cosim_instr_p)
      ,.memsize_i(testbench.cosim_memsize_p)
@@ -247,10 +247,10 @@ bind bp_be_top
    perf
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
-     ,.freeze_i(scheduler.int_regfile.cfg_bus.freeze)
+     ,.freeze_i(calculator.pipe_sys.csr.cfg_bus_cast_i.freeze)
      ,.warmup_instr_i(testbench.warmup_instr_p)
 
-     ,.mhartid_i(scheduler.int_regfile.cfg_bus.core_id)
+     ,.mhartid_i(calculator.pipe_sys.csr.cfg_bus_cast_i.core_id)
 
      ,.commit_v_i(calculator.commit_pkt.instret)
 
@@ -266,9 +266,9 @@ bind bp_be_top
      watchdog
       (.clk_i(clk_i)
        ,.reset_i(reset_i)
-       ,.freeze_i(scheduler.int_regfile.cfg_bus.freeze)
+       ,.freeze_i(calculator.pipe_sys.csr.cfg_bus_cast_i.freeze)
 
-       ,.mhartid_i(scheduler.int_regfile.cfg_bus.core_id)
+       ,.mhartid_i(calculator.pipe_sys.csr.cfg_bus_cast_i.core_id)
 
        ,.npc_i(director.npc_r)
        ,.instret_i(calculator.commit_pkt.instret)
@@ -280,9 +280,9 @@ bind bp_be_top
      npc_tracer
       (.clk_i(clk_i & (testbench.npc_trace_p == 1))
        ,.reset_i(reset_i)
-       ,.freeze_i(scheduler.int_regfile.cfg_bus.freeze)
+       ,.freeze_i(calculator.pipe_sys.csr.cfg_bus_cast_i.freeze)
 
-       ,.mhartid_i(scheduler.int_regfile.cfg_bus.core_id)
+       ,.mhartid_i(calculator.pipe_sys.csr.cfg_bus_cast_i.core_id)
 
        ,.npc_w_v(npc_w_v)
        ,.npc_n(npc_n)
@@ -408,9 +408,9 @@ bind bp_be_top
     vm_tracer
       (.clk_i(clk_i & (testbench.vm_trace_p == 1))
        ,.reset_i(reset_i)
-       ,.freeze_i(be.scheduler.int_regfile.cfg_bus.freeze)
+       ,.freeze_i(be.calculator.pipe_sys.csr.cfg_bus_cast_i.freeze)
 
-       ,.mhartid_i(be.scheduler.int_regfile.cfg_bus.core_id)
+       ,.mhartid_i(be.calculator.pipe_sys.csr.cfg_bus_cast_i.core_id)
 
        ,.itlb_clear_i(fe.mem.itlb.flush_i)
        ,.itlb_fill_v_i(fe.mem.itlb.v_i & fe.mem.itlb.w_i)
@@ -448,9 +448,9 @@ bind bp_be_top
      core_profiler
       (.clk_i(clk_i & (testbench.core_profile_p == 1))
        ,.reset_i(reset_i)
-       ,.freeze_i(be.scheduler.int_regfile.cfg_bus.freeze)
+       ,.freeze_i(be.calculator.pipe_sys.csr.cfg_bus_cast_i.freeze)
 
-       ,.mhartid_i(be.scheduler.int_regfile.cfg_bus.core_id)
+       ,.mhartid_i(be.calculator.pipe_sys.csr.cfg_bus_cast_i.core_id)
 
        ,.fe_wait_stall(fe.pc_gen.is_wait)
        ,.fe_queue_stall(~fe.pc_gen.fe_queue_ready_i)
@@ -496,9 +496,9 @@ bind bp_be_top
      pc_profiler
       (.clk_i(clk_i & (testbench.core_profile_p == 1))
        ,.reset_i(reset_i)
-       ,.freeze_i(be.scheduler.int_regfile.cfg_bus.freeze)
+       ,.freeze_i(be.calculator.pipe_sys.csr.cfg_bus_cast_i.freeze)
 
-       ,.mhartid_i(be.scheduler.int_regfile.cfg_bus.core_id)
+       ,.mhartid_i(be.calculator.pipe_sys.csr.cfg_bus_cast_i.core_id)
 
        ,.commit_pkt(be.calculator.commit_pkt)
 


### PR DESCRIPTION
- Adds a separately addressed bootrom to host
- Restores bootrom checking in dromajo
- Removes config bus read ports from module to reduce fanout and critical path

Depends on [BaseJump STL PR](https://github.com/bespoke-silicon-group/basejump_stl/pull/317)