### PR TITLE
enforce memory credits on mem_cmd for normal mode and in FSM CCE

### DIFF
--- a/bp_me/src/v/cce/bp_cce.v
+++ b/bp_me/src/v/cce/bp_cce.v
@@ -227,6 +227,7 @@ module bp_cce
   logic                                      msg_lce_resp_busy_lo;
   logic                                      msg_mem_resp_busy_lo;
   logic                                      msg_busy_lo;
+  logic                                      msg_mem_credits_empty_lo;
 
   // From Stall Unit
   //logic [counter_width_lp-1:0]               stall_count_lo;
@@ -623,6 +624,8 @@ module bp_cce
       ,.mem_resp_busy_o(msg_mem_resp_busy_lo)
       // Stall ucode (as in inv command being processed)
       ,.busy_o(msg_busy_lo)
+      // memory credits empty
+      ,.mem_credits_empty_o(msg_mem_credits_empty_lo)
 
       );
 
@@ -668,6 +671,7 @@ module bp_cce
 
       ,.lce_cmd_ready_i(lce_cmd_ready_i)
       ,.mem_cmd_ready_i(mem_cmd_ready_i)
+      ,.mem_credits_empty_i(msg_mem_credits_empty_lo)
 
       // From Messague Unit
       ,.msg_busy_i(msg_busy_lo)

--- a/bp_me/src/v/cce/bp_cce_inst_stall.v
+++ b/bp_me/src/v/cce/bp_cce_inst_stall.v
@@ -26,6 +26,7 @@ module bp_cce_inst_stall
    // output queue ready signals
    , input                                       lce_cmd_ready_i
    , input                                       mem_cmd_ready_i
+   , input                                       mem_credits_empty_i
 
    // Messague Unit resource busy signals
 
@@ -82,6 +83,7 @@ module bp_cce_inst_stall
     // Message send
     stall_o |= (decoded_inst_i.lce_cmd_v & ~lce_cmd_ready);
     stall_o |= (decoded_inst_i.mem_cmd_v & ~mem_cmd_ready);
+    stall_o |= (decoded_inst_i.mem_cmd_v & mem_credits_empty_i);
 
     // Wait for queue operation
     stall_o |= (decoded_inst_i.wfq_v & ~(|(wfq_mask & wfq_v_vec)));

--- a/bp_me/src/v/cce/bp_cce_msg.v
+++ b/bp_me/src/v/cce/bp_cce_msg.v
@@ -112,6 +112,8 @@ module bp_cce_msg
    , output logic                                      mem_resp_busy_o
    , output logic                                      busy_o
 
+   , output logic                                      mem_credits_empty_o
+
   );
 
   // LCE-CCE and Mem-CCE Interface
@@ -187,6 +189,7 @@ module bp_cce_msg
 
   wire mem_credits_empty = (mem_credit_count_lo == mem_noc_max_credits_p);
   wire mem_credits_full = (mem_credit_count_lo == 0);
+  assign mem_credits_empty_o = mem_credits_empty;
 
   // Registers for inputs
   logic  [paddr_width_p-1:0] addr_r, addr_n;
@@ -665,7 +668,7 @@ module bp_cce_msg
                 & ((decoded_inst_i.pending_w_v & ~pending_w_v_o)
                    | ~decoded_inst_i.pending_w_v)) begin
 
-              mem_cmd_v_o = mem_cmd_ready_i;
+              mem_cmd_v_o = mem_cmd_ready_i & ~mem_credits_empty;
 
               // All commands use message type
               mem_cmd.header.msg_type = decoded_inst_i.mem_cmd;


### PR DESCRIPTION
This change forces the ucode CCE normal mode to account for available memory credits when sending a mem_cmd, stalling the ucode engine if there are no credits available.

This change also adds memory credit flow control to the FSM CCE.