### PR TITLE
Merging the store data into the store miss response

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -70,6 +70,7 @@ module bp_be_calculator_top
   , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
   , output logic                                    cache_req_metadata_v_o
   , input                                           cache_req_critical_i
+  , input                                           cache_req_safe_i
   , input                                           cache_req_complete_i
 
   // data_mem
@@ -306,6 +307,7 @@ module bp_be_calculator_top
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
      ,.cache_req_critical_i(cache_req_critical_i)
+     ,.cache_req_safe_i(cache_req_safe_i)
      ,.cache_req_complete_i(cache_req_complete_i)
 
      ,.data_mem_pkt_i(data_mem_pkt_i)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.v
@@ -68,6 +68,7 @@ module bp_be_pipe_mem
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
    , input                                           cache_req_critical_i
+   , input                                           cache_req_safe_i
    , input                                           cache_req_complete_i
 
    // data_mem
@@ -273,6 +274,7 @@ module bp_be_pipe_mem
       ,.cache_req_metadata_o(cache_req_metadata_o)
       ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
       ,.cache_req_critical_i(cache_req_critical_i)
+      ,.cache_req_safe_i(cache_req_safe_i)
       ,.cache_req_complete_i(cache_req_complete_i)
 
       ,.data_mem_pkt_v_i(data_mem_pkt_v_i)

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -647,8 +647,8 @@ module bp_be_dcache
     cache_req_cast_o = '0;
 
     // Assigning sizes to cache miss packet
-    if (uncached_tv_r | wt_req | l2_amo_req) begin
-      if (decode_tv_r.double_op)
+    if (uncached_tv_r | wt_req | l2_amo_req | store_miss_tv) begin
+      unique if (decode_tv_r.double_op)
         cache_req_cast_o.size = e_size_8B;
       else if (decode_tv_r.word_op)
         cache_req_cast_o.size = e_size_4B;
@@ -656,6 +656,8 @@ module bp_be_dcache
         cache_req_cast_o.size = e_size_2B;
       else if (decode_tv_r.byte_op)
         cache_req_cast_o.size = e_size_1B;
+      else
+        cache_req_cast_o.size = e_size_8B;
     end
     else
       cache_req_cast_o.size = e_size_64B;
@@ -712,7 +714,7 @@ module bp_be_dcache
     end
 
     cache_req_cast_o.addr = paddr_tv_r;
-    cache_req_cast_o.data = data_tv_r;
+    cache_req_cast_o.data = store_miss_tv ? wbuf_entry_in.data : data_tv_r;
   end
 
   // Cache metadata is valid after the request goes out

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -145,6 +145,7 @@ module bp_be_dcache
 
     , input cache_req_complete_i
     , input cache_req_critical_i
+    , input cache_req_safe_i
 
     // data_mem
     , input data_mem_pkt_v_i
@@ -745,7 +746,7 @@ module bp_be_dcache
      ,.clear_i(cache_req_complete_i)
      ,.data_o(cache_miss_r)
      );
-  assign ready_o = cache_req_ready_i & ~cache_miss_r;
+  assign ready_o = (cache_req_ready_i & ~cache_miss_r) | cache_req_safe_i;
 
   assign early_v_o = v_tv_r & ((uncached_tv_r & (decode_tv_r.load_op & uncached_load_data_v_r))
                               | (uncached_tv_r & (decode_tv_r.store_op & cache_req_ready_i))

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -746,7 +746,7 @@ module bp_be_dcache
      ,.clear_i(cache_req_complete_i)
      ,.data_o(cache_miss_r)
      );
-  assign ready_o = (cache_req_ready_i & ~cache_miss_r) | cache_req_safe_i;
+  assign ready_o = cache_req_ready_i & ~cache_miss_r;
 
   assign early_v_o = v_tv_r & ((uncached_tv_r & (decode_tv_r.load_op & uncached_load_data_v_r))
                               | (uncached_tv_r & (decode_tv_r.store_op & cache_req_ready_i))

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -715,7 +715,7 @@ module bp_be_dcache
     end
 
     cache_req_cast_o.addr = paddr_tv_r;
-    cache_req_cast_o.data = store_miss_tv ? wbuf_entry_in.data : data_tv_r;
+    cache_req_cast_o.data = wbuf_entry_in.data;
   end
 
   // Cache metadata is valid after the request goes out

--- a/bp_be/src/v/bp_be_top.v
+++ b/bp_be/src/v/bp_be_top.v
@@ -52,6 +52,7 @@ module bp_be_top
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
    , input                                           cache_req_critical_i
+   , input                                           cache_req_safe_i
    , input                                           cache_req_complete_i
 
    // data_mem
@@ -220,6 +221,7 @@ module bp_be_top
      ,.cache_req_ready_i(cache_req_ready_i)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
      ,.cache_req_critical_i(cache_req_critical_i)
+     ,.cache_req_safe_i(cache_req_safe_i)
      ,.cache_req_complete_i(cache_req_complete_i)
 
      ,.data_mem_pkt_v_i(data_mem_pkt_v_i)

--- a/bp_be/syn/flist.vcs
+++ b/bp_be/syn/flist.vcs
@@ -222,6 +222,7 @@ $BP_FE_DIR/src/v/bp_fe_top.v
 $BP_ME_DIR/src/v/lce/bp_lce.v
 $BP_ME_DIR/src/v/lce/bp_lce_req.v
 $BP_ME_DIR/src/v/lce/bp_lce_cmd.v
+$BP_ME_DIR/src/v/lce/bp_store_data_merge.v
 # Cache
 $BP_ME_DIR/src/v/cache/bp_me_cache_dma_to_cce.v
 $BP_ME_DIR/src/v/cache/bp_me_cache_slice.v

--- a/bp_fe/src/v/bp_fe_icache.v
+++ b/bp_fe/src/v/bp_fe_icache.v
@@ -77,6 +77,7 @@ module bp_fe_icache
 
     , input                                            cache_req_complete_i
     , input                                            cache_req_critical_i
+    , input                                            cache_req_safe_i
 
     // data_mem
     , input data_mem_pkt_v_i
@@ -385,7 +386,7 @@ module bp_fe_icache
      ,.data_o(cache_miss)
      );
 
-  assign vaddr_ready_o = cache_req_ready_i & ~cache_miss & ~cache_req_v_o;
+  assign vaddr_ready_o = (cache_req_ready_i & ~cache_miss & ~cache_req_v_o) | cache_req_safe_i;
 
   assign data_v_o = v_tv_r & ((uncached_tv_r & uncached_load_data_v_r)
                               | (~uncached_tv_r & ~fencei_op_tv_r & ~miss_tv)

--- a/bp_fe/src/v/bp_fe_icache.v
+++ b/bp_fe/src/v/bp_fe_icache.v
@@ -386,7 +386,7 @@ module bp_fe_icache
      ,.data_o(cache_miss)
      );
 
-  assign vaddr_ready_o = (cache_req_ready_i & ~cache_miss & ~cache_req_v_o) | cache_req_safe_i;
+  assign vaddr_ready_o = cache_req_ready_i & ~cache_miss & ~cache_req_v_o;
 
   assign data_v_o = v_tv_r & ((uncached_tv_r & uncached_load_data_v_r)
                               | (~uncached_tv_r & ~fencei_op_tv_r & ~miss_tv)

--- a/bp_fe/src/v/bp_fe_mem.v
+++ b/bp_fe/src/v/bp_fe_mem.v
@@ -51,6 +51,7 @@ module bp_fe_mem
 
    , input                                            cache_req_complete_i
    , input                                            cache_req_critical_i
+   , input                                            cache_req_safe_i
 
    , input [icache_data_mem_pkt_width_lp-1:0]         data_mem_pkt_i
    , input                                            data_mem_pkt_v_i
@@ -177,6 +178,7 @@ bp_fe_icache
 
    ,.cache_req_complete_i(cache_req_complete_i)
    ,.cache_req_critical_i(cache_req_critical_i)
+   ,.cache_req_safe_i(cache_req_safe_i)
 
    ,.data_mem_pkt_i(data_mem_pkt_i)
    ,.data_mem_pkt_v_i(data_mem_pkt_v_i)

--- a/bp_fe/src/v/bp_fe_top.v
+++ b/bp_fe/src/v/bp_fe_top.v
@@ -52,6 +52,7 @@ module bp_fe_top
 
    , input                                            cache_req_complete_i
    , input                                            cache_req_critical_i
+   , input                                            cache_req_safe_i
    , input [icache_data_mem_pkt_width_lp-1:0]         data_mem_pkt_i
    , input                                            data_mem_pkt_v_i
    , output logic                                     data_mem_pkt_yumi_o
@@ -131,6 +132,7 @@ bp_fe_mem
 
    ,.cache_req_complete_i(cache_req_complete_i)
    ,.cache_req_critical_i(cache_req_critical_i)
+   ,.cache_req_safe_i(cache_req_safe_i)
 
    ,.data_mem_pkt_i(data_mem_pkt_i)
    ,.data_mem_pkt_v_i(data_mem_pkt_v_i)

--- a/bp_me/src/v/cce/bp_uce.v
+++ b/bp_me/src/v/cce/bp_uce.v
@@ -359,7 +359,9 @@ module bp_uce
     )
     store_data_merge
      (.data0_i(mem_resp_cast_i.data[0+:fill_width_p])
-      ,.cache_req_i(cache_req_r)
+      ,.data1_i(cache_req_r.data)
+      ,.addr_i(cache_req_r.addr)
+      ,.size_i(cache_req_r.size)
       ,.write_v_i(miss_store_v_li & (fill_cnt == '0))
       ,.data_o(data_to_l1)
       );

--- a/bp_me/src/v/cce/bp_uce.v
+++ b/bp_me/src/v/cce/bp_uce.v
@@ -601,7 +601,7 @@ module bp_uce
         e_send_critical:
           if (miss_v_li)
             begin
-              mem_cmd_cast_o.header.msg_type       = e_cce_mem_rd;
+              mem_cmd_cast_o.header.msg_type       = e_mem_msg_rd;
               mem_cmd_cast_o.header.addr           = critical_addr;
               mem_cmd_cast_o.header.size           = block_msg_size_lp;
               mem_cmd_cast_o.header.payload.way_id = lce_assoc_p'(cache_req_metadata_r.repl_way);

--- a/bp_me/src/v/cce/bp_uce.v
+++ b/bp_me/src/v/cce/bp_uce.v
@@ -56,6 +56,7 @@ module bp_uce
     , input                                          cache_req_metadata_v_i
     , output logic                                   cache_req_complete_o
     , output logic                                   cache_req_critical_o
+    , output logic                                   cache_req_safe_o
 
     , output logic [cache_tag_mem_pkt_width_lp-1:0]  tag_mem_pkt_o
     , output logic                                   tag_mem_pkt_v_o
@@ -465,6 +466,7 @@ module bp_uce
 
       cache_req_complete_o = '0;
       cache_req_critical_o = '0;
+      cache_req_safe_o = '0;
 
       mem_cmd_cast_o   = '0;
       mem_cmd_v_o      = '0;
@@ -729,6 +731,7 @@ module bp_uce
             data_mem_pkt_v_o = load_resp_v_li;
 
             cache_req_complete_o = data_mem_pkt_yumi_i;
+            cache_req_safe_o = '0;
             mem_resp_yumi_lo = cache_req_complete_o;
 
             state_n = cache_req_complete_o ? e_ready : e_uc_read_wait;

--- a/bp_me/src/v/lce/bp_lce.v
+++ b/bp_me/src/v/lce/bp_lce.v
@@ -84,6 +84,7 @@ module bp_lce
 
     , output logic                                   cache_req_complete_o
     , output logic                                   cache_req_critical_o
+    , output logic                                   cache_req_safe_o
 
     // LCE-CCE interface
     // Req: ready->valid
@@ -194,6 +195,7 @@ module bp_lce
       ,.sync_done_o(cmd_sync_done_lo)
       ,.cache_req_complete_o(cache_req_complete_o)
       ,.cache_req_critical_o(cache_req_critical_o)
+      ,.cache_req_safe_o(cache_req_safe_o)
       ,.uc_store_req_complete_o(uc_store_req_complete_lo)
 
       ,.data_mem_pkt_o(data_mem_pkt)

--- a/bp_me/src/v/lce/bp_lce.v
+++ b/bp_me/src/v/lce/bp_lce.v
@@ -234,6 +234,7 @@ module bp_lce
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
+     // The condition for clear should change when partial fill is supported
      ,.clear_i(cache_req_complete_o | uc_store_req_complete_lo)
      ,.set_i((cache_req_r.msg_type == e_miss_store) & lce_req_v_o)
      ,.data_o(store_miss)
@@ -248,7 +249,9 @@ module bp_lce
     )
     store_data_merge
      (.data0_i(data_mem_pkt.data)
-      ,.cache_req_i(cache_req_r)
+      ,.data1_i(cache_req_r.data)
+      ,.addr_i(cache_req_r.addr)
+      ,.size_i(cache_req_r.size)
       ,.write_v_i(store_miss)
       ,.data_o(data_to_l1)
       );

--- a/bp_me/src/v/lce/bp_lce_cmd.v
+++ b/bp_me/src/v/lce/bp_lce_cmd.v
@@ -95,6 +95,7 @@ module bp_lce_cmd
     // cache_req_complete_o is routed to the cache to indicate a blocking request is complete
     , output logic                                   cache_req_complete_o
     , output logic                                   cache_req_critical_o
+    , output logic                                   cache_req_safe_o
     // uncached store request complete is used by the LCE to decrement the request credit counter
     // when an uncached store complete, but is not routed to the cache because the caches do not
     // block (miss) on uncached stores
@@ -271,6 +272,7 @@ module bp_lce_cmd
     cache_req_complete_o = 1'b0;
     //TODO: support partial fill, currently not supported
     cache_req_critical_o = 1'b0;
+    cache_req_safe_o = 1'b0;
 
     // LCE-CCE Interface signals
     lce_cmd_yumi_o = 1'b0;

--- a/bp_me/src/v/lce/bp_lce_req.v
+++ b/bp_me/src/v/lce/bp_lce_req.v
@@ -73,6 +73,7 @@ module bp_lce_req
     , input                                          cache_req_v_i
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
+    , output [cache_req_width_lp-1:0]                cache_req_r_o
 
     // LCE-Cache Interface
     , output logic                                   credits_full_o
@@ -155,6 +156,8 @@ module bp_lce_req
      ,.data_i(cache_req_metadata_i)
      ,.data_o(cache_req_metadata_r)
      );
+
+  assign cache_req_r_o = cache_req_r;
 
   // Outstanding request credit counter
   logic [`BSG_WIDTH(credits_p)-1:0] credit_count_lo;

--- a/bp_me/src/v/lce/bp_store_data_merge.v
+++ b/bp_me/src/v/lce/bp_store_data_merge.v
@@ -1,0 +1,102 @@
+/**
+ *  Name:
+ *    bp_store_data_merge.v
+ *
+ *
+ *  Description:
+ *    Common module performing the merging of store data into the incoming
+ *    memory packet
+ *
+ */
+
+module bp_store_data_merge
+  import bp_common_pkg::*;
+  import bp_common_aviary_pkg::*;
+ #(parameter bp_params_e bp_params_p = e_bp_inv_cfg
+   `declare_bp_proc_params(bp_params_p)
+
+   , parameter assoc_p       = "inv"
+   , parameter sets_p        = "inv"
+   , parameter block_width_p = "inv"
+   , parameter fill_width_p  = block_width_p
+
+   , localparam bank_width_lp          = block_width_p / assoc_p
+   , localparam num_dwords_per_fill_lp = fill_width_p/ dword_width_p
+   , localparam byte_offset_width_lp   = `BSG_SAFE_CLOG2(bank_width_lp>>3)
+   , localparam bank_offset_width_lp   = `BSG_SAFE_CLOG2(assoc_p)
+   , localparam block_offset_width_lp  = (bank_offset_width_lp + byte_offset_width_lp)
+   , localparam block_size_in_fill_lp  = block_width_p / fill_width_p
+   , localparam fill_cnt_width_lp      = `BSG_SAFE_CLOG2(block_size_in_fill_lp)
+
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache)
+  )
+  (
+    input [fill_width_p-1:0] data0_i
+    , input [cache_req_width_lp-1:0] cache_req_i
+
+    , input write_v_i
+    , output [fill_width_p-1:0] data_o
+  );
+
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache);
+
+  `bp_cast_i(bp_cache_req_s, cache_req);
+
+  logic [`BSG_SAFE_CLOG2(fill_width_p)-1:0] addr_fill_slice;
+  logic [5:0] byte_select;
+  logic [fill_width_p-1:0] write_mask;
+
+  if (fill_width_p == 64)
+    begin : fill_dword
+      assign addr_fill_slice = '0;
+    end
+  else if (fill_width_p == block_width_p)
+    begin : fill_block
+      assign addr_fill_slice = (cache_req_cast_i.addr[block_offset_width_lp-1:3] << 6);
+    end
+  else 
+    begin : fill_chunks
+      assign addr_fill_slice = (cache_req_cast_i.addr[block_offset_width_lp-fill_cnt_width_lp-1:3] << 6);
+    end
+
+  assign byte_select = (cache_req_cast_i.addr[2:0] << 3);
+
+  bsg_mux_bitwise
+   #(.width_p(fill_width_p))
+    write_merge_mux
+     (.data0_i(data0_i)
+      ,.data1_i({num_dwords_per_fill_lp{cache_req_cast_i.data}})
+      ,.sel_i(write_mask)
+      ,.data_o(data_o)
+      );
+
+  always_comb
+    begin
+      if (write_v_i) begin
+        case(cache_req_cast_i.size)
+          e_size_1B:
+            begin
+              write_mask = fill_width_p'(({8{1'b1}} << addr_fill_slice) << byte_select);
+            end
+          e_size_2B:
+            begin
+              write_mask = fill_width_p'(({16{1'b1}} << addr_fill_slice) << byte_select);
+            end
+          e_size_4B:
+            begin
+              write_mask = fill_width_p'(({32{1'b1}} << addr_fill_slice) << byte_select);
+            end
+          e_size_8B:
+            begin
+              write_mask = fill_width_p'(({64{1'b1}} << addr_fill_slice) << byte_select);
+            end
+          default: 
+            begin
+              write_mask = fill_width_p'(({64{1'b1}} << addr_fill_slice) << byte_select);
+            end
+        endcase
+      end else
+        write_mask = '0;
+    end
+
+endmodule    

--- a/bp_top/src/v/bp_core.v
+++ b/bp_top/src/v/bp_core.v
@@ -129,6 +129,7 @@ module bp_core
 
      ,.dcache_req_complete_i(dcache_req_complete_lo)
      ,.dcache_req_critical_i(dcache_req_critical_lo)
+     ,.dcache_req_safe_i('0)
 
      ,.icache_req_o(icache_req_cast_lo)
      ,.icache_req_v_o(icache_req_v_lo)
@@ -138,6 +139,7 @@ module bp_core
 
      ,.icache_req_complete_i(icache_req_complete_lo)
      ,.icache_req_critical_i(icache_req_critical_lo)
+     ,.icache_req_safe_i('0)
      // response side - Interface from D$ LCE
      ,.dcache_data_mem_pkt_i(dcache_data_mem_pkt_li)
      ,.dcache_data_mem_pkt_v_i(dcache_data_mem_pkt_v_li)

--- a/bp_top/src/v/bp_core.v
+++ b/bp_top/src/v/bp_core.v
@@ -71,6 +71,7 @@ module bp_core
 
   logic icache_req_complete_lo, dcache_req_complete_lo;
   logic icache_req_critical_lo, dcache_req_critical_lo;
+  logic icache_req_safe_lo, dcache_req_safe_lo;
   logic dcache_credits_full_lo, dcache_credits_empty_lo;
 
   logic [1:0] lr_hit_lo;
@@ -129,7 +130,7 @@ module bp_core
 
      ,.dcache_req_complete_i(dcache_req_complete_lo)
      ,.dcache_req_critical_i(dcache_req_critical_lo)
-     ,.dcache_req_safe_i('0)
+     ,.dcache_req_safe_i(dcache_req_safe_lo)
 
      ,.icache_req_o(icache_req_cast_lo)
      ,.icache_req_v_o(icache_req_v_lo)
@@ -139,7 +140,7 @@ module bp_core
 
      ,.icache_req_complete_i(icache_req_complete_lo)
      ,.icache_req_critical_i(icache_req_critical_lo)
-     ,.icache_req_safe_i('0)
+     ,.icache_req_safe_i(icache_req_safe_lo)
      // response side - Interface from D$ LCE
      ,.dcache_data_mem_pkt_i(dcache_data_mem_pkt_li)
      ,.dcache_data_mem_pkt_v_i(dcache_data_mem_pkt_v_li)
@@ -205,6 +206,7 @@ module bp_core
 
      ,.cache_req_complete_o(icache_req_complete_lo)
      ,.cache_req_critical_o(icache_req_critical_lo)
+     ,.cache_req_safe_o(icache_req_safe_lo)
 
      ,.data_mem_pkt_o(icache_data_mem_pkt_li)
      ,.data_mem_pkt_v_o(icache_data_mem_pkt_v_li)
@@ -269,6 +271,7 @@ module bp_core
 
      ,.cache_req_complete_o(dcache_req_complete_lo)
      ,.cache_req_critical_o(dcache_req_critical_lo)
+     ,.cache_req_safe_o(dcache_req_safe_lo)
 
      ,.data_mem_pkt_o(dcache_data_mem_pkt_li)
      ,.data_mem_pkt_v_o(dcache_data_mem_pkt_v_li)

--- a/bp_top/src/v/bp_core_minimal.v
+++ b/bp_top/src/v/bp_core_minimal.v
@@ -40,6 +40,7 @@ module bp_core_minimal
 
     , input dcache_req_complete_i
     , input dcache_req_critical_i
+    , input dcache_req_safe_i
 
     , output logic [icache_req_width_lp-1:0] icache_req_o
     , output logic icache_req_v_o
@@ -49,6 +50,7 @@ module bp_core_minimal
 
     , input icache_req_complete_i
     , input icache_req_critical_i
+    , input icache_req_safe_i
 
     // D$ response interface
     , input [dcache_data_mem_pkt_width_lp-1:0] dcache_data_mem_pkt_i
@@ -122,6 +124,7 @@ module bp_core_minimal
      ,.cache_req_metadata_v_o(icache_req_metadata_v_o)
      ,.cache_req_complete_i(icache_req_complete_i)
      ,.cache_req_critical_i(icache_req_critical_i)
+     ,.cache_req_safe_i(icache_req_safe_i)
 
      ,.data_mem_pkt_i(icache_data_mem_pkt_i)
      ,.data_mem_pkt_v_i(icache_data_mem_pkt_v_i)
@@ -213,6 +216,7 @@ module bp_core_minimal
 
      ,.cache_req_complete_i(dcache_req_complete_i)
      ,.cache_req_critical_i(dcache_req_critical_i)
+     ,.cache_req_safe_i(dcache_req_safe_i)
 
      ,.data_mem_pkt_i(dcache_data_mem_pkt_i)
      ,.data_mem_pkt_v_i(dcache_data_mem_pkt_v_i)

--- a/bp_top/src/v/bp_unicore.v
+++ b/bp_top/src/v/bp_unicore.v
@@ -88,6 +88,7 @@ module bp_unicore
 
   logic dcache_req_complete_li, icache_req_complete_li;
   logic dcache_req_critical_li, icache_req_critical_li;
+  logic dcache_req_safe_li, icache_req_safe_li;
 
   logic [1:0] credits_full_li, credits_empty_li;
   logic timer_irq_li, software_irq_li, external_irq_li;
@@ -141,6 +142,7 @@ module bp_unicore
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
      ,.dcache_req_complete_i(dcache_req_complete_li)
      ,.dcache_req_critical_i(dcache_req_critical_li)
+     ,.dcache_req_safe_i(dcache_req_safe_li)
 
      ,.icache_req_o(icache_req_lo)
      ,.icache_req_v_o(icache_req_v_lo)
@@ -149,6 +151,7 @@ module bp_unicore
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
      ,.icache_req_complete_i(icache_req_complete_li)
      ,.icache_req_critical_i(icache_req_critical_li)
+     ,.icache_req_safe_i(icache_req_safe_li)
 
      ,.dcache_tag_mem_pkt_i(dcache_tag_mem_pkt_li)
      ,.dcache_tag_mem_pkt_v_i(dcache_tag_mem_pkt_v_li)
@@ -229,6 +232,7 @@ module bp_unicore
 
     ,.cache_req_complete_o(dcache_req_complete_li)
     ,.cache_req_critical_o(dcache_req_critical_li)
+    ,.cache_req_safe_o(dcache_req_safe_li)
 
     ,.credits_full_o(credits_full_li[1])
     ,.credits_empty_o(credits_empty_li[1])
@@ -278,6 +282,7 @@ module bp_unicore
 
     ,.cache_req_complete_o(icache_req_complete_li)
     ,.cache_req_critical_o(icache_req_critical_li)
+    ,.cache_req_safe_o(icache_req_safe_li)
 
     ,.credits_full_o(credits_full_li[0])
     ,.credits_empty_o(credits_empty_li[0])

--- a/bp_top/src/v/bp_unicore.v
+++ b/bp_top/src/v/bp_unicore.v
@@ -13,27 +13,27 @@ module bp_unicore
    `declare_bp_proc_params(bp_params_p)
   
    , localparam uce_mem_data_width_lp = `BSG_MAX(icache_fill_width_p, dcache_fill_width_p) 
-   `declare_bp_mem_if_widths(paddr_width_p, uce_mem_data_width_lp, lce_id_width_p, lce_assoc_p, uce_mem)
    `declare_bp_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce_mem)
+   `declare_bp_mem_if_widths(paddr_width_p, uce_mem_data_width_lp, lce_id_width_p, lce_assoc_p, uce_mem)
    )
-  (  input                                               clk_i
+  (  input                                             clk_i
    , input                                             reset_i
 
    // Outgoing I/O
-   , output [cce_mem_msg_width_lp-1:0]                 io_cmd_o
+   , output [uce_mem_msg_width_lp-1:0]                 io_cmd_o
    , output                                            io_cmd_v_o
    , input                                             io_cmd_ready_i
 
-   , input [cce_mem_msg_width_lp-1:0]                  io_resp_i
+   , input [uce_mem_msg_width_lp-1:0]                  io_resp_i
    , input                                             io_resp_v_i
    , output                                            io_resp_yumi_o
 
    // Incoming I/O
-   , input [cce_mem_msg_width_lp-1:0]                  io_cmd_i
+   , input [uce_mem_msg_width_lp-1:0]                  io_cmd_i
    , input                                             io_cmd_v_i
    , output                                            io_cmd_yumi_o
 
-   , output [cce_mem_msg_width_lp-1:0]                 io_resp_o
+   , output [uce_mem_msg_width_lp-1:0]                 io_resp_o
    , output                                            io_resp_v_o
    , input                                             io_resp_ready_i
 
@@ -341,7 +341,7 @@ module bp_unicore
   assign proc_cmd_v_lo[2] = io_cmd_v_i;
   assign io_cmd_yumi_o = proc_cmd_ready_li[2] & proc_cmd_v_lo[2];
 
-  assign io_resp_o = cce_mem_msg_width_lp'(proc_resp_li[2]); 
+  assign io_resp_o = uce_mem_msg_width_lp'(proc_resp_li[2]); 
   assign io_resp_v_o = proc_resp_v_li[2];
   assign proc_resp_yumi_lo[2] = io_resp_ready_i & io_resp_v_o;
 

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -222,6 +222,7 @@ $BP_FE_DIR/src/v/bp_fe_top.v
 $BP_ME_DIR/src/v/lce/bp_lce.v
 $BP_ME_DIR/src/v/lce/bp_lce_req.v
 $BP_ME_DIR/src/v/lce/bp_lce_cmd.v
+$BP_ME_DIR/src/v/lce/bp_store_data_merge.v
 # Cache
 $BP_ME_DIR/src/v/cache/bp_me_cache_dma_to_cce.v
 $BP_ME_DIR/src/v/cache/bp_me_cache_slice.v

--- a/bp_top/test/tb/bp_tethered/wrapper.v
+++ b/bp_top/test/tb/bp_tethered/wrapper.v
@@ -17,6 +17,7 @@ module wrapper
  import bsg_noc_pkg::*;
  #(parameter bp_params_e bp_params_p = BP_CFG_FLOWVAR
    `declare_bp_proc_params(bp_params_p)
+
    `declare_bp_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce_mem)
    )
   (input                                               clk_i
@@ -58,10 +59,26 @@ module wrapper
       || (bp_params_p == e_bp_unicore_l1_medium_cfg)
       )
     begin : unicore
+      localparam uce_mem_data_width_lp = `BSG_MAX(icache_fill_width_p, dcache_fill_width_p);
+      `declare_bp_mem_if(paddr_width_p, uce_mem_data_width_lp, lce_id_width_p, lce_assoc_p, uce_mem);
+      bp_uce_mem_msg_s io_cmd_lo, io_cmd_li;
+      bp_uce_mem_msg_s io_resp_lo, io_resp_li;
+
+      // We need to expand the IO ports to their full width here
       bp_unicore
        #(.bp_params_p(bp_params_p))
        dut
-        (.*);
+        (.io_cmd_o(io_cmd_lo)
+         ,.io_cmd_i(io_cmd_li)
+         ,.io_resp_o(io_resp_lo)
+         ,.io_resp_i(io_resp_li)
+         ,.*
+         );
+
+      assign io_cmd_o = io_cmd_lo;
+      assign io_cmd_li = io_cmd_i;
+      assign io_resp_o = io_resp_lo;
+      assign io_resp_li = io_resp_i;
     end
   else
     begin : multicore


### PR DESCRIPTION
This PR adds the following:

- A store_merge module that merges the store data at the appropriate place in the store miss fill response
- Connections to this module in both UCE and LCE
- Connections for the cache_req_safe signal