### PR TITLE
Separate out header / data from wormhole definitions

### DIFF
--- a/bp_me/src/include/v/bp_mem_wormhole.vh
+++ b/bp_me/src/include/v/bp_mem_wormhole.vh
@@ -23,7 +23,7 @@
                                         \
   typedef struct packed                 \
   {                                     \
-    logic [(flit_width_mp-(2*cord_width_mp+2*cid_width_mp+len_width_mp+$bits(msg_hdr_name_mp))%flit_width_mp)-1:0] \
+    logic [`bp_mem_wormhole_packet_pad_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, $bits(msg_hdr_name_mp))-1:0] \
                               pad;      \
     msg_hdr_name_mp           msg_hdr;  \
     bp_mem_router_header_s    wh_hdr;   \
@@ -35,6 +35,9 @@
     bp_mem_wormhole_header_s  header;   \
   }  bp_mem_wormhole_packet_s;
 
+`define bp_mem_wormhole_packet_pad_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
+  ((flit_width_mp-(2*cord_width_mp+2*cid_width_mp+len_width_mp+msg_hdr_width_mp)%flit_width_mp))
+
 `define bp_mem_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp, data_width_mp) \
   (cid_width_mp + cord_width_mp + cid_width_mp + msg_hdr_width_mp + data_width_mp \
    + `bp_mem_wormhole_packet_pad_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
@@ -45,7 +48,7 @@
    + `bp_mem_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
    )
 
-`define bp_mem_noc_header_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
+`define bp_mem_wormhole_header_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
   (cord_width_mp + len_width_mp \
    + `bp_mem_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
    )
@@ -60,17 +63,20 @@
                                        \
   typedef struct packed                \
   {                                    \
-    logic [(flit_width_mp-(cord_width_mp+cid_width_mp+len_width_mp+$bits(msg_hdr_name_mp))%flit_width_mp-1:0] \
+    logic [`bp_coh_wormhole_pad_width(flit_width_mp, cord_width_mp, cid_width_mp, len_width_mp, $bits(msg_hdr_name_mp))-1:0] \
                               pad;     \
     msg_hdr_name_mp           msg_hdr; \
     bp_coh_router_header_s    wh_hdr;  \
-  }  bp_coh_noc_header_s;              \
+  }  bp_coh_wormhole_header_s;         \
                                        \
   typedef struct packed                \
   {                                    \
     logic [data_width_mp-1:0] data;    \
-    bp_coh_noc_header_s       header;  \
+    bp_coh_wormhole_header_s  header;  \
   }  bp_coh_wormhole_packet_s;
+
+`define bp_coh_wormhole_pad_width(flit_width_mp, cord_width_mp, cid_width_mp, len_width_mp, msg_hdr_width_mp) \
+  ((flit_width_mp-(cord_width_mp+cid_width_mp+len_width_mp+msg_hdr_width_mp)%flit_width_mp)
 
 `define bp_coh_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
   (cid_width_mp + msg_hdr_width_mp \

--- a/bp_me/src/include/v/bp_mem_wormhole.vh
+++ b/bp_me/src/include/v/bp_mem_wormhole.vh
@@ -11,57 +11,80 @@
 `include "bsg_noc_links.vh"
 `include "bsg_wormhole_router.vh"
 
-`define declare_bp_mem_wormhole_packet_s(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_width_mp, data_width_mp, struct_name_mp) \
+`define declare_bp_mem_wormhole_packet_s(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_name_mp, data_width_mp) \
   typedef struct packed                 \
   {                                     \
-    logic [data_width_mp-1:0] data;     \
-    logic [`bp_mem_wormhole_packet_pad_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_width_mp)-1:0] \
-                              pad;      \
-    logic [msg_width_mp-1:0]  msg;      \
     logic [cid_width_mp-1:0]  src_cid;  \
     logic [cord_width_mp-1:0] src_cord; \
     logic [cid_width_mp-1:0]  cid;      \
     logic [len_width_mp-1:0]  len;      \
     logic [cord_width_mp-1:0] cord;     \
-  }  struct_name_mp
+  }  bp_mem_router_header_s;            \
+                                        \
+  typedef struct packed                 \
+  {                                     \
+    logic [(flit_width_mp-(2*cord_width_mp+2*cid_width_mp+len_width_mp+$bits(msg_hdr_name_mp))%flit_width_mp)-1:0] \
+                              pad;      \
+    msg_hdr_name_mp           msg_hdr;  \
+    bp_mem_router_header_s    wh_hdr;   \
+  }  bp_mem_wormhole_header_s;          \
+                                        \
+  typedef struct packed                 \
+  {                                     \
+    logic [data_width_mp-1:0] data;     \
+    bp_mem_wormhole_header_s  header;   \
+  }  bp_mem_wormhole_packet_s;
 
-`define bp_mem_wormhole_packet_pad_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_width_mp) \
-  ((2*cord_width_mp+2*cid_width_mp+len_width_mp+msg_width_mp)%flit_width_mp==0   \
-   ? flit_width_mp                                                               \
-   : (2*cord_width_mp+2*cid_width_mp+len_width_mp+msg_width_mp)%flit_width_mp    \
+`define bp_mem_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp, data_width_mp) \
+  (cid_width_mp + cord_width_mp + cid_width_mp + msg_hdr_width_mp + data_width_mp \
+   + `bp_mem_wormhole_packet_pad_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
    )
 
-`define bp_mem_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_width_mp, data_width_mp) \
-  (cid_width_mp   \
-   +cord_width_mp \
-   +cid_width_mp  \
-   +msg_width_mp  \
-   +`bp_mem_wormhole_packet_pad_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_width_mp) \
-   +data_width_mp \
+`define bp_mem_wormhole_packet_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp, data_width_mp) \
+  (cord_width_mp + len_width_mp + data_width_mp \
+   + `bp_mem_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
    )
 
-`define bp_mem_wormhole_packet_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_width_mp, data_width_mp) \
-  (cord_width_mp   \
-   +len_width_mp   \
-   +`bp_mem_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_width_mp, data_width_mp) \
+`define bp_mem_noc_header_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
+  (cord_width_mp + len_width_mp \
+   + `bp_mem_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
    )
 
-`define declare_bp_lce_wormhole_packet_s(cord_width_mp, cid_width_mp, len_width_mp, msg_width_mp, flit_width_mp, data_width_mp, struct_name_mp) \
-  typedef struct packed              \
-  {                                  \
-    logic [data_width_mp-1:0] data;  \
-    logic [`bp_lce_wormhole_packet_pad_width(cord_width_mp, cid_width_mp, len_width_mp, msg_width_mp, flit_width_mp)] \
-                              pad;   \
-    logic [msg_width_mp-1:0]  msg;   \
-    logic [cid_width_mp-1:0]  cid;   \
-    logic [len_width_mp-1:0]  len;   \
-    logic [cord_width_mp-1:0] cord;  \
-  } struct_name_mp
+`define declare_bp_coh_wormhole_packet_s(flit_width_mp, cord_width_mp, cid_width_mp, len_width_mp, msg_hdr_name_mp, struct_name_mp) \
+  typedef struct packed                \
+  {                                    \
+    logic [cid_width_mp-1:0]  cid;     \
+    logic [len_width_mp-1:0]  len;     \
+    logic [cord_wisth_mp-1:0] cord;    \
+  }  bp_coh_router_header_s;           \
+                                       \
+  typedef struct packed                \
+  {                                    \
+    logic [(flit_width_mp-(cord_width_mp+cid_width_mp+len_width_mp+$bits(msg_hdr_name_mp))%flit_width_mp-1:0] \
+                              pad;     \
+    msg_hdr_name_mp           msg_hdr; \
+    bp_coh_router_header_s    wh_hdr;  \
+  }  bp_coh_noc_header_s;              \
+                                       \
+  typedef struct packed                \
+  {                                    \
+    logic [data_width_mp-1:0] data;    \
+    bp_coh_noc_header_s       header;  \
+  }  bp_coh_wormhole_packet_s;
 
-`define bp_lce_wormhole_packet_pad_width(cord_width_mp, cid_width_mp, len_width_mp, msg_width_mp, flit_width_mp) \
-  ((cord_width_mp+cid_width_mp+len_width_mp+msg_width_mp)%flit_width_mp==0   \
-   ? flit_width_mp                                                           \
-   : cord_width_mp+cid_width_mp+len_width_mp+msg_width_mp)%flit_width_mp     \
+`define bp_coh_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
+  (cid_width_mp + msg_hdr_width_mp \
+   + `bp_coh_wormhole_packet_pad_width(flit_width_mp, cord_width_mp, cid_width_mp, len_width_mp, msg_hdr_name_mp) \
+   )
+
+`define bp_coh_wormhole_packet_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp, data_width_mp) \
+  (cord_width_mp + len_width_mp + data_width_mp \
+   + `bp_coh_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
+   )
+
+`define bp_coh_wormhole_header_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
+  (cord_width_mp + len_width_mp \
+   + `bp_coh_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
    )
 
 `endif

--- a/bp_me/src/include/v/bp_mem_wormhole.vh
+++ b/bp_me/src/include/v/bp_mem_wormhole.vh
@@ -36,62 +36,71 @@
   }  bp_mem_wormhole_packet_s;
 
 `define bp_mem_wormhole_packet_pad_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
-  ((flit_width_mp-(2*cord_width_mp+2*cid_width_mp+len_width_mp+msg_hdr_width_mp)%flit_width_mp))
+  (flit_width_mp-((2*cord_width_mp+2*cid_width_mp+len_width_mp+msg_hdr_width_mp)%flit_width_mp))
 
-`define bp_mem_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp, data_width_mp) \
-  (cid_width_mp + cord_width_mp + cid_width_mp + msg_hdr_width_mp + data_width_mp \
+`define bp_mem_wormhole_header_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
+  (cord_width_mp + len_width_mp + cid_width_mp + cord_width_mp + cid_width_mp + msg_hdr_width_mp \
    + `bp_mem_wormhole_packet_pad_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
    )
 
 `define bp_mem_wormhole_packet_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp, data_width_mp) \
-  (cord_width_mp + len_width_mp + data_width_mp \
-   + `bp_mem_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
+  (data_width_mp \
+   + `bp_mem_wormhole_header_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
    )
 
-`define bp_mem_wormhole_header_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
-  (cord_width_mp + len_width_mp \
-   + `bp_mem_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
+`define bp_mem_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp, data_width_mp) \
+  (`bp_mem_wormhole_packet_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp, data_width_mp) \
+   - len_width_mp - cord_width_mp \
    )
 
-`define declare_bp_coh_wormhole_packet_s(flit_width_mp, cord_width_mp, cid_width_mp, len_width_mp, msg_hdr_name_mp, struct_name_mp) \
-  typedef struct packed                \
-  {                                    \
-    logic [cid_width_mp-1:0]  cid;     \
-    logic [len_width_mp-1:0]  len;     \
-    logic [cord_wisth_mp-1:0] cord;    \
-  }  bp_coh_router_header_s;           \
-                                       \
-  typedef struct packed                \
-  {                                    \
-    logic [`bp_coh_wormhole_pad_width(flit_width_mp, cord_width_mp, cid_width_mp, len_width_mp, $bits(msg_hdr_name_mp))-1:0] \
-                              pad;     \
-    msg_hdr_name_mp           msg_hdr; \
-    bp_coh_router_header_s    wh_hdr;  \
-  }  bp_coh_wormhole_header_s;         \
-                                       \
-  typedef struct packed                \
-  {                                    \
-    logic [data_width_mp-1:0] data;    \
-    bp_coh_wormhole_header_s  header;  \
-  }  bp_coh_wormhole_packet_s;
+`define declare_bp_coh_wormhole_packet_s(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_name_mp, struct_name_mp, data_width_mp) \
+  typedef struct packed                     \
+  {                                         \
+    logic [cid_width_mp-1:0]  cid;          \
+    logic [len_width_mp-1:0]  len;          \
+    logic [cord_width_mp-1:0] cord;         \
+  }  bp_``struct_name_mp``_router_header_s; \
+                                            \
+  typedef struct packed                     \
+  {                                         \
+    logic [`bp_coh_wormhole_packet_pad_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, $bits(msg_hdr_name_mp))-1:0] \
+                                          pad;      \
+    msg_hdr_name_mp                       msg_hdr;  \
+    bp_``struct_name_mp``_router_header_s wh_hdr;   \
+  }  bp_``struct_name_mp``_wormhole_header_s;       \
+                                                    \
+  typedef struct packed                             \
+  {                                                 \
+    logic [data_width_mp-1:0]               data;   \
+    bp_``struct_name_mp``_wormhole_header_s header; \
+  }  bp_``struct_name_mp``_wormhole_packet_s;
 
-`define bp_coh_wormhole_pad_width(flit_width_mp, cord_width_mp, cid_width_mp, len_width_mp, msg_hdr_width_mp) \
-  ((flit_width_mp-(cord_width_mp+cid_width_mp+len_width_mp+msg_hdr_width_mp)%flit_width_mp)
+`define bp_coh_wormhole_packet_pad_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
+  (flit_width_mp-((cord_width_mp+cid_width_mp+len_width_mp+msg_hdr_width_mp)%flit_width_mp))
 
-`define bp_coh_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
-  (cid_width_mp + msg_hdr_width_mp \
-   + `bp_coh_wormhole_packet_pad_width(flit_width_mp, cord_width_mp, cid_width_mp, len_width_mp, msg_hdr_name_mp) \
+`define bp_coh_wormhole_header_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
+  (cord_width_mp + len_width_mp + cid_width_mp + msg_hdr_width_mp \
+   + `bp_coh_wormhole_packet_pad_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
    )
 
 `define bp_coh_wormhole_packet_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp, data_width_mp) \
-  (cord_width_mp + len_width_mp + data_width_mp \
-   + `bp_coh_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
+  (data_width_mp \
+   + `bp_coh_wormhole_header_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
    )
 
-`define bp_coh_wormhole_header_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
-  (cord_width_mp + len_width_mp \
-   + `bp_coh_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp) \
+`define bp_coh_wormhole_payload_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp, data_width_mp) \
+  (`bp_coh_wormhole_packet_width(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_width_mp, data_width_mp) \
+   - len_width_mp - cord_width_mp \
    )
+
+`define declare_bp_lce_req_wormhole_packet_s(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_name_mp, data_width_mp) \
+  `declare_bp_coh_wormhole_packet_s(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_name_mp, lce_req, data_width_mp)
+
+`define declare_bp_lce_cmd_wormhole_packet_s(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_name_mp, data_width_mp) \
+  `declare_bp_coh_wormhole_packet_s(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_name_mp, lce_cmd, data_width_mp)
+
+`define declare_bp_lce_resp_wormhole_packet_s(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_name_mp, data_width_mp) \
+  `declare_bp_coh_wormhole_packet_s(flit_width_mp, cord_width_mp, len_width_mp, cid_width_mp, msg_hdr_name_mp, lce_resp, data_width_mp)
 
 `endif
 

--- a/bp_me/src/v/wormhole/bp_me_cce_to_mem_link_client.v
+++ b/bp_me/src/v/wormhole/bp_me_cce_to_mem_link_client.v
@@ -52,6 +52,7 @@ module bp_me_cce_to_mem_link_client
   bp_mem_wormhole_packet_s mem_cmd_packet_lo;
   logic mem_cmd_packet_v_lo, mem_cmd_packet_yumi_li;
   bp_mem_wormhole_packet_s mem_resp_packet_lo;
+  bp_mem_wormhole_header_s mem_resp_header_lo;
   bsg_wormhole_router_adapter
    #(.max_payload_width_p(payload_width_lp)
      ,.len_width_p(len_width_p)
@@ -105,6 +106,8 @@ module bp_me_cce_to_mem_link_client
   wire [cord_width_p-1:0] dst_cord_lo = src_cord_lo;
   wire [cid_width_p-1:0]  dst_cid_lo  = src_cid_lo;
 
+  bp_cce_mem_msg_s mem_resp_cast_i;
+  assign mem_resp_cast_i = mem_resp_i;
   bp_me_wormhole_packet_encode_mem_resp
    #(.bp_params_p(bp_params_p)
      ,.flit_width_p(flit_width_p)
@@ -113,13 +116,14 @@ module bp_me_cce_to_mem_link_client
      ,.len_width_p(len_width_p)
      )
    mem_resp_encode
-    (.mem_resp_i(mem_resp_i)
+    (.mem_resp_header_i(mem_resp_cast_i.header)
      ,.src_cord_i(src_cord_lo)
      ,.src_cid_i(src_cid_lo)
      ,.dst_cord_i(dst_cord_lo)
      ,.dst_cid_i(dst_cid_lo)
-     ,.packet_o(mem_resp_packet_lo)
+     ,.wh_header_o(mem_resp_header_lo)
      );
+  assign mem_resp_packet_lo = '{header: mem_resp_header_lo, data: mem_resp_cast_i.data};
   
 endmodule
 

--- a/bp_me/src/v/wormhole/bp_me_cce_to_mem_link_master.v
+++ b/bp_me/src/v/wormhole/bp_me_cce_to_mem_link_master.v
@@ -56,6 +56,7 @@ assign mem_resp_o = mem_resp_cast_o;
 localparam payload_width_lp = `bp_mem_wormhole_payload_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, $bits(bp_cce_mem_msg_header_s), cce_block_width_p);
 
 bp_mem_wormhole_packet_s mem_cmd_packet_li;
+bp_mem_wormhole_header_s mem_cmd_header_li;
 bp_me_wormhole_packet_encode_mem_cmd
  #(.bp_params_p(bp_params_p)
    ,.flit_width_p(flit_width_p)
@@ -64,13 +65,14 @@ bp_me_wormhole_packet_encode_mem_cmd
    ,.len_width_p(len_width_p)
    )
  mem_cmd_encode
-  (.mem_cmd_i(mem_cmd_cast_i)
+  (.mem_cmd_header_i(mem_cmd_cast_i.header)
    ,.src_cord_i(my_cord_i)
    ,.src_cid_i(my_cid_i)
    ,.dst_cord_i(dst_cord_i)
    ,.dst_cid_i(dst_cid_i)
-   ,.packet_o(mem_cmd_packet_li)
+   ,.wh_header_o(mem_cmd_header_li)
    );
+assign mem_cmd_packet_li = '{header: mem_cmd_header_li, data: mem_cmd_cast_i.data};
 
 bp_mem_wormhole_packet_s mem_resp_packet_lo;
 bsg_wormhole_router_adapter

--- a/bp_me/src/v/wormhole/bp_me_cce_to_mem_link_master.v
+++ b/bp_me/src/v/wormhole/bp_me_cce_to_mem_link_master.v
@@ -52,12 +52,10 @@ assign mem_cmd_cast_i = mem_cmd_i;
 assign mem_resp_o = mem_resp_cast_o;
 
 // CCE-MEM IF to Wormhole routed interface
-`declare_bp_mem_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-cce_block_width_p, cce_block_width_p, mem_cmd_packet_s);
-`declare_bp_mem_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-cce_block_width_p, cce_block_width_p, mem_resp_packet_s);
+`declare_bp_mem_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, bp_cce_mem_msg_header_s, cce_block_width_p);
+localparam payload_width_lp = `bp_mem_wormhole_payload_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, $bits(bp_cce_mem_msg_header_s), cce_block_width_p);
 
-localparam payload_width_lp = `bp_mem_wormhole_payload_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-cce_block_width_p, cce_block_width_p);
-
-mem_cmd_packet_s mem_cmd_packet_li;
+bp_mem_wormhole_packet_s mem_cmd_packet_li;
 bp_me_wormhole_packet_encode_mem_cmd
  #(.bp_params_p(bp_params_p)
    ,.flit_width_p(flit_width_p)
@@ -74,7 +72,7 @@ bp_me_wormhole_packet_encode_mem_cmd
    ,.packet_o(mem_cmd_packet_li)
    );
 
-mem_resp_packet_s mem_resp_packet_lo;
+bp_mem_wormhole_packet_s mem_resp_packet_lo;
 bsg_wormhole_router_adapter
  #(.max_payload_width_p(payload_width_lp)
    ,.len_width_p(len_width_p)
@@ -96,7 +94,7 @@ bsg_wormhole_router_adapter
    ,.v_o(mem_resp_v_o)
    ,.yumi_i(mem_resp_yumi_i)
    );
-assign mem_resp_cast_o = {mem_resp_packet_lo.data, mem_resp_packet_lo.msg};
+assign mem_resp_cast_o = {mem_resp_packet_lo.data, mem_resp_packet_lo.header.msg_hdr};
 
 endmodule
 

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_cmd.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_cmd.v
@@ -15,61 +15,62 @@ module bp_me_wormhole_packet_encode_lce_cmd
   import bp_common_aviary_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
+    `declare_bp_lce_cce_if_header_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p)
     `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
 
-    , localparam lce_cmd_packet_width_lp =
-        `bsg_wormhole_concentrator_packet_width(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cmd_width_lp)
-    , localparam lce_cmd_packet_hdr_width_lp = (lce_cmd_packet_width_lp-cce_block_width_p)
+    , localparam lce_cmd_wormhole_header_lp = `bp_coh_wormhole_header_width(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cmd_header_width_lp)
     )
-   (input [lce_cmd_width_lp-1:0]           payload_i
-    , output [lce_cmd_packet_width_lp-1:0] packet_o
+   (input [lce_cmd_header_width_lp-1:0]       lce_cmd_header_i
+    , output [lce_cmd_wormhole_header_lp-1:0] wh_header_o
     );
 
   `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
-  `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cmd_width_lp, lce_cmd_packet_s);
+  `declare_bp_lce_cmd_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_lce_cmd_header_s, cce_block_width_p);
 
-  bp_lce_cmd_s payload_cast_i;
-  lce_cmd_packet_s packet_cast_o;
-  assign payload_cast_i = payload_i;
-  assign packet_o = packet_cast_o;
+  bp_lce_cmd_header_s header_cast_i;
+  bp_lce_cmd_wormhole_header_s header_cast_o;
+  assign header_cast_i = lce_cmd_header_i;
+  assign wh_header_o = header_cast_o;
 
   // LCE Command with no data
   localparam lce_cmd_cmd_len_lp =
-    `BSG_CDIV(lce_cmd_packet_hdr_width_lp, coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cmd_wormhole_header_lp, coh_noc_flit_width_p) - 1;
   // LCE Commands with 1B to 128B of data
   localparam lce_cmd_data_len_1_lp =
-    `BSG_CDIV(lce_cmd_packet_hdr_width_lp+(1*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cmd_wormhole_header_lp+(1*8), coh_noc_flit_width_p) - 1;
   localparam lce_cmd_data_len_2_lp =
-    `BSG_CDIV(lce_cmd_packet_hdr_width_lp+(2*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cmd_wormhole_header_lp+(2*8), coh_noc_flit_width_p) - 1;
   localparam lce_cmd_data_len_4_lp =
-    `BSG_CDIV(lce_cmd_packet_hdr_width_lp+(4*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cmd_wormhole_header_lp+(4*8), coh_noc_flit_width_p) - 1;
   localparam lce_cmd_data_len_8_lp =
-    `BSG_CDIV(lce_cmd_packet_hdr_width_lp+(8*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cmd_wormhole_header_lp+(8*8), coh_noc_flit_width_p) - 1;
   localparam lce_cmd_data_len_16_lp =
-    `BSG_CDIV(lce_cmd_packet_hdr_width_lp+(16*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cmd_wormhole_header_lp+(16*8), coh_noc_flit_width_p) - 1;
   localparam lce_cmd_data_len_32_lp =
-    `BSG_CDIV(lce_cmd_packet_hdr_width_lp+(32*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cmd_wormhole_header_lp+(32*8), coh_noc_flit_width_p) - 1;
   localparam lce_cmd_data_len_64_lp =
-    `BSG_CDIV(lce_cmd_packet_hdr_width_lp+(64*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cmd_wormhole_header_lp+(64*8), coh_noc_flit_width_p) - 1;
   localparam lce_cmd_data_len_128_lp =
-    `BSG_CDIV(lce_cmd_packet_hdr_width_lp+(128*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cmd_wormhole_header_lp+(128*8), coh_noc_flit_width_p) - 1;
 
   logic [coh_noc_cord_width_p-1:0] lce_cord_li;
   logic [coh_noc_cid_width_p-1:0]  lce_cid_li;
   bp_me_lce_id_to_cord
    #(.bp_params_p(bp_params_p))
    router_cord
-    (.lce_id_i(payload_cast_i.header.dst_id)
+    (.lce_id_i(header_cast_i.dst_id)
      ,.lce_cord_o(lce_cord_li)
      ,.lce_cid_o(lce_cid_li)
      );
 
   always_comb begin
-    packet_cast_o.payload = payload_cast_i;
-    packet_cast_o.cid     = lce_cid_li;
-    packet_cast_o.cord    = lce_cord_li;
+    header_cast_o = '0;
 
-    unique case (payload_cast_i.header.msg_type)
+    header_cast_o.msg_hdr     = header_cast_i;
+    header_cast_o.wh_hdr.cid  = lce_cid_li;
+    header_cast_o.wh_hdr.cord = lce_cord_li;
+
+    unique case (header_cast_i.msg_type)
       // most commands have no data
       e_lce_cmd_sync
       ,e_lce_cmd_set_clear
@@ -81,22 +82,22 @@ module bp_me_wormhole_packet_encode_lce_cmd
       ,e_lce_cmd_tr
       ,e_lce_cmd_st_tr
       ,e_lce_cmd_st_tr_wb
-      ,e_lce_cmd_uc_st_done: packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_cmd_len_lp);
+      ,e_lce_cmd_uc_st_done: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cmd_cmd_len_lp);
       // data and uncached data commands have data
       e_lce_cmd_data
       ,e_lce_cmd_uc_data:
-        unique case (payload_cast_i.header.size)
-          e_mem_msg_size_1: packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_data_len_1_lp);
-          e_mem_msg_size_2: packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_data_len_2_lp);
-          e_mem_msg_size_4: packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_data_len_4_lp);
-          e_mem_msg_size_8: packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_data_len_8_lp);
-          e_mem_msg_size_16: packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_data_len_16_lp);
-          e_mem_msg_size_32: packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_data_len_32_lp);
-          e_mem_msg_size_64: packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_data_len_64_lp);
-          e_mem_msg_size_128: packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_data_len_128_lp);
-          default: packet_cast_o.len = coh_noc_len_width_p'(lce_cmd_cmd_len_lp);
+        unique case (header_cast_i.size)
+          e_mem_msg_size_1: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cmd_data_len_1_lp);
+          e_mem_msg_size_2: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cmd_data_len_2_lp);
+          e_mem_msg_size_4: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cmd_data_len_4_lp);
+          e_mem_msg_size_8: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cmd_data_len_8_lp);
+          e_mem_msg_size_16: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cmd_data_len_16_lp);
+          e_mem_msg_size_32: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cmd_data_len_32_lp);
+          e_mem_msg_size_64: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cmd_data_len_64_lp);
+          e_mem_msg_size_128: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cmd_data_len_128_lp);
+          default: begin end
         endcase
-      default: packet_cast_o = '0;
+      default: begin end
     endcase
   end
 

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_req.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_req.v
@@ -19,77 +19,77 @@ module bp_me_wormhole_packet_encode_lce_req
     `declare_bp_lce_cce_if_header_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p)
     `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
 
-    , localparam lce_cce_req_packet_width_lp =
-        `bsg_wormhole_concentrator_packet_width(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_req_width_lp)
-    , localparam lce_cce_req_packet_hdr_width_lp = (lce_cce_req_packet_width_lp-cce_block_width_p)
+    , localparam lce_cce_req_wormhole_header_lp = `bp_coh_wormhole_header_width(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_req_header_width_lp)
     )
-   (input [lce_cce_req_width_lp-1:0]           payload_i
-    , output [lce_cce_req_packet_width_lp-1:0] packet_o
+   (input [lce_cce_req_header_width_lp-1:0]       lce_req_header_i
+    , output [lce_cce_req_wormhole_header_lp-1:0] wh_header_o
     );
 
   `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
-  `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_req_width_lp, lce_cce_req_packet_s);
+  `declare_bp_lce_req_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_lce_cce_req_header_s, cce_block_width_p);
 
-  bp_lce_cce_req_s payload_cast_i;
-  lce_cce_req_packet_s packet_cast_o;
-  assign payload_cast_i = payload_i;
-  assign packet_o = packet_cast_o;
+  bp_lce_cce_req_header_s header_cast_i;
+  bp_lce_req_wormhole_header_s header_cast_o;
+  assign header_cast_i = lce_req_header_i;
+  assign wh_header_o = header_cast_o;
 
   // LCE Request with no data
   localparam lce_cce_req_req_len_lp =
-    `BSG_CDIV(lce_cce_req_packet_hdr_width_lp, coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_req_wormhole_header_lp, coh_noc_flit_width_p) - 1;
   // LCE Requests with 1B to 128B of data
   localparam lce_cce_req_data_len_1_lp =
-    `BSG_CDIV(lce_cce_req_packet_hdr_width_lp+(1*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_req_wormhole_header_lp+(1*8), coh_noc_flit_width_p) - 1;
   localparam lce_cce_req_data_len_2_lp =
-    `BSG_CDIV(lce_cce_req_packet_hdr_width_lp+(2*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_req_wormhole_header_lp+(2*8), coh_noc_flit_width_p) - 1;
   localparam lce_cce_req_data_len_4_lp =
-    `BSG_CDIV(lce_cce_req_packet_hdr_width_lp+(4*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_req_wormhole_header_lp+(4*8), coh_noc_flit_width_p) - 1;
   localparam lce_cce_req_data_len_8_lp =
-    `BSG_CDIV(lce_cce_req_packet_hdr_width_lp+(8*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_req_wormhole_header_lp+(8*8), coh_noc_flit_width_p) - 1;
   localparam lce_cce_req_data_len_16_lp =
-    `BSG_CDIV(lce_cce_req_packet_hdr_width_lp+(16*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_req_wormhole_header_lp+(16*8), coh_noc_flit_width_p) - 1;
   localparam lce_cce_req_data_len_32_lp =
-    `BSG_CDIV(lce_cce_req_packet_hdr_width_lp+(32*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_req_wormhole_header_lp+(32*8), coh_noc_flit_width_p) - 1;
   localparam lce_cce_req_data_len_64_lp =
-    `BSG_CDIV(lce_cce_req_packet_hdr_width_lp+(64*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_req_wormhole_header_lp+(64*8), coh_noc_flit_width_p) - 1;
   localparam lce_cce_req_data_len_128_lp =
-    `BSG_CDIV(lce_cce_req_packet_hdr_width_lp+(128*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_req_wormhole_header_lp+(128*8), coh_noc_flit_width_p) - 1;
 
   logic [coh_noc_cord_width_p-1:0] cce_cord_li;
   logic [coh_noc_cid_width_p-1:0]  cce_cid_li;
   bp_me_cce_id_to_cord
    #(.bp_params_p(bp_params_p))
    router_cord
-    (.cce_id_i(payload_cast_i.header.dst_id)
+    (.cce_id_i(header_cast_i.dst_id)
      ,.cce_cord_o(cce_cord_li)
      ,.cce_cid_o(cce_cid_li)
      );
 
   always_comb begin
-    packet_cast_o.payload = payload_cast_i;
-    packet_cast_o.cid     = cce_cid_li;
-    packet_cast_o.cord    = cce_cord_li;
+    header_cast_o = '0;
 
-    unique case (payload_cast_i.header.msg_type)
+    header_cast_o.msg_hdr     = header_cast_i;
+    header_cast_o.wh_hdr.cid  = cce_cid_li;
+    header_cast_o.wh_hdr.cord = cce_cord_li;
+
+    unique case (header_cast_i.msg_type)
       // read, write, and uncached read requests have no data
       e_lce_req_type_rd
       ,e_lce_req_type_wr
-      ,e_lce_req_type_uc_rd: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_req_len_lp);
+      ,e_lce_req_type_uc_rd: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cce_req_req_len_lp);
       // uncached write (store) has data
       e_lce_req_type_uc_wr:
-        unique case (payload_cast_i.header.size)
-          e_mem_msg_size_1: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_data_len_1_lp);
-          e_mem_msg_size_2: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_data_len_2_lp);
-          e_mem_msg_size_4: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_data_len_4_lp);
-          e_mem_msg_size_8: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_data_len_8_lp);
-          e_mem_msg_size_16: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_data_len_16_lp);
-          e_mem_msg_size_32: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_data_len_32_lp);
-          e_mem_msg_size_64: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_data_len_64_lp);
-          e_mem_msg_size_128: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_data_len_128_lp);
-          default: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_req_req_len_lp);
+        unique case (header_cast_i.size)
+          e_mem_msg_size_1: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cce_req_data_len_1_lp);
+          e_mem_msg_size_2: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cce_req_data_len_2_lp);
+          e_mem_msg_size_4: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cce_req_data_len_4_lp);
+          e_mem_msg_size_8: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cce_req_data_len_8_lp);
+          e_mem_msg_size_16: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cce_req_data_len_16_lp);
+          e_mem_msg_size_32: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cce_req_data_len_32_lp);
+          e_mem_msg_size_64: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cce_req_data_len_64_lp);
+          e_mem_msg_size_128: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cce_req_data_len_128_lp);
+          default: begin end
         endcase
-      default: packet_cast_o = '0;
+      default: begin end
     endcase
   end
 

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_resp.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_resp.v
@@ -15,80 +15,81 @@ module bp_me_wormhole_packet_encode_lce_resp
   import bp_common_aviary_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
+    `declare_bp_lce_cce_if_header_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p)
     `declare_bp_lce_cce_if_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p)
 
-    , localparam lce_cce_resp_packet_width_lp =
-        `bsg_wormhole_concentrator_packet_width(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_resp_width_lp)
-    , localparam lce_cce_resp_packet_hdr_width_lp = (lce_cce_resp_packet_width_lp-cce_block_width_p)
+    , localparam lce_cce_resp_wormhole_header_lp = `bp_coh_wormhole_header_width(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_resp_header_width_lp)
     )
-   (input [lce_cce_resp_width_lp-1:0]           payload_i
-    , output [lce_cce_resp_packet_width_lp-1:0] packet_o
+   (input [lce_cce_resp_header_width_lp-1:0]       lce_resp_header_i
+    , output [lce_cce_resp_wormhole_header_lp-1:0] wh_header_o
     );
 
   `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
-  `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_resp_width_lp, lce_cce_resp_packet_s);
+  `declare_bp_lce_resp_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_lce_cce_resp_header_s, cce_block_width_p);
 
-  bp_lce_cce_resp_s payload_cast_i;
-  lce_cce_resp_packet_s packet_cast_o;
-  assign payload_cast_i = payload_i;
-  assign packet_o = packet_cast_o;
+  bp_lce_cce_resp_header_s header_cast_i;
+  bp_lce_resp_wormhole_header_s header_cast_o;
+  assign header_cast_i = lce_resp_header_i;
+  assign wh_header_o = header_cast_o;
 
   // LCE Request with no data
   localparam lce_cce_resp_ack_len_lp =
-    `BSG_CDIV(lce_cce_resp_packet_hdr_width_lp, coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_resp_wormhole_header_lp, coh_noc_flit_width_p) - 1;
   // LCE Requests with 1B to 128B of data
   localparam lce_cce_resp_data_len_1_lp =
-    `BSG_CDIV(lce_cce_resp_packet_hdr_width_lp+(1*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_resp_wormhole_header_lp+(1*8), coh_noc_flit_width_p) - 1;
   localparam lce_cce_resp_data_len_2_lp =
-    `BSG_CDIV(lce_cce_resp_packet_hdr_width_lp+(2*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_resp_wormhole_header_lp+(2*8), coh_noc_flit_width_p) - 1;
   localparam lce_cce_resp_data_len_4_lp =
-    `BSG_CDIV(lce_cce_resp_packet_hdr_width_lp+(4*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_resp_wormhole_header_lp+(4*8), coh_noc_flit_width_p) - 1;
   localparam lce_cce_resp_data_len_8_lp =
-    `BSG_CDIV(lce_cce_resp_packet_hdr_width_lp+(8*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_resp_wormhole_header_lp+(8*8), coh_noc_flit_width_p) - 1;
   localparam lce_cce_resp_data_len_16_lp =
-    `BSG_CDIV(lce_cce_resp_packet_hdr_width_lp+(16*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_resp_wormhole_header_lp+(16*8), coh_noc_flit_width_p) - 1;
   localparam lce_cce_resp_data_len_32_lp =
-    `BSG_CDIV(lce_cce_resp_packet_hdr_width_lp+(32*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_resp_wormhole_header_lp+(32*8), coh_noc_flit_width_p) - 1;
   localparam lce_cce_resp_data_len_64_lp =
-    `BSG_CDIV(lce_cce_resp_packet_hdr_width_lp+(64*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_resp_wormhole_header_lp+(64*8), coh_noc_flit_width_p) - 1;
   localparam lce_cce_resp_data_len_128_lp =
-    `BSG_CDIV(lce_cce_resp_packet_hdr_width_lp+(128*8), coh_noc_flit_width_p) - 1;
+    `BSG_CDIV(lce_cce_resp_wormhole_header_lp+(128*8), coh_noc_flit_width_p) - 1;
 
   logic [coh_noc_cord_width_p-1:0] cce_cord_li;
   logic [coh_noc_cid_width_p-1:0]  cce_cid_li;
   bp_me_cce_id_to_cord
    #(.bp_params_p(bp_params_p))
    router_cord
-    (.cce_id_i(payload_cast_i.header.dst_id)
+    (.cce_id_i(header_cast_i.dst_id)
      ,.cce_cord_o(cce_cord_li)
      ,.cce_cid_o(cce_cid_li)
      );
 
   always_comb begin
-    packet_cast_o.payload = payload_cast_i;
-    packet_cast_o.cid     = cce_cid_li;
-    packet_cast_o.cord    = cce_cord_li;
+    header_cast_o = '0;
 
-    unique case (payload_cast_i.header.msg_type)
+    header_cast_o.msg_hdr     = header_cast_i;
+    header_cast_o.wh_hdr.cid  = cce_cid_li;
+    header_cast_o.wh_hdr.cord = cce_cord_li;
+
+    unique case (header_cast_i.msg_type)
       // acks and null wb send no data
       e_lce_cce_sync_ack
       ,e_lce_cce_inv_ack
       ,e_lce_cce_coh_ack
-      ,e_lce_cce_resp_null_wb: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_ack_len_lp);
+      ,e_lce_cce_resp_null_wb: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cce_resp_ack_len_lp);
       // writeback sends data
       e_lce_cce_resp_wb:
-        unique case (payload_cast_i.header.size)
-          e_mem_msg_size_1: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_data_len_1_lp);
-          e_mem_msg_size_2: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_data_len_2_lp);
-          e_mem_msg_size_4: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_data_len_4_lp);
-          e_mem_msg_size_8: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_data_len_8_lp);
-          e_mem_msg_size_16: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_data_len_16_lp);
-          e_mem_msg_size_32: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_data_len_32_lp);
-          e_mem_msg_size_64: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_data_len_64_lp);
-          e_mem_msg_size_128: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_data_len_128_lp);
-          default: packet_cast_o.len = coh_noc_len_width_p'(lce_cce_resp_ack_len_lp);
+        unique case (header_cast_i.size)
+          e_mem_msg_size_1: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cce_resp_data_len_1_lp);
+          e_mem_msg_size_2: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cce_resp_data_len_2_lp);
+          e_mem_msg_size_4: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cce_resp_data_len_4_lp);
+          e_mem_msg_size_8: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cce_resp_data_len_8_lp);
+          e_mem_msg_size_16: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cce_resp_data_len_16_lp);
+          e_mem_msg_size_32: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cce_resp_data_len_32_lp);
+          e_mem_msg_size_64: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cce_resp_data_len_64_lp);
+          e_mem_msg_size_128: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cce_resp_data_len_128_lp);
+          default: begin end
         endcase
-      default: packet_cast_o = '0;
+      default: begin end
     endcase
   end
 

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v
@@ -25,60 +25,59 @@ module bp_me_wormhole_packet_encode_mem_cmd
     , parameter cid_width_p = "inv"
     , parameter len_width_p = "inv"
 
-    , localparam mem_cmd_packet_width_lp = 
-        `bp_mem_wormhole_packet_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_header_width_lp, cce_block_width_p)
+    , localparam mem_cmd_wormhole_header_lp =
+        `bp_mem_wormhole_header_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_header_width_lp)
     )
-   (input [cce_mem_msg_width_lp-1:0]       mem_cmd_i
+   (input [cce_mem_msg_header_width_lp-1:0]   mem_cmd_header_i
    
-    , input [cord_width_p-1:0]             src_cord_i
-    , input [cid_width_p-1:0]              src_cid_i
-    , input [cord_width_p-1:0]             dst_cord_i
-    , input [cid_width_p-1:0]              dst_cid_i
+    , input [cord_width_p-1:0]                src_cord_i
+    , input [cid_width_p-1:0]                 src_cid_i
+    , input [cord_width_p-1:0]                dst_cord_i
+    , input [cid_width_p-1:0]                 dst_cid_i
 
-    , output [mem_cmd_packet_width_lp-1:0] packet_o
+    , output [mem_cmd_wormhole_header_lp-1:0] wh_header_o
     );
 
   `declare_bp_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce_mem);
   `declare_bp_mem_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, bp_cce_mem_msg_header_s, cce_block_width_p);
 
-  bp_cce_mem_msg_s mem_cmd_cast_i;
-  bp_mem_wormhole_packet_s packet_cast_o;
+  bp_cce_mem_msg_header_s header_cast_i;
+  bp_mem_wormhole_header_s header_cast_o;
 
-  assign mem_cmd_cast_i = mem_cmd_i;
-  assign packet_o       = packet_cast_o;
+  assign header_cast_i = mem_cmd_header_i;
+  assign wh_header_o   = header_cast_o;
 
   localparam mem_cmd_req_len_lp =
-    `BSG_CDIV(mem_cmd_packet_width_lp-$bits(mem_cmd_cast_i.data), mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_cmd_wormhole_header_lp, mem_noc_flit_width_p) - 1;
   localparam mem_cmd_data_len_1_lp =
-    `BSG_CDIV(mem_cmd_packet_width_lp-$bits(mem_cmd_cast_i.data) + 8*1, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*1, mem_noc_flit_width_p) - 1;
   localparam mem_cmd_data_len_2_lp =
-    `BSG_CDIV(mem_cmd_packet_width_lp-$bits(mem_cmd_cast_i.data) + 8*2, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*2, mem_noc_flit_width_p) - 1;
   localparam mem_cmd_data_len_4_lp =
-    `BSG_CDIV(mem_cmd_packet_width_lp-$bits(mem_cmd_cast_i.data) + 8*4, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*4, mem_noc_flit_width_p) - 1;
   localparam mem_cmd_data_len_8_lp =
-    `BSG_CDIV(mem_cmd_packet_width_lp-$bits(mem_cmd_cast_i.data) + 8*8, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*8, mem_noc_flit_width_p) - 1;
   localparam mem_cmd_data_len_16_lp =
-    `BSG_CDIV(mem_cmd_packet_width_lp-$bits(mem_cmd_cast_i.data) + 8*16, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*16, mem_noc_flit_width_p) - 1;
   localparam mem_cmd_data_len_32_lp =
-    `BSG_CDIV(mem_cmd_packet_width_lp-$bits(mem_cmd_cast_i.data) + 8*32, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*32, mem_noc_flit_width_p) - 1;
   localparam mem_cmd_data_len_64_lp =
-    `BSG_CDIV(mem_cmd_packet_width_lp-$bits(mem_cmd_cast_i.data) + 8*64, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*64, mem_noc_flit_width_p) - 1;
   localparam mem_cmd_data_len_128_lp =
-    `BSG_CDIV(mem_cmd_packet_width_lp-$bits(mem_cmd_cast_i.data) + 8*128, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*128, mem_noc_flit_width_p) - 1;
 
   logic [len_width_p-1:0] data_cmd_len_li;
 
   always_comb begin
-    packet_cast_o = '0;
+    header_cast_o = '0;
 
-    packet_cast_o.data                   = mem_cmd_cast_i.data;
-    packet_cast_o.header.msg_hdr         = mem_cmd_cast_i.header;
-    packet_cast_o.header.wh_hdr.src_cord = src_cord_i;
-    packet_cast_o.header.wh_hdr.src_cid  = src_cid_i;
-    packet_cast_o.header.wh_hdr.cord     = dst_cord_i;
-    packet_cast_o.header.wh_hdr.cid      = dst_cid_i;
+    header_cast_o.msg_hdr         = header_cast_i;
+    header_cast_o.wh_hdr.src_cord = src_cord_i;
+    header_cast_o.wh_hdr.src_cid  = src_cid_i;
+    header_cast_o.wh_hdr.cord     = dst_cord_i;
+    header_cast_o.wh_hdr.cid      = dst_cid_i;
 
-    case (mem_cmd_cast_i.header.size)
+    case (header_cast_i.size)
       e_mem_msg_size_1 : data_cmd_len_li = len_width_p'(mem_cmd_data_len_1_lp);
       e_mem_msg_size_2 : data_cmd_len_li = len_width_p'(mem_cmd_data_len_2_lp);
       e_mem_msg_size_4 : data_cmd_len_li = len_width_p'(mem_cmd_data_len_4_lp);
@@ -90,13 +89,13 @@ module bp_me_wormhole_packet_encode_mem_cmd
       default: data_cmd_len_li = '0;
     endcase
 
-    case (mem_cmd_cast_i.header.msg_type)
+    case (header_cast_i.msg_type)
       e_mem_msg_rd
       ,e_mem_msg_uc_rd
-      ,e_mem_msg_pre  : packet_cast_o.header.wh_hdr.len = len_width_p'(mem_cmd_req_len_lp);
+      ,e_mem_msg_pre  : header_cast_o.wh_hdr.len = len_width_p'(mem_cmd_req_len_lp);
       e_mem_msg_uc_wr
-      ,e_mem_msg_wr   : packet_cast_o.header.wh_hdr.len = data_cmd_len_li;
-      default: packet_cast_o = '0;
+      ,e_mem_msg_wr   : header_cast_o.wh_hdr.len = data_cmd_len_li;
+      default: header_cast_o.wh_hdr.len = '0;
     endcase
   end
 

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
@@ -25,58 +25,58 @@ module bp_me_wormhole_packet_encode_mem_resp
     , parameter cid_width_p = "inv"
     , parameter len_width_p = "inv"
 
-    , localparam mem_resp_packet_width_lp = 
-        `bp_mem_wormhole_packet_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_header_width_lp, cce_block_width_p)
+    , localparam mem_resp_wormhole_header_width_lp = 
+        `bp_mem_wormhole_header_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_header_width_lp)
     )
-   (input [cce_mem_msg_width_lp-1:0]        mem_resp_i
-    , input [cord_width_p-1:0]              src_cord_i
-    , input [cid_width_p-1:0]               src_cid_i
-    , input [cord_width_p-1:0]              dst_cord_i
-    , input [cid_width_p-1:0]               dst_cid_i
-    , output [mem_resp_packet_width_lp-1:0] packet_o
+   (input [cce_mem_msg_header_width_lp-1:0]          mem_resp_header_i
+    , input [cord_width_p-1:0]                       src_cord_i
+    , input [cid_width_p-1:0]                        src_cid_i
+    , input [cord_width_p-1:0]                       dst_cord_i
+    , input [cid_width_p-1:0]                        dst_cid_i
+
+    , output [mem_resp_wormhole_header_width_lp-1:0] wh_header_o
     );
 
   `declare_bp_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce_mem);
   `declare_bp_mem_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, bp_cce_mem_msg_header_s, cce_block_width_p);
 
-  bp_cce_mem_msg_s mem_resp_cast_i;
-  bp_mem_wormhole_packet_s packet_cast_o;
+  bp_cce_mem_msg_header_s header_cast_i;
+  bp_mem_wormhole_header_s header_cast_o;
 
-  assign mem_resp_cast_i = mem_resp_i;
-  assign packet_o        = packet_cast_o;
+  assign header_cast_i = mem_resp_header_i;
+  assign wh_header_o = header_cast_o;
 
   localparam mem_resp_ack_len_lp =
-    `BSG_CDIV(mem_resp_packet_width_lp-$bits(mem_resp_cast_i.data), mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_resp_wormhole_header_width_lp, mem_noc_flit_width_p) - 1;
   localparam mem_resp_data_len_1_lp =
-    `BSG_CDIV(mem_resp_packet_width_lp-$bits(mem_resp_cast_i.data) + 8*1, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*1, mem_noc_flit_width_p) - 1;
   localparam mem_resp_data_len_2_lp =
-    `BSG_CDIV(mem_resp_packet_width_lp-$bits(mem_resp_cast_i.data) + 8*2, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*2, mem_noc_flit_width_p) - 1;
   localparam mem_resp_data_len_4_lp =
-    `BSG_CDIV(mem_resp_packet_width_lp-$bits(mem_resp_cast_i.data) + 8*4, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*4, mem_noc_flit_width_p) - 1;
   localparam mem_resp_data_len_8_lp =
-    `BSG_CDIV(mem_resp_packet_width_lp-$bits(mem_resp_cast_i.data) + 8*8, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*8, mem_noc_flit_width_p) - 1;
   localparam mem_resp_data_len_16_lp =
-    `BSG_CDIV(mem_resp_packet_width_lp-$bits(mem_resp_cast_i.data) + 8*16, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*16, mem_noc_flit_width_p) - 1;
   localparam mem_resp_data_len_32_lp =
-    `BSG_CDIV(mem_resp_packet_width_lp-$bits(mem_resp_cast_i.data) + 8*32, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*32, mem_noc_flit_width_p) - 1;
   localparam mem_resp_data_len_64_lp =
-    `BSG_CDIV(mem_resp_packet_width_lp-$bits(mem_resp_cast_i.data) + 8*64, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*64, mem_noc_flit_width_p) - 1;
   localparam mem_resp_data_len_128_lp =
-    `BSG_CDIV(mem_resp_packet_width_lp-$bits(mem_resp_cast_i.data) + 8*128, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*128, mem_noc_flit_width_p) - 1;
 
   logic [len_width_p-1:0] data_resp_len_li;
 
   always_comb begin
-    packet_cast_o = '0;
+    header_cast_o = '0;
 
-    packet_cast_o.data                   = mem_resp_cast_i.data;
-    packet_cast_o.header.msg_hdr         = mem_resp_cast_i.header;
-    packet_cast_o.header.wh_hdr.src_cord = src_cord_i;
-    packet_cast_o.header.wh_hdr.src_cid  = src_cid_i;
-    packet_cast_o.header.wh_hdr.cord     = dst_cord_i;
-    packet_cast_o.header.wh_hdr.cid      = dst_cid_i;
+    header_cast_o.msg_hdr         = header_cast_i;
+    header_cast_o.wh_hdr.src_cord = src_cord_i;
+    header_cast_o.wh_hdr.src_cid  = src_cid_i;
+    header_cast_o.wh_hdr.cord     = dst_cord_i;
+    header_cast_o.wh_hdr.cid      = dst_cid_i;
 
-    case (mem_resp_cast_i.header.size)
+    case (header_cast_i.size)
       e_mem_msg_size_1 : data_resp_len_li = len_width_p'(mem_resp_data_len_1_lp);
       e_mem_msg_size_2 : data_resp_len_li = len_width_p'(mem_resp_data_len_2_lp);
       e_mem_msg_size_4 : data_resp_len_li = len_width_p'(mem_resp_data_len_4_lp);
@@ -88,13 +88,13 @@ module bp_me_wormhole_packet_encode_mem_resp
       default: data_resp_len_li = '0;
     endcase
 
-    case (mem_resp_cast_i.header.msg_type)
+    case (header_cast_i.msg_type)
       e_mem_msg_rd
-      ,e_mem_msg_uc_rd: packet_cast_o.header.wh_hdr.len = data_resp_len_li;
+      ,e_mem_msg_uc_rd: header_cast_o.wh_hdr.len = data_resp_len_li;
       e_mem_msg_uc_wr
       ,e_mem_msg_wr
-      ,e_mem_msg_pre  : packet_cast_o.header.wh_hdr.len = len_width_p'(mem_resp_ack_len_lp);
-      default: packet_cast_o = '0;
+      ,e_mem_msg_pre  : header_cast_o.wh_hdr.len = len_width_p'(mem_resp_ack_len_lp);
+      default: header_cast_o.wh_hdr.len = '0;
     endcase
   end
 

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
@@ -26,7 +26,7 @@ module bp_me_wormhole_packet_encode_mem_resp
     , parameter len_width_p = "inv"
 
     , localparam mem_resp_packet_width_lp = 
-        `bp_mem_wormhole_packet_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-cce_block_width_p, cce_block_width_p)
+        `bp_mem_wormhole_packet_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_header_width_lp, cce_block_width_p)
     )
    (input [cce_mem_msg_width_lp-1:0]        mem_resp_i
     , input [cord_width_p-1:0]              src_cord_i
@@ -37,10 +37,10 @@ module bp_me_wormhole_packet_encode_mem_resp
     );
 
   `declare_bp_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce_mem);
-  `declare_bp_mem_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_msg_width_lp-cce_block_width_p, cce_block_width_p, bp_resp_wormhole_packet_s);
+  `declare_bp_mem_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, bp_cce_mem_msg_header_s, cce_block_width_p);
 
   bp_cce_mem_msg_s mem_resp_cast_i;
-  bp_resp_wormhole_packet_s packet_cast_o;
+  bp_mem_wormhole_packet_s packet_cast_o;
 
   assign mem_resp_cast_i = mem_resp_i;
   assign packet_o        = packet_cast_o;
@@ -69,13 +69,12 @@ module bp_me_wormhole_packet_encode_mem_resp
   always_comb begin
     packet_cast_o = '0;
 
-    packet_cast_o.data       = mem_resp_cast_i.data;
-    packet_cast_o.msg        = mem_resp_cast_i[0+:cce_mem_msg_width_lp-cce_block_width_p];
-    packet_cast_o.src_cord   = src_cord_i;
-    packet_cast_o.src_cid    = src_cid_i;
-
-    packet_cast_o.cord    = dst_cord_i;
-    packet_cast_o.cid     = dst_cid_i;
+    packet_cast_o.data                   = mem_resp_cast_i.data;
+    packet_cast_o.header.msg_hdr         = mem_resp_cast_i.header;
+    packet_cast_o.header.wh_hdr.src_cord = src_cord_i;
+    packet_cast_o.header.wh_hdr.src_cid  = src_cid_i;
+    packet_cast_o.header.wh_hdr.cord     = dst_cord_i;
+    packet_cast_o.header.wh_hdr.cid      = dst_cid_i;
 
     case (mem_resp_cast_i.header.size)
       e_mem_msg_size_1 : data_resp_len_li = len_width_p'(mem_resp_data_len_1_lp);
@@ -91,10 +90,10 @@ module bp_me_wormhole_packet_encode_mem_resp
 
     case (mem_resp_cast_i.header.msg_type)
       e_mem_msg_rd
-      ,e_mem_msg_uc_rd: packet_cast_o.len = data_resp_len_li;
+      ,e_mem_msg_uc_rd: packet_cast_o.header.wh_hdr.len = data_resp_len_li;
       e_mem_msg_uc_wr
       ,e_mem_msg_wr
-      ,e_mem_msg_pre  : packet_cast_o.len = len_width_p'(mem_resp_ack_len_lp);
+      ,e_mem_msg_pre  : packet_cast_o.header.wh_hdr.len = len_width_p'(mem_resp_ack_len_lp);
       default: packet_cast_o = '0;
     endcase
   end

--- a/bp_top/src/v/bp_cacc_tile.v
+++ b/bp_top/src/v/bp_cacc_tile.v
@@ -4,11 +4,10 @@ module bp_cacc_tile
  import bp_cce_pkg::*;
  import bp_me_pkg::*;
  import bsg_cache_pkg::*;
-   import bp_be_pkg::*;
-   import bsg_noc_pkg::*;
-   import bp_common_cfg_link_pkg::*;
-   import bsg_wormhole_router_pkg::*;
-  
+ import bp_be_pkg::*;
+ import bsg_noc_pkg::*;
+ import bp_common_cfg_link_pkg::*;
+ import bsg_wormhole_router_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_lce_cce_if_header_widths(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p)
@@ -16,7 +15,7 @@ module bp_cacc_tile
 
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam io_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(io_noc_flit_width_p)
-   , parameter accelerator_type_p = 1 
+   , parameter accelerator_type_p = e_cacc_vdp
    )
   (input                                    clk_i
    , input                                  reset_i
@@ -37,11 +36,6 @@ module bp_cacc_tile
   `declare_bp_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce_mem);
   `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
 
-  `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_req_header_width_lp+dword_width_p, lce_req_packet_s);
-  `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_req_width_lp, cce_lce_req_packet_s);
-  `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cmd_width_lp, lce_cmd_packet_s);
-  `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_resp_width_lp, lce_resp_packet_s);
-   
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, bp_coh_ready_and_link_s);
  
   //io-cce-side connections 
@@ -56,7 +50,7 @@ module bp_cacc_tile
   logic cce_io_resp_v_li, cce_io_resp_yumi_lo;
 
   // accelerator-side connections network connections
-  logic [lce_cce_req_header_width_lp+dword_width_p-1:0]  lce_req_lo;
+  bp_lce_cce_req_s  lce_req_lo;
   logic             lce_req_v_lo, lce_req_ready_li;
   bp_lce_cce_resp_s lce_resp_lo;
   logic             lce_resp_v_lo, lce_resp_ready_li;
@@ -105,18 +99,35 @@ module bp_cacc_tile
 
 
 ////////////////////////////////////////////////////////////////////
-  lce_req_packet_s lce_req_packet_lo;
-  cce_lce_req_packet_s lce_req_packet_li;
+  `declare_bp_lce_req_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_lce_cce_req_header_s, cce_block_width_p);
+  localparam lce_req_payload_width_lp = `bp_coh_wormhole_payload_width(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, $bits(bp_lce_cce_req_header_s), cce_block_width_p);
+  bp_lce_req_wormhole_packet_s lce_req_packet_lo, lce_req_packet_li;
+  bp_lce_req_wormhole_header_s lce_req_header_lo, lce_req_header_li;
+
+  `declare_bp_lce_cmd_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_lce_cmd_header_s, cce_block_width_p);
+  localparam lce_cmd_payload_width_lp = `bp_coh_wormhole_payload_width(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, $bits(bp_lce_cmd_header_s), cce_block_width_p);
+  bp_lce_cmd_wormhole_packet_s lce_cmd_packet_lo, lce_cmd_packet_li, cce_lce_cmd_packet_lo;
+  bp_lce_cmd_wormhole_header_s lce_cmd_header_lo, lce_cmd_header_li, cce_lce_cmd_header_lo;
+
+  bp_coh_ready_and_link_s lce_cmd_link_li, lce_cmd_link_lo;
+  bp_coh_ready_and_link_s cce_lce_cmd_link_li, cce_lce_cmd_link_lo;  
+  
+  `declare_bp_lce_resp_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_lce_cce_resp_header_s, cce_block_width_p);
+  localparam lce_resp_payload_width_lp = `bp_coh_wormhole_payload_width(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, $bits(bp_lce_cce_resp_header_s), cce_block_width_p);
+  bp_lce_resp_wormhole_packet_s lce_resp_packet_lo;
+  bp_lce_resp_wormhole_header_s lce_resp_header_lo;
+
   bp_me_wormhole_packet_encode_lce_req
    #(.bp_params_p(bp_params_p)
      )
    req_encode
-    (.payload_i(lce_req_lo)
-     ,.packet_o(lce_req_packet_lo)
+    (.lce_req_header_i(lce_req_lo.header)
+     ,.wh_header_o(lce_req_header_lo)
      );
+  assign lce_req_packet_lo = '{header: lce_req_header_lo, data: lce_req_lo.data};
 
   bsg_wormhole_router_adapter
-   #(.max_payload_width_p($bits(lce_req_packet_s)-coh_noc_cord_width_p-coh_noc_len_width_p)
+   #(.max_payload_width_p(lce_req_payload_width_lp)
      ,.len_width_p(coh_noc_len_width_p)
      ,.cord_width_p(coh_noc_cord_width_p)
      ,.flit_width_p(coh_noc_flit_width_p)
@@ -136,18 +147,18 @@ module bp_cacc_tile
      ,.v_o(cce_lce_req_v_li)
      ,.yumi_i(cce_lce_req_yumi_lo)
      );
-   assign cce_lce_req_li = lce_req_packet_li.payload;
+   assign cce_lce_req_li = '{header: lce_req_packet_li.header.msg_hdr, data: lce_req_packet_li.data};
 
-  lce_resp_packet_s lce_resp_packet_lo;
   bp_me_wormhole_packet_encode_lce_resp
     #(.bp_params_p(bp_params_p))
     resp_encode
-      (.payload_i(lce_resp_lo)
-       ,.packet_o(lce_resp_packet_lo)
-       );
+     (.lce_resp_header_i(lce_resp_lo.header)
+      ,.wh_header_o(lce_resp_header_lo)
+      );
+  assign lce_resp_packet_lo = '{header: lce_resp_header_lo, data: lce_resp_lo.data};
 
   bsg_wormhole_router_adapter_in
-    #(.max_payload_width_p($bits(lce_resp_packet_s)-coh_noc_cord_width_p-coh_noc_len_width_p)
+    #(.max_payload_width_p(lce_resp_payload_width_lp)
       ,.len_width_p(coh_noc_len_width_p)
       ,.cord_width_p(coh_noc_cord_width_p)
       ,.flit_width_p(coh_noc_flit_width_p)
@@ -164,51 +175,47 @@ module bp_cacc_tile
      ,.link_o(lce_resp_link_o)
      );
 
+  bp_me_wormhole_packet_encode_lce_cmd
+   #(.bp_params_p(bp_params_p))
+   cmd_encode
+    (.lce_cmd_header_i(lce_cmd_lo.header)
+     ,.wh_header_o(lce_cmd_header_lo)
+     );
+  assign lce_cmd_packet_lo = '{header: lce_cmd_header_lo, data: lce_cmd_lo.data};
 
-    bp_coh_ready_and_link_s lce_cmd_link_li, lce_cmd_link_lo;
-    bp_coh_ready_and_link_s cce_lce_cmd_link_li, cce_lce_cmd_link_lo;  
-    lce_cmd_packet_s lce_cmd_packet_li, lce_cmd_packet_lo;
-    bp_me_wormhole_packet_encode_lce_cmd
-     #(.bp_params_p(bp_params_p))
-     cmd_encode
-      (.payload_i(lce_cmd_lo)
-       ,.packet_o(lce_cmd_packet_lo)
-       );
+  bsg_wormhole_router_adapter
+   #(.max_payload_width_p(lce_cmd_payload_width_lp)
+     ,.len_width_p(coh_noc_len_width_p)
+     ,.cord_width_p(coh_noc_cord_width_p)
+     ,.flit_width_p(coh_noc_flit_width_p)
+     )
+   cmd_adapter
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
 
-    bsg_wormhole_router_adapter
-     #(.max_payload_width_p($bits(lce_cmd_packet_s)-coh_noc_cord_width_p-coh_noc_len_width_p)
-       ,.len_width_p(coh_noc_len_width_p)
-       ,.cord_width_p(coh_noc_cord_width_p)
-       ,.flit_width_p(coh_noc_flit_width_p)
-       )
-     cmd_adapter
-      (.clk_i(clk_i)
-       ,.reset_i(reset_i)
+     ,.packet_i(lce_cmd_packet_lo)
+     ,.v_i(lce_cmd_v_lo)
+     ,.ready_o(lce_cmd_ready_li)
 
-       ,.packet_i(lce_cmd_packet_lo)
-       ,.v_i(lce_cmd_v_lo)
-       ,.ready_o(lce_cmd_ready_li)
+     ,.link_i(lce_cmd_link_li)
+     ,.link_o(lce_cmd_link_lo)
 
-       ,.link_i(lce_cmd_link_li)
-       ,.link_o(lce_cmd_link_lo)
-
-       ,.packet_o(lce_cmd_packet_li)
-       ,.v_o(lce_cmd_v_li)
-       ,.yumi_i(lce_cmd_yumi_lo)
-       );
-    assign lce_cmd_li = lce_cmd_packet_li.payload;
-
-
+     ,.packet_o(lce_cmd_packet_li)
+     ,.v_o(lce_cmd_v_li)
+     ,.yumi_i(lce_cmd_yumi_lo)
+     );
+  assign lce_cmd_li = '{header: lce_cmd_packet_li.header.msg_hdr, data: lce_cmd_packet_li.data};
    
-  lce_cmd_packet_s cce_lce_cmd_packet_lo;
   bp_me_wormhole_packet_encode_lce_cmd
    #(.bp_params_p(bp_params_p))
    cce_cmd_encode
-    (.payload_i(cce_lce_cmd_lo)
-     ,.packet_o(cce_lce_cmd_packet_lo)
+    (.lce_cmd_header_i(cce_lce_cmd_lo.header)
+     ,.wh_header_o(cce_lce_cmd_header_lo)
      );
+  assign cce_lce_cmd_packet_lo = '{header: cce_lce_cmd_header_lo, data: cce_lce_cmd_lo.data};
+
   bsg_wormhole_router_adapter_in
-   #(.max_payload_width_p($bits(lce_cmd_packet_s)-coh_noc_cord_width_p-coh_noc_len_width_p)
+   #(.max_payload_width_p(lce_cmd_payload_width_lp)
      ,.len_width_p(coh_noc_len_width_p)
      ,.cord_width_p(coh_noc_cord_width_p)
      ,.flit_width_p(coh_noc_flit_width_p)
@@ -224,7 +231,6 @@ module bp_cacc_tile
      ,.link_i(cce_lce_cmd_link_li)
      ,.link_o(cce_lce_cmd_link_lo)
      );
-
 
   bp_coh_ready_and_link_s lce_cmd_link_cast_i, lce_cmd_link_cast_o;
   bp_coh_ready_and_link_s cmd_concentrated_link_li, cmd_concentrated_link_lo;
@@ -253,42 +259,42 @@ module bp_cacc_tile
      );
 
 
- if(cacc_type_p == e_cacc_vdp)
-   begin: cacc_vdp
-   bp_cacc_vdp
-   #(.bp_params_p(bp_params_p))
-   accelerator_link
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+  if (cacc_type_p == e_cacc_vdp)
+    begin : cacc_vdp
+      bp_cacc_vdp
+       #(.bp_params_p(bp_params_p))
+       accelerator_link
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
 
-     ,.lce_id_i(lce_id_li)
+         ,.lce_id_i(lce_id_li)
 
-     ,.io_cmd_i(cce_io_cmd_lo)
-     ,.io_cmd_v_i(cce_io_cmd_v_lo)
-     ,.io_cmd_ready_o(cce_io_cmd_ready_li)
+         ,.io_cmd_i(cce_io_cmd_lo)
+         ,.io_cmd_v_i(cce_io_cmd_v_lo)
+         ,.io_cmd_ready_o(cce_io_cmd_ready_li)
 
-     ,.io_resp_o(cce_io_resp_li)
-     ,.io_resp_v_o(cce_io_resp_v_li)
-     ,.io_resp_yumi_i(cce_io_resp_yumi_lo)
+         ,.io_resp_o(cce_io_resp_li)
+         ,.io_resp_v_o(cce_io_resp_v_li)
+         ,.io_resp_yumi_i(cce_io_resp_yumi_lo)
 
-     ,.lce_req_o(lce_req_lo)
-     ,.lce_req_v_o(lce_req_v_lo)
-     ,.lce_req_ready_i(lce_req_ready_li)
+         ,.lce_req_o(lce_req_lo)
+         ,.lce_req_v_o(lce_req_v_lo)
+         ,.lce_req_ready_i(lce_req_ready_li)
 
-     ,.lce_cmd_o(lce_cmd_lo)
-     ,.lce_cmd_v_o(lce_cmd_v_lo)
-     ,.lce_cmd_ready_i(lce_cmd_ready_li)
+         ,.lce_cmd_o(lce_cmd_lo)
+         ,.lce_cmd_v_o(lce_cmd_v_lo)
+         ,.lce_cmd_ready_i(lce_cmd_ready_li)
 
-     ,.lce_resp_o(lce_resp_lo)
-     ,.lce_resp_v_o(lce_resp_v_lo)
-     ,.lce_resp_ready_i(lce_resp_ready_li)
+         ,.lce_resp_o(lce_resp_lo)
+         ,.lce_resp_v_o(lce_resp_v_lo)
+         ,.lce_resp_ready_i(lce_resp_ready_li)
 
-     ,.lce_cmd_i(lce_cmd_li)
-     ,.lce_cmd_v_i(lce_cmd_v_li)
-     ,.lce_cmd_yumi_o(lce_cmd_yumi_lo)
+         ,.lce_cmd_i(lce_cmd_li)
+         ,.lce_cmd_v_i(lce_cmd_v_li)
+         ,.lce_cmd_yumi_o(lce_cmd_yumi_lo)
 
-     );
-  end
+         );
+    end
 
 endmodule
 

--- a/bp_top/src/v/bp_cacc_vdp.v
+++ b/bp_top/src/v/bp_cacc_vdp.v
@@ -47,12 +47,12 @@ module bp_cacc_vdp
     );
 
 
- `declare_bp_be_dcache_pkt_s(bp_page_offset_width_gp, dword_width_p);
+ `declare_bp_be_dcache_pkt_s(bp_page_offset_width_gp, dpath_width_p);
  `declare_bp_be_mem_structs(vaddr_width_p, ptag_width_p, lce_sets_p, cce_block_width_p/8);
    
   bp_be_dcache_pkt_s        dcache_pkt;   
   logic                     dcache_ready, dcache_v;
-  logic [dword_width_p-1:0] dcache_data;
+  logic [dpath_width_p-1:0] dcache_data;
   logic                     dcache_tlb_miss, dcache_poison;
   logic [ptag_width_p-1:0]  dcache_ptag;
   logic                     dcache_uncached;
@@ -69,7 +69,7 @@ module bp_cacc_vdp
   data_mem_pkt_v_i, data_mem_pkt_yumi_o,
   tag_mem_pkt_v_i, tag_mem_pkt_yumi_o,
   stat_mem_pkt_v_i, stat_mem_pkt_yumi_o,
-  cache_req_complete_lo;
+  cache_req_complete_lo, cache_req_critical_lo;
 
   `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, acache_sets_p, acache_assoc_p, dword_width_p, acache_block_width_p, acache_fill_width_p, cache);
 
@@ -85,7 +85,10 @@ module bp_cacc_vdp
 bp_pma
  #(.bp_params_p(bp_params_p))
   pma
-   (.ptag_v_i(dcache_pkt_v)
+   (.clk_i(clk_i)
+    ,.reset_i(reset_i)
+    
+    ,.ptag_v_i(dcache_pkt_v)
     ,.ptag_i(dcache_ptag)
 
     ,.uncached_o(dcache_uncached)
@@ -116,6 +119,7 @@ bp_be_dcache
 
     // D$-LCE Interface
     ,.cache_req_complete_i(cache_req_complete_lo)
+    ,.cache_req_critical_i(cache_req_critical_lo)
     ,.cache_req_o(cache_req_cast_o)
     ,.cache_req_v_o(cache_req_v_o)
     ,.cache_req_ready_i(cache_req_ready_i)
@@ -137,13 +141,23 @@ bp_be_dcache
     );
 
 
-bp_be_dcache_lce
- #(.bp_params_p(bp_params_p))
+bp_lce
+ #(.bp_params_p(bp_params_p)
+   ,.assoc_p(dcache_assoc_p)
+   ,.sets_p(dcache_sets_p)
+   ,.block_width_p(dcache_block_width_p)
+   ,.fill_width_p(dcache_fill_width_p)
+   ,.timeout_max_limit_p(4)
+   ,.credits_p(coh_noc_max_credits_p)
+   ,.data_mem_invert_clk_p(1)
+   ,.tag_mem_invert_clk_p(1)
+   )
   be_lce
    (.clk_i(clk_i)
     ,.reset_i(reset_i)
 
     ,.lce_id_i(cfg_bus_cast_i.dcache_id)
+    ,.lce_mode_i(cfg_bus_cast_i.dcache_mode)
 
     ,.cache_req_i(cache_req_cast_o)
     ,.cache_req_v_i(cache_req_v_o)
@@ -152,6 +166,7 @@ bp_be_dcache_lce
     ,.cache_req_metadata_v_i(cache_req_metadata_v_o)
 
     ,.cache_req_complete_o(cache_req_complete_lo)
+    ,.cache_req_critical_o(cache_req_critical_lo)
 
     ,.data_mem_pkt_o(data_mem_pkt_i)
     ,.data_mem_pkt_v_o(data_mem_pkt_v_i)

--- a/bp_top/src/v/bp_io_tile.v
+++ b/bp_top/src/v/bp_io_tile.v
@@ -34,7 +34,6 @@ module bp_io_tile
 
   `declare_bp_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce_mem);
   `declare_bp_lce_cce_if(cce_id_width_p, lce_id_width_p, paddr_width_p, lce_assoc_p, cce_block_width_p);
-  `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_req_width_lp, lce_req_packet_s);
   `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cmd_width_lp, lce_cmd_packet_s);
 
   bp_lce_cce_req_s  cce_lce_req_li, lce_lce_req_lo;
@@ -109,17 +108,21 @@ module bp_io_tile
      ,.io_resp_yumi_o(cce_io_resp_yumi_lo)
      );
 
-  lce_req_packet_s lce_req_packet_li, lce_req_packet_lo;
+  `declare_bp_lce_req_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_lce_cce_req_header_s, cce_block_width_p);
+  bp_lce_req_wormhole_packet_s lce_req_packet_li, lce_req_packet_lo;
+  bp_lce_req_wormhole_header_s lce_req_header_li, lce_req_header_lo;
   bp_me_wormhole_packet_encode_lce_req
    #(.bp_params_p(bp_params_p)
      )
    req_encode
-    (.payload_i(lce_lce_req_lo)
-     ,.packet_o(lce_req_packet_lo)
+    (.lce_req_header_i(lce_lce_req_lo.header)
+     ,.wh_header_o(lce_req_header_lo)
      );
+  assign lce_req_packet_lo = '{header: lce_req_header_lo, data: lce_lce_req_lo.data};
 
+  localparam lce_req_payload_width_lp = `bp_coh_wormhole_payload_width(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, $bits(bp_lce_cce_req_header_s), cce_block_width_p);
   bsg_wormhole_router_adapter
-   #(.max_payload_width_p($bits(lce_req_packet_s)-coh_noc_cord_width_p-coh_noc_len_width_p)
+   #(.max_payload_width_p(lce_req_payload_width_lp)
      ,.len_width_p(coh_noc_len_width_p)
      ,.cord_width_p(coh_noc_cord_width_p)
      ,.flit_width_p(coh_noc_flit_width_p)
@@ -139,18 +142,22 @@ module bp_io_tile
      ,.v_o(cce_lce_req_v_li)
      ,.yumi_i(cce_lce_req_yumi_lo)
      );
-  assign cce_lce_req_li = lce_req_packet_li.payload;
+  assign cce_lce_req_li = '{header: lce_req_packet_li.header.msg_hdr, data: lce_req_packet_li.data};
 
-  lce_cmd_packet_s lce_cmd_packet_li, lce_cmd_packet_lo;
+  `declare_bp_lce_cmd_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_lce_cmd_header_s, cce_block_width_p);
+  bp_lce_cmd_wormhole_packet_s lce_cmd_packet_li, lce_cmd_packet_lo;
+  bp_lce_cmd_wormhole_header_s lce_cmd_header_li, lce_cmd_header_lo;
   bp_me_wormhole_packet_encode_lce_cmd
    #(.bp_params_p(bp_params_p))
    cmd_encode
-    (.payload_i(cce_lce_cmd_lo)
-     ,.packet_o(lce_cmd_packet_lo)
+    (.lce_cmd_header_i(cce_lce_cmd_lo.header)
+     ,.wh_header_o(lce_cmd_header_lo)
      );
+  assign lce_cmd_packet_lo = '{header: lce_cmd_header_lo, data: cce_lce_cmd_lo.data};
 
+  localparam lce_cmd_payload_width_lp = `bp_coh_wormhole_payload_width(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, $bits(bp_lce_cmd_header_s), cce_block_width_p);
   bsg_wormhole_router_adapter
-   #(.max_payload_width_p($bits(lce_cmd_packet_s)-coh_noc_cord_width_p-coh_noc_len_width_p)
+   #(.max_payload_width_p(lce_cmd_payload_width_lp)
      ,.len_width_p(coh_noc_len_width_p)
      ,.cord_width_p(coh_noc_cord_width_p)
      ,.flit_width_p(coh_noc_flit_width_p)
@@ -170,7 +177,7 @@ module bp_io_tile
      ,.v_o(lce_lce_cmd_v_li)
      ,.yumi_i(lce_lce_cmd_yumi_lo)
      );
-  assign lce_lce_cmd_li = lce_cmd_packet_li.payload;
+  assign lce_lce_cmd_li = '{header: lce_cmd_packet_li.header.msg_hdr, data: lce_cmd_packet_li.data};
 
   logic [io_noc_did_width_p-1:0]  dst_did_lo;
   logic [io_noc_cord_width_p-1:0] dst_cord_lo;

--- a/bp_top/src/v/bp_sacc_vdp.v
+++ b/bp_top/src/v/bp_sacc_vdp.v
@@ -317,6 +317,7 @@ module bp_sacc_vdp
    assign dot_product_temp = sum_l2[0] + sum_l2[1];
 
 //SPM
+wire [`BSG_SAFE_CLOG2(20)-1:0] spm_addr_li = spm_addr >> 3;
 bsg_mem_1rw_sync
   #(.width_p(64)
     ,.els_p(20)
@@ -325,7 +326,7 @@ bsg_mem_1rw_sync
   (.clk_i(clk_i)
    ,.reset_i(reset_i)
    ,.data_i(spm_data_li)
-   ,.addr_i(spm_addr >> 3)
+   ,.addr_i(spm_addr_li)
    ,.v_i(spm_internal_read_v_li | spm_external_read_v_li | spm_internal_write_v_li | spm_external_write_v_li)
    ,.w_i(spm_internal_write_v_li | spm_external_write_v_li)
    ,.data_o(spm_data_lo)

--- a/bp_top/src/v/bp_tile.v
+++ b/bp_top/src/v/bp_tile.v
@@ -234,13 +234,20 @@ bp_cce_wrapper
    ,.mem_resp_yumi_o(cce_mem_resp_yumi_lo)
    );
 
-`declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_req_width_lp, lce_req_packet_s);
-`declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cmd_width_lp, lce_cmd_packet_s);
-`declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cce_resp_width_lp, lce_resp_packet_s);
+`declare_bp_lce_req_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_lce_cce_req_header_s, cce_block_width_p);
+localparam lce_req_payload_width_lp = `bp_coh_wormhole_payload_width(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, $bits(bp_lce_cce_req_header_s), cce_block_width_p);
+bp_lce_req_wormhole_packet_s [1:0] lce_req_packet_lo;
+bp_lce_req_wormhole_header_s [1:0] lce_req_header_lo;
 
-lce_req_packet_s [1:0]  lce_req_packet_lo;
-lce_cmd_packet_s [1:0]  lce_cmd_packet_lo, lce_cmd_packet_li;
-lce_resp_packet_s [1:0] lce_resp_packet_lo;
+`declare_bp_lce_cmd_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_lce_cmd_header_s, cce_block_width_p);
+localparam lce_cmd_payload_width_lp = `bp_coh_wormhole_payload_width(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, $bits(bp_lce_cmd_header_s), cce_block_width_p);
+bp_lce_cmd_wormhole_packet_s [1:0] lce_cmd_packet_lo, lce_cmd_packet_li;
+bp_lce_cmd_wormhole_header_s [1:0] lce_cmd_header_lo, lce_cmd_header_li;
+
+`declare_bp_lce_resp_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_lce_cce_resp_header_s, cce_block_width_p);
+localparam lce_resp_payload_width_lp = `bp_coh_wormhole_payload_width(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, $bits(bp_lce_cce_resp_header_s), cce_block_width_p);
+bp_lce_resp_wormhole_packet_s [1:0] lce_resp_packet_lo;
+bp_lce_resp_wormhole_header_s [1:0] lce_resp_header_lo;
 
 bp_coh_ready_and_link_s [1:0] lce_req_link_li, lce_req_link_lo;
 bp_coh_ready_and_link_s [1:0] lce_cmd_link_li, lce_cmd_link_lo;
@@ -256,12 +263,13 @@ for (genvar i = 0; i < 2; i++)
      #(.bp_params_p(bp_params_p)
        )
      req_encode
-      (.payload_i(lce_req_lo[i])
-       ,.packet_o(lce_req_packet_lo[i])
+      (.lce_req_header_i(lce_req_lo[i].header)
+       ,.wh_header_o(lce_req_header_lo[i])
        );
+    assign lce_req_packet_lo[i] = '{header: lce_req_header_lo[i], data: lce_req_lo[i].data};
 
     bsg_wormhole_router_adapter_in
-     #(.max_payload_width_p($bits(lce_req_packet_s)-coh_noc_cord_width_p-coh_noc_len_width_p)
+     #(.max_payload_width_p(lce_req_payload_width_lp)
        ,.len_width_p(coh_noc_len_width_p)
        ,.cord_width_p(coh_noc_cord_width_p)
        ,.flit_width_p(coh_noc_flit_width_p)
@@ -281,12 +289,13 @@ for (genvar i = 0; i < 2; i++)
     bp_me_wormhole_packet_encode_lce_cmd
      #(.bp_params_p(bp_params_p))
      cmd_encode
-      (.payload_i(lce_cmd_lo[i])
-       ,.packet_o(lce_cmd_packet_lo[i])
+      (.lce_cmd_header_i(lce_cmd_lo[i].header)
+       ,.wh_header_o(lce_cmd_header_lo[i])
        );
+    assign lce_cmd_packet_lo[i] = '{header: lce_cmd_header_lo[i], data: lce_cmd_lo[i].data};
 
     bsg_wormhole_router_adapter
-     #(.max_payload_width_p($bits(lce_cmd_packet_s)-coh_noc_cord_width_p-coh_noc_len_width_p)
+     #(.max_payload_width_p(lce_cmd_payload_width_lp)
        ,.len_width_p(coh_noc_len_width_p)
        ,.cord_width_p(coh_noc_cord_width_p)
        ,.flit_width_p(coh_noc_flit_width_p)
@@ -306,17 +315,18 @@ for (genvar i = 0; i < 2; i++)
        ,.v_o(lce_cmd_v_li[i])
        ,.yumi_i(lce_cmd_yumi_lo[i])
        );
-    assign lce_cmd_li[i] = lce_cmd_packet_li[i].payload;
+    assign lce_cmd_li[i] = '{header: lce_cmd_packet_li[i].header.msg_hdr, data: lce_cmd_packet_li[i].data};
 
     bp_me_wormhole_packet_encode_lce_resp
      #(.bp_params_p(bp_params_p))
      resp_encode
-      (.payload_i(lce_resp_lo[i])
-       ,.packet_o(lce_resp_packet_lo[i])
+      (.lce_resp_header_i(lce_resp_lo[i].header)
+       ,.wh_header_o(lce_resp_header_lo[i])
        );
+    assign lce_resp_packet_lo[i] = '{header: lce_resp_header_lo[i], data: lce_resp_lo[i].data};
 
     bsg_wormhole_router_adapter_in
-     #(.max_payload_width_p($bits(lce_resp_packet_s)-coh_noc_cord_width_p-coh_noc_len_width_p)
+     #(.max_payload_width_p(lce_resp_payload_width_lp)
        ,.len_width_p(coh_noc_len_width_p)
        ,.cord_width_p(coh_noc_cord_width_p)
        ,.flit_width_p(coh_noc_flit_width_p)
@@ -334,9 +344,9 @@ for (genvar i = 0; i < 2; i++)
        );
   end
 
-  lce_req_packet_s cce_lce_req_packet_li;
+  bp_lce_req_wormhole_packet_s cce_lce_req_packet_li;
   bsg_wormhole_router_adapter_out
-   #(.max_payload_width_p($bits(lce_req_packet_s)-coh_noc_cord_width_p-coh_noc_len_width_p)
+   #(.max_payload_width_p(lce_req_payload_width_lp)
      ,.len_width_p(coh_noc_len_width_p)
      ,.cord_width_p(coh_noc_cord_width_p)
      ,.flit_width_p(coh_noc_flit_width_p)
@@ -352,18 +362,20 @@ for (genvar i = 0; i < 2; i++)
     ,.v_o(cce_lce_req_v_li)
     ,.yumi_i(cce_lce_req_yumi_lo)
     );
-  assign cce_lce_req_li = cce_lce_req_packet_li.payload;
+  assign cce_lce_req_li = '{header: cce_lce_req_packet_li.header.msg_hdr, data: cce_lce_req_packet_li.data};
 
-  lce_cmd_packet_s cce_lce_cmd_packet_lo;
+  bp_lce_cmd_wormhole_packet_s cce_lce_cmd_packet_lo;
+  bp_lce_cmd_wormhole_header_s cce_lce_cmd_header_lo;
   bp_me_wormhole_packet_encode_lce_cmd
    #(.bp_params_p(bp_params_p))
    cmd_encode
-    (.payload_i(cce_lce_cmd_lo)
-     ,.packet_o(cce_lce_cmd_packet_lo)
+    (.lce_cmd_header_i(cce_lce_cmd_lo.header)
+     ,.wh_header_o(cce_lce_cmd_header_lo)
      );
+  assign cce_lce_cmd_packet_lo = '{header: cce_lce_cmd_header_lo, data: cce_lce_cmd_lo.data};
 
   bsg_wormhole_router_adapter_in
-   #(.max_payload_width_p($bits(lce_cmd_packet_s)-coh_noc_cord_width_p-coh_noc_len_width_p)
+   #(.max_payload_width_p(lce_cmd_payload_width_lp)
      ,.len_width_p(coh_noc_len_width_p)
      ,.cord_width_p(coh_noc_cord_width_p)
      ,.flit_width_p(coh_noc_flit_width_p)
@@ -380,9 +392,9 @@ for (genvar i = 0; i < 2; i++)
      ,.link_o(cce_lce_cmd_link_lo)
      );
 
-  lce_resp_packet_s cce_lce_resp_packet_li;
+  bp_lce_resp_wormhole_packet_s cce_lce_resp_packet_li;
   bsg_wormhole_router_adapter_out
-   #(.max_payload_width_p($bits(lce_resp_packet_s)-coh_noc_cord_width_p-coh_noc_len_width_p)
+   #(.max_payload_width_p(lce_resp_payload_width_lp)
      ,.len_width_p(coh_noc_len_width_p)
      ,.cord_width_p(coh_noc_cord_width_p)
      ,.flit_width_p(coh_noc_flit_width_p)
@@ -398,7 +410,7 @@ for (genvar i = 0; i < 2; i++)
     ,.v_o(cce_lce_resp_v_li)
     ,.yumi_i(cce_lce_resp_yumi_lo)
     );
-  assign cce_lce_resp_li = cce_lce_resp_packet_li.payload;
+  assign cce_lce_resp_li = '{header: cce_lce_resp_packet_li.header.msg_hdr, data: cce_lce_resp_packet_li.data};
 
   bp_coh_ready_and_link_s req_concentrated_link_li, req_concentrated_link_lo;
   bp_coh_ready_and_link_s cmd_concentrated_link_li, cmd_concentrated_link_lo;
@@ -497,7 +509,7 @@ for (genvar i = 0; i < 2; i++)
      ,.reqs_i({loopback_mem_resp_v_lo, clint_mem_resp_v_lo, cfg_mem_resp_v_lo, cache_mem_resp_v_lo})
      ,.grants_o({loopback_mem_resp_yumi_li, clint_mem_resp_yumi_li, cfg_mem_resp_yumi_li, cache_mem_resp_yumi_li})
      );
-  assign cce_mem_resp_v_li = loopback_mem_resp_lo | cache_mem_resp_v_lo | cfg_mem_resp_v_lo | clint_mem_resp_v_lo;
+  assign cce_mem_resp_v_li = loopback_mem_resp_v_lo | cache_mem_resp_v_lo | cfg_mem_resp_v_lo | clint_mem_resp_v_lo;
   assign cce_mem_resp_li = cache_mem_resp_v_lo
                            ? cache_mem_resp_lo
                            : cfg_mem_resp_v_lo

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -266,12 +266,12 @@ $BP_ME_DIR/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
 ## TOP
 $BP_TOP_DIR/src/v/bp_nd_socket.v
 $BP_TOP_DIR/src/v/bp_cacc_vdp.v
-#$BP_TOP_DIR/src/v/bp_cacc_tile.v
-#$BP_TOP_DIR/src/v/bp_cacc_tile_node.v
+$BP_TOP_DIR/src/v/bp_cacc_tile.v
+$BP_TOP_DIR/src/v/bp_cacc_tile_node.v
 $BP_TOP_DIR/src/v/bp_cacc_complex.v
 $BP_TOP_DIR/src/v/bp_sacc_vdp.v
-#$BP_TOP_DIR/src/v/bp_sacc_tile.v
-#$BP_TOP_DIR/src/v/bp_sacc_tile_node.v
+$BP_TOP_DIR/src/v/bp_sacc_tile.v
+$BP_TOP_DIR/src/v/bp_sacc_tile_node.v
 $BP_TOP_DIR/src/v/bp_sacc_complex.v
 $BP_TOP_DIR/src/v/bp_cfg.v
 $BP_TOP_DIR/src/v/bp_core.v

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -266,12 +266,12 @@ $BP_ME_DIR/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
 ## TOP
 $BP_TOP_DIR/src/v/bp_nd_socket.v
 $BP_TOP_DIR/src/v/bp_cacc_vdp.v
-$BP_TOP_DIR/src/v/bp_cacc_tile.v
-$BP_TOP_DIR/src/v/bp_cacc_tile_node.v
+#$BP_TOP_DIR/src/v/bp_cacc_tile.v
+#$BP_TOP_DIR/src/v/bp_cacc_tile_node.v
 $BP_TOP_DIR/src/v/bp_cacc_complex.v
 $BP_TOP_DIR/src/v/bp_sacc_vdp.v
-$BP_TOP_DIR/src/v/bp_sacc_tile.v
-$BP_TOP_DIR/src/v/bp_sacc_tile_node.v
+#$BP_TOP_DIR/src/v/bp_sacc_tile.v
+#$BP_TOP_DIR/src/v/bp_sacc_tile_node.v
 $BP_TOP_DIR/src/v/bp_sacc_complex.v
 $BP_TOP_DIR/src/v/bp_cfg.v
 $BP_TOP_DIR/src/v/bp_core.v


### PR DESCRIPTION
This PR is mostly in preparation for wormhole streamer changes, which require separation of header/data ports for various modules.  No functional change / no PPA change.

- Separating out header / data in wormhole definitions
- Fixing wormhole padding definitions in bp_mem_wormhole.vh (Fixes #464)
- Refactored wormhole encoders to only translate header->header
- Minor bug fix: Line 512 of bp_tile _lo -> _v_lo