### PR TITLE
Adding I$ miss message and backend infrastructure

### DIFF
--- a/bp_be/src/include/bp_be_ctl_defines.vh
+++ b/bp_be/src/include/bp_be_ctl_defines.vh
@@ -226,6 +226,7 @@ typedef struct packed
   bp_be_baddr_e                     baddr_sel;
 
   logic                             itlb_miss;
+  logic                             icache_miss;
   logic                             instr_access_fault;
   logic                             instr_page_fault;
   logic                             illegal_instr;
@@ -247,6 +248,7 @@ typedef struct packed
 
   // BP "exceptions"
   logic itlb_miss;
+  logic icache_miss;
   logic dtlb_miss;
   logic dcache_miss;
   logic fencei_v;

--- a/bp_be/src/include/bp_be_internal_if_defines.vh
+++ b/bp_be/src/include/bp_be_internal_if_defines.vh
@@ -152,6 +152,7 @@
     logic                           fencei;                                                        \
     logic                           sfence;                                                        \
     logic                           satp;                                                          \
+    logic                           icache_miss;                                                   \
     logic                           rollback;                                                      \
   }  bp_be_trap_pkt_s;                                                                             \
                                                                                                    \
@@ -241,7 +242,7 @@
    )
 
 `define bp_be_trap_pkt_width(vaddr_width_mp) \
-  (1 + 1 * vaddr_width_mp + rv64_priv_width_gp + 8)
+  (1 + 1 * vaddr_width_mp + rv64_priv_width_gp + 9)
 
 `define bp_be_wb_pkt_width(vaddr_width_mp) \
   (1                                                                                               \

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -586,6 +586,7 @@ module bp_be_calculator_top
           exc_stage_n[3].poison_v        = exc_stage_r[2].poison_v | pipe_sys_miss_v_lo | pipe_sys_exc_v_lo;
 
           exc_stage_n[0].exc.itlb_miss          = reservation_n.decode.itlb_miss;
+          exc_stage_n[0].exc.icache_miss        = reservation_n.decode.icache_miss;
           exc_stage_n[0].exc.instr_access_fault = reservation_n.decode.instr_access_fault;
           exc_stage_n[0].exc.instr_page_fault   = reservation_n.decode.instr_page_fault;
           exc_stage_n[0].exc.illegal_instr      = reservation_n.decode.illegal_instr;

--- a/bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v
@@ -595,6 +595,7 @@ module bp_be_instr_decoder
             e_instr_access_fault: decode.instr_access_fault = 1'b1;
             e_instr_page_fault  : decode.instr_page_fault   = 1'b1;
             e_itlb_miss         : decode.itlb_miss          = 1'b1;
+            e_icache_miss       : decode.icache_miss        = 1'b1;
           endcase
         end
       else if (illegal_instr)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.v
@@ -191,7 +191,6 @@ module bp_be_pipe_mem
     (.clk_i(~clk_i)
      ,.reset_i(reset_i)
      ,.flush_i(sfence_i)
-     ,.translation_en_i(trans_info.translation_en)
 
      ,.v_i(dtlb_r_v | dtlb_w_v)
      ,.w_i(dtlb_w_v)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.v
@@ -212,7 +212,9 @@ module bp_be_pipe_sys
      );
 
   assign data_o           = csr_data_lo;
-  assign exc_v_o          = trap_pkt.exception | (ptw_miss_pkt.instr_miss_v | ptw_miss_pkt.load_miss_v | ptw_miss_pkt.store_miss_v);
+  assign exc_v_o          = trap_pkt.exception
+                            | trap_pkt.icache_miss
+                            | (ptw_miss_pkt.instr_miss_v | ptw_miss_pkt.load_miss_v | ptw_miss_pkt.store_miss_v);
   assign miss_v_o         = trap_pkt.rollback;
 
 endmodule

--- a/bp_be/src/v/bp_be_checker/bp_be_director.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.v
@@ -231,6 +231,15 @@ module bp_be_director
 
           flush_o = 1'b1;
         end
+      else if (trap_pkt.icache_miss)
+        begin
+          fe_cmd_li.opcode = e_op_icache_fill_response;
+          fe_cmd_li.vaddr = trap_pkt.npc;
+
+          fe_cmd_v_li = fe_cmd_ready_lo;
+
+          flush_o = 1'b1;
+        end
       // Redirect the pc if there's an NPC mismatch
       // Should not lump trap and ret into branch misprediction
       else if (trap_pkt.exception | trap_pkt._interrupt | trap_pkt.eret)

--- a/bp_be/src/v/bp_be_mem/bp_be_csr.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_csr.v
@@ -670,7 +670,7 @@ assign interrupt_ready_o = ~is_debug_mode & (m_interrupt_icode_v_li | s_interrup
 
 assign csr_data_o = dword_width_p'(csr_data_lo);
 
-assign trap_pkt_cast_o.v                = |{csr_cmd.exc.fencei_v, sfence_v_o, exception_v_o, interrupt_v_o, ret_v_o, satp_v_o, csr_cmd.exc.dcache_miss | csr_cmd.exc.dtlb_miss};
+assign trap_pkt_cast_o.v                = |{csr_cmd.exc.fencei_v, sfence_v_o, exception_v_o, interrupt_v_o, ret_v_o, satp_v_o, csr_cmd.exc.icache_miss, csr_cmd.exc.dcache_miss, csr_cmd.exc.dtlb_miss};
 assign trap_pkt_cast_o.npc              = apc_n;
 assign trap_pkt_cast_o.priv_n           = priv_mode_n;
 assign trap_pkt_cast_o.translation_en_n = translation_en_n;
@@ -680,6 +680,7 @@ assign trap_pkt_cast_o.exception        = exception_v_o;
 assign trap_pkt_cast_o._interrupt       = interrupt_v_o;
 assign trap_pkt_cast_o.eret             = ret_v_o;
 assign trap_pkt_cast_o.satp             = satp_v_o;
+assign trap_pkt_cast_o.icache_miss      = csr_cmd.exc.icache_miss;
 assign trap_pkt_cast_o.rollback         = csr_cmd.exc.dcache_miss | csr_cmd.exc.dtlb_miss;
 
 assign trans_info_cast_o.priv_mode = priv_mode_r;

--- a/bp_common/src/include/bp_common_fe_be_if.vh
+++ b/bp_common/src/include/bp_common_fe_be_if.vh
@@ -203,12 +203,13 @@ typedef enum logic
  */
 typedef enum logic [2:0]
 {
-  e_op_state_reset         = 0
-  ,e_op_pc_redirection     = 1
-  ,e_op_attaboy            = 2
-  ,e_op_icache_fence       = 3
-  ,e_op_itlb_fill_response = 4
-  ,e_op_itlb_fence         = 5
+  e_op_state_reset           = 0
+  ,e_op_pc_redirection       = 1
+  ,e_op_attaboy              = 2
+  ,e_op_icache_fill_response = 3
+  ,e_op_icache_fence         = 4
+  ,e_op_itlb_fill_response   = 5
+  ,e_op_itlb_fence           = 6
 } bp_fe_command_queue_opcodes_e;
 
 /*
@@ -228,12 +229,13 @@ typedef enum logic [1:0]
  * miss. e_instruction_access_fault is when the access control is violated.
  * e_instr_page_fault is when the instruction page is accessed with insufficent privilege
  */
-typedef enum logic [1:0]
+typedef enum logic [2:0]
 {
   e_itlb_miss           = 0
-  ,e_instr_misaligned   = 1
-  ,e_instr_access_fault = 2
-  ,e_instr_page_fault   = 3
+  ,e_icache_miss        = 1
+  ,e_instr_misaligned   = 2
+  ,e_instr_access_fault = 3
+  ,e_instr_page_fault   = 4
 } bp_fe_exception_code_e;
 
 /*

--- a/bp_common/src/v/bp_tlb.v
+++ b/bp_common/src/v/bp_tlb.v
@@ -12,7 +12,6 @@ module bp_tlb
  (input                               clk_i
   , input                             reset_i
   , input                             flush_i
-  , input                             translation_en_i
   
   , input                             v_i
   , input                             w_i
@@ -52,7 +51,7 @@ logic tlb_last_read_r;
 logic r_entry_bypass_v_r;
 bp_pte_entry_leaf_s r_entry_bypass_r;
 
-assign tlb_bypass = ((vtag_i == vtag_r) & tlb_last_read_r) | ~translation_en_i;
+assign tlb_bypass = ((vtag_i == vtag_r) & tlb_last_read_r);
 
 bsg_dff_reset #(.width_p(1))
   tlb_bypass_reg
@@ -70,7 +69,7 @@ bsg_dff_reset #(.width_p(1))
    ,.data_o(tlb_last_read_r)
   );
 
-bp_pte_entry_leaf_s r_entry, passthrough_entry;
+bp_pte_entry_leaf_s r_entry;
 logic r_v_lo;
 bsg_cam_1r1w_sync
  #(.els_p(tlb_els_p)

--- a/bp_fe/src/v/bp_fe_mem.v
+++ b/bp_fe/src/v/bp_fe_mem.v
@@ -96,7 +96,6 @@ bp_tlb
   (.clk_i(clk_i)
    ,.reset_i(reset_i)
    ,.flush_i(itlb_fence_v)
-   ,.translation_en_i(mem_translation_en_i)
 
    ,.v_i((fetch_v | itlb_fill_v) & mem_translation_en_i)
    ,.w_i(itlb_fill_v)


### PR DESCRIPTION
This PR adds an I$ miss message to the FE-BE interface, as well as the infrastructure to redirect the FE based on it. The message is unused and will be implemented in the next PR