### PR TITLE
Fix cache late restart due to dirty data writeback

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -61,7 +61,8 @@ module bp_be_calculator_top
 
   , output logic [dcache_req_width_lp-1:0]          cache_req_o
   , output logic                                    cache_req_v_o
-  , input                                           cache_req_ready_i
+  , input                                           cache_req_yumi_i
+  , input                                           cache_req_busy_i
   , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
   , output logic                                    cache_req_metadata_v_o
   , input                                           cache_req_critical_i
@@ -271,7 +272,8 @@ module bp_be_calculator_top
 
      ,.cache_req_o(cache_req_o)
      ,.cache_req_v_o(cache_req_v_o)
-     ,.cache_req_ready_i(cache_req_ready_i)
+     ,.cache_req_yumi_i(cache_req_yumi_i)
+     ,.cache_req_busy_i(cache_req_busy_i)
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
      ,.cache_req_critical_i(cache_req_critical_i)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.v
@@ -65,7 +65,8 @@ module bp_be_pipe_mem
    // signals to LCE
    , output logic [dcache_req_width_lp-1:0]          cache_req_o
    , output logic                                    cache_req_v_o
-   , input                                           cache_req_ready_i
+   , input                                           cache_req_yumi_i
+   , input                                           cache_req_busy_i
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
    , input                                           cache_req_critical_i
@@ -269,7 +270,8 @@ module bp_be_pipe_mem
       // D$-LCE Interface
       ,.cache_req_o(cache_req_cast_o)
       ,.cache_req_v_o(cache_req_v_o)
-      ,.cache_req_ready_i(cache_req_ready_i)
+      ,.cache_req_yumi_i(cache_req_yumi_i)
+      ,.cache_req_busy_i(cache_req_busy_i)
       ,.cache_req_metadata_o(cache_req_metadata_o)
       ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
       ,.cache_req_critical_i(cache_req_critical_i)

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -633,8 +633,7 @@ module bp_be_dcache
   logic tag_mem_pkt_v;
   logic stat_mem_pkt_v;
 
-  wire wt_success = v_tv_r & decode_tv_r.store_op & store_hit_tv & ~sc_fail & ~uncached_tv_r & ~decode_tv_r.l2_op & (writethrough_p == 1);
-  wire wt_req = wt_success & ~flush_i;
+  wire wt_req = v_tv_r & decode_tv_r.store_op & store_hit_tv & ~sc_fail & ~uncached_tv_r & ~decode_tv_r.l2_op & (writethrough_p == 1) & ~flush_i;
 
   localparam num_bytes_lp = dcache_block_width_p >> 3;
   localparam bp_cache_req_size_e max_req_size = (num_bytes_lp == 16)
@@ -1156,7 +1155,7 @@ module bp_be_dcache
     assign wbuf_success = v_tv_r & decode_tv_r.store_op & store_hit_tv & ~sc_fail & ~uncached_tv_r & ~decode_tv_r.l2_op;
   end
   else begin : wt_wbuf
-    assign wbuf_success = wt_success & cache_req_yumi_i;
+    assign wbuf_success = wt_req & cache_req_yumi_i;
   end
   assign wbuf_v_li = wbuf_success & ~flush_i;
   assign wbuf_yumi_li = wbuf_v_lo & ~(decode_lo.load_op & tl_we) & ~data_mem_pkt_yumi_o;

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -672,10 +672,10 @@ module bp_be_dcache
     end
     else if(wt_req) begin
       cache_req_cast_o.msg_type = e_wt_store;
-      cache_req_v_o = 1'b1;
+      cache_req_v_o = ~flush_i;
     end
     else if (l2_amo_req & ~uncached_load_data_v_r) begin
-      cache_req_v_o = 1'b1;
+      cache_req_v_o = ~flush_i;
       unique if (lr_req)
         cache_req_cast_o.msg_type = e_amo_lr;
       else if (sc_req)
@@ -710,7 +710,7 @@ module bp_be_dcache
     else if(fencei_req) begin
       // Don't flush on fencei when coherent
       cache_req_cast_o.msg_type = e_cache_flush;
-      cache_req_v_o = gdirty_r & (l1_coherent_p == 0);
+      cache_req_v_o = gdirty_r & (l1_coherent_p == 0) & ~flush_i;
     end
 
     cache_req_cast_o.addr = paddr_tv_r;
@@ -1156,7 +1156,7 @@ module bp_be_dcache
     assign wbuf_success = v_tv_r & decode_tv_r.store_op & store_hit_tv & ~sc_fail & ~uncached_tv_r & ~decode_tv_r.l2_op;
   end
   else begin : wt_wbuf
-    assign wbuf_success = v_tv_r & decode_tv_r.store_op & store_hit_tv & ~sc_fail & ~uncached_tv_r & ~decode_tv_r.l2_op & cache_req_yumi_i;
+    assign wbuf_success = wt_success & cache_req_yumi_i;
   end
   assign wbuf_v_li = wbuf_success & ~flush_i;
   assign wbuf_yumi_li = wbuf_v_lo & ~(decode_lo.load_op & tl_we) & ~data_mem_pkt_yumi_o;

--- a/bp_be/src/v/bp_be_top.v
+++ b/bp_be/src/v/bp_be_top.v
@@ -44,7 +44,8 @@ module bp_be_top
    // signals to LCE
    , output logic [dcache_req_width_lp-1:0]          cache_req_o
    , output logic                                    cache_req_v_o
-   , input                                           cache_req_ready_i
+   , input                                           cache_req_yumi_i
+   , input                                           cache_req_busy_i
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
    , input                                           cache_req_critical_i
@@ -197,7 +198,8 @@ module bp_be_top
      ,.cache_req_o(cache_req_o)
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_v_o(cache_req_v_o)
-     ,.cache_req_ready_i(cache_req_ready_i)
+     ,.cache_req_yumi_i(cache_req_yumi_i)
+     ,.cache_req_busy_i(cache_req_busy_i)  
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
      ,.cache_req_critical_i(cache_req_critical_i)
      ,.cache_req_complete_i(cache_req_complete_i)

--- a/bp_be/test/tb/bp_be_dcache/wrapper.v
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.v
@@ -72,7 +72,7 @@ module wrapper
    // D$ - LCE Interface signals
    // Miss, Management Interfaces
    logic [num_caches_p-1:0] cache_req_v_lo, cache_req_metadata_v_lo;
-   logic [num_caches_p-1:0] cache_req_ready_lo;
+   logic [num_caches_p-1:0] cache_req_yumi_lo, cache_req_busy_lo;
    logic [num_caches_p-1:0] cache_req_complete_lo, cache_req_critical_lo;
    logic [num_caches_p-1:0][dcache_req_width_lp-1:0] cache_req_lo;
    logic [num_caches_p-1:0][dcache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
@@ -222,7 +222,8 @@ module wrapper
        ,.cache_req_o(cache_req_lo[i])
        ,.cache_req_metadata_o(cache_req_metadata_lo[i])
        ,.cache_req_metadata_v_o(cache_req_metadata_v_lo[i])
-       ,.cache_req_ready_i(cache_req_ready_lo[i])
+       ,.cache_req_yumi_i(cache_req_yumi_lo[i])
+       ,.cache_req_busy_i(cache_req_busy_lo[i])
        ,.cache_req_complete_i(cache_req_complete_lo[i])
        ,.cache_req_critical_i(cache_req_critical_lo[i])
        ,.cache_req_credits_full_i(cache_req_credits_full_lo[i])
@@ -269,7 +270,8 @@ module wrapper
 
            ,.cache_req_i(cache_req_lo[i])
            ,.cache_req_v_i(cache_req_v_lo[i])
-           ,.cache_req_ready_o(cache_req_ready_lo[i])
+           ,.cache_req_yumi_o(cache_req_yumi_lo[i])
+           ,.cache_req_busy_o(cache_req_busy_lo[i])
            ,.cache_req_metadata_i(cache_req_metadata_lo[i])
            ,.cache_req_metadata_v_i(cache_req_metadata_v_lo[i])
            ,.cache_req_critical_o(cache_req_critical_lo[i])
@@ -387,7 +389,8 @@ module wrapper
 
             ,.cache_req_i(cache_req_lo)
             ,.cache_req_v_i(cache_req_v_lo)
-            ,.cache_req_ready_o(cache_req_ready_lo)
+            ,.cache_req_yumi_o(cache_req_yumi_lo)
+            ,.cache_req_busy_o(cache_req_busy_lo)
             ,.cache_req_metadata_i(cache_req_metadata_lo)
             ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
             ,.cache_req_critical_o(cache_req_critical_lo)

--- a/bp_fe/src/v/bp_fe_top.v
+++ b/bp_fe/src/v/bp_fe_top.v
@@ -44,7 +44,8 @@ module bp_fe_top
 
    , output logic [icache_req_width_lp-1:0]           cache_req_o
    , output logic                                     cache_req_v_o
-   , input                                            cache_req_ready_i
+   , input                                            cache_req_yumi_i
+   , input                                            cache_req_busy_i
    , output logic [icache_req_metadata_width_lp-1:0]  cache_req_metadata_o
    , output logic                                     cache_req_metadata_v_o
    , input                                            cache_req_critical_i
@@ -203,7 +204,8 @@ module bp_fe_top
   
      ,.cache_req_o(cache_req_o)
      ,.cache_req_v_o(cache_req_v_o)
-     ,.cache_req_ready_i(cache_req_ready_i)
+     ,.cache_req_yumi_i(cache_req_yumi_i)
+     ,.cache_req_busy_i(cache_req_busy_i)
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
      ,.cache_req_critical_i(cache_req_critical_i)

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.v
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.v
@@ -62,7 +62,7 @@ module wrapper
 
   // I$-LCE Interface signals
   // Miss, Management Interfaces
-  logic cache_req_ready_li;
+  logic cache_req_yumi_li, cache_req_busy_li;
   logic [icache_req_width_lp-1:0] cache_req_lo;
   logic cache_req_v_lo;
   logic [icache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
@@ -201,9 +201,10 @@ module wrapper
     ,.data_o(data_o)
     ,.data_v_o(data_v_o)
 
-    ,.cache_req_ready_i(cache_req_ready_li)
     ,.cache_req_o(cache_req_lo)
     ,.cache_req_v_o(cache_req_v_lo)
+    ,.cache_req_yumi_i(cache_req_yumi_li)
+    ,.cache_req_busy_i(cache_req_busy_li)
     ,.cache_req_metadata_o(cache_req_metadata_lo)
     ,.cache_req_metadata_v_o(cache_req_metadata_v_lo)
     ,.cache_req_critical_i(cache_req_critical_li)
@@ -254,7 +255,8 @@ module wrapper
 
       ,.cache_req_v_i(cache_req_v_lo)
       ,.cache_req_i(cache_req_lo)
-      ,.cache_req_ready_o(cache_req_ready_li)
+      ,.cache_req_yumi_o(cache_req_yumi_li)
+      ,.cache_req_busy_o(cache_req_busy_li)
       ,.cache_req_metadata_i(cache_req_metadata_lo)
       ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
       ,.cache_req_critical_o(cache_req_critical_li)
@@ -366,7 +368,8 @@ module wrapper
 
       ,.cache_req_i(cache_req_lo)
       ,.cache_req_v_i(cache_req_v_lo)
-      ,.cache_req_ready_o(cache_req_ready_li)
+      ,.cache_req_yumi_o(cache_req_yumi_li)
+      ,.cache_req_busy_o(cache_req_busy_li)
       ,.cache_req_metadata_i(cache_req_metadata_lo)
       ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
       ,.cache_req_critical_o(cache_req_critical_li)

--- a/bp_me/src/v/cce/bp_uce.v
+++ b/bp_me/src/v/cce/bp_uce.v
@@ -51,7 +51,8 @@ module bp_uce
 
     , input [cache_req_width_lp-1:0]                 cache_req_i
     , input                                          cache_req_v_i
-    , output logic                                   cache_req_ready_o
+    , output logic                                   cache_req_yumi_o
+    , output logic                                   cache_req_busy_o
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
     , output logic                                   cache_req_critical_o
@@ -104,7 +105,7 @@ module bp_uce
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.set_i(cache_req_v_i)
+     ,.set_i(cache_req_yumi_o)
      ,.clear_i(cache_req_complete_o)
      ,.data_o(cache_req_v_r)
      );
@@ -116,7 +117,7 @@ module bp_uce
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.en_i(cache_req_v_i)
+     ,.en_i(cache_req_yumi_o)
      ,.data_i(cache_req_cast_i)
      ,.data_o(cache_req_r)
      );
@@ -129,7 +130,7 @@ module bp_uce
      ,.reset_i(reset_i)
 
      ,.set_i(cache_req_metadata_v_i)
-     ,.clear_i(cache_req_v_i)
+     ,.clear_i(cache_req_yumi_o)
      ,.data_o(cache_req_metadata_v_r)
      );
 
@@ -333,7 +334,7 @@ module bp_uce
         (.clk_i(clk_i)
         ,.reset_i(reset_i)
 
-        ,.set_i(cache_req_v_i)
+        ,.set_i(cache_req_yumi_o)
         ,.en_i(mem_cmd_up)
         ,.val_i(first_cmd_cnt)
         ,.count_o(mem_cmd_cnt)
@@ -341,7 +342,7 @@ module bp_uce
       
       assign first_cmd_cnt = cache_req_cast_i.addr[block_offset_width_lp-1-:fill_cnt_width_lp];
       assign last_cmd_cnt = (cache_req_r.addr[fill_offset_width_lp+:fill_cnt_width_lp] - fill_cnt_width_lp'(1));
-      assign mem_cmd_done = cache_req_v_r & (mem_cmd_cnt == last_cmd_cnt);
+      assign mem_cmd_done = (mem_cmd_cnt == last_cmd_cnt);
       assign critical_addr = {cache_req_r.addr[paddr_width_p-1:fill_offset_width_lp], (fill_offset_width_lp)'(0)};
     end
 
@@ -379,7 +380,7 @@ module bp_uce
     );
   wire way_done = (way_cnt == assoc_p-1);
 
-  logic mem_cmd_done_r;
+  logic writeback_complete, mem_cmd_done_r;
   bsg_dff_reset_set_clear
    #(.width_p(1)
     ,.clear_over_set_p(1)) // if 1, clear overrides set.
@@ -387,7 +388,7 @@ module bp_uce
     (.clk_i(clk_i)
     ,.reset_i(reset_i)
     ,.set_i(mem_cmd_done & mem_cmd_v_o)
-    ,.clear_i(cache_req_complete_o | way_up)
+    ,.clear_i(cache_req_complete_o | way_up | writeback_complete)
     ,.data_o(mem_cmd_done_r)
     );
 
@@ -446,14 +447,16 @@ module bp_uce
   // We ack mem_resps for uncached stores no matter what, so mem_resp_yumi_lo is for other responses
   logic mem_resp_yumi_lo;
   assign mem_resp_yumi_o = mem_resp_yumi_lo | store_resp_v_li;
+  assign cache_req_busy_o = is_reset | is_clear | credits_full_o;
   always_comb
     begin
-      cache_req_ready_o = '0;
+      cache_req_yumi_o = '0; 
 
       index_up = '0;
       way_up   = '0;
       fill_up  = '0;
       mem_cmd_up = '0;
+      writeback_complete = '0;
 
       tag_mem_pkt_cast_o  = '0;
       tag_mem_pkt_v_o     = '0;
@@ -570,7 +573,7 @@ module bp_uce
           begin
             // TODO: ready shouldn't depend on credits, the cache should
             //   handle the flow control
-            cache_req_ready_o = mem_cmd_ready_i & ~cache_req_credits_full_o;
+            cache_req_yumi_o = cache_req_v_i & mem_cmd_ready_i & ~cache_req_credits_full_o;
             if (uc_store_v_li)
               begin
                 mem_cmd_cast_o.header.msg_type       = e_bedrock_mem_uc_wr;
@@ -579,7 +582,7 @@ module bp_uce
                 mem_cmd_cast_payload.lce_id          = lce_id_i;
                 mem_cmd_cast_o.header.payload = mem_cmd_cast_payload;
                 mem_cmd_cast_o.data                  = cache_req_cast_i.data;
-                mem_cmd_v_o = mem_cmd_ready_i;
+                mem_cmd_v_o = cache_req_yumi_o;
               end
             else if (wt_store_v_li)
               begin
@@ -589,11 +592,11 @@ module bp_uce
                 mem_cmd_cast_payload.lce_id          = lce_id_i;
                 mem_cmd_cast_o.header.payload = mem_cmd_cast_payload;
                 mem_cmd_cast_o.data                  = cache_req_cast_i.data;
-                mem_cmd_v_o = mem_cmd_ready_i;
+                mem_cmd_v_o = cache_req_yumi_o;
               end
             else
               begin
-                state_n = cache_req_v_i
+                state_n = cache_req_yumi_o
                           ? flush_v_li
                             ? e_flush_read
                             : clear_v_li
@@ -677,10 +680,11 @@ module bp_uce
             mem_cmd_cast_payload.way_id          = lce_assoc_p'(cache_req_metadata_r.repl_way);
             mem_cmd_cast_payload.lce_id          = lce_id_i;
             mem_cmd_cast_o.header.payload = mem_cmd_cast_payload;
-            mem_cmd_v_o = mem_cmd_ready_i & ~mem_cmd_done_r;
+            mem_cmd_v_o = mem_cmd_ready_i & ~mem_cmd_done_r & ~credits_full_o;
             mem_cmd_up = mem_cmd_v_o;
 
-            state_n = (fill_done & mem_cmd_done_r & tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i) ? e_writeback_write_req : e_writeback_read_req;
+            cache_req_complete_o = fill_done & mem_cmd_done_r & tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+            state_n = cache_req_complete_o ? e_writeback_write_req : e_writeback_read_req;
           end
         e_writeback_write_req:
           begin
@@ -693,8 +697,8 @@ module bp_uce
             mem_cmd_v_o = mem_cmd_ready_i & dirty_data_v_r & dirty_tag_v_r;
             mem_cmd_up = mem_cmd_v_o;
 
-            cache_req_complete_o = mem_cmd_done & mem_cmd_v_o;
-            state_n = cache_req_complete_o ? e_ready : e_writeback_write_req;
+            writeback_complete = mem_cmd_done & mem_cmd_v_o;
+            state_n = writeback_complete ? e_ready : e_writeback_write_req;
           end
         e_read_req:
           begin
@@ -723,7 +727,7 @@ module bp_uce
             mem_cmd_cast_payload.way_id          = lce_assoc_p'(cache_req_metadata_r.repl_way);
             mem_cmd_cast_payload.lce_id          = lce_id_i;
             mem_cmd_cast_o.header.payload = mem_cmd_cast_payload;
-            mem_cmd_v_o = mem_cmd_ready_i & ~mem_cmd_done_r;
+            mem_cmd_v_o = mem_cmd_ready_i & ~mem_cmd_done_r & ~credits_full_o;
             mem_cmd_up = mem_cmd_v_o;
 
             cache_req_complete_o = fill_done & mem_cmd_done_r & tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;

--- a/bp_me/src/v/cce/bp_uce.v
+++ b/bp_me/src/v/cce/bp_uce.v
@@ -447,7 +447,7 @@ module bp_uce
   // We ack mem_resps for uncached stores no matter what, so mem_resp_yumi_lo is for other responses
   logic mem_resp_yumi_lo;
   assign mem_resp_yumi_o = mem_resp_yumi_lo | store_resp_v_li;
-  assign cache_req_busy_o = is_reset | is_clear | credits_full_o;
+  assign cache_req_busy_o = is_reset | is_clear | cache_req_credits_full_o;
   always_comb
     begin
       cache_req_yumi_o = '0; 
@@ -680,7 +680,7 @@ module bp_uce
             mem_cmd_cast_payload.way_id          = lce_assoc_p'(cache_req_metadata_r.repl_way);
             mem_cmd_cast_payload.lce_id          = lce_id_i;
             mem_cmd_cast_o.header.payload = mem_cmd_cast_payload;
-            mem_cmd_v_o = mem_cmd_ready_i & ~mem_cmd_done_r & ~credits_full_o;
+            mem_cmd_v_o = mem_cmd_ready_i & ~mem_cmd_done_r & ~cache_req_credits_full_o;
             mem_cmd_up = mem_cmd_v_o;
 
             cache_req_complete_o = fill_done & mem_cmd_done_r & tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
@@ -727,7 +727,7 @@ module bp_uce
             mem_cmd_cast_payload.way_id          = lce_assoc_p'(cache_req_metadata_r.repl_way);
             mem_cmd_cast_payload.lce_id          = lce_id_i;
             mem_cmd_cast_o.header.payload = mem_cmd_cast_payload;
-            mem_cmd_v_o = mem_cmd_ready_i & ~mem_cmd_done_r & ~credits_full_o;
+            mem_cmd_v_o = mem_cmd_ready_i & ~mem_cmd_done_r & ~cache_req_credits_full_o;
             mem_cmd_up = mem_cmd_v_o;
 
             cache_req_complete_o = fill_done & mem_cmd_done_r & tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;

--- a/bp_me/src/v/lce/bp_lce.v
+++ b/bp_me/src/v/lce/bp_lce.v
@@ -122,7 +122,7 @@ module bp_lce
   //synopsys translate_on
 
   // LCE Request Module
-  logic req_yumi_lo;
+  logic req_ready_lo, req_yumi_lo;
   logic uc_store_req_complete_lo;
   logic sync_done_lo;
   bp_lce_req
@@ -142,6 +142,7 @@ module bp_lce
       ,.lce_mode_i(lce_mode_i)
       ,.sync_done_i(sync_done_lo)
 
+      ,.ready_o(req_ready_lo)
       ,.yumi_o(req_yumi_lo)
 
       ,.cache_req_i(cache_req_i)
@@ -242,10 +243,10 @@ module bp_lce
   wire timeout = (timeout_cnt_r == timeout_max_limit_p);
 
   // LCE is ready to accept new cache requests if:
-  // - LCE Request module is in ready state and free credits exist (with yumi_o)
+  // - LCE Request module is in ready state and free credits exist
   // - timout signal is low, indicating LCE isn't blocked on using data/tag/stat mem
   // - LCE Command module is ready to process commands (raised after initialization complete)
-  assign cache_req_busy_o = cache_req_credits_full_o | timeout | ~cmd_ready_lo;
+  assign cache_req_busy_o = cache_req_credits_full_o | timeout | ~cmd_ready_lo | ~req_ready_lo;
   assign cache_req_yumi_o = req_yumi_lo & ~cache_req_busy_o;
 
 endmodule

--- a/bp_me/src/v/lce/bp_lce.v
+++ b/bp_me/src/v/lce/bp_lce.v
@@ -145,7 +145,7 @@ module bp_lce
       ,.ready_o(req_ready_lo)
 
       ,.cache_req_i(cache_req_i)
-      ,.cache_req_v_i(cache_req_v_i)
+      ,.cache_req_v_i(cache_req_v_i & req_ready_lo)
       ,.cache_req_metadata_i(cache_req_metadata_i)
       ,.cache_req_metadata_v_i(cache_req_metadata_v_i)
       ,.cache_req_complete_i(cache_req_complete_o)

--- a/bp_me/src/v/lce/bp_lce.v
+++ b/bp_me/src/v/lce/bp_lce.v
@@ -122,7 +122,7 @@ module bp_lce
   //synopsys translate_on
 
   // LCE Request Module
-  logic req_ready_lo;
+  logic req_yumi_lo;
   logic uc_store_req_complete_lo;
   logic sync_done_lo;
   bp_lce_req
@@ -142,10 +142,10 @@ module bp_lce
       ,.lce_mode_i(lce_mode_i)
       ,.sync_done_i(sync_done_lo)
 
-      ,.ready_o(req_ready_lo)
+      ,.yumi_o(req_yumi_lo)
 
       ,.cache_req_i(cache_req_i)
-      ,.cache_req_v_i(cache_req_v_i & req_ready_lo)
+      ,.cache_req_v_i(cache_req_v_i)
       ,.cache_req_metadata_i(cache_req_metadata_i)
       ,.cache_req_metadata_v_i(cache_req_metadata_v_i)
       ,.cache_req_complete_i(cache_req_complete_o)
@@ -218,7 +218,7 @@ module bp_lce
   // LCE can read/write to data_mem, tag_mem, and stat_mem during cycles the cache itself is
   // not using them. To prevent the LCE from stalling for too long while waiting for one of
   // these ports, or when processing an inbound LCE command, there is a timer that deasserts the
-  // LCE's cache_req_yumi_o signal to prevent the cache from issuing a new request, thereby
+  // LCE's busy_o signal to prevent the cache from issuing a new request, thereby
   // freeing up a cycle for the LCE to use these resources.
 
   logic [`BSG_SAFE_CLOG2(timeout_max_limit_p+1)-1:0] timeout_cnt_r;
@@ -242,10 +242,10 @@ module bp_lce
   wire timeout = (timeout_cnt_r == timeout_max_limit_p);
 
   // LCE is ready to accept new cache requests if:
-  // - LCE Request module is ready (raised when in ready state and free credits exist)
+  // - LCE Request module is in ready state and free credits exist (with yumi_o)
   // - timout signal is low, indicating LCE isn't blocked on using data/tag/stat mem
   // - LCE Command module is ready to process commands (raised after initialization complete)
-  assign cache_req_yumi_o = cache_req_v_i & req_ready_lo & cmd_ready_lo & ~timeout;
   assign cache_req_busy_o = cache_req_credits_full_o | timeout | ~cmd_ready_lo;
+  assign cache_req_yumi_o = req_yumi_lo & ~cache_req_busy_o;
 
 endmodule

--- a/bp_me/src/v/lce/bp_lce.v
+++ b/bp_me/src/v/lce/bp_lce.v
@@ -54,7 +54,8 @@ module bp_lce
     // can arrive, as indicated by the metadata_v_i signal
     , input [cache_req_width_lp-1:0]                 cache_req_i
     , input                                          cache_req_v_i
-    , output logic                                   cache_req_ready_o
+    , output logic                                   cache_req_yumi_o
+    , output logic                                   cache_req_busy_o
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
     , output logic                                   cache_req_critical_o
@@ -159,7 +160,7 @@ module bp_lce
       );
 
   // LCE Command Module
-  logic cmd_ready_lo;
+  logic cmd_ready_lo, cmd_busy_lo;
   bp_lce_cmd
     #(.bp_params_p(bp_params_p)
       ,.assoc_p(assoc_p)
@@ -217,7 +218,7 @@ module bp_lce
   // LCE can read/write to data_mem, tag_mem, and stat_mem during cycles the cache itself is
   // not using them. To prevent the LCE from stalling for too long while waiting for one of
   // these ports, or when processing an inbound LCE command, there is a timer that deasserts the
-  // LCE's cache_req_ready_o signal to prevent the cache from issuing a new request, thereby
+  // LCE's cache_req_yumi_o signal to prevent the cache from issuing a new request, thereby
   // freeing up a cycle for the LCE to use these resources.
 
   logic [`BSG_SAFE_CLOG2(timeout_max_limit_p+1)-1:0] timeout_cnt_r;
@@ -244,6 +245,7 @@ module bp_lce
   // - LCE Request module is ready (raised when in ready state and free credits exist)
   // - timout signal is low, indicating LCE isn't blocked on using data/tag/stat mem
   // - LCE Command module is ready to process commands (raised after initialization complete)
-  assign cache_req_ready_o = req_ready_lo & cmd_ready_lo & ~timeout;
+  assign cache_req_yumi_o = cache_req_v_i & req_ready_lo & cmd_ready_lo & ~timeout;
+  assign cache_req_busy_o = credits_full_o | timeout | ~cmd_ready_lo;
 
 endmodule

--- a/bp_me/src/v/lce/bp_lce.v
+++ b/bp_me/src/v/lce/bp_lce.v
@@ -246,6 +246,6 @@ module bp_lce
   // - timout signal is low, indicating LCE isn't blocked on using data/tag/stat mem
   // - LCE Command module is ready to process commands (raised after initialization complete)
   assign cache_req_yumi_o = cache_req_v_i & req_ready_lo & cmd_ready_lo & ~timeout;
-  assign cache_req_busy_o = credits_full_o | timeout | ~cmd_ready_lo;
+  assign cache_req_busy_o = cache_req_credits_full_o | timeout | ~cmd_ready_lo;
 
 endmodule

--- a/bp_me/src/v/lce/bp_lce_req.v
+++ b/bp_me/src/v/lce/bp_lce_req.v
@@ -62,6 +62,7 @@ module bp_lce_req
     , input                                          sync_done_i
 
     // LCE Req is able to sink any requests this cycle
+    , output logic                                   ready_o
     , output logic                                   yumi_o
 
     // Cache-LCE Interface
@@ -186,6 +187,7 @@ module bp_lce_req
   always_comb begin
     state_n = state_r;
 
+    ready_o= 1'b0;
     yumi_o = 1'b0;
 
     lce_req_v_o = 1'b0;
@@ -205,7 +207,8 @@ module bp_lce_req
       // Ready for new request
       e_ready: begin
         // yumi a new request if LCE hasn't used all its credits
-        yumi_o = ~credits_full_o & lce_req_ready_i & ((lce_mode_i == e_lce_mode_uncached) || sync_done_i) & cache_req_v_i;
+        ready_o = ~credits_full_o & lce_req_ready_i & ((lce_mode_i == e_lce_mode_uncached) || sync_done_i);
+        yumi_o = ready_o & cache_req_v_i;
         if (yumi_o) begin
           unique case (cache_req.msg_type)
             e_miss_store

--- a/bp_me/src/v/lce/bp_lce_req.v
+++ b/bp_me/src/v/lce/bp_lce_req.v
@@ -62,10 +62,10 @@ module bp_lce_req
     , input                                          sync_done_i
 
     // LCE Req is able to sink any requests this cycle
-    , output logic                                   ready_o
+    , output logic                                   yumi_o
 
     // Cache-LCE Interface
-    // ready_o->valid_i handshake
+    // valid_i -> yumi_o handshake
     // metadata arrives in the same cycle as req, or any cycle after, but before the next request
     // can arrive, as indicated by the metadata_v_i signal
     , input [cache_req_width_lp-1:0]                 cache_req_i
@@ -119,7 +119,7 @@ module bp_lce_req
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.data_i(cache_req_v_i)
+     ,.data_i(yumi_o)
      ,.data_o(cache_req_v_r)
      );
 
@@ -128,7 +128,7 @@ module bp_lce_req
     #(.width_p($bits(bp_cache_req_s)))
     req_reg
      (.clk_i(clk_i)
-      ,.en_i(cache_req_v_i)
+      ,.en_i(yumi_o)
       ,.data_i(cache_req_i)
       ,.data_o(cache_req_r)
       );
@@ -141,7 +141,7 @@ module bp_lce_req
      ,.reset_i(reset_i)
 
      ,.set_i(cache_req_metadata_v_i)
-     ,.clear_i(cache_req_v_i)
+     ,.clear_i(yumi_o)
      ,.data_o(cache_req_metadata_v_r)
      );
 
@@ -186,7 +186,7 @@ module bp_lce_req
   always_comb begin
     state_n = state_r;
 
-    ready_o = 1'b0;
+    yumi_o = 1'b0;
 
     lce_req_v_o = 1'b0;
 
@@ -204,9 +204,9 @@ module bp_lce_req
 
       // Ready for new request
       e_ready: begin
-        // ready for new request if LCE hasn't used all its credits
-        ready_o = ~credits_full_o & lce_req_ready_i & ((lce_mode_i == e_lce_mode_uncached) || sync_done_i);
-        if (cache_req_v_i) begin
+        // yumi a new request if LCE hasn't used all its credits
+        yumi_o = ~credits_full_o & lce_req_ready_i & ((lce_mode_i == e_lce_mode_uncached) || sync_done_i) & cache_req_v_i;
+        if (yumi_o) begin
           unique case (cache_req.msg_type)
             e_miss_store
             , e_miss_load: begin

--- a/bp_top/src/v/bp_core.v
+++ b/bp_top/src/v/bp_core.v
@@ -58,14 +58,14 @@ module bp_core
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
   bp_icache_req_s icache_req_lo;
-  logic icache_req_ready_li, icache_req_v_lo;
+  logic icache_req_v_lo, icache_req_yumi_li, icache_req_busy_li;
   bp_icache_req_metadata_s icache_req_metadata_lo;
   logic icache_req_metadata_v_lo;
   logic icache_req_critical_li, icache_req_complete_li;
   logic icache_req_credits_full_li, icache_req_credits_empty_li;
 
   bp_dcache_req_s dcache_req_lo;
-  logic dcache_req_ready_li, dcache_req_v_lo;
+  logic dcache_req_v_lo, dcache_req_yumi_li, dcache_req_busy_li;
   bp_dcache_req_metadata_s dcache_req_metadata_lo;
   logic dcache_req_metadata_v_lo;
   logic dcache_req_critical_li, dcache_req_complete_li;
@@ -110,7 +110,8 @@ module bp_core
 
      ,.icache_req_o(icache_req_lo)
      ,.icache_req_v_o(icache_req_v_lo)
-     ,.icache_req_ready_i(icache_req_ready_li)
+     ,.icache_req_yumi_i(icache_req_yumi_li)
+     ,.icache_req_busy_i(icache_req_busy_li)
      ,.icache_req_metadata_o(icache_req_metadata_lo)
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
      ,.icache_req_complete_i(icache_req_complete_li)
@@ -135,7 +136,8 @@ module bp_core
 
      ,.dcache_req_o(dcache_req_lo)
      ,.dcache_req_v_o(dcache_req_v_lo)
-     ,.dcache_req_ready_i(dcache_req_ready_li)
+     ,.dcache_req_yumi_i(dcache_req_yumi_li)
+     ,.dcache_req_busy_i(dcache_req_busy_li)
      ,.dcache_req_metadata_o(dcache_req_metadata_lo)
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
      ,.dcache_req_complete_i(dcache_req_complete_li)
@@ -182,7 +184,8 @@ module bp_core
 
      ,.cache_req_i(icache_req_lo)
      ,.cache_req_v_i(icache_req_v_lo)
-     ,.cache_req_ready_o(icache_req_ready_li)
+     ,.cache_req_yumi_o(icache_req_yumi_li)
+     ,.cache_req_busy_o(icache_req_busy_li)
      ,.cache_req_metadata_i(icache_req_metadata_lo)
      ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
      ,.cache_req_critical_o(icache_req_critical_li)
@@ -242,7 +245,8 @@ module bp_core
 
      ,.cache_req_i(dcache_req_lo)
      ,.cache_req_v_i(dcache_req_v_lo)
-     ,.cache_req_ready_o(dcache_req_ready_li)
+     ,.cache_req_yumi_o(dcache_req_yumi_li)
+     ,.cache_req_busy_o(dcache_req_busy_li)
      ,.cache_req_metadata_i(dcache_req_metadata_lo)
      ,.cache_req_metadata_v_i(dcache_req_metadata_v_lo)
      ,.cache_req_critical_o(dcache_req_critical_li)

--- a/bp_top/src/v/bp_core_minimal.v
+++ b/bp_top/src/v/bp_core_minimal.v
@@ -24,7 +24,8 @@ module bp_core_minimal
 
    , output logic [icache_req_width_lp-1:0]          icache_req_o
    , output logic                                    icache_req_v_o
-   , input                                           icache_req_ready_i
+   , input                                           icache_req_yumi_i
+   , input                                           icache_req_busy_i
    , output logic [icache_req_metadata_width_lp-1:0] icache_req_metadata_o
    , output logic                                    icache_req_metadata_v_o
    , input                                           icache_req_critical_i
@@ -49,7 +50,8 @@ module bp_core_minimal
 
    , output logic [dcache_req_width_lp-1:0]          dcache_req_o
    , output logic                                    dcache_req_v_o
-   , input                                           dcache_req_ready_i
+   , input                                           dcache_req_yumi_i
+   , input                                           dcache_req_busy_i
    , output logic [dcache_req_metadata_width_lp-1:0] dcache_req_metadata_o
    , output logic                                    dcache_req_metadata_v_o
    , input                                           dcache_req_critical_i
@@ -105,7 +107,8 @@ module bp_core_minimal
 
      ,.cache_req_o(icache_req_o)
      ,.cache_req_v_o(icache_req_v_o)
-     ,.cache_req_ready_i(icache_req_ready_i)
+     ,.cache_req_yumi_i(icache_req_yumi_i)
+     ,.cache_req_busy_i(icache_req_busy_i)
      ,.cache_req_metadata_o(icache_req_metadata_o)
      ,.cache_req_metadata_v_o(icache_req_metadata_v_o)
      ,.cache_req_critical_i(icache_req_critical_i)
@@ -147,7 +150,8 @@ module bp_core_minimal
 
      ,.cache_req_o(dcache_req_o)
      ,.cache_req_v_o(dcache_req_v_o)
-     ,.cache_req_ready_i(dcache_req_ready_i)
+     ,.cache_req_yumi_i(dcache_req_yumi_i)
+     ,.cache_req_busy_i(dcache_req_busy_i)
      ,.cache_req_metadata_o(dcache_req_metadata_o)
      ,.cache_req_metadata_v_o(dcache_req_metadata_v_o)
      ,.cache_req_critical_i(dcache_req_critical_i)

--- a/bp_top/src/v/bp_unicore.v
+++ b/bp_top/src/v/bp_unicore.v
@@ -66,7 +66,7 @@ module bp_unicore
   `declare_bp_bedrock_mem_if(paddr_width_p, dword_width_p, lce_id_width_p, lce_assoc_p, xce);
 
   bp_icache_req_s icache_req_lo;
-  logic icache_req_v_lo, icache_req_ready_li;
+  logic icache_req_v_lo, icache_req_yumi_li, icache_req_busy_li;
   bp_icache_req_metadata_s icache_req_metadata_lo;
   logic icache_req_metadata_v_lo;
   logic icache_req_critical_li, icache_req_complete_li;
@@ -85,7 +85,7 @@ module bp_unicore
   bp_icache_stat_info_s icache_stat_mem_lo;
 
   bp_dcache_req_s dcache_req_lo;
-  logic dcache_req_v_lo, dcache_req_ready_li;
+  logic dcache_req_v_lo, dcache_req_yumi_li, dcache_req_busy_li;
   bp_dcache_req_metadata_s dcache_req_metadata_lo;
   logic dcache_req_metadata_v_lo;
   logic dcache_req_critical_li, dcache_req_complete_li;
@@ -172,7 +172,8 @@ module bp_unicore
 
      ,.icache_req_o(icache_req_lo)
      ,.icache_req_v_o(icache_req_v_lo)
-     ,.icache_req_ready_i(icache_req_ready_li)
+     ,.icache_req_yumi_i(icache_req_yumi_li)
+     ,.icache_req_busy_i(icache_req_busy_li)
      ,.icache_req_metadata_o(icache_req_metadata_lo)
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
      ,.icache_req_complete_i(icache_req_complete_li)
@@ -197,7 +198,8 @@ module bp_unicore
 
      ,.dcache_req_o(dcache_req_lo)
      ,.dcache_req_v_o(dcache_req_v_lo)
-     ,.dcache_req_ready_i(dcache_req_ready_li)
+     ,.dcache_req_yumi_i(dcache_req_yumi_li)
+     ,.dcache_req_busy_i(dcache_req_busy_li)
      ,.dcache_req_metadata_o(dcache_req_metadata_lo)
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
      ,.dcache_req_complete_i(dcache_req_complete_li)
@@ -244,7 +246,8 @@ module bp_unicore
 
     ,.cache_req_i(dcache_req_lo)
     ,.cache_req_v_i(dcache_req_v_lo)
-    ,.cache_req_ready_o(dcache_req_ready_li)
+    ,.cache_req_yumi_o(dcache_req_yumi_li)
+    ,.cache_req_busy_o(dcache_req_busy_li)
     ,.cache_req_metadata_i(dcache_req_metadata_lo)
     ,.cache_req_metadata_v_i(dcache_req_metadata_v_lo)
     ,.cache_req_critical_o(dcache_req_critical_li)
@@ -292,7 +295,8 @@ module bp_unicore
 
      ,.cache_req_i(icache_req_lo)
      ,.cache_req_v_i(icache_req_v_lo)
-     ,.cache_req_ready_o(icache_req_ready_li)
+     ,.cache_req_yumi_o(icache_req_yumi_li)
+     ,.cache_req_busy_o(icache_req_busy_li)
      ,.cache_req_metadata_i(icache_req_metadata_lo)
      ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
      ,.cache_req_critical_o(icache_req_critical_li)


### PR DESCRIPTION
This PR includes 2 updates:
1. Change the cache_req interface between L1 cache and UCE from ready-then-valid to valid-then_yumi.
2. UCE sends cache_req_complete_o to L1 cache and then write back dirty data, so L1 cache can restart early.

The updates is test with cache_hammer, riscv_testlist and beebs testlist with full block size and sub-block size. A possible known issue is that the credits counter may overflow when fill_width_p==64. This issues results from the 8 credits for dirty data writeback may come back later than new credits issued by the next command, but this is no longer a concern if the when it is merged with the stream pump updates because it will only consume 1 credit.