### PR TITLE
Using wormhole streamers for DMA

### DIFF
--- a/bp_be/syn/flist.vcs
+++ b/bp_be/syn/flist.vcs
@@ -163,6 +163,9 @@ $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter_out.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_decoder_dor.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_input_control.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_stream_control.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_stream_in.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_stream_out.v
 # HardFloat files
 $HARDFLOAT_DIR/source/addRecFN.v
 $HARDFLOAT_DIR/source/compareRecFN.v
@@ -226,6 +229,7 @@ $BP_ME_DIR/src/v/lce/bp_lce_cmd.v
 # Cache
 $BP_ME_DIR/src/v/cache/bp_me_cache_dma_to_cce.v
 $BP_ME_DIR/src/v/cache/bp_me_cache_slice.v
+$BP_ME_DIR/src/v/cache/bp_me_cache_slice_burst.v
 $BP_ME_DIR/src/v/cache/bp_me_cce_to_cache.v
 # CCE
 $BP_ME_DIR/src/v/cce/bp_cce.v

--- a/bp_common/src/include/bp_common_aviary_pkg.vh
+++ b/bp_common/src/include/bp_common_aviary_pkg.vh
@@ -516,6 +516,7 @@ package bp_common_aviary_pkg;
     ,bp_multicore_1_cce_ucode_cfg_p
     ,bp_multicore_1_l1_medium_cfg_p
     ,bp_multicore_1_l1_small_cfg_p
+    ,bp_multicore_1_no_l2_cfg_p
     ,bp_multicore_1_cfg_p
 
     // Unicore configurations
@@ -536,30 +537,31 @@ package bp_common_aviary_pkg;
   typedef enum bit [lg_max_cfgs-1:0]
   {
     // Various testing configs
-    e_bp_multicore_cce_ucode_half_cfg       = 29
-    ,e_bp_multicore_half_cfg                = 28
-    ,e_bp_unicore_half_cfg                  = 27
+    e_bp_multicore_cce_ucode_half_cfg       = 30
+    ,e_bp_multicore_half_cfg                = 29
+    ,e_bp_unicore_half_cfg                  = 28
 
     // Multicore configurations
-    ,e_bp_multicore_16_cce_ucode_cfg        = 26
-    ,e_bp_multicore_16_cfg                  = 25
-    ,e_bp_multicore_12_cce_ucode_cfg        = 24
-    ,e_bp_multicore_12_cfg                  = 23
-    ,e_bp_multicore_8_cce_ucode_cfg         = 22
-    ,e_bp_multicore_8_cfg                   = 21
-    ,e_bp_multicore_6_cce_ucode_cfg         = 20
-    ,e_bp_multicore_6_cfg                   = 19
-    ,e_bp_multicore_4_accelerator_cfg       = 18
-    ,e_bp_multicore_4_cce_ucode_cfg         = 17
-    ,e_bp_multicore_4_cfg                   = 16
-    ,e_bp_multicore_3_cce_ucode_cfg         = 15
-    ,e_bp_multicore_3_cfg                   = 14
-    ,e_bp_multicore_2_cce_ucode_cfg         = 13
-    ,e_bp_multicore_2_cfg                   = 12
-    ,e_bp_multicore_1_accelerator_cfg       = 11
-    ,e_bp_multicore_1_cce_ucode_cfg         = 10
-    ,e_bp_multicore_1_l1_medium_cfg         = 9
-    ,e_bp_multicore_1_l1_small_cfg          = 8
+    ,e_bp_multicore_16_cce_ucode_cfg        = 27
+    ,e_bp_multicore_16_cfg                  = 26
+    ,e_bp_multicore_12_cce_ucode_cfg        = 25
+    ,e_bp_multicore_12_cfg                  = 24
+    ,e_bp_multicore_8_cce_ucode_cfg         = 23
+    ,e_bp_multicore_8_cfg                   = 22
+    ,e_bp_multicore_6_cce_ucode_cfg         = 21
+    ,e_bp_multicore_6_cfg                   = 20
+    ,e_bp_multicore_4_accelerator_cfg       = 19
+    ,e_bp_multicore_4_cce_ucode_cfg         = 18
+    ,e_bp_multicore_4_cfg                   = 17
+    ,e_bp_multicore_3_cce_ucode_cfg         = 16
+    ,e_bp_multicore_3_cfg                   = 15
+    ,e_bp_multicore_2_cce_ucode_cfg         = 14
+    ,e_bp_multicore_2_cfg                   = 13
+    ,e_bp_multicore_1_accelerator_cfg       = 12
+    ,e_bp_multicore_1_cce_ucode_cfg         = 11
+    ,e_bp_multicore_1_l1_medium_cfg         = 10
+    ,e_bp_multicore_1_l1_small_cfg          = 9
+    ,e_bp_multicore_1_no_l2_cfg             = 8
     ,e_bp_multicore_1_cfg                   = 7
 
     // Unicore configurations

--- a/bp_fe/syn/flist.vcs
+++ b/bp_fe/syn/flist.vcs
@@ -163,6 +163,9 @@ $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter_out.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_decoder_dor.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_input_control.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_stream_control.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_stream_in.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_stream_out.v
 # HardFloat files
 $HARDFLOAT_DIR/source/addRecFN.v
 $HARDFLOAT_DIR/source/compareRecFN.v
@@ -226,6 +229,7 @@ $BP_ME_DIR/src/v/lce/bp_lce_cmd.v
 # Cache
 $BP_ME_DIR/src/v/cache/bp_me_cache_dma_to_cce.v
 $BP_ME_DIR/src/v/cache/bp_me_cache_slice.v
+$BP_ME_DIR/src/v/cache/bp_me_cache_slice_burst.v
 $BP_ME_DIR/src/v/cache/bp_me_cce_to_cache.v
 # CCE
 $BP_ME_DIR/src/v/cce/bp_cce.v

--- a/bp_me/src/v/cache/bp_me_cache_slice_burst.v
+++ b/bp_me/src/v/cache/bp_me_cache_slice_burst.v
@@ -1,0 +1,149 @@
+
+`include "bp_mem_wormhole.vh"
+
+module bp_me_cache_slice_burst
+ import bp_common_pkg::*;
+ import bp_common_aviary_pkg::*;
+ import bp_be_pkg::*;
+ import bp_common_rv64_pkg::*;
+ import bp_cce_pkg::*;
+ import bsg_cache_pkg::*;
+ import bsg_noc_pkg::*;
+ import bp_common_cfg_link_pkg::*;
+ import bsg_wormhole_router_pkg::*;
+ import bp_me_pkg::*;
+ #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+   `declare_bp_proc_params(bp_params_p)
+
+   `declare_bp_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, xce_mem)
+   `declare_bp_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, dram_mem)
+
+   , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
+   )
+  (input                                       clk_i
+   , input                                     reset_i
+
+   , input [xce_mem_msg_width_lp-1:0]          mem_cmd_i
+   , input                                     mem_cmd_v_i
+   , output                                    mem_cmd_ready_o
+
+   , output [xce_mem_msg_width_lp-1:0]         mem_resp_o
+   , output                                    mem_resp_v_o
+   , input                                     mem_resp_yumi_i
+
+   , output [dram_mem_msg_header_width_lp-1:0] mem_cmd_header_o
+   , output                                    mem_cmd_header_v_o
+   , input                                     mem_cmd_header_yumi_i
+
+   // Currently only support cache width == dword width
+   , output [dword_width_p-1:0]                mem_cmd_data_o
+   , output                                    mem_cmd_data_v_o
+   , input                                     mem_cmd_data_yumi_i
+
+   , input [dram_mem_msg_header_width_lp-1:0]  mem_resp_header_i
+   , input                                     mem_resp_header_v_i
+   , output                                    mem_resp_header_ready_o
+
+   // Currently only support cache width == dword width
+   , input [dword_width_p-1:0]                 mem_resp_data_i
+   , input                                     mem_resp_data_v_i
+   , output                                    mem_resp_data_ready_o
+   );
+
+  `declare_bp_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce_mem);
+  `declare_bsg_cache_pkt_s(paddr_width_p, dword_width_p);
+  bsg_cache_pkt_s cache_pkt_li;
+  logic cache_pkt_v_li, cache_pkt_ready_lo;
+  logic [dword_width_p-1:0] cache_data_lo;
+  logic cache_data_v_lo, cache_data_yumi_li;
+  bp_me_cce_to_cache
+   #(.bp_params_p(bp_params_p))
+   cce_to_cache
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.mem_cmd_i(mem_cmd_i)
+     ,.mem_cmd_v_i(mem_cmd_v_i)
+     ,.mem_cmd_ready_o(mem_cmd_ready_o)
+
+     ,.mem_resp_o(mem_resp_o)
+     ,.mem_resp_v_o(mem_resp_v_o)
+     ,.mem_resp_yumi_i(mem_resp_yumi_i)
+
+     ,.cache_pkt_o(cache_pkt_li)
+     ,.v_o(cache_pkt_v_li)
+     ,.ready_i(cache_pkt_ready_lo)
+
+     ,.data_i(cache_data_lo)
+     ,.v_i(cache_data_v_lo)
+     ,.yumi_o(cache_data_yumi_li)
+     );
+
+  `declare_bsg_cache_dma_pkt_s(paddr_width_p);
+  bsg_cache_dma_pkt_s dma_pkt_lo;
+  logic dma_pkt_v_lo, dma_pkt_yumi_li;
+  bsg_cache
+   #(.addr_width_p(paddr_width_p)
+     ,.data_width_p(dword_width_p)
+     ,.block_size_in_words_p(cce_block_width_p/dword_width_p)
+     ,.sets_p(l2_sets_p)
+     ,.ways_p(l2_assoc_p)
+     )
+   cache
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.cache_pkt_i(cache_pkt_li)
+     ,.v_i(cache_pkt_v_li)
+     ,.ready_o(cache_pkt_ready_lo)
+
+     ,.data_o(cache_data_lo)
+     ,.v_o(cache_data_v_lo)
+     ,.yumi_i(cache_data_yumi_li)
+
+     ,.dma_pkt_o(dma_pkt_lo)
+     ,.dma_pkt_v_o(dma_pkt_v_lo)
+     ,.dma_pkt_yumi_i(dma_pkt_yumi_li)
+
+     ,.dma_data_i(mem_resp_data_i)
+     ,.dma_data_v_i(mem_resp_data_v_i)
+     ,.dma_data_ready_o(mem_resp_data_ready_o)
+
+     ,.dma_data_o(mem_cmd_data_o)
+     ,.dma_data_v_o(mem_cmd_data_v_o)
+     ,.dma_data_yumi_i(mem_cmd_data_yumi_i)
+
+     ,.v_we_o()
+     );
+
+  // coherence message block size
+  // block size smaller than 8-bytes not supported
+  bp_mem_msg_size_e mem_cmd_block_size =
+    (cce_block_width_p == 1024)
+    ? e_mem_msg_size_128
+    : (cce_block_width_p == 512)
+      ? e_mem_msg_size_64
+      : (cce_block_width_p == 256)
+        ? e_mem_msg_size_32
+        : (cce_block_width_p == 128)
+          ? e_mem_msg_size_16
+          : e_mem_msg_size_8;
+
+  `declare_bp_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, dram_mem);
+  bp_dram_mem_msg_header_s dma_cmd_header_lo;
+  assign dma_cmd_header_lo = '{msg_type : dma_pkt_lo.write_not_read ? e_mem_msg_wr : e_mem_msg_rd
+                               ,size    : mem_cmd_block_size
+                               ,addr    : dma_pkt_lo.addr
+                               ,payload : '0
+                               };
+  assign mem_cmd_header_o = dma_cmd_header_lo;
+  assign mem_cmd_header_v_o = dma_pkt_v_lo;
+  assign dma_pkt_yumi_li = mem_cmd_header_yumi_i;
+
+  // We're always "ready" for a mem_resp, because when we send a mem_cmd, the cache is waiting
+  //   for the DMA data. Unsolicited mem_resp are not allowed by the protocol
+  assign mem_resp_header_ready_o = 1'b1;
+  wire unused = mem_resp_header_v_i;
+
+endmodule
+

--- a/bp_me/src/v/wormhole/bp_lite_to_stream.v
+++ b/bp_me/src/v/wormhole/bp_lite_to_stream.v
@@ -1,0 +1,132 @@
+
+module bp_lite_to_stream
+ import bp_common_pkg::*;
+ import bp_common_aviary_pkg::*;
+ import bp_me_pkg::*;
+ #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+   `declare_bp_proc_params(bp_params_p)
+
+   , parameter in_data_width_p  = "inv"
+   , parameter out_data_width_p = "inv"
+
+   , parameter logic master_p = 0
+
+   `declare_bp_mem_if_widths(paddr_width_p, in_data_width_p, lce_id_width_p, lce_assoc_p, in_mem)
+   `declare_bp_mem_if_widths(paddr_width_p, out_data_width_p, lce_id_width_p, lce_assoc_p, out_mem)
+   )
+  (input                                            clk_i
+   , input                                          reset_i
+
+   // Master BP Lite
+   , input [in_mem_msg_width_lp-1:0]                mem_i
+   , input                                          mem_v_i
+   , output logic                                   mem_ready_o
+
+   // Client BP Stream
+   , output logic [out_mem_msg_header_width_lp-1:0] mem_header_o
+   , output logic [out_data_width_p-1:0]            mem_data_o
+   , output logic                                   mem_v_o
+   , input                                          mem_yumi_i
+   , output logic                                   mem_lock_o
+   );
+
+  `declare_bp_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, in_mem);
+  `declare_bp_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, out_mem);
+  bp_in_mem_msg_s mem_cast_i;
+  assign mem_cast_i = mem_i;
+
+  localparam in_data_bytes_lp = in_data_width_p/8;
+  localparam out_data_bytes_lp = out_data_width_p/8;
+  localparam stream_words_lp = in_data_width_p/out_data_width_p;
+  localparam stream_offset_width_lp = `BSG_SAFE_CLOG2(out_data_bytes_lp);
+
+  bp_in_mem_msg_header_s header_lo;
+  logic mem_v_lo, mem_yumi_li;
+  bsg_one_fifo
+   #(.width_p($bits(bp_in_mem_msg_header_s)))
+   header_fifo
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.data_i(mem_cast_i.header)
+     ,.v_i(mem_v_i)
+
+     ,.data_o(header_lo)
+     ,.v_o(mem_v_lo)
+     ,.yumi_i(mem_yumi_li)
+
+     ,.ready_o(mem_ready_o)
+     );
+
+  wire is_wr = mem_cast_i.header.msg_type inside {e_mem_msg_uc_wr, e_mem_msg_wr};
+  localparam data_len_width_lp = `BSG_SAFE_CLOG2(stream_words_lp);
+  wire [data_len_width_lp-1:0] num_stream_cmds = (master_p ^ is_wr)
+    ? 1'b1
+    : `BSG_MAX(((1'b1 << mem_cast_i.header.size) / out_data_bytes_lp), 1'b1);
+  logic [out_data_width_p-1:0] data_lo;
+  bsg_parallel_in_serial_out_dynamic
+   #(.width_p(out_data_width_p), .max_els_p(stream_words_lp))
+   piso
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.data_i(mem_cast_i.data)
+     ,.len_i(num_stream_cmds - 1'b1)
+     ,.v_i(mem_v_i)
+
+     ,.data_o(mem_data_o)
+     ,.v_o(mem_v_o)
+     ,.yumi_i(mem_yumi_i)
+
+     // We rely on the header fifo to handle ready/valid handshaking
+     ,.len_v_o(/* Unused */)
+     ,.ready_o(/* Unused */)
+     );
+
+  // We wouldn't need this counter if we could peek into the PISO...
+  localparam data_ptr_width_lp = `BSG_WIDTH(stream_words_lp);
+  logic [data_ptr_width_lp-1:0] data_cnt;
+  bsg_counter_clear_up
+   #(.max_val_p(stream_words_lp), .init_val_p(0))
+   data_counter
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.clear_i(mem_v_i)
+     ,.up_i(mem_yumi_i)
+     ,.count_o(data_cnt)
+     );
+  wire last_data = (data_cnt == (num_stream_cmds-1'b1));
+
+  bp_out_mem_msg_header_s mem_header_cast_o;
+  assign mem_header_o = mem_header_cast_o;
+  always_comb
+    begin
+      // Autoincrement address
+      mem_header_cast_o = header_lo;
+      mem_header_cast_o.addr = header_lo.addr + (data_cnt << stream_offset_width_lp);
+    end
+  assign mem_lock_o = mem_v_o;
+  assign mem_yumi_li = last_data & mem_yumi_i;
+
+  //synopsys translate_off
+  initial
+    begin
+      assert (in_data_width_p >= out_data_width_p)
+        else $error("Master data cannot be smaller than client");
+      assert (in_data_width_p % out_data_width_p)
+        else $error("Master data must be a multiple of client data");
+    end
+
+  always_ff @(negedge clk_i)
+    begin
+      //if (mem_ready_o & mem_v_i)
+      //  $display("[%t] Msg received: %p", $time, mem_cast_i);
+
+      //if (mem_yumi_i)
+      //  $display("[%t] Stream sent: %p %x CNT: %x", $time, mem_header_cast_o, mem_data_o, data_cnt);
+    end
+  //synopsys translate_on
+
+endmodule
+

--- a/bp_me/src/v/wormhole/bp_lite_to_stream.v
+++ b/bp_me/src/v/wormhole/bp_lite_to_stream.v
@@ -85,18 +85,21 @@ module bp_lite_to_stream
 
   // We wouldn't need this counter if we could peek into the PISO...
   localparam data_ptr_width_lp = `BSG_WIDTH(stream_words_lp);
-  logic [data_ptr_width_lp-1:0] data_cnt;
-  bsg_counter_clear_up
-   #(.max_val_p(stream_words_lp), .init_val_p(0))
+  logic [data_ptr_width_lp-1:0] first_cnt, last_cnt, current_cnt;
+  bsg_counter_set_en
+   #(.max_val_p(stream_words_lp), .reset_val_p(0))
    data_counter
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.clear_i(mem_v_i)
-     ,.up_i(mem_yumi_i)
-     ,.count_o(data_cnt)
+     ,.set_i(mem_v_i)
+     ,.en_i(mem_yumi_i)
+     ,.val_i(first_cmd_cnt)
+     ,.count_o(current_cnt)
      );
-  wire last_data = (data_cnt == (num_stream_cmds-1'b1));
+  assign first_cnt = header_lo.addr[stream_offset_width_lp+:data_ptr_width_lp];
+  assign last_cnt  = first_cnt - 1'b1;
+  wire cnt_done = mem_yumi_i & (current_cnt == last_cnt);
 
   bp_out_mem_msg_header_s mem_header_cast_o;
   assign mem_header_o = mem_header_cast_o;
@@ -104,10 +107,13 @@ module bp_lite_to_stream
     begin
       // Autoincrement address
       mem_header_cast_o = header_lo;
-      mem_header_cast_o.addr = header_lo.addr + (data_cnt << stream_offset_width_lp);
+      mem_header_cast_o.addr = {header_lo.addr[paddr_width_p-1:stream_offset_width_lp+data_ptr_width_lp]
+                                ,current_cnt
+                                ,header_lo.addr[0+:stream_offset_width_lp]
+                                };
     end
   assign mem_lock_o = mem_v_o;
-  assign mem_yumi_li = last_data & mem_yumi_i;
+  assign mem_yumi_li = cnt_done & mem_yumi_i;
 
   //synopsys translate_off
   initial
@@ -124,7 +130,7 @@ module bp_lite_to_stream
       //  $display("[%t] Msg received: %p", $time, mem_cast_i);
 
       //if (mem_yumi_i)
-      //  $display("[%t] Stream sent: %p %x CNT: %x", $time, mem_header_cast_o, mem_data_o, data_cnt);
+      //  $display("[%t] Stream sent: %p %x CNT: %x", $time, mem_header_cast_o, mem_data_o, current_cnt);
     end
   //synopsys translate_on
 

--- a/bp_me/src/v/wormhole/bp_stream_to_lite.v
+++ b/bp_me/src/v/wormhole/bp_stream_to_lite.v
@@ -1,0 +1,114 @@
+
+module bp_stream_to_lite
+ import bp_common_pkg::*;
+ import bp_common_aviary_pkg::*;
+ import bp_me_pkg::*;
+ #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+   `declare_bp_proc_params(bp_params_p)
+
+   , parameter in_data_width_p  = "inv"
+   , parameter out_data_width_p = "inv"
+
+   , parameter logic master_p = 0
+
+   `declare_bp_mem_if_widths(paddr_width_p, in_data_width_p, lce_id_width_p, lce_assoc_p, in_mem)
+   `declare_bp_mem_if_widths(paddr_width_p, out_data_width_p, lce_id_width_p, lce_assoc_p, out_mem)
+   )
+  (input                                     clk_i
+   , input                                   reset_i
+
+   // Master BP Stream
+   , input [in_mem_msg_header_width_lp-1:0]  mem_header_i
+   , input [in_data_width_p-1:0]             mem_data_i
+   , input                                   mem_v_i
+   , output logic                            mem_ready_o
+   , input                                   mem_lock_i
+
+   // Client BP Lite
+   , output logic [out_mem_msg_width_lp-1:0] mem_o
+   , output logic                            mem_v_o
+   , input                                   mem_yumi_i
+   );
+
+  `declare_bp_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, in_mem);
+  `declare_bp_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, out_mem);
+
+  localparam in_data_bytes_lp = in_data_width_p/8;
+  localparam out_data_bytes_lp = out_data_width_p/8;
+  localparam stream_words_lp = out_data_width_p/in_data_width_p;
+  localparam stream_offset_width_lp = `BSG_SAFE_CLOG2(out_data_bytes_lp);
+
+  bp_in_mem_msg_header_s header_lo;
+  bsg_one_fifo
+   #(.width_p($bits(bp_in_mem_msg_header_s)))
+   header_fifo
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.data_i(mem_header_i)
+     // We ready on ready/and failing on the stream after the first
+     ,.v_i(mem_v_i)
+
+     ,.data_o(header_lo)
+     ,.yumi_i(mem_yumi_i)
+
+     // We use the sipo ready/valid
+     ,.ready_o(/* Unused */)
+     ,.v_o(/* Unused */)
+     );
+
+  bp_in_mem_msg_header_s mem_header_cast_i;
+  assign mem_header_cast_i = mem_header_i;
+  wire is_wr = mem_header_cast_i.msg_type inside {e_mem_msg_uc_wr, e_mem_msg_wr};
+  localparam data_len_width_lp = `BSG_SAFE_CLOG2(stream_words_lp);
+  wire [data_len_width_lp-1:0] num_stream_cmds = (master_p ^ is_wr)
+    ? 1'b1
+    : `BSG_MAX(((1'b1 << mem_header_cast_i.size) / in_data_bytes_lp), 1'b1);
+  logic [out_data_width_p-1:0] data_lo;
+  logic data_ready_lo, len_ready_lo;
+  bsg_serial_in_parallel_out_dynamic
+   #(.width_p(in_data_width_p), .max_els_p(stream_words_lp))
+   sipo
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.data_i(mem_data_i)
+     ,.len_i(num_stream_cmds-1'b1)
+     ,.v_i(mem_v_i)
+
+     ,.data_o(data_lo)
+     ,.v_o(mem_v_o)
+     ,.yumi_i(mem_yumi_i)
+
+     // We rely on fifo ready signal
+     ,.ready_o(mem_ready_o)
+     ,.len_ready_o(/* Unused */)
+     );
+
+  wire unused = &{mem_lock_i};
+
+  bp_out_mem_msg_s mem_cast_o;
+  assign mem_cast_o = '{header: header_lo, data: data_lo};
+  assign mem_o = mem_cast_o;
+
+  //synopsys translate_off
+  initial
+    begin
+      assert (in_data_width_p < out_data_width_p)
+        else $error("Master data cannot be larger than client");
+      assert (out_data_width_p % in_data_width_p)
+        else $error("Client data must be a multiple of master data");
+    end
+
+  always_ff @(negedge clk_i)
+    begin
+    //  if (mem_v_i)
+    //    $display("[%t] Stream received: %p %x", $time, mem_header_cast_i, mem_data_i);
+
+    //  if (mem_yumi_i)
+    //    $display("[%t] Msg sent: %p", $time, mem_cast_o);
+    end
+  //synopsys translate_on
+
+endmodule
+

--- a/bp_me/syn/flist.vcs
+++ b/bp_me/syn/flist.vcs
@@ -150,6 +150,9 @@ $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter_out.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_decoder_dor.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_input_control.v  
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.v 
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_stream_control.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_stream_in.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_stream_out.v
 ## ME files
 # CCE
 $BP_ME_DIR/src/v/cce/bp_cce_alu.v

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -163,6 +163,9 @@ $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_adapter_out.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_decoder_dor.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_input_control.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_stream_control.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_stream_in.v
+$BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_stream_out.v
 # HardFloat files
 $HARDFLOAT_DIR/source/addRecFN.v
 $HARDFLOAT_DIR/source/compareRecFN.v
@@ -226,6 +229,7 @@ $BP_ME_DIR/src/v/lce/bp_lce_cmd.v
 # Cache
 $BP_ME_DIR/src/v/cache/bp_me_cache_dma_to_cce.v
 $BP_ME_DIR/src/v/cache/bp_me_cache_slice.v
+$BP_ME_DIR/src/v/cache/bp_me_cache_slice_burst.v
 $BP_ME_DIR/src/v/cache/bp_me_cce_to_cache.v
 # CCE
 $BP_ME_DIR/src/v/cce/bp_cce.v

--- a/bp_top/test/tb/bp_tethered/Makefile.cfgs
+++ b/bp_top/test/tb/bp_tethered/Makefile.cfgs
@@ -21,6 +21,7 @@ e_bp_multicore_1_accelerator_cfg_cores  := 1
 e_bp_multicore_1_cce_ucode_cfg_cores    := 1
 e_bp_multicore_1_l1_medium_cfg_cores    := 1
 e_bp_multicore_1_l1_small_cfg_cores     := 1
+e_bp_multicore_1_no_l2_cfg_cores        := 1
 e_bp_multicore_1_cfg_cores              := 1
 
 e_bp_unicore_writethrough_cfg_cores     := 1


### PR DESCRIPTION
This PR replaces the ser/des of the L2 cache fill.  It leverages the wormhole streamer modules (needs this PR to go through) https://github.com/bespoke-silicon-group/basejump_stl/pull/232 to basically gearbox between the cache adapter and the wormhole router directly.

It also adds a missing configuration for multicore without L2.