### PR TITLE
upstream bugfixes from me_dev for wormhole modules

### DIFF
--- a/bp_me/src/v/wormhole/bp_me_cce_to_mem_link_bidir.v
+++ b/bp_me/src/v/wormhole/bp_me_cce_to_mem_link_bidir.v
@@ -15,7 +15,7 @@ module bp_me_cce_to_mem_link_bidir
    , parameter cid_width_p  = "inv"
    , parameter len_width_p  = "inv"
 
-   , localparam bsg_ready_and_link_sif_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
+   , localparam bsg_ready_and_link_sif_width_lp = `bsg_ready_and_link_sif_width(flit_width_p)
    )
 
   (input                                          clk_i
@@ -53,7 +53,7 @@ module bp_me_cce_to_mem_link_bidir
    , output [bsg_ready_and_link_sif_width_lp-1:0] resp_link_o
    );
 
-`declare_bsg_ready_and_link_sif_s(mem_noc_flit_width_p, bsg_ready_and_link_sif_s);
+`declare_bsg_ready_and_link_sif_s(flit_width_p, bsg_ready_and_link_sif_s);
 bsg_ready_and_link_sif_s cmd_link_cast_i, cmd_link_cast_o, resp_link_cast_i, resp_link_cast_o;
 bsg_ready_and_link_sif_s master_cmd_link_lo, master_resp_link_li;
 bsg_ready_and_link_sif_s client_cmd_link_li, client_resp_link_lo;

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v
@@ -48,23 +48,23 @@ module bp_me_wormhole_packet_encode_mem_cmd
   assign wh_header_o   = header_cast_o;
 
   localparam mem_cmd_req_len_lp =
-    `BSG_CDIV(mem_cmd_wormhole_header_lp, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_cmd_wormhole_header_lp, flit_width_p) - 1;
   localparam mem_cmd_data_len_1_lp =
-    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*1, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*1, flit_width_p) - 1;
   localparam mem_cmd_data_len_2_lp =
-    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*2, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*2, flit_width_p) - 1;
   localparam mem_cmd_data_len_4_lp =
-    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*4, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*4, flit_width_p) - 1;
   localparam mem_cmd_data_len_8_lp =
-    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*8, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*8, flit_width_p) - 1;
   localparam mem_cmd_data_len_16_lp =
-    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*16, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*16, flit_width_p) - 1;
   localparam mem_cmd_data_len_32_lp =
-    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*32, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*32, flit_width_p) - 1;
   localparam mem_cmd_data_len_64_lp =
-    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*64, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*64, flit_width_p) - 1;
   localparam mem_cmd_data_len_128_lp =
-    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*128, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_cmd_wormhole_header_lp + 8*128, flit_width_p) - 1;
 
   logic [len_width_p-1:0] data_cmd_len_li;
 

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v
@@ -47,23 +47,23 @@ module bp_me_wormhole_packet_encode_mem_resp
   assign wh_header_o = header_cast_o;
 
   localparam mem_resp_ack_len_lp =
-    `BSG_CDIV(mem_resp_wormhole_header_width_lp, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_resp_wormhole_header_width_lp, flit_width_p) - 1;
   localparam mem_resp_data_len_1_lp =
-    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*1, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*1, flit_width_p) - 1;
   localparam mem_resp_data_len_2_lp =
-    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*2, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*2, flit_width_p) - 1;
   localparam mem_resp_data_len_4_lp =
-    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*4, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*4, flit_width_p) - 1;
   localparam mem_resp_data_len_8_lp =
-    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*8, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*8, flit_width_p) - 1;
   localparam mem_resp_data_len_16_lp =
-    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*16, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*16, flit_width_p) - 1;
   localparam mem_resp_data_len_32_lp =
-    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*32, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*32, flit_width_p) - 1;
   localparam mem_resp_data_len_64_lp =
-    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*64, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*64, flit_width_p) - 1;
   localparam mem_resp_data_len_128_lp =
-    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*128, mem_noc_flit_width_p) - 1;
+    `BSG_CDIV(mem_resp_wormhole_header_width_lp + 8*128, flit_width_p) - 1;
 
   logic [len_width_p-1:0] data_resp_len_li;
 


### PR DESCRIPTION
Upstreams fixes to for flit width parameters and use in a few of the wormhole modules.