### PR TITLE
Concentrator-based Design between UCE/CCE and Mem

### DIFF
--- a/bp_me/src/v/cache/bp_me_cce_to_cache.v
+++ b/bp_me/src/v/cache/bp_me_cce_to_cache.v
@@ -295,7 +295,7 @@ module bp_me_cce_to_cache
       end
       RESP_READY: begin
         is_resp_ready = 1'b1;
-        if (mem_cmd_v_lo)
+        if (mem_cmd_v_lo & cmd_state_r inside {READY, SEND})
           begin
             case (mem_cmd_lo.header.size)
               e_mem_msg_size_1

--- a/bp_me/src/v/wormhole/bp_me_cce_to_mem_link_master.v
+++ b/bp_me/src/v/wormhole/bp_me_cce_to_mem_link_master.v
@@ -64,6 +64,7 @@ bp_me_wormhole_packet_encode_mem_cmd
    ,.cord_width_p(cord_width_p)
    ,.cid_width_p(cid_width_p)
    ,.len_width_p(len_width_p)
+   ,.data_width_p(cce_block_width_p)
    )
  mem_cmd_encode
   (.mem_cmd_i(mem_cmd_cast_i)
@@ -80,6 +81,7 @@ bsg_wormhole_router_adapter
    ,.len_width_p(len_width_p)
    ,.cord_width_p(cord_width_p)
    ,.flit_width_p(flit_width_p)
+   ,.data_width_p(cce_block_width_p)
    )
  mem_adapter
   (.clk_i(clk_i)

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v
@@ -18,15 +18,16 @@ module bp_me_wormhole_packet_encode_mem_cmd
   import bp_me_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
     `declare_bp_proc_params(bp_params_p)
-    `declare_bp_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce_mem)
 
     , parameter flit_width_p = "inv"
     , parameter cord_width_p = "inv"
     , parameter cid_width_p = "inv"
     , parameter len_width_p = "inv"
+    , parameter data_width_p = "inv"
 
+    `declare_bp_mem_if_widths(paddr_width_p, data_width_p, lce_id_width_p, lce_assoc_p, cce_mem) 
     , localparam mem_cmd_packet_width_lp = 
-        `bp_mem_wormhole_packet_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-cce_block_width_p, cce_block_width_p)
+        `bp_mem_wormhole_packet_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-data_width_p, data_width_p)
     )
    (input [cce_mem_msg_width_lp-1:0]       mem_cmd_i
    
@@ -38,8 +39,8 @@ module bp_me_wormhole_packet_encode_mem_cmd
     , output [mem_cmd_packet_width_lp-1:0] packet_o
     );
 
-  `declare_bp_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce_mem);
-  `declare_bp_mem_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-cce_block_width_p, cce_block_width_p, bp_cmd_wormhole_packet_s);
+  `declare_bp_mem_if(paddr_width_p, data_width_p, lce_id_width_p, lce_assoc_p, cce_mem);
+  `declare_bp_mem_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-data_width_p, data_width_p, bp_cmd_wormhole_packet_s);
 
   bp_cce_mem_msg_s mem_cmd_cast_i;
   bp_cmd_wormhole_packet_s packet_cast_o;

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
@@ -18,15 +18,16 @@ module bp_me_wormhole_packet_encode_mem_resp
   import bp_me_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
     `declare_bp_proc_params(bp_params_p)
-    `declare_bp_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce_mem)
 
     , parameter flit_width_p = "inv"
     , parameter cord_width_p = "inv"
     , parameter cid_width_p = "inv"
     , parameter len_width_p = "inv"
+    , parameter data_width_p = "inv"
 
+    `declare_bp_mem_if_widths(paddr_width_p, data_width_p, lce_id_width_p, lce_assoc_p, cce_mem)
     , localparam mem_resp_packet_width_lp = 
-        `bp_mem_wormhole_packet_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-cce_block_width_p, cce_block_width_p)
+        `bp_mem_wormhole_packet_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-data_width_p, data_width_p)
     )
    (input [cce_mem_msg_width_lp-1:0]        mem_resp_i
     , input [cord_width_p-1:0]              src_cord_i
@@ -36,8 +37,8 @@ module bp_me_wormhole_packet_encode_mem_resp
     , output [mem_resp_packet_width_lp-1:0] packet_o
     );
 
-  `declare_bp_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce_mem);
-  `declare_bp_mem_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-cce_block_width_p, cce_block_width_p, bp_resp_wormhole_packet_s);
+  `declare_bp_mem_if(paddr_width_p, data_width_p, lce_id_width_p, lce_assoc_p, cce_mem);
+  `declare_bp_mem_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-data_width_p, data_width_p, bp_resp_wormhole_packet_s);
 
   bp_cce_mem_msg_s mem_resp_cast_i;
   bp_resp_wormhole_packet_s packet_cast_o;
@@ -70,7 +71,7 @@ module bp_me_wormhole_packet_encode_mem_resp
     packet_cast_o = '0;
 
     packet_cast_o.data       = mem_resp_cast_i.data;
-    packet_cast_o.msg        = mem_resp_cast_i[0+:cce_mem_msg_width_lp-cce_block_width_p];
+    packet_cast_o.msg        = mem_resp_cast_i[0+:cce_mem_msg_width_lp-data_width_p];
     packet_cast_o.src_cord   = src_cord_i;
     packet_cast_o.src_cid    = src_cid_i;
 


### PR DESCRIPTION
Progress code review on concentrator-based design between UCE and mem in unicore cfg

An interim version is implemented. (Schematics: Slide 5 @ https://docs.google.com/presentation/d/1zYQiMsIGADDS19U77o_-9BlmiorkVAnXTqtTkVT1oAg/edit?usp=sharing). This interim version works with multiple headers + data packets.

Note. It seems there is a significant mIPC drop compared to the baseline, perhaps because filt_width is set to be 64 and no extra FIFOs is added so that it can not do 1 uncached store / cycle.