### PR TITLE
Adding writeback packet to memory pipe

### DIFF
--- a/bp_be/src/include/bp_be_internal_if_defines.vh
+++ b/bp_be/src/include/bp_be_internal_if_defines.vh
@@ -95,6 +95,7 @@
   typedef struct packed                                                                            \
   {                                                                                                \
     logic                           v;                                                             \
+    logic                           trap_v;                                                        \
     logic                           queue_v;                                                       \
     logic                           instret;                                                       \
     logic [vaddr_width_p-1:0]       pc;                                                            \
@@ -179,7 +180,7 @@
   (3 + vaddr_width_mp)
 
 `define bp_be_commit_pkt_width(vaddr_width_mp) \
-  (3 + 2 * vaddr_width_mp + instr_width_p + rv64_priv_width_gp + 8)
+  (4 + 2 * vaddr_width_mp + instr_width_p + rv64_priv_width_gp + 8)
 
 `define bp_be_wb_pkt_width(vaddr_width_mp) \
   (2                                                                                               \

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -96,7 +96,7 @@ module bp_be_calculator_top
   // Cast input and output ports
   bp_be_dispatch_pkt_s   dispatch_pkt;
   bp_cfg_bus_s           cfg_bus;
-  bp_be_wb_pkt_s         long_iwb_pkt, long_fwb_pkt, calc_iwb_pkt, calc_fwb_pkt;
+  bp_be_wb_pkt_s         long_iwb_pkt, long_fwb_pkt, calc_iwb_pkt, calc_fwb_pkt, mem_iwb_pkt, mem_fwb_pkt;
   bp_be_commit_pkt_s       commit_pkt;
 
   assign dispatch_pkt = dispatch_pkt_i;
@@ -127,14 +127,12 @@ module bp_be_calculator_top
 
   logic pipe_ctl_data_lo_v, pipe_int_data_lo_v, pipe_aux_data_lo_v, pipe_mem_early_data_lo_v, pipe_mem_final_data_lo_v, pipe_sys_data_lo_v, pipe_mul_data_lo_v, pipe_fma_data_lo_v;
   logic pipe_long_idata_lo_v, pipe_long_fdata_lo_v;
+  logic pipe_mem_late_idata_lo_v, pipe_mem_late_fdata_lo_v;
   logic [dpath_width_p-1:0] pipe_ctl_data_lo, pipe_int_data_lo, pipe_aux_data_lo, pipe_mem_early_data_lo, pipe_mem_final_data_lo, pipe_sys_data_lo, pipe_mul_data_lo, pipe_fma_data_lo;
   rv64_fflags_s pipe_aux_fflags_lo, pipe_fma_fflags_lo;
 
   logic [vaddr_width_p-1:0] pipe_mem_vaddr_lo;
   logic pipe_sys_exc_v_lo, pipe_sys_miss_v_lo;
-
-  logic [vaddr_width_p-1:0] br_tgt_int1;
-  logic btaken_int1;
 
   // Forwarding information
   logic [pipe_stage_els_lp:1]                        comp_stage_n_slice_iwb_v;
@@ -309,6 +307,10 @@ module bp_be_calculator_top
      ,.early_v_o(pipe_mem_early_data_lo_v)
      ,.final_v_o(pipe_mem_final_data_lo_v)
      ,.final_vaddr_o(pipe_mem_vaddr_lo)
+     ,.late_iwb_pkt_o(mem_iwb_pkt)
+     ,.late_iwb_pkt_v_o(pipe_mem_late_idata_lo_v)
+     ,.late_fwb_pkt_o(mem_fwb_pkt)
+     ,.late_fwb_pkt_v_o(pipe_mem_late_fdata_lo_v)
 
      ,.trans_info_i(trans_info_lo)
      );
@@ -520,8 +522,8 @@ module bp_be_calculator_top
   assign calc_fwb_pkt.fflags_w_v  = comp_stage_r[5].fflags_w_v;
   assign calc_fwb_pkt.fflags      = comp_stage_r[5].fflags;
 
-  assign iwb_pkt_o = pipe_long_idata_lo_v ? long_iwb_pkt : calc_iwb_pkt;
-  assign fwb_pkt_o = pipe_long_fdata_lo_v ? long_fwb_pkt : calc_fwb_pkt;
+  assign iwb_pkt_o = pipe_mem_late_idata_lo_v ? mem_iwb_pkt : pipe_long_idata_lo_v ? long_iwb_pkt : calc_iwb_pkt;
+  assign fwb_pkt_o = pipe_mem_late_fdata_lo_v ? mem_fwb_pkt : pipe_long_fdata_lo_v ? long_fwb_pkt : calc_fwb_pkt;
 
   assign mem_ready_o  = pipe_mem_ready_lo;
   assign long_ready_o = pipe_long_ready_lo;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.v
@@ -190,8 +190,7 @@ module bp_be_pipe_sys
      ,.csr_cmd_v_i(csr_cmd_v_lo & commit_v_i)
      ,.csr_data_o(csr_data_lo)
 
-     // Simplify
-     ,.instret_i(commit_v_i & ~commit_pkt.exception & ~commit_pkt.rollback)
+     ,.instret_i(commit_pkt.instret)
      ,.fflags_acc_i(({5{iwb_pkt.fflags_w_v}} & iwb_pkt.fflags) | ({5{fwb_pkt.fflags_w_v}} & fwb_pkt.fflags))
      ,.frf_w_v_i(fwb_pkt.frd_w_v)
 

--- a/bp_be/src/v/bp_be_checker/bp_be_director.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.v
@@ -89,7 +89,7 @@ module bp_be_director
 
   // Module instantiations
   // Update the NPC on a valid instruction in ex1 or a cache miss or a tlb miss
-  wire npc_w_v = br_pkt.v | commit_pkt.v | ptw_fill_pkt.itlb_fill_v;
+  wire npc_w_v = br_pkt.v | commit_pkt.trap_v | ptw_fill_pkt.itlb_fill_v;
   bsg_dff_reset_en
    #(.width_p(vaddr_width_p), .reset_val_p($unsigned(boot_pc_p)))
    npc
@@ -100,7 +100,7 @@ module bp_be_director
      ,.data_i(npc_n)
      ,.data_o(npc_r)
      );
-  assign npc_n = ptw_fill_pkt.itlb_fill_v ? ptw_fill_pkt.vaddr : commit_pkt.v ? commit_pkt.npc : br_pkt.npc;
+  assign npc_n = ptw_fill_pkt.itlb_fill_v ? ptw_fill_pkt.vaddr : commit_pkt.trap_v ? commit_pkt.npc : br_pkt.npc;
 
   assign npc_mismatch_v = isd_status.isd_v & (expected_npc_o != isd_status.isd_pc);
   assign poison_isd_o = npc_mismatch_v | flush_o;

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.v
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.v
@@ -74,7 +74,7 @@ module bp_be_scheduler
   assign fwb_pkt         = fwb_pkt_i;
 
   wire fe_queue_clr_li  = suppress_iss_i;
-  wire fe_queue_deq_li  = commit_pkt.queue_v & ~commit_pkt.rollback;
+  wire fe_queue_deq_li  = commit_pkt.queue_v;
   wire fe_queue_roll_li = commit_pkt.rollback;
   bp_be_issue_pkt_s preissue_pkt, issue_pkt;
   bp_be_issue_queue

--- a/bp_be/src/v/bp_be_mem/bp_be_csr.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_csr.v
@@ -671,9 +671,10 @@ assign interrupt_ready_o = ~is_debug_mode & ~cfg_bus_cast_i.freeze & (m_interrup
 
 assign csr_data_o = dword_width_p'(csr_data_lo);
 
-assign commit_pkt_cast_o.v                = |{csr_cmd.exc.fencei_v, sfence_v_o, exception_v_o, interrupt_v_o, ret_v_o, satp_v_o, csr_cmd.exc.dcache_miss | csr_cmd.exc.dtlb_miss};
-assign commit_pkt_cast_o.queue_v          = exception_queue_v_i;
-assign commit_pkt_cast_o.instret          = instret_i;
+assign commit_pkt_cast_o.v                = commit_pkt_cast_o.instret | commit_pkt_cast_o.exception | commit_pkt_cast_o._interrupt;
+assign commit_pkt_cast_o.trap_v           = |{csr_cmd.exc.fencei_v, sfence_v_o, exception_v_o, interrupt_v_o, ret_v_o, satp_v_o, csr_cmd.exc.dcache_miss | csr_cmd.exc.dtlb_miss};
+assign commit_pkt_cast_o.queue_v          = exception_queue_v_i & ~csr_cmd.exc.dtlb_miss | csr_cmd.exc.itlb_miss;
+assign commit_pkt_cast_o.instret          = exception_v_i & ~exception_v_o & ~interrupt_v_o & ~csr_cmd.exc.dtlb_miss & ~csr_cmd.exc.itlb_miss;
 assign commit_pkt_cast_o.pc               = exception_pc_i;
 assign commit_pkt_cast_o.instr            = exception_instr_i;
 assign commit_pkt_cast_o.npc              = apc_n;

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -391,10 +391,6 @@ module bp_be_dcache
   wire amomaxu_req = v_tv_r & decode_tv_r.amomaxu_op;
   wire l2_amo_req  = v_tv_r & decode_tv_r.l2_op;
 
-  // Uncached and L2 atomic refactor
-  logic uncached_load_data_v_r;
-  logic [dword_width_p-1:0] uncached_load_data_r;
-
   // load reserved / store conditional
   logic lr_hit_tv;
   logic sc_success;
@@ -439,7 +435,7 @@ module bp_be_dcache
 
   // Fail if we have a store conditional without success
   assign sc_fail     = v_tv_r & decode_tv_r.sc_op & ~sc_success;
-  assign uncached_load_req = v_tv_r & decode_tv_r.load_op & uncached_tv_r & ~uncached_load_data_v_r;
+  assign uncached_load_req = v_tv_r & decode_tv_r.load_op & uncached_tv_r;
   assign uncached_store_req = v_tv_r & decode_tv_r.store_op & uncached_tv_r;
   assign fencei_req = v_tv_r & decode_tv_r.fencei_op;
 
@@ -671,7 +667,7 @@ module bp_be_dcache
       cache_req_cast_o.msg_type = e_wt_store;
       cache_req_v_o = cache_req_ready_i & ~flush_i;
     end
-    else if (l2_amo_req & ~uncached_load_data_v_r) begin
+    else if (l2_amo_req) begin
       cache_req_v_o = cache_req_ready_i;
       unique if (lr_req)
         cache_req_cast_o.msg_type = e_amo_lr;
@@ -744,8 +740,7 @@ module bp_be_dcache
      );
   assign ready_o = cache_req_ready_i & ~cache_miss_r;
 
-  assign early_v_o = v_tv_r & ((uncached_tv_r & (decode_tv_r.load_op & uncached_load_data_v_r))
-                              | (uncached_tv_r & (decode_tv_r.store_op & cache_req_ready_i))
+  assign early_v_o = v_tv_r & ((uncached_tv_r & (decode_tv_r.store_op & cache_req_ready_i))
                               | (~uncached_tv_r & ~decode_tv_r.l2_op & ~decode_tv_r.fencei_op & ~miss_tv)
                               // Always send fencei when coherent
                               | (fencei_req & (~gdirty_r | (l1_coherent_p == 1)))
@@ -857,16 +852,6 @@ module bp_be_dcache
     ,.data_o(bypass_data_masked)
   );
 
-  logic [dword_width_p-1:0] result_data;
-  bsg_mux #(
-    .width_p(dword_width_p)
-    ,.els_p(2)
-  ) final_data_mux (
-    .data_i({uncached_load_data_r, bypass_data_masked})
-    ,.sel_i(uncached_tv_r)
-    ,.data_o(result_data)
-  );
-
   logic [3:0][dword_width_p-1:0] sigext_data;
   for (genvar i = 0; i < 4; i++)
     begin : alignment
@@ -877,7 +862,7 @@ module bp_be_dcache
         .width_p(slice_width_lp)
         ,.els_p(dword_width_p/slice_width_lp)
       ) align_mux (
-        .data_i(result_data)
+        .data_i(bypass_data_masked)
         ,.sel_i(paddr_tv_r[i+:`BSG_MAX(1, 3-i)])
         ,.data_o(slice_data)
       );
@@ -886,18 +871,18 @@ module bp_be_dcache
       assign sigext_data[i] = {{(dword_width_p-slice_width_lp){sigext}}, slice_data};
     end
 
-  logic [dword_width_p-1:0] final_data;
+  logic [dword_width_p-1:0] early_data;
   bsg_mux_one_hot #(
     .width_p(dword_width_p)
     ,.els_p(4)
   ) byte_mux (
     .data_i(sigext_data)
     ,.sel_one_hot_i({decode_tv_r.double_op, decode_tv_r.word_op, decode_tv_r.half_op, decode_tv_r.byte_op})
-    ,.data_o(final_data)
+    ,.data_o(early_data)
   );
 
   assign early_data_o = (decode_tv_r.load_op | (sc_req & decode_tv_r.l2_op))
-    ? final_data
+    ? early_data
     : decode_tv_r.sc_op & ~sc_success;
 
   // DM stage
@@ -909,15 +894,35 @@ module bp_be_dcache
   logic double_op_dm_r, word_op_dm_r, half_op_dm_r, byte_op_dm_r;
   logic signed_op_dm_r, float_op_dm_r;
 
-  assign dm_we = v_tv_r & early_v_o;
+  logic [dword_width_p-1:0] snoop_word;
+  localparam snoop_offset_width_p = `BSG_SAFE_CLOG2(dcache_fill_width_p/dword_width_p);
+  wire [snoop_offset_width_p-1:0] snoop_word_offset = paddr_tv_r[2+:snoop_offset_width_p];
+  bsg_mux
+   #(.width_p(dword_width_p), .els_p(dcache_fill_width_p/dword_width_p))
+   snoop_mux
+    (.data_i(data_mem_pkt.data)
+     ,.sel_i(snoop_word_offset)
+     ,.data_o(snoop_word)
+     );
+
+  logic [dword_width_p-1:0] data_dm_n;
+  bsg_mux
+   #(.width_p(dword_width_p), .els_p(2))
+   ld_data_mux
+    (.data_i({snoop_word, early_data})
+     ,.sel_i(cache_req_critical_i)
+     ,.data_o(data_dm_n)
+     );
+
+  assign dm_we = v_tv_r;
   always_ff @(posedge clk_i) begin
     if (reset_i) begin
       v_dm_r <= '0;
     end else begin
-      v_dm_r <= dm_we & ~flush_i;
+      v_dm_r <= (dm_we & early_v_o & ~flush_i) | cache_req_critical_i;
 
       if (dm_we) begin
-        data_dm_r        <= early_data_o;
+        data_dm_r        <= data_dm_n;
         byte_offset_dm_r <= paddr_tv_r[0+:4];
         signed_op_dm_r   <= decode_tv_r.signed_op;
         float_op_dm_r    <= decode_tv_r.float_op;
@@ -925,6 +930,10 @@ module bp_be_dcache
         word_op_dm_r     <= decode_tv_r.word_op;
         half_op_dm_r     <= decode_tv_r.half_op;
         byte_op_dm_r     <= decode_tv_r.byte_op;
+      end
+
+      if (cache_req_critical_i) begin
+        data_dm_r        <= data_dm_n;
       end
     end
   end
@@ -1225,33 +1234,6 @@ module bp_be_dcache
       assign load_reserved_tag_r = '0;
       assign load_reserved_index_r = '0;
     end
-
-  //  uncached load data logic
-  //
-  wire uncached_load_set = data_mem_pkt_yumi_o & (data_mem_pkt.opcode == e_cache_data_mem_uncached);
-  // Invalidate uncached data if the cache is flushed or we successfully complete the request
-  // NOTE: This method is not valid for non-idempotent loads, will cause replay
-  wire uncached_load_clear = flush_i | early_v_o;
-  bsg_dff_reset_set_clear
-   #(.width_p(1))
-   uncached_load_data_v_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.set_i(uncached_load_set)
-     ,.clear_i(uncached_load_clear)
-     ,.data_o(uncached_load_data_v_r)
-     );
-
-  bsg_dff_en
-   #(.width_p(dword_width_p))
-   uncached_load_data_reg
-    (.clk_i(clk_i)
-     ,.en_i(uncached_load_set)
-
-     ,.data_i(data_mem_pkt.data[0+:dword_width_p])
-     ,.data_o(uncached_load_data_r)
-     );
 
   // LCE tag_mem
 

--- a/bp_me/src/v/cce/bp_uce.v
+++ b/bp_me/src/v/cce/bp_uce.v
@@ -667,7 +667,6 @@ module bp_uce
             data_mem_pkt_cast_o.fill_index = 1'b1 << fill_index_shift;
             data_mem_pkt_v_o = load_resp_v_li;
 
-            cache_req_critical_o = '0;
             fill_up = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
             mem_resp_yumi_lo = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
             // request next sub-block
@@ -714,7 +713,6 @@ module bp_uce
             data_mem_pkt_cast_o.fill_index = 1'b1 << fill_index_shift;
             data_mem_pkt_v_o = load_resp_v_li;
 
-            cache_req_critical_o = '0;
             fill_up = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
             mem_resp_yumi_lo = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
             // request next sub-block
@@ -732,8 +730,9 @@ module bp_uce
           end
         e_uc_read_wait:
           begin
+            // TODO: Should be dynamic, not always dword sized
             data_mem_pkt_cast_o.opcode = e_cache_data_mem_uncached;
-            data_mem_pkt_cast_o.data = mem_resp_cast_i.data;
+            data_mem_pkt_cast_o.data = {(fill_width_p/dword_width_p){mem_resp_cast_i.data[0+:dword_width_p]}};
             data_mem_pkt_v_o = load_resp_v_li;
 
             cache_req_complete_o = data_mem_pkt_yumi_i;

--- a/bp_me/src/v/lce/bp_lce_cmd.v
+++ b/bp_me/src/v/lce/bp_lce_cmd.v
@@ -545,7 +545,8 @@ module bp_lce_cmd
             // when data sends and command is dequeued
             e_bedrock_cmd_uc_data: begin
               data_mem_pkt.index = lce_cmd_addr_index;
-              data_mem_pkt.data = lce_cmd.data;
+              // TODO: Should be dynamic, not always dword sized
+              data_mem_pkt.data = {(fill_width_p/dword_width_p){lce_cmd.data[0+:dword_width_p]}};
               data_mem_pkt.fill_index = {block_size_in_fill_lp{1'b1}};
               data_mem_pkt.opcode = e_cache_data_mem_uncached;
               data_mem_pkt_v_o = lce_cmd_v_i;

--- a/bp_me/src/v/lce/bp_lce_cmd.v
+++ b/bp_me/src/v/lce/bp_lce_cmd.v
@@ -418,6 +418,10 @@ module bp_lce_cmd
               tag_mem_pkt.opcode = e_cache_tag_mem_set_tag;
               tag_mem_pkt_v_o = lce_cmd_v_i;
 
+              // TODO: This is sufficient for the critical signal when only
+              //   line width fills
+              cache_req_critical_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+
               // send coherence ack after updating tag and data memories
               state_n = (tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i)
                         ? e_coh_ack


### PR DESCRIPTION
- Adds writeback packet to memory pipe
- Rolls back on D$ miss, but still dequeues
- Adds rudimentary critical word first and data replication to support this
- Minor change to commit packet to clarify difference between commit and trap

Fixes non-idempotency of uncached loads/atomics