### PR TITLE
Disable co-simulation checks in debug mode

### DIFF
--- a/bp_top/test/common/bp_nonsynth_cosim.v
+++ b/bp_top/test/common/bp_nonsynth_cosim.v
@@ -39,6 +39,7 @@ module bp_nonsynth_cosim
 
     , input                                   interrupt_v_i
     , input [dword_width_p-1:0]               cause_i
+    , input                                   is_debug_mode_i
     );
 
 import "DPI-C" context function void dromajo_init(string cfg_f_name, int hartid, int ncpus, int memory_size, bit checkpoint);
@@ -75,20 +76,21 @@ always_ff @(negedge reset_i)
   logic                     commit_frd_w_v_r;
   logic                     interrupt_v_r;
   logic [dword_width_p-1:0] cause_r;
+  logic                     is_debug_mode_r;
   logic commit_fifo_v_lo, commit_fifo_yumi_li;
   wire commit_ird_w_v_li = commit_v_i & (decode_r.irf_w_v | decode_r.late_iwb_v);
   wire commit_frd_w_v_li = commit_v_i & (decode_r.frf_w_v | decode_r.late_fwb_v);
   bsg_fifo_1r1w_small
-   #(.width_p(2+vaddr_width_p+instr_width_p+2+dword_width_p), .els_p(16))
+   #(.width_p(2+vaddr_width_p+instr_width_p+2+dword_width_p+1), .els_p(16))
    commit_fifo
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.data_i({commit_v_i, commit_pc_i, commit_instr_i, commit_ird_w_v_li, commit_frd_w_v_li, interrupt_v_i, cause_i})
+     ,.data_i({commit_v_i, commit_pc_i, commit_instr_i, commit_ird_w_v_li, commit_frd_w_v_li, interrupt_v_i, cause_i, is_debug_mode_i})
      ,.v_i(commit_v_i | interrupt_v_i)
      ,.ready_o()
 
-     ,.data_o({commit_v_r, commit_pc_r, commit_instr_r, commit_ird_w_v_r, commit_frd_w_v_r, interrupt_v_r, cause_r})
+     ,.data_o({commit_v_r, commit_pc_r, commit_instr_r, commit_ird_w_v_r, commit_frd_w_v_r, interrupt_v_r, cause_r, is_debug_mode_r})
      ,.v_o(commit_fifo_v_lo)
      ,.yumi_i(commit_fifo_yumi_li)
      );
@@ -149,12 +151,14 @@ always_ff @(negedge reset_i)
                                                    | (commit_frd_w_v_r & frd_fifo_v_lo)
                                                    );
 
+  wire disable_cosim = is_debug_mode_r;
+
   logic [`BSG_SAFE_CLOG2(max_instr_lp+1)-1:0] instr_cnt;
   bsg_counter_clear_up
    #(.max_val_p(max_instr_lp), .init_val_p(0))
    instr_counter
     (.clk_i(clk_i)
-     ,.reset_i(reset_i | freeze_i)
+     ,.reset_i(reset_i | freeze_i | disable_cosim)
 
      ,.clear_i(1'b0)
      ,.up_i(commit_v_i)
@@ -177,7 +181,7 @@ always_ff @(negedge reset_i)
     if(en_i) begin
       if(commit_fifo_yumi_li & interrupt_v_r) begin
         dromajo_trap(mhartid_i, cause_r);
-      end else if (commit_fifo_yumi_li & commit_v_r & commit_pc_r != '0) begin
+      end else if (commit_fifo_yumi_li & commit_v_r & ~disable_cosim & commit_pc_r != '0) begin
         if (dromajo_step(mhartid_i, 64'($signed(commit_pc_r)), commit_instr_r, frd_fifo_yumi_li ? frd_raw_li : iwb_data_r)) begin
           $display("COSIM_FAIL");
           $finish();

--- a/bp_top/test/common/bp_nonsynth_cosim.v
+++ b/bp_top/test/common/bp_nonsynth_cosim.v
@@ -151,14 +151,12 @@ always_ff @(negedge reset_i)
                                                    | (commit_frd_w_v_r & frd_fifo_v_lo)
                                                    );
 
-  wire disable_cosim = is_debug_mode_r;
-
   logic [`BSG_SAFE_CLOG2(max_instr_lp+1)-1:0] instr_cnt;
   bsg_counter_clear_up
    #(.max_val_p(max_instr_lp), .init_val_p(0))
    instr_counter
     (.clk_i(clk_i)
-     ,.reset_i(reset_i | freeze_i | disable_cosim)
+     ,.reset_i(reset_i | freeze_i | is_debug_mode_r)
 
      ,.clear_i(1'b0)
      ,.up_i(commit_v_i)
@@ -181,7 +179,7 @@ always_ff @(negedge reset_i)
     if(en_i) begin
       if(commit_fifo_yumi_li & interrupt_v_r) begin
         dromajo_trap(mhartid_i, cause_r);
-      end else if (commit_fifo_yumi_li & commit_v_r & ~disable_cosim & commit_pc_r != '0) begin
+      end else if (commit_fifo_yumi_li & commit_v_r  & ~is_debug_mode_r & commit_pc_r != '0) begin
         if (dromajo_step(mhartid_i, 64'($signed(commit_pc_r)), commit_instr_r, frd_fifo_yumi_li ? frd_raw_li : iwb_data_r)) begin
           $display("COSIM_FAIL");
           $finish();

--- a/bp_top/test/common/dromajo_cosim.cpp
+++ b/bp_top/test/common/dromajo_cosim.cpp
@@ -21,7 +21,6 @@ extern "C" void dromajo_init(char* cfg_f_name, int hartid, int ncpus, int memory
     string memsize_str = "--memory_size=" + to_string(memory_size);
     string mmio_str = "--mmio_range=0x20000:0x80000000";
     char* load_str = "--load=prog";
-    char* bootrom_str = "--bootrom=bootrom.bin";
 
     if(checkpoint) {
       char* argv[] = {"dromajo", (char*)(&ncpus_str[0]), (char*)(&memsize_str[0]), (char*)(&mmio_str[0]), load_str, "prog.elf"};

--- a/bp_top/test/common/dromajo_cosim.cpp
+++ b/bp_top/test/common/dromajo_cosim.cpp
@@ -28,8 +28,8 @@ extern "C" void dromajo_init(char* cfg_f_name, int hartid, int ncpus, int memory
       dromajo_pointer = dromajo_cosim_init(6, argv);
     }
     else {
-      char* argv[] = {"dromajo", (char*)(&ncpus_str[0]), (char*)(&memsize_str[0]), (char*)(&mmio_str[0]), bootrom_str, "prog.elf"};
-      dromajo_pointer = dromajo_cosim_init(6, argv);
+      char* argv[] = {"dromajo", (char*)(&ncpus_str[0]), (char*)(&memsize_str[0]), (char*)(&mmio_str[0]), "prog.elf"};
+      dromajo_pointer = dromajo_cosim_init(5, argv);
     }
   }
 }
@@ -45,7 +45,7 @@ extern "C" bool dromajo_step(int      hartid,
                                      wdata,
                                      0,
                                      true,
-                                     false);
+                                     true);
   if(exit_code != 0)
     return true;
   else

--- a/bp_top/test/common/dromajo_cosim.cpp
+++ b/bp_top/test/common/dromajo_cosim.cpp
@@ -45,7 +45,7 @@ extern "C" bool dromajo_step(int      hartid,
                                      wdata,
                                      0,
                                      true,
-                                     true);
+                                     false);
   if(exit_code != 0)
     return true;
   else

--- a/bp_top/test/tb/bp_tethered/Makefile.vcs
+++ b/bp_top/test/tb/bp_tethered/Makefile.vcs
@@ -63,7 +63,7 @@ SIM_COLLATERAL  = $(addprefix $(SIM_DIR)/, simv simv.daidir)
 SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, prog.riscv prog.elf prog.mem prog.nbf prog.dump)
 SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, cce_ucode.mem)
 SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, dram_ch.ini dram_sys.ini)
-SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, bootrom.riscv bootrom.bin bootrom.mem bootrom.dump)
+SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, bootrom.riscv bootrom.mem bootrom.dump)
 
 SAMPLE_COLLATERAL  = $(addprefix $(SIM_DIR)/, simv simv.daidir)
 SAMPLE_COLLATERAL += $(addprefix $(SIM_DIR)/, prog.riscv prog.elf prog.dump)

--- a/bp_top/test/tb/bp_tethered/Makefile.vcs
+++ b/bp_top/test/tb/bp_tethered/Makefile.vcs
@@ -45,8 +45,8 @@ $(SIM_DIR)/dram_ch.ini $(SIM_DIR)/dram_sys.ini:
 $(SIM_DIR)/bootrom.riscv: $(BP_TEST_MEM_DIR)/bootrom.riscv
 	cp $^ $@
 
-$(SIM_DIR)/bootrom.mem: $(SIM_DIR)/bootrom.bin
-	$(RISCV_OBJCOPY) -I binary $< -O verilog --reverse-bytes=4 --verilog-data-width=4 $@
+$(SIM_DIR)/bootrom.mem: $(SIM_DIR)/bootrom.riscv
+	$(RISCV_OBJCOPY) -O verilog --reverse-bytes=4 --verilog-data-width=4 $< $@
 
 NBF_INPUTS = $(NCPUS)
 NBF_INPUTS += cce_ucode.mem

--- a/bp_top/test/tb/bp_tethered/Makefile.verilator
+++ b/bp_top/test/tb/bp_tethered/Makefile.verilator
@@ -56,8 +56,8 @@ $(SIM_DIR)/prog.nbf: $(SIM_DIR)/cce_ucode.mem $(SIM_DIR)/prog.mem
 $(SIM_DIR)/bootrom.riscv: $(BP_TEST_MEM_DIR)/bootrom.riscv
 	cp $^ $@
 
-$(SIM_DIR)/bootrom.mem: $(SIM_DIR)/bootrom.bin
-	$(RISCV_OBJCOPY) -I binary $< -O verilog --reverse-bytes=4 --verilog-data-width=4 $@
+$(SIM_DIR)/bootrom.mem: $(SIM_DIR)/bootrom.riscv
+	$(RISCV_OBJCOPY) -O verilog --reverse-bytes=4 --verilog-data-width=4 $< $@
 
 SIM_COLLATERAL  = $(addprefix $(SIM_DIR)/, simsc)
 SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, prog.riscv prog.elf prog.mem prog.nbf prog.dump)

--- a/bp_top/test/tb/bp_tethered/Makefile.verilator
+++ b/bp_top/test/tb/bp_tethered/Makefile.verilator
@@ -63,7 +63,7 @@ SIM_COLLATERAL  = $(addprefix $(SIM_DIR)/, simsc)
 SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, prog.riscv prog.elf prog.mem prog.nbf prog.dump)
 SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, cce_ucode.mem)
 SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, dram_ch.ini dram_sys.ini)
-SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, bootrom.riscv bootrom.bin bootrom.mem bootrom.dump)
+SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, bootrom.riscv bootrom.mem bootrom.dump)
 
 sim_sample.sc: build.sc
 sim_sample.sc: $(SIM_DIR)/run_samplesc

--- a/bp_top/test/tb/bp_tethered/testbench.v
+++ b/bp_top/test/tb/bp_tethered/testbench.v
@@ -245,6 +245,7 @@ bind bp_be_top
                ? calculator.pipe_sys.csr.scause_li
                : calculator.pipe_sys.csr.mcause_li
                )
+     ,.is_debug_mode_i(calculator.pipe_sys.csr.is_debug_mode)
      );
 
 always_ff @(posedge clk_i) begin


### PR DESCRIPTION
This PR adds code to disable co-simulation checking during debug mode. This will be helpful for the next version of the bootrom which will set up the configuration as well copy the program to the memory. 

In the future, an optional checking of the boot flow will also be provided. 

Note: A specific commit in Dromajo still needs to be reverted (https://github.com/bsg-external/dromajo/commit/4485477adcfb7f16a62dfb66b95ec1d62d8c1a32) but since I do not have access to the repository, I am unable to make this change. 