### PR TITLE
override bootrom by default for bp_top sim

### DIFF
--- a/bp_top/test/tb/bp_tethered/Makefile.vcs
+++ b/bp_top/test/tb/bp_tethered/Makefile.vcs
@@ -40,7 +40,7 @@ $(SIM_DIR)/prog.elf: $(BP_TEST_MEM_DIR)/$(SUITE)/$(PROG).riscv
 $(SIM_DIR)/cce_ucode.mem: $(CCE_MEM_PATH)/$(CCE_MEM)
 	@cp $^ $@
 
-OVERRIDE_BOOTROM ?= 0
+OVERRIDE_BOOTROM ?= 1
 $(SIM_DIR)/bootrom.riscv: bootrom
 	cp $(BP_TEST_DIR)/src/bootrom/bootrom.riscv $@
 

--- a/bp_top/test/tb/bp_tethered/Makefile.verilator
+++ b/bp_top/test/tb/bp_tethered/Makefile.verilator
@@ -48,7 +48,7 @@ endif
 $(SIM_DIR)/prog.nbf: $(SIM_DIR)/cce_ucode.mem $(SIM_DIR)/prog.mem
 	cd $(@D); python $(MEM2NBF) $(NBF_INPUTS) > $@
 
-OVERRIDE_BOOTROM ?= 0
+OVERRIDE_BOOTROM ?= 1
 $(SIM_DIR)/bootrom.riscv: bootrom
 	cp $(BP_TEST_DIR)/src/bootrom/bootrom.riscv $@
 
@@ -91,6 +91,7 @@ $(SIM_DIR)/run_samplesc: $(SAMPLE_COLLATERAL)
 	-@grep "STATS" -A 3 $(SIM_LOG) > $(SIM_REPORT)
 
 tire_kick: $(SIM_DIR)/tire_kick
+tire_kick: OVERRIDE_BOOTROM := 0
 tire_kick: SIM_LOG    := $(LOG_DIR)/$(TB).$(CFG).$(TAG).sim.$(SUITE).$(PROG).log
 tire_kick: SIM_REPORT := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).sim.$(SUITE).$(PROG).rpt
 tire_kick: SIM_ERROR  := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).sim.$(SUITE).$(PROG).err


### PR DESCRIPTION
Make OVERRIDE_BOOTROM parameter default to 1 so bootroms build for tests in bp_top