### PR TITLE
Wrap around logic for ordering addresses sent to the memory

### DIFF
--- a/bp_me/src/v/cce/bp_uce.v
+++ b/bp_me/src/v/cce/bp_uce.v
@@ -581,7 +581,7 @@ module bp_uce
         e_send_critical:
           if (miss_v_li)
             begin
-              mem_cmd_cast_o.header.msg_type       = e_cce_mem_rd;
+              mem_cmd_cast_o.header.msg_type       = e_mem_msg_rd;
               mem_cmd_cast_o.header.addr           = critical_addr;
               mem_cmd_cast_o.header.size           = block_msg_size_lp;
               mem_cmd_cast_o.header.payload.way_id = lce_assoc_p'(cache_req_metadata_r.repl_way);

--- a/bp_me/src/v/cce/bp_uce.v
+++ b/bp_me/src/v/cce/bp_uce.v
@@ -307,7 +307,7 @@ module bp_uce
     end
   else 
     begin : fill_less_than_block
-      logic [fill_cnt_width_lp-1:0] first_addr, last_addr;
+      logic [fill_cnt_width_lp-1:0] first_cmd_cnt, last_cmd_cnt;
       logic [fill_cnt_width_lp-1:0] fill_cnt;
       bsg_counter_clear_up
        #(.max_val_p(block_size_in_fill_lp-1)
@@ -333,14 +333,14 @@ module bp_uce
 
         ,.set_i(cache_req_v_i)
         ,.en_i(mem_cmd_up)
-        ,.val_i(first_addr)
+        ,.val_i(first_cmd_cnt)
         ,.count_o(mem_cmd_cnt)
         );
       
-      assign first_addr = cache_req_cast_i.addr[block_offset_width_lp-1-:fill_cnt_width_lp];
-      assign last_addr = (cache_req_r.addr[block_offset_width_lp-1-:fill_cnt_width_lp] - fill_cnt_width_lp'(1));
-      assign mem_cmd_done = cache_req_v_r & (mem_cmd_cnt == last_addr);
-      assign critical_addr = {cache_req_r.addr[paddr_width_p-1-:(paddr_width_p-fill_offset_width_lp)], (fill_offset_width_lp)'(0)};
+      assign first_cmd_cnt = cache_req_cast_i.addr[block_offset_width_lp-1-:fill_cnt_width_lp];
+      assign last_cmd_cnt = (cache_req_r.addr[fill_offset_width_lp+:fill_cnt_width_lp] - fill_cnt_width_lp'(1));
+      assign mem_cmd_done = cache_req_v_r & (mem_cmd_cnt == last_cmd_cnt);
+      assign critical_addr = {cache_req_r.addr[paddr_width_p-1:fill_offset_width_lp], (fill_offset_width_lp)'(0)};
     end
 
   logic [index_width_lp-1:0] index_cnt;

--- a/bp_me/src/v/cce/bp_uce.v
+++ b/bp_me/src/v/cce/bp_uce.v
@@ -283,7 +283,7 @@ module bp_uce
   logic [fill_cnt_width_lp-1:0] mem_cmd_cnt;
   logic [block_size_in_fill_lp-1:0] fill_index_shift;
   logic [bank_offset_width_lp-1:0] bank_index;
-  logic [fill_cnt_width_lp-1:0] mem_cmd_init_slice, mem_cmd_init_slice_r;
+  logic [fill_cnt_width_lp-1:0] mem_cmd_init_slice, mem_cmd_final_slice;
   logic [paddr_width_p-1:0] critical_addr;
 
   if (fill_size_in_bank_lp == 1)
@@ -337,10 +337,8 @@ module bp_uce
         );
       
       assign mem_cmd_init_slice = cache_req_cast_i.addr[block_offset_width_lp-1-:fill_cnt_width_lp]; 
-      assign mem_cmd_init_slice_r = cache_req_r.addr[block_offset_width_lp-1-:fill_cnt_width_lp]; 
-      assign mem_cmd_done = (mem_cmd_init_slice_r == fill_cnt_width_lp'(0))
-                            ? cache_req_v_r & (mem_cmd_cnt == ((1'b1 << fill_cnt_width_lp)-1))
-                            : cache_req_v_r & (mem_cmd_cnt == (mem_cmd_init_slice_r-1));
+      assign mem_cmd_final_slice = (cache_req_r.addr[block_offset_width_lp-1-:fill_cnt_width_lp] + {fill_cnt_width_lp{1'b1}});
+      assign mem_cmd_done = cache_req_v_r & (mem_cmd_cnt == mem_cmd_final_slice);
       assign critical_addr = {cache_req_r.addr[paddr_width_p-1:(block_offset_width_lp-fill_cnt_width_lp)], (block_offset_width_lp-fill_cnt_width_lp)'(0)};
     end
 

--- a/docs/interface_specification.md
+++ b/docs/interface_specification.md
@@ -152,7 +152,6 @@ A UCE implementation must support the following operations:
 - Handle both uncached and cached requests
 - Support both write-through and write-back protocols
 - Support credit-based flow control, to support fencing in the core
-- Support ordering addresses starting from the requested address (aligned based on the fill width), continuing with the higher addresses and wrapping around to the lower addresses
 
 The request interface is ready-valid and uses a parameterized struct to pass arguments,
 bp_cache_req_s, which contains the following fields.
@@ -225,6 +224,11 @@ A memory command or response packet is composed of:
   - Coherence state
   - Whether this is a speculative request
 - Data
+
+Misaligned addresses return data wrapped around the request size using the following scheme:
+
+Request: 0x0 [d c b a]
+Request: 0x2 [b a d c]
 
 ## LCE-CCE Interface
 

--- a/docs/interface_specification.md
+++ b/docs/interface_specification.md
@@ -152,6 +152,7 @@ A UCE implementation must support the following operations:
 - Handle both uncached and cached requests
 - Support both write-through and write-back protocols
 - Support credit-based flow control, to support fencing in the core
+- Support ordering addresses starting from the requested address (aligned based on the fill width), continuing with the higher addresses and wrapping around to the lower addresses
 
 The request interface is ready-valid and uses a parameterized struct to pass arguments,
 bp_cache_req_s, which contains the following fields.


### PR DESCRIPTION
This PR adds support for sending the critical fill address request first over the mem_cmd signal in the UCE. The higher fill addresses follow and a wrap around to the lower fill addresses occurs once the highest fill address of the current block is sent.