### PR TITLE
Rudimentary critical word first support

### DIFF
--- a/bp_me/src/v/cce/bp_uce.v
+++ b/bp_me/src/v/cce/bp_uce.v
@@ -248,19 +248,19 @@ module bp_uce
 
   // We can do a little better by sending the read_request before the writeback
   enum logic [3:0] {e_reset, e_clear, e_flush_read, e_flush_scan, e_flush_write, e_flush_fence, e_ready, e_send_critical, e_writeback_evict, e_writeback_read_req, e_writeback_write_req, e_write_wait, e_read_req, e_uc_read_wait} state_n, state_r;
-  wire is_reset         = (state_r == e_reset);
-  wire is_clear         = (state_r == e_clear);
-  wire is_flush_read    = (state_r == e_flush_read);
-  wire is_flush_scan    = (state_r == e_flush_scan);
-  wire is_flush_write   = (state_r == e_flush_write);
-  wire is_flush_fence   = (state_r == e_flush_fence);
-  wire is_ready         = (state_r == e_ready);
-  wire is_send_critical = (state_r == e_send_critical);
+  wire is_reset           = (state_r == e_reset);
+  wire is_clear           = (state_r == e_clear);
+  wire is_flush_read      = (state_r == e_flush_read);
+  wire is_flush_scan      = (state_r == e_flush_scan);
+  wire is_flush_write     = (state_r == e_flush_write);
+  wire is_flush_fence     = (state_r == e_flush_fence);
+  wire is_ready           = (state_r == e_ready);
+  wire is_send_critical   = (state_r == e_send_critical);
   wire is_writeback_evict = (state_r == e_writeback_evict); // read dirty data from cache to UCE
-  wire is_writeback_read = (state_r == e_writeback_read_req); // read data from L2 to cache
-  wire is_writeback_wb   = (state_r == e_writeback_write_req); // send dirty data from UCE to L2
-  wire is_write_request  = (state_r == e_write_wait);
-  wire is_read_request   = (state_r == e_read_req);
+  wire is_writeback_read  = (state_r == e_writeback_read_req); // read data from L2 to cache
+  wire is_writeback_wb    = (state_r == e_writeback_write_req); // send dirty data from UCE to L2
+  wire is_write_request   = (state_r == e_write_wait);
+  wire is_read_request    = (state_r == e_read_req);
 
   // We check for uncached stores ealier than other requests, because they get sent out in ready
   wire flush_v_li         = cache_req_v_i & cache_req_cast_i.msg_type inside {e_cache_flush};
@@ -416,12 +416,30 @@ module bp_uce
   logic [fill_width_p-1:0] writeback_data;
   bsg_mux
    #(.width_p(fill_width_p)
-    ,.els_p(block_size_in_fill_lp))
+     ,.els_p(block_size_in_fill_lp)
+     )
    writeback_mux
     (.data_i(dirty_data_r)
-    ,.sel_i(mem_cmd_cnt)
-    ,.data_o(writeback_data)
-    );
+     ,.sel_i(mem_cmd_cnt)
+     ,.data_o(writeback_data)
+     );
+
+  // We expect the critical word to come back first, so we can simply
+  //   start waiting when we enter the sending state, and then we'll
+  //   know the next non-write response will be critical
+  logic critical_pending;
+  wire critical_sent = is_send_critical & mem_cmd_v_o;
+  wire critical_recv = mem_resp_yumi_o & load_resp_v_li;
+  bsg_dff_reset_set_clear
+   #(.width_p(1))
+   critical_pending_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.set_i(critical_sent)
+     ,.clear_i(critical_recv)
+     ,.data_o(critical_pending)
+     );
+  assign cache_req_critical_o = critical_pending & critical_recv;
 
   // We ack mem_resps for uncached stores no matter what, so mem_resp_yumi_lo is for other responses
   logic mem_resp_yumi_lo;
@@ -443,7 +461,6 @@ module bp_uce
       stat_mem_pkt_v_o    = '0;
 
       cache_req_complete_o = '0;
-      cache_req_critical_o = '0;
 
       mem_cmd_cast_o   = '0;
       mem_cmd_v_o      = '0;

--- a/bp_me/src/v/lce/bp_lce_cmd.v
+++ b/bp_me/src/v/lce/bp_lce_cmd.v
@@ -413,6 +413,10 @@ module bp_lce_cmd
               tag_mem_pkt.opcode = e_cache_tag_mem_set_tag;
               tag_mem_pkt_v_o = lce_cmd_v_i;
 
+              // TODO: This is sufficient for the critical signal when only
+              //   line width fills
+              cache_req_critical_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+
               // send coherence ack after updating tag and data memories
               state_n = (tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i)
                         ? e_coh_ack


### PR DESCRIPTION
...in the UCE and LCE.  This PR simply raises critical signal when the word is being written in the data_mem_pkt.

(PR is made to FE dev because it is first in a series of related PRs)