### PR TITLE
Removing instr_v field from BE

### DIFF
--- a/bp_be/src/include/bp_be_ctl_defines.vh
+++ b/bp_be/src/include/bp_be_ctl_defines.vh
@@ -193,7 +193,6 @@ typedef enum logic
 typedef struct packed
 {
   logic                             v;
-  logic                             instr_v;
 
   logic                             pipe_ctl_v;
   logic                             pipe_int_v;

--- a/bp_be/src/include/bp_be_internal_if_defines.vh
+++ b/bp_be/src/include/bp_be_internal_if_defines.vh
@@ -52,7 +52,6 @@
     rv64_instr_s                       instr;                                                      \
                                                                                                    \
     logic                              v;                                                          \
-    logic                              instr_v;                                                    \
     logic                              pipe_ctl_v;                                                 \
     logic                              pipe_int_v;                                                 \
     logic                              pipe_mem_early_v;                                           \
@@ -119,7 +118,6 @@
   typedef struct packed                                                                            \
   {                                                                                                \
     logic                                    ex1_v;                                                \
-    logic                                    ex1_instr_v;                                          \
     logic [vaddr_width_p-1:0]                ex1_npc;                                              \
     logic                                    ex1_br_or_jmp;                                        \
     logic                                    ex1_btaken;                                           \
@@ -146,9 +144,9 @@
     logic [instr_width_p-1:0]    instr;                                                            \
   }  bp_be_commit_pkt_s;                                                                           \
                                                                                                    \
-  /* TODO: make opcode */                                                                          \
   typedef struct packed                                                                            \
   {                                                                                                \
+    logic                           v;                                                             \
     logic [vaddr_width_p-1:0]       npc;                                                           \
     logic [rv64_priv_width_gp-1:0]  priv_n;                                                        \
     logic                           translation_en_n;                                              \
@@ -226,7 +224,7 @@
 `define bp_be_pipe_stage_reg_width(vaddr_width_mp) \
    (vaddr_width_mp                                                                                 \
    + rv64_instr_width_gp                                                                           \
-   + 16                                                                                            \
+   + 15                                                                                            \
    )
 
 `define bp_be_comp_stage_reg_width \
@@ -239,7 +237,7 @@
   (14 + rv64_reg_addr_width_gp)
 
 `define bp_be_calc_status_width(vaddr_width_mp) \
-  (2                                                                                               \
+  (1                                                                                               \
    + vaddr_width_p                                                                                 \
    + 5                                                                                             \
    + 6 * `bp_be_dep_status_width                                                                   \
@@ -252,7 +250,7 @@
    )
 
 `define bp_be_trap_pkt_width(vaddr_width_mp) \
-  (1 * vaddr_width_mp + rv64_priv_width_gp + 8)
+  (1 + 1 * vaddr_width_mp + rv64_priv_width_gp + 8)
 
 `define bp_be_wb_pkt_width(vaddr_width_mp) \
   (1                                                                                               \

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -488,7 +488,6 @@ module bp_be_calculator_top
       calc_stage_isd.pc             = reservation_n.pc;
       calc_stage_isd.instr          = reservation_n.instr;
       calc_stage_isd.v              = reservation_n.v;
-      calc_stage_isd.instr_v        = reservation_n.decode.instr_v;
       calc_stage_isd.pipe_ctl_v     = reservation_n.decode.pipe_ctl_v;
       calc_stage_isd.pipe_aux_v     = reservation_n.decode.pipe_aux_v;
       calc_stage_isd.pipe_int_v     = reservation_n.decode.pipe_int_v;
@@ -509,7 +508,6 @@ module bp_be_calculator_top
       calc_status.ex1_npc                  = br_tgt_int1;
       calc_status.ex1_br_or_jmp            = reservation_r.decode.pipe_ctl_v;
       calc_status.ex1_btaken               = btaken_int1;
-      calc_status.ex1_instr_v              = reservation_r.decode.instr_v & ~exc_stage_r[0].poison_v;
 
       calc_status.long_busy                = ~pipe_long_ready_lo;
       calc_status.mem_busy                 = ~pipe_mem_ready_lo;
@@ -518,7 +516,7 @@ module bp_be_calculator_top
       // Dependency information for pipelines
       for (integer i = 0; i < pipe_stage_els_lp; i++)
         begin : dep_status
-          calc_status.dep_status[i].instr_v    = calc_stage_r[i].instr_v
+          calc_status.dep_status[i].instr_v    = calc_stage_r[i].v
                                                  & ~exc_stage_n[i+1].poison_v;
           calc_status.dep_status[i].fflags_w_v = calc_stage_r[i].fflags_w_v
                                                  & ~exc_stage_n[i+1].poison_v;
@@ -610,7 +608,7 @@ module bp_be_calculator_top
 
   assign commit_pkt.v          = calc_stage_r[2].v & ~exc_stage_r[2].poison_v;
   assign commit_pkt.queue_v    = calc_stage_r[2].v & ~exc_stage_r[2].roll_v;
-  assign commit_pkt.instret    = calc_stage_r[2].v & calc_stage_r[2].instr_v & ~exc_stage_n[3].poison_v;
+  assign commit_pkt.instret    = calc_stage_r[2].v & ~exc_stage_r[2].poison_v & ~pipe_sys_miss_v_lo & ~pipe_sys_exc_v_lo;
   assign commit_pkt.pc         = calc_stage_r[2].pc;
   assign commit_pkt.npc        = calc_stage_r[1].pc;
   assign commit_pkt.instr      = calc_stage_r[2].instr;

--- a/bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v
@@ -52,7 +52,6 @@ module bp_be_instr_decoder
       // Set decoded defaults
       // NOPs are set after bypassing for critical path reasons
       decode               = '0;
-      decode.instr_v       = 1'b1;
 
       // Destination pipe
       decode.pipe_ctl_v       = '0;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.v
@@ -212,7 +212,7 @@ module bp_be_pipe_sys
      );
 
   assign data_o           = csr_data_lo;
-  assign exc_v_o          = trap_pkt.exception;
+  assign exc_v_o          = trap_pkt.exception | (ptw_miss_pkt.instr_miss_v | ptw_miss_pkt.load_miss_v | ptw_miss_pkt.store_miss_v);
   assign miss_v_o         = trap_pkt.rollback;
 
 endmodule

--- a/bp_be/src/v/bp_be_mem/bp_be_csr.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_csr.v
@@ -670,6 +670,7 @@ assign interrupt_ready_o = ~is_debug_mode & (m_interrupt_icode_v_li | s_interrup
 
 assign csr_data_o = dword_width_p'(csr_data_lo);
 
+assign trap_pkt_cast_o.v                = |{csr_cmd.exc.fencei_v, sfence_v_o, exception_v_o, interrupt_v_o, ret_v_o, satp_v_o, csr_cmd.exc.dcache_miss | csr_cmd.exc.dtlb_miss};
 assign trap_pkt_cast_o.npc              = apc_n;
 assign trap_pkt_cast_o.priv_n           = priv_mode_n;
 assign trap_pkt_cast_o.translation_en_n = translation_en_n;


### PR DESCRIPTION
Minor fix to remove the "instr_v" field from various structures.  There were some weird edge cases differentiating between v and instr_v, now they are all combined into v.  (tested on linux boot)