### PR TITLE
bootrom build fixes

### DIFF
--- a/bp_common/test/src/bootrom/Makefile
+++ b/bp_common/test/src/bootrom/Makefile
@@ -3,8 +3,11 @@ RISCV_GCC = $(CROSS_COMPILE)gcc -march=rv64im -mabi=lp64 -mcmodel=medany -static
 
 UCODE2BOOT = $(BP_COMMON_DIR)/software/py/ucode2boot.py
 
-BOOT_INPUTS = --ucode=$(CCE_MEM_PATH)/$(CCE_MEM)
-BOOT_INPUTS += --path=$(BP_COMMON_DIR)/test/src/bootrom
+# Override these variables to change where the ucode comes from and where output goes to
+BOOTROM_UCODE ?= $(CCE_MEM_PATH)/$(CCE_MEM)
+BOOTROM_PATH ?= $(BP_COMMON_DIR)/test/src/bootrom
+
+BOOTROM_INPUTS = --ucode=$(BOOTROM_UCODE) --path=$(BOOTROM_PATH)
 
 XXD ?= xxd
 
@@ -17,6 +20,6 @@ clean:
 	@rm -f cce_ucode.mem cce_ucode.bin
 
 build:
-	python3 $(UCODE2BOOT)	$(BOOT_INPUTS)
-	$(XXD) -r -p cce_ucode.mem > cce_ucode.bin
-	$(RISCV_GCC) bootrom.S -o bootrom.riscv -Tlink.ld -static -Wl,--no-gc-sections
+	python3 $(UCODE2BOOT)	$(BOOTROM_INPUTS)
+	$(XXD) -r -p $(BOOTROM_PATH)/cce_ucode.mem > $(BOOTROM_PATH)/cce_ucode.bin
+	$(RISCV_GCC) bootrom.S -I$(BOOTROM_PATH) -o $(BOOTROM_PATH)/bootrom.riscv -Tlink.ld -static -Wl,--no-gc-sections

--- a/bp_top/test/tb/bp_tethered/Makefile.vcs
+++ b/bp_top/test/tb/bp_tethered/Makefile.vcs
@@ -40,8 +40,8 @@ $(SIM_DIR)/prog.elf: $(BP_TEST_MEM_DIR)/$(SUITE)/$(PROG).riscv
 $(SIM_DIR)/cce_ucode.mem: $(CCE_MEM_PATH)/$(CCE_MEM)
 	@cp $^ $@
 
+export BOOTROM_PATH := $(SIM_DIR)
 $(SIM_DIR)/bootrom.riscv: bootrom
-	cp $(BP_TEST_DIR)/src/bootrom/bootrom.riscv $@
 
 $(SIM_DIR)/bootrom.mem: $(SIM_DIR)/bootrom.riscv
 	$(RISCV_OBJCOPY) -O verilog --reverse-bytes=8 --verilog-data-width=8 $< $@

--- a/bp_top/test/tb/bp_tethered/Makefile.verilator
+++ b/bp_top/test/tb/bp_tethered/Makefile.verilator
@@ -48,8 +48,8 @@ endif
 $(SIM_DIR)/prog.nbf: $(SIM_DIR)/cce_ucode.mem $(SIM_DIR)/prog.mem
 	cd $(@D); python $(MEM2NBF) $(NBF_INPUTS) > $@
 
+export BOOTROM_PATH := $(SIM_DIR)
 $(SIM_DIR)/bootrom.riscv: bootrom
-	cp $(BP_TEST_DIR)/src/bootrom/bootrom.riscv $@
 
 $(SIM_DIR)/bootrom.mem: $(SIM_DIR)/bootrom.riscv
 	$(RISCV_OBJCOPY) -O verilog --reverse-bytes=8 --verilog-data-width=8 $< $@


### PR DESCRIPTION
Make bootrom build process happen in user-specified directories to avoid thrashing when running tests concurrently.