### PR TITLE
Fixing Weird Cache Configs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,7 +83,6 @@ update-cache: &update-cache-manual
     - me_dev
     - top_dev
     - sw_dev
-    - dev_fix_weirdcacheconfigs
   before_script:
     - echo "Forcefully updating submodules"
     - git submodule update --init --force
@@ -195,11 +194,11 @@ tire_kick:
   script:
     - $CI_PROJECT_DIR/ci/tire_kick.sh
 
+# Takes too long to build
 weird-verilator:
   <<: *job_definition
   when: manual
   stage: test-short
-  allow_failure: true
   tags:
     - verilator
   script:
@@ -207,9 +206,7 @@ weird-verilator:
 
 weird-vcs:
   <<: *job_definition
-  when: manual
   stage: test-short
-  allow_failure: true
   tags:
     - vcs
   script:
@@ -320,6 +317,47 @@ top-riscvdv-vcs:
   script:
     - $CI_PROJECT_DIR/ci/single_core_testlist.sh vcs RISCVDV_TESTLIST $CI_CORES
 
+top-checkpoint-verilator:
+  <<: *job_definition
+  stage: test-medium
+  tags:
+    - verilator
+  script:
+    - $CI_PROJECT_DIR/ci/checkpoint.sh verilator $CI_CORES
+
+top-checkpoint-vcs:
+  <<: *job_definition
+  stage: test-medium
+  tags:
+    - vcs
+  script:
+    - $CI_PROJECT_DIR/ci/checkpoint.sh vcs $CI_CORES
+
+check-loops:
+  <<: *job_definition
+  stage: test-medium
+  tags:
+    - dc
+  script:
+    - $CI_PROJECT_DIR/ci/check_loops.sh $CI_CORES
+
+top-dram-vcs:
+  <<: *job_definition
+  stage: test-medium
+  tags:
+    - vcs
+  script:
+    - $CI_PROJECT_DIR/ci/dram.sh
+
+top-linux-verilator:
+  <<: *job_definition
+  when: manual
+  stage: test-ultralong
+  tags:
+    - verilator
+  script:
+    $CI_PROJECT_DIR/ci/linux.sh verilator $CI_CORES
+
 top-coremark-verilator:
   <<: *job_definition
   stage: test-long
@@ -352,40 +390,6 @@ top-beebs-vcs:
   script:
     - $CI_PROJECT_DIR/ci/single_core_testlist.sh vcs BEEBS_TESTLIST $CI_CORES
 
-top-checkpoint-verilator:
-  <<: *job_definition
-  stage: test-medium
-  tags:
-    - verilator
-  script:
-    - $CI_PROJECT_DIR/ci/checkpoint.sh verilator $CI_CORES
-
-top-checkpoint-vcs:
-  <<: *job_definition
-  stage: test-medium
-  tags:
-    - vcs
-  script:
-    - $CI_PROJECT_DIR/ci/checkpoint.sh vcs $CI_CORES
-
-check-loops:
-  <<: *job_definition
-  stage: test-medium
-  tags:
-    - dc
-  script:
-    - $CI_PROJECT_DIR/ci/check_loops.sh $CI_CORES
-
-top-linux-verilator:
-  <<: *job_definition
-  when: manual
-  stage: test-ultralong
-  tags:
-    - verilator
-  script:
-    $CI_PROJECT_DIR/ci/linux.sh verilator $CI_CORES
-
-
 top-linux-vcs:
   <<: *job_definition
   when: manual
@@ -395,11 +399,3 @@ top-linux-vcs:
   script:
     $CI_PROJECT_DIR/ci/linux.sh vcs $CI_CORES
 
-top-dram-vcs:
-  <<: *job_definition
-  when: manual
-  stage: test-medium
-  tags:
-    - vcs
-  script:
-    - $CI_PROJECT_DIR/ci/dram.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,6 +83,7 @@ update-cache: &update-cache-manual
     - me_dev
     - top_dev
     - sw_dev
+    - dev_fix_weirdcacheconfigs
   before_script:
     - echo "Forcefully updating submodules"
     - git submodule update --init --force

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -639,6 +639,12 @@ module bp_be_dcache
 
   wire wt_req = (wbuf_v_li & (writethrough_p == 1));
 
+  localparam num_bytes_lp = dcache_block_width_p >> 3;
+  localparam bp_cache_req_size_e max_req_size = (num_bytes_lp == 16)
+                                                ? e_size_16B
+                                                : (num_bytes_lp == 32)
+                                                  ? e_size_32B
+                                                  : e_size_64B;
   // Assigning message types
   always_comb begin
     cache_req_v_o = 1'b0;
@@ -657,7 +663,7 @@ module bp_be_dcache
         cache_req_cast_o.size = e_size_1B;
     end
     else
-      cache_req_cast_o.size = e_size_64B;
+      cache_req_cast_o.size = max_req_size;
 
     if(load_miss_tv) begin
       cache_req_cast_o.msg_type = e_miss_load;

--- a/bp_common/src/include/bp_common_aviary_pkg.vh
+++ b/bp_common/src/include/bp_common_aviary_pkg.vh
@@ -121,14 +121,18 @@ package bp_common_aviary_pkg;
                         );
 
   localparam bp_proc_param_s bp_unicore_l1_medium_override_p =
-    '{icache_sets         : 64
+    '{icache_sets         : 128
       ,icache_assoc       : 4
       ,icache_block_width : 256
       ,icache_fill_width  : 256
-      ,dcache_sets        : 64
+      ,dcache_sets        : 128
       ,dcache_assoc       : 4
       ,dcache_block_width : 256
       ,dcache_fill_width  : 256
+      ,acache_sets        : 128
+      ,acache_assoc       : 4
+      ,acache_block_width : 256
+      ,acache_fill_width  : 256
       ,default : "inv"
       };
   `bp_aviary_derive_cfg(bp_unicore_l1_medium_cfg_p
@@ -137,14 +141,18 @@ package bp_common_aviary_pkg;
                         );
 
   localparam bp_proc_param_s bp_unicore_l1_small_override_p =
-    '{icache_sets         : 64
+    '{icache_sets         : 256
       ,icache_assoc       : 2
       ,icache_block_width : 128
       ,icache_fill_width  : 128
-      ,dcache_sets        : 64
+      ,dcache_sets        : 256
       ,dcache_assoc       : 2
       ,dcache_block_width : 128
       ,dcache_fill_width  : 128
+      ,acache_sets        : 256
+      ,acache_assoc       : 2
+      ,acache_block_width : 128
+      ,acache_fill_width  : 128
       ,default : "inv"
       };
   `bp_aviary_derive_cfg(bp_unicore_l1_small_cfg_p
@@ -184,14 +192,18 @@ package bp_common_aviary_pkg;
                         );
 
   localparam bp_proc_param_s bp_multicore_1_l1_medium_override_p =
-    '{icache_sets         : 64
+    '{icache_sets         : 128
       ,icache_assoc       : 4
       ,icache_block_width : 256
       ,icache_fill_width  : 256
-      ,dcache_sets        : 64
+      ,dcache_sets        : 128
       ,dcache_assoc       : 4
       ,dcache_block_width : 256
       ,dcache_fill_width  : 256
+      ,acache_sets        : 128
+      ,acache_assoc       : 4
+      ,acache_block_width : 256
+      ,acache_fill_width  : 256
       ,default : "inv"
       };
   `bp_aviary_derive_cfg(bp_multicore_1_l1_medium_cfg_p
@@ -200,14 +212,18 @@ package bp_common_aviary_pkg;
                         );
 
   localparam bp_proc_param_s bp_multicore_1_l1_small_override_p =
-    '{icache_sets         : 64
+    '{icache_sets         : 256
       ,icache_assoc       : 2
       ,icache_block_width : 128
       ,icache_fill_width  : 128
-      ,dcache_sets        : 64
+      ,dcache_sets        : 256
       ,dcache_assoc       : 2
       ,dcache_block_width : 128
       ,dcache_fill_width  : 128
+      ,acache_sets        : 256
+      ,acache_assoc       : 2
+      ,acache_block_width : 128
+      ,acache_fill_width  : 128
       ,default : "inv"
       };
   `bp_aviary_derive_cfg(bp_multicore_1_l1_small_cfg_p

--- a/bp_common/src/include/bp_common_aviary_pkg.vh
+++ b/bp_common/src/include/bp_common_aviary_pkg.vh
@@ -129,10 +129,6 @@ package bp_common_aviary_pkg;
       ,dcache_assoc       : 4
       ,dcache_block_width : 256
       ,dcache_fill_width  : 256
-      ,acache_sets        : 128
-      ,acache_assoc       : 4
-      ,acache_block_width : 256
-      ,acache_fill_width  : 256
       ,default : "inv"
       };
   `bp_aviary_derive_cfg(bp_unicore_l1_medium_cfg_p
@@ -149,14 +145,26 @@ package bp_common_aviary_pkg;
       ,dcache_assoc       : 2
       ,dcache_block_width : 128
       ,dcache_fill_width  : 128
-      ,acache_sets        : 256
-      ,acache_assoc       : 2
-      ,acache_block_width : 128
-      ,acache_fill_width  : 128
       ,default : "inv"
       };
   `bp_aviary_derive_cfg(bp_unicore_l1_small_cfg_p
                         ,bp_unicore_l1_small_override_p
+                        ,bp_unicore_cfg_p
+                        );
+
+  localparam bp_proc_param_s bp_unicore_l1_hetero_override_p =
+    '{icache_sets         : 256
+      ,icache_assoc       : 2
+      ,icache_block_width : 128
+      ,icache_fill_width  : 128
+      ,dcache_sets        : 128
+      ,dcache_assoc       : 4
+      ,dcache_block_width : 256
+      ,dcache_fill_width  : 256
+      ,default : "inv"
+      };
+  `bp_aviary_derive_cfg(bp_unicore_l1_hetero_cfg_p
+                        ,bp_unicore_l1_hetero_override_p
                         ,bp_unicore_cfg_p
                         );
 
@@ -559,6 +567,7 @@ package bp_common_aviary_pkg;
 
     // Unicore configurations
     ,bp_unicore_writethrough_cfg_p
+    ,bp_unicore_l1_hetero_cfg_p
     ,bp_unicore_l1_small_cfg_p
     ,bp_unicore_l1_medium_cfg_p
     ,bp_unicore_no_l2_cfg_p
@@ -576,40 +585,41 @@ package bp_common_aviary_pkg;
   typedef enum bit [lg_max_cfgs-1:0]
   {
     // Various testing configs
-    e_bp_multicore_cce_ucode_half_cfg       = 32
-    ,e_bp_multicore_half_cfg                = 31
-    ,e_bp_unicore_half_cfg                  = 30
+    e_bp_multicore_cce_ucode_half_cfg       = 33
+    ,e_bp_multicore_half_cfg                = 32
+    ,e_bp_unicore_half_cfg                  = 31
 
     // Accelerator configurations
-    ,e_bp_multicore_1_accelerator_cfg       = 29
+    ,e_bp_multicore_1_accelerator_cfg       = 30
 
     // Ucode configurations
-    ,e_bp_multicore_16_cce_ucode_cfg        = 28
-    ,e_bp_multicore_12_cce_ucode_cfg        = 27
-    ,e_bp_multicore_8_cce_ucode_cfg         = 26
-    ,e_bp_multicore_6_cce_ucode_cfg         = 25
-    ,e_bp_multicore_4_cce_ucode_cfg         = 24
-    ,e_bp_multicore_3_cce_ucode_cfg         = 23
-    ,e_bp_multicore_2_cce_ucode_cfg         = 22
-    ,e_bp_multicore_1_cce_ucode_bootrom_cfg = 21
-    ,e_bp_multicore_1_cce_ucode_cfg         = 20
+    ,e_bp_multicore_16_cce_ucode_cfg        = 29
+    ,e_bp_multicore_12_cce_ucode_cfg        = 28
+    ,e_bp_multicore_8_cce_ucode_cfg         = 27
+    ,e_bp_multicore_6_cce_ucode_cfg         = 26
+    ,e_bp_multicore_4_cce_ucode_cfg         = 25
+    ,e_bp_multicore_3_cce_ucode_cfg         = 24
+    ,e_bp_multicore_2_cce_ucode_cfg         = 23
+    ,e_bp_multicore_1_cce_ucode_bootrom_cfg = 22
+    ,e_bp_multicore_1_cce_ucode_cfg         = 21
 
     // Multicore configurations
-    ,e_bp_multicore_16_cfg                  = 19
-    ,e_bp_multicore_12_cfg                  = 18
-    ,e_bp_multicore_8_cfg                   = 17
-    ,e_bp_multicore_6_cfg                   = 16
-    ,e_bp_multicore_4_cfg                   = 15
-    ,e_bp_multicore_3_cfg                   = 14
-    ,e_bp_multicore_2_cfg                   = 13
-    ,e_bp_multicore_1_l1_small_cfg          = 12
-    ,e_bp_multicore_1_l1_medium_cfg         = 11
-    ,e_bp_multicore_1_no_l2_cfg             = 10
-    ,e_bp_multicore_1_bootrom_cfg           = 9
-    ,e_bp_multicore_1_cfg                   = 8
+    ,e_bp_multicore_16_cfg                  = 20
+    ,e_bp_multicore_12_cfg                  = 19
+    ,e_bp_multicore_8_cfg                   = 18
+    ,e_bp_multicore_6_cfg                   = 17
+    ,e_bp_multicore_4_cfg                   = 16
+    ,e_bp_multicore_3_cfg                   = 15
+    ,e_bp_multicore_2_cfg                   = 14
+    ,e_bp_multicore_1_l1_small_cfg          = 13
+    ,e_bp_multicore_1_l1_medium_cfg         = 12
+    ,e_bp_multicore_1_no_l2_cfg             = 11
+    ,e_bp_multicore_1_bootrom_cfg           = 10
+    ,e_bp_multicore_1_cfg                   = 9
 
     // Unicore configurations
-    ,e_bp_unicore_writethrough_cfg          = 7
+    ,e_bp_unicore_writethrough_cfg          = 8
+    ,e_bp_unicore_l1_hetero_cfg             = 7
     ,e_bp_unicore_l1_small_cfg              = 6
     ,e_bp_unicore_l1_medium_cfg             = 5
     ,e_bp_unicore_no_l2_cfg                 = 4

--- a/bp_common/src/include/bp_common_aviary_pkg.vh
+++ b/bp_common/src/include/bp_common_aviary_pkg.vh
@@ -168,6 +168,22 @@ package bp_common_aviary_pkg;
                         ,bp_unicore_cfg_p
                         );
 
+  localparam bp_proc_param_s bp_unicore_l1_wide_override_p =
+    '{icache_sets         : 64
+      ,icache_assoc       : 4
+      ,icache_block_width : 512
+      ,icache_fill_width  : 512
+      ,dcache_sets        : 64
+      ,dcache_assoc       : 4
+      ,dcache_block_width : 512
+      ,dcache_fill_width  : 512
+      ,default : "inv"
+      };
+  `bp_aviary_derive_cfg(bp_unicore_l1_wide_cfg_p
+                        ,bp_unicore_l1_wide_override_p
+                        ,bp_unicore_cfg_p
+                        );
+
   localparam bp_proc_param_s bp_multicore_1_override_p =
     '{multicore      : 1
       ,num_cce       : 1
@@ -567,6 +583,7 @@ package bp_common_aviary_pkg;
 
     // Unicore configurations
     ,bp_unicore_writethrough_cfg_p
+    ,bp_unicore_l1_wide_cfg_p
     ,bp_unicore_l1_hetero_cfg_p
     ,bp_unicore_l1_small_cfg_p
     ,bp_unicore_l1_medium_cfg_p
@@ -584,41 +601,42 @@ package bp_common_aviary_pkg;
   // This enum MUST be kept up to date with the parameter array above
   typedef enum bit [lg_max_cfgs-1:0]
   {
-    // Various testing configs
-    e_bp_multicore_cce_ucode_half_cfg       = 33
-    ,e_bp_multicore_half_cfg                = 32
-    ,e_bp_unicore_half_cfg                  = 31
+    // Various testing config
+    e_bp_multicore_cce_ucode_half_cfg       = 34
+    ,e_bp_multicore_half_cfg                = 33
+    ,e_bp_unicore_half_cfg                  = 32
 
     // Accelerator configurations
-    ,e_bp_multicore_1_accelerator_cfg       = 30
+    ,e_bp_multicore_1_accelerator_cfg       = 31
 
     // Ucode configurations
-    ,e_bp_multicore_16_cce_ucode_cfg        = 29
-    ,e_bp_multicore_12_cce_ucode_cfg        = 28
-    ,e_bp_multicore_8_cce_ucode_cfg         = 27
-    ,e_bp_multicore_6_cce_ucode_cfg         = 26
-    ,e_bp_multicore_4_cce_ucode_cfg         = 25
-    ,e_bp_multicore_3_cce_ucode_cfg         = 24
-    ,e_bp_multicore_2_cce_ucode_cfg         = 23
-    ,e_bp_multicore_1_cce_ucode_bootrom_cfg = 22
-    ,e_bp_multicore_1_cce_ucode_cfg         = 21
+    ,e_bp_multicore_16_cce_ucode_cfg        = 30
+    ,e_bp_multicore_12_cce_ucode_cfg        = 29
+    ,e_bp_multicore_8_cce_ucode_cfg         = 28
+    ,e_bp_multicore_6_cce_ucode_cfg         = 27
+    ,e_bp_multicore_4_cce_ucode_cfg         = 26
+    ,e_bp_multicore_3_cce_ucode_cfg         = 25
+    ,e_bp_multicore_2_cce_ucode_cfg         = 24
+    ,e_bp_multicore_1_cce_ucode_bootrom_cfg = 23
+    ,e_bp_multicore_1_cce_ucode_cfg         = 22
 
     // Multicore configurations
-    ,e_bp_multicore_16_cfg                  = 20
-    ,e_bp_multicore_12_cfg                  = 19
-    ,e_bp_multicore_8_cfg                   = 18
-    ,e_bp_multicore_6_cfg                   = 17
-    ,e_bp_multicore_4_cfg                   = 16
-    ,e_bp_multicore_3_cfg                   = 15
-    ,e_bp_multicore_2_cfg                   = 14
-    ,e_bp_multicore_1_l1_small_cfg          = 13
-    ,e_bp_multicore_1_l1_medium_cfg         = 12
-    ,e_bp_multicore_1_no_l2_cfg             = 11
-    ,e_bp_multicore_1_bootrom_cfg           = 10
-    ,e_bp_multicore_1_cfg                   = 9
+    ,e_bp_multicore_16_cfg                  = 21
+    ,e_bp_multicore_12_cfg                  = 20
+    ,e_bp_multicore_8_cfg                   = 19
+    ,e_bp_multicore_6_cfg                   = 18
+    ,e_bp_multicore_4_cfg                   = 17
+    ,e_bp_multicore_3_cfg                   = 16
+    ,e_bp_multicore_2_cfg                   = 15
+    ,e_bp_multicore_1_l1_small_cfg          = 14
+    ,e_bp_multicore_1_l1_medium_cfg         = 13
+    ,e_bp_multicore_1_no_l2_cfg             = 12
+    ,e_bp_multicore_1_bootrom_cfg           = 11
+    ,e_bp_multicore_1_cfg                   = 10
 
     // Unicore configurations
-    ,e_bp_unicore_writethrough_cfg          = 8
+    ,e_bp_unicore_writethrough_cfg          = 9
+    ,e_bp_unicore_l1_wide_cfg               = 8
     ,e_bp_unicore_l1_hetero_cfg             = 7
     ,e_bp_unicore_l1_small_cfg              = 6
     ,e_bp_unicore_l1_medium_cfg             = 5

--- a/bp_common/syn/Makefile.dc
+++ b/bp_common/syn/Makefile.dc
@@ -40,6 +40,7 @@ $(BUILD_DIR)/check: $(CHK_COLLATERAL)
 		-@grep --color      "undeclared symbol"                    $(CHK_LOG) | tee -a $(CHK_ERROR)
 		-@grep --color      "(ELAB-395)"                           $(CHK_LOG) | tee -a $(CHK_ERROR)
 		-@grep --color      "(OPT-150)"                            $(CHK_LOG) | tee -a $(CHK_ERROR)
+		-@grep --color      "declaration initial"                  $(CHK_LOG) | tee -a $(CHK_ERROR)
 		-@test -s $(CHK_ERROR) && echo "Design Compiler check_synth: FAILED" > $(CHK_REPORT) \
 		|| (echo "Design Compiler check_synth: PASSED" > $(CHK_REPORT) && rm $(CHK_ERROR))
 

--- a/bp_fe/src/v/bp_fe_icache.v
+++ b/bp_fe/src/v/bp_fe_icache.v
@@ -39,11 +39,10 @@ module bp_fe_icache
     , localparam bank_offset_width_lp = `BSG_SAFE_CLOG2(icache_assoc_p)
     , localparam index_width_lp=`BSG_SAFE_CLOG2(icache_sets_p)
     , localparam block_offset_width_lp = (bank_offset_width_lp+byte_offset_width_lp)
-    , localparam ptag_width_lp=(paddr_width_p-bp_page_offset_width_gp)
     , localparam block_size_in_fill_lp = icache_block_width_p / icache_fill_width_p
     , localparam fill_size_in_bank_lp = icache_fill_width_p / bank_width_lp
 
-    `declare_bp_icache_widths(vaddr_width_p, ptag_width_lp, icache_assoc_p)
+    `declare_bp_icache_widths(vaddr_width_p, ptag_width_p, icache_assoc_p)
 
     , localparam stat_width_lp = `bp_cache_stat_info_width(icache_assoc_p)
     , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
@@ -88,7 +87,7 @@ module bp_fe_icache
     , input tag_mem_pkt_v_i
     , input [icache_tag_mem_pkt_width_lp-1:0] tag_mem_pkt_i
     , output logic tag_mem_pkt_yumi_o
-    , output logic [ptag_width_lp-1:0] tag_mem_o
+    , output logic [ptag_width_p-1:0] tag_mem_o
 
     // stat_mem
     , input stat_mem_pkt_v_i
@@ -112,7 +111,7 @@ module bp_fe_icache
   logic [bank_offset_width_lp-1:0]      vaddr_offset;
 
   logic [icache_assoc_p-1:0]            way_v_tv_r; // valid bits of each way
-  logic [lg_icache_assoc_lp-1:0]           way_invalid_index; // first invalid way
+  logic [lg_icache_assoc_lp-1:0]        way_invalid_index; // first invalid way
   logic                                 invalid_exist;
 
   logic uncached_req;
@@ -150,12 +149,12 @@ module bp_fe_icache
   logic                                                                tag_mem_v_li;
   logic                                                                tag_mem_w_li;
   logic [index_width_lp-1:0]                                           tag_mem_addr_li;
-  logic [icache_assoc_p-1:0][$bits(bp_coh_states_e)+ptag_width_lp-1:0] tag_mem_data_li;
-  logic [icache_assoc_p-1:0][$bits(bp_coh_states_e)+ptag_width_lp-1:0] tag_mem_w_mask_li;
-  logic [icache_assoc_p-1:0][$bits(bp_coh_states_e)+ptag_width_lp-1:0] tag_mem_data_lo;
+  logic [icache_assoc_p-1:0][$bits(bp_coh_states_e)+ptag_width_p-1:0] tag_mem_data_li;
+  logic [icache_assoc_p-1:0][$bits(bp_coh_states_e)+ptag_width_p-1:0] tag_mem_w_mask_li;
+  logic [icache_assoc_p-1:0][$bits(bp_coh_states_e)+ptag_width_p-1:0] tag_mem_data_lo;
 
   bsg_mem_1rw_sync_mask_write_bit #(
-    .width_p(icache_assoc_p*($bits(bp_coh_states_e)+ptag_width_lp))
+    .width_p(icache_assoc_p*($bits(bp_coh_states_e)+ptag_width_p))
     ,.els_p(icache_sets_p)
     ,.latch_last_read_p(1)
   ) tag_mem (
@@ -170,11 +169,11 @@ module bp_fe_icache
   );
 
   logic [icache_assoc_p-1:0][$bits(bp_coh_states_e)-1:0] state_tl;
-  logic [icache_assoc_p-1:0][ptag_width_lp-1:0] tag_tl;
+  logic [icache_assoc_p-1:0][ptag_width_p-1:0] tag_tl;
 
   for (genvar i = 0; i < icache_assoc_p; i++) begin
-    assign state_tl[i] = tag_mem_data_lo[i][ptag_width_lp+:$bits(bp_coh_states_e)];
-    assign tag_tl[i]   = tag_mem_data_lo[i][0+:ptag_width_lp];
+    assign state_tl[i] = tag_mem_data_lo[i][ptag_width_p+:$bits(bp_coh_states_e)];
+    assign tag_tl[i]   = tag_mem_data_lo[i][0+:ptag_width_p];
   end
 
   // data memory
@@ -203,7 +202,7 @@ module bp_fe_icache
     );
   end
 
-  logic [ptag_width_lp-1:0]        addr_tag_tl;
+  logic [ptag_width_p-1:0]         addr_tag_tl;
   logic [bank_offset_width_lp-1:0] addr_bank_offset_tl;
   logic [icache_assoc_p-1:0]       addr_bank_offset_dec_tl;
   logic [icache_assoc_p-1:0]       hit_v_tl;
@@ -213,7 +212,7 @@ module bp_fe_icache
   logic [vtag_width_p-1:0]         vaddr_vtag_tl;
    
   assign addr_tl = {ptag_i, vaddr_tl_r[0+:bp_page_offset_width_gp]};
-  assign addr_tag_tl = addr_tl[block_offset_width_lp+index_width_lp+:ptag_width_lp];
+  assign addr_tag_tl = addr_tl[block_offset_width_lp+index_width_lp+:ptag_width_p];
   assign addr_bank_offset_tl = addr_tl[byte_offset_width_lp+:bank_offset_width_lp];
 
   assign vaddr_index_tl = vaddr_tl_r[block_offset_width_lp+:index_width_lp];
@@ -237,10 +236,10 @@ module bp_fe_icache
   logic                                                      uncached_tv_r;
   logic [paddr_width_p-1:0]                                  addr_tv_r;
   logic [vaddr_width_p-1:0]                                  vaddr_tv_r;
-  logic [icache_assoc_p-1:0][ptag_width_lp-1:0]              tag_tv_r;
+  logic [icache_assoc_p-1:0][ptag_width_p-1:0]               tag_tv_r;
   logic [icache_assoc_p-1:0][$bits(bp_coh_states_e)-1:0]     state_tv_r;
   logic [icache_assoc_p-1:0][bank_width_lp-1:0]              ld_data_tv_r;
-  logic [ptag_width_lp-1:0]                                  addr_tag_tv_r;
+  logic [ptag_width_p-1:0]                                   addr_tag_tv_r;
   logic [icache_assoc_p-1:0]                                 addr_bank_offset_dec_tv_r;
   logic [index_width_lp-1:0]                                 addr_index_tv;
   logic                                                      fencei_op_tv_r;
@@ -333,15 +332,19 @@ module bp_fe_icache
   assign tag_mem_pkt = tag_mem_pkt_i;
   bp_icache_stat_mem_pkt_s stat_mem_pkt;
   assign stat_mem_pkt = stat_mem_pkt_i;
-
+  
+  // Weird Calculation to find correct request size instead of adding another
+  // mux
+  bp_cache_req_size_e req_size = bp_cache_req_size_e'(`BSG_SAFE_CLOG2(icache_block_width_p) - 3);
+  
   always_comb begin
     cache_req_cast_lo = '0;
     cache_req_v_o = '0;
-
+    
     if (miss_tv) begin
       cache_req_cast_lo.addr = addr_tv_r;
       cache_req_cast_lo.msg_type = e_miss_load;
-      cache_req_cast_lo.size = e_size_64B;
+      cache_req_cast_lo.size = req_size;
       cache_req_v_o = cache_req_ready_i;
     end
     else if (uncached_req) begin
@@ -555,19 +558,19 @@ module bp_fe_icache
       e_cache_tag_mem_set_clear: begin
         for (integer i = 0 ; i < icache_assoc_p; i++) begin
           tag_mem_data_li[i]    = '0;
-          tag_mem_w_mask_li[i]  = {($bits(bp_coh_states_e)+ptag_width_lp){1'b1}};
+          tag_mem_w_mask_li[i]  = {($bits(bp_coh_states_e)+ptag_width_p){1'b1}};
         end
       end
       e_cache_tag_mem_set_tag: begin
         for (integer i = 0; i < icache_assoc_p; i++) begin
           tag_mem_data_li[i]   = {tag_mem_pkt.state, tag_mem_pkt.tag};
-          tag_mem_w_mask_li[i] = {($bits(bp_coh_states_e)+ptag_width_lp){tag_mem_way_one_hot[i]}};
+          tag_mem_w_mask_li[i] = {($bits(bp_coh_states_e)+ptag_width_p){tag_mem_way_one_hot[i]}};
         end
       end
       e_cache_tag_mem_set_state: begin
         for (integer i = 0; i < icache_assoc_p; i++) begin
           tag_mem_data_li[i]   = {tag_mem_pkt.state, '0};
-          tag_mem_w_mask_li[i] = {{$bits(bp_coh_states_e){tag_mem_way_one_hot[i]}}, {ptag_width_lp{1'b0}}};
+          tag_mem_w_mask_li[i] = {{$bits(bp_coh_states_e){tag_mem_way_one_hot[i]}}, {ptag_width_p{1'b0}}};
         end
       end
       default: begin
@@ -672,7 +675,7 @@ module bp_fe_icache
     end
   end
 
-  assign tag_mem_o = tag_mem_data_lo[tag_mem_pkt_way_r][0+:ptag_width_lp];
+  assign tag_mem_o = tag_mem_data_lo[tag_mem_pkt_way_r][0+:ptag_width_p];
   assign tag_mem_pkt_yumi_o = tag_mem_pkt_v_i & ~tl_we;
 
   // LCE: stat_mem

--- a/bp_me/src/v/cache/bp_me_cce_to_cache.v
+++ b/bp_me/src/v/cache/bp_me_cce_to_cache.v
@@ -277,35 +277,13 @@ module bp_me_cce_to_cache
      ,.data_o(mem_resp_cast_o.header)
      );
   
-  localparam num_bytes_lp = cce_block_width_p/8;
-  localparam lg_num_bytes_lp = `BSG_SAFE_CLOG2(num_bytes_lp);
-  localparam num_els_lp = 2**`BSG_WIDTH(lg_num_bytes_lp);
-  logic [num_els_lp-1:0][cce_block_width_p-1:0] repeated_data;
-  logic [cce_block_width_p-1:0] repeated_resp_data;
-  wire [cce_block_width_p-1:0] resp_data_r_cast = resp_data_r;
-  for (genvar i = 0; i <= lg_num_bytes_lp; i++)
-    begin : rep
-      localparam slice_width_lp = 8*(2**i);
-      assign repeated_data[i] = {cce_block_width_p/slice_width_lp{resp_data_r_cast[0+:slice_width_lp]}};
-    end
-
-  bsg_mux
-   #(.width_p(cce_block_width_p)
-    ,.els_p(num_els_lp)
-    )
-    rep_mux
-     (.data_i(repeated_data)
-     ,.sel_i(mem_resp_cast_o.header.size)
-     ,.data_o(repeated_resp_data)
-     );
-
   bsg_bus_pack
    #(.width_p(cce_block_width_p))
-   pack
-    (.data_i(repeated_resp_data)
-     ,.sel_i(mem_resp_cast_o.header.addr[0+:block_offset_width_lp])
+   repl_mux
+    (.data_i(resp_data_r)
+     // Response data is always aggregated from zero in this module
+     ,.sel_i('0)
      ,.size_i(mem_resp_cast_o.header.size)
-
      ,.data_o(mem_resp_cast_o.data)
      );
 

--- a/bp_me/src/v/cache/bp_me_cce_to_cache.v
+++ b/bp_me/src/v/cache/bp_me_cce_to_cache.v
@@ -258,6 +258,7 @@ module bp_me_cce_to_cache
       resp_state_r      <= RESP_RESET;
       resp_counter_r    <= '0;
       resp_max_count_r  <= '0;
+      resp_data_r       <= '0;
     end
     else begin
       resp_state_r      <= resp_state_n;

--- a/bp_me/src/v/cce/bp_cce_loopback.v
+++ b/bp_me/src/v/cce/bp_cce_loopback.v
@@ -11,7 +11,7 @@ module bp_cce_loopback
   import bp_me_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce)
+    `declare_bp_bedrock_mem_if_widths(paddr_width_p, dword_width_p, lce_id_width_p, lce_assoc_p, cce)
     )
    (input                                           clk_i
     , input                                         reset_i

--- a/bp_me/src/v/lce/bp_lce.v
+++ b/bp_me/src/v/lce/bp_lce.v
@@ -34,10 +34,9 @@ module bp_lce
     , localparam block_size_in_bytes_lp = (block_width_p/8)
     , localparam lg_sets_lp = `BSG_SAFE_CLOG2(sets_p)
     , localparam lg_block_size_in_bytes_lp = `BSG_SAFE_CLOG2(block_size_in_bytes_lp)
-    , localparam ptag_width_lp = (paddr_width_p-lg_sets_lp-lg_block_size_in_bytes_lp)
 
    `declare_bp_bedrock_lce_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_lp, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache)
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache)
 
     , localparam stat_info_width_lp = `bp_cache_stat_info_width(assoc_p)
   )
@@ -71,7 +70,7 @@ module bp_lce
     , output logic                                   tag_mem_pkt_v_o
     , output logic [cache_tag_mem_pkt_width_lp-1:0]  tag_mem_pkt_o
     , input                                          tag_mem_pkt_yumi_i
-    , input [ptag_width_lp-1:0]                      tag_mem_i
+    , input [ptag_width_p-1:0]                       tag_mem_i
 
     , output logic                                   stat_mem_pkt_v_o
     , output logic [cache_stat_mem_pkt_width_lp-1:0] stat_mem_pkt_o

--- a/bp_me/src/v/lce/bp_lce_cmd.v
+++ b/bp_me/src/v/lce/bp_lce_cmd.v
@@ -35,10 +35,9 @@ module bp_lce_cmd
     , localparam lg_assoc_lp = `BSG_SAFE_CLOG2(assoc_p)
     , localparam lg_sets_lp = `BSG_SAFE_CLOG2(sets_p)
     , localparam lg_block_size_in_bytes_lp = `BSG_SAFE_CLOG2(block_size_in_bytes_lp)
-    , localparam ptag_width_lp = (paddr_width_p-lg_sets_lp-lg_block_size_in_bytes_lp)
 
    `declare_bp_bedrock_lce_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_lp, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache)
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache)
 
     // width for counter used during initiliazation and for sync messages
     , localparam cnt_width_lp = `BSG_MAX(cce_id_width_p+1, `BSG_SAFE_CLOG2(sets_p)+1)
@@ -82,7 +81,7 @@ module bp_lce_cmd
     , output logic                                   tag_mem_pkt_v_o
     , output logic [cache_tag_mem_pkt_width_lp-1:0]  tag_mem_pkt_o
     , input                                          tag_mem_pkt_yumi_i
-    , input [ptag_width_lp-1:0]                      tag_mem_i
+    , input [ptag_width_p-1:0]                      tag_mem_i
 
     , output logic                                   stat_mem_pkt_v_o
     , output logic [cache_stat_mem_pkt_width_lp-1:0] stat_mem_pkt_o
@@ -119,7 +118,7 @@ module bp_lce_cmd
   );
 
   `declare_bp_bedrock_lce_if(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_lp, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache);
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache);
 
   // FSM states
   typedef enum logic [3:0] {
@@ -239,11 +238,11 @@ module bp_lce_cmd
 
   // common fields from LCE Command used in many states for responses or pkt fields
   logic [lg_sets_lp-1:0] lce_cmd_addr_index;
-  logic [ptag_width_lp-1:0] lce_cmd_addr_tag;
+  logic [ptag_width_p-1:0] lce_cmd_addr_tag;
   logic [lg_assoc_lp-1:0] lce_cmd_way_id;
 
   assign lce_cmd_addr_index = lce_cmd.header.addr[lg_block_size_in_bytes_lp+:lg_sets_lp];
-  assign lce_cmd_addr_tag = lce_cmd.header.addr[(paddr_width_p-1) -: ptag_width_lp];
+  assign lce_cmd_addr_tag = lce_cmd.header.addr[(paddr_width_p-1) -: ptag_width_p];
   assign lce_cmd_way_id = lce_cmd_payload.way_id[0+:lg_assoc_lp];
 
   // LCE Command module is ready after it clears the cache's tag and stat memories

--- a/bp_me/src/v/lce/bp_lce_req.v
+++ b/bp_me/src/v/lce/bp_lce_req.v
@@ -32,11 +32,10 @@ module bp_lce_req
     , localparam block_size_in_bytes_lp = (block_width_p/8)
     , localparam lg_sets_lp = `BSG_SAFE_CLOG2(sets_p)
     , localparam lg_block_size_in_bytes_lp = `BSG_SAFE_CLOG2(block_size_in_bytes_lp)
-    , localparam ptag_width_lp = (paddr_width_p-lg_sets_lp-lg_block_size_in_bytes_lp)
     , localparam lg_lce_assoc_lp = `BSG_SAFE_CLOG2(lce_assoc_p)
 
    `declare_bp_bedrock_lce_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_lp, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache)
+   `declare_bp_cache_service_if_widths(paddr_width_p, ptag_width_p, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache)
 
     , localparam stat_info_width_lp = `bp_cache_stat_info_width(assoc_p)
 
@@ -94,7 +93,7 @@ module bp_lce_req
   );
 
   `declare_bp_bedrock_lce_if(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
-  `declare_bp_cache_service_if(paddr_width_p, ptag_width_lp, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache);
+  `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache);
 
   // FSM states
   typedef enum logic [2:0] {

--- a/bp_top/src/v/bp_cfg.v
+++ b/bp_top/src/v/bp_cfg.v
@@ -9,7 +9,7 @@ module bp_cfg
  import bp_common_cfg_link_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, xce)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, dword_width_p, lce_id_width_p, lce_assoc_p, xce)
 
    // TODO: Should I be a global param
    , localparam cfg_max_outstanding_p = 1

--- a/bp_top/src/v/bp_clint_slice.v
+++ b/bp_top/src/v/bp_clint_slice.v
@@ -10,7 +10,7 @@ module bp_clint_slice
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, xce)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, dword_width_p, lce_id_width_p, lce_assoc_p, xce)
 
    // TODO: Should I be a global param?
    , localparam clint_max_outstanding_p = 2

--- a/bp_top/src/v/bp_tile.v
+++ b/bp_top/src/v/bp_tile.v
@@ -102,12 +102,12 @@ logic                  loopback_mem_cmd_v_li, loopback_mem_cmd_ready_lo;
 bp_bedrock_cce_mem_msg_s       loopback_mem_resp_lo;
 bp_bedrock_xce_mem_msg_s       loopback_mem_resp;
 logic                  loopback_mem_resp_v_lo, loopback_mem_resp_yumi_li;
-assign loopback_mem_cmd = {header: loopback_mem_cmd_li.header
-                          ,data: loopback_mem_cmd_li.data[0+:dword_width_p]
-                          };
-assign loopback_mem_resp_lo = {header: loopback_mem_resp.header
-                              ,data: {'0, loopback_mem_resp.data}
-                              };
+assign loopback_mem_cmd = '{header: loopback_mem_cmd_li.header
+                           ,data: loopback_mem_cmd_li.data[0+:dword_width_p]
+                           };
+assign loopback_mem_resp_lo = '{header: loopback_mem_resp.header
+                               ,data: {'0, loopback_mem_resp.data}
+                               };
 
 bp_bedrock_cce_mem_msg_s       cache_mem_cmd_li;
 logic                  cache_mem_cmd_v_li, cache_mem_cmd_ready_lo;
@@ -120,12 +120,12 @@ logic                  cfg_mem_cmd_v_li, cfg_mem_cmd_ready_lo;
 bp_bedrock_cce_mem_msg_s       cfg_mem_resp_lo;
 bp_bedrock_xce_mem_msg_s       cfg_mem_resp;
 logic                  cfg_mem_resp_v_lo, cfg_mem_resp_yumi_li;
-assign cfg_mem_cmd = {header: cfg_mem_cmd_li.header
+assign cfg_mem_cmd = '{header: cfg_mem_cmd_li.header
                       ,data: cfg_mem_cmd_li.data[0+:dword_width_p]
-                     };
-assign cfg_mem_resp_lo = {header: cfg_mem_resp.header
-                         ,data: {'0, cfg_mem_resp.data}
-                         };
+                      };
+assign cfg_mem_resp_lo = '{header: cfg_mem_resp.header
+                          ,data: {'0, cfg_mem_resp.data}
+                          };
 
 bp_bedrock_cce_mem_msg_s       clint_mem_cmd_li;
 bp_bedrock_xce_mem_msg_s       clint_mem_cmd;
@@ -133,12 +133,12 @@ logic                  clint_mem_cmd_v_li, clint_mem_cmd_ready_lo;
 bp_bedrock_cce_mem_msg_s       clint_mem_resp_lo;
 bp_bedrock_xce_mem_msg_s       clint_mem_resp;
 logic                  clint_mem_resp_v_lo, clint_mem_resp_yumi_li;
-assign clint_mem_cmd = {header: clint_mem_cmd_li.header
-                       ,data: clint_mem_cmd_li.data[0+:dword_width_p]
-                       };
-assign clint_mem_resp_lo = {header: clint_mem_resp.header
-                           ,data: {'0, clint_mem_resp.data}
-                           };
+assign clint_mem_cmd = '{header: clint_mem_cmd_li.header
+                        ,data: clint_mem_cmd_li.data[0+:dword_width_p]
+                        };
+assign clint_mem_resp_lo = '{header: clint_mem_resp.header
+                            ,data: {'0, clint_mem_resp.data}
+                            };
 
 logic reset_r;
 always_ff @(posedge clk_i)

--- a/bp_top/src/v/bp_tile.v
+++ b/bp_top/src/v/bp_tile.v
@@ -106,7 +106,7 @@ assign loopback_mem_cmd = '{header: loopback_mem_cmd_li.header
                            ,data: loopback_mem_cmd_li.data[0+:dword_width_p]
                            };
 assign loopback_mem_resp_lo = '{header: loopback_mem_resp.header
-                               ,data: {'0, loopback_mem_resp.data}
+                               ,data: {cce_block_width_p/dword_width_p{loopback_mem_resp.data}}
                                };
 
 bp_bedrock_cce_mem_msg_s       cache_mem_cmd_li;
@@ -124,7 +124,7 @@ assign cfg_mem_cmd = '{header: cfg_mem_cmd_li.header
                       ,data: cfg_mem_cmd_li.data[0+:dword_width_p]
                       };
 assign cfg_mem_resp_lo = '{header: cfg_mem_resp.header
-                          ,data: {'0, cfg_mem_resp.data}
+                          ,data: {cce_block_width_p/dword_width_p{cfg_mem_resp.data}}
                           };
 
 bp_bedrock_cce_mem_msg_s       clint_mem_cmd_li;
@@ -137,7 +137,7 @@ assign clint_mem_cmd = '{header: clint_mem_cmd_li.header
                         ,data: clint_mem_cmd_li.data[0+:dword_width_p]
                         };
 assign clint_mem_resp_lo = '{header: clint_mem_resp.header
-                            ,data: {'0, clint_mem_resp.data}
+                            ,data: {cce_block_width_p/dword_width_p{clint_mem_resp.data}}
                             };
 
 logic reset_r;

--- a/bp_top/src/v/bp_unicore.v
+++ b/bp_top/src/v/bp_unicore.v
@@ -582,7 +582,7 @@ module bp_unicore
         (.clk_i(clk_i)
          ,.reset_i(reset_i)
 
-         ,.mem_i(cache_cmd_li)
+         ,.mem_i(cache_cmd)
          ,.mem_v_i(cache_cmd_v_li)
          ,.mem_ready_and_o(cache_cmd_ready_lo)
 
@@ -614,7 +614,7 @@ module bp_unicore
          ,.mem_data_v_i(mem_resp_data_v_i)
          ,.mem_data_ready_and_o(mem_resp_data_ready_lo)
 
-         ,.mem_o(cache_resp_lo)
+         ,.mem_o(cache_resp)
          ,.mem_v_o(cache_resp_v_lo)
          ,.mem_ready_and_i(cache_resp_yumi_li)
          );

--- a/bp_top/src/v/bp_unicore.v
+++ b/bp_top/src/v/bp_unicore.v
@@ -111,12 +111,12 @@ module bp_unicore
   bp_bedrock_uce_mem_msg_s cfg_resp_lo;
   bp_bedrock_xce_mem_msg_s cfg_resp;
   logic cfg_resp_v_lo, cfg_resp_yumi_li;
-  assign cfg_cmd = {header: cfg_cmd_li.header
-                   ,data: cfg_cmd_li.data[0+:dword_width_p]
-                   };
-  assign cfg_resp_lo = {header: cfg_resp.header
-                       ,data: {'0,cfg_resp.data}
-                       };
+  assign cfg_cmd = '{header: cfg_cmd_li.header
+                    ,data: cfg_cmd_li.data[0+:dword_width_p]
+                    };
+  assign cfg_resp_lo = '{header: cfg_resp.header
+                        ,data: {'0,cfg_resp.data}
+                        };
 
   bp_bedrock_uce_mem_msg_s clint_cmd_li;
   bp_bedrock_xce_mem_msg_s clint_cmd;
@@ -124,12 +124,12 @@ module bp_unicore
   bp_bedrock_uce_mem_msg_s clint_resp_lo;
   bp_bedrock_xce_mem_msg_s clint_resp;
   logic clint_resp_v_lo, clint_resp_yumi_li;
-  assign clint_cmd = {header: clint_cmd_li.header
-                     ,data: clint_cmd_li.data[0+:dword_width_p]
-                     };
-  assign clint_resp_lo = {header: clint_resp.header
-                         ,data: {'0,clint_resp.data}
-                         };
+  assign clint_cmd = '{header: clint_cmd_li.header
+                      ,data: clint_cmd_li.data[0+:dword_width_p]
+                      };
+  assign clint_resp_lo = '{header: clint_resp.header
+                          ,data: {'0,clint_resp.data}
+                          };
 
   bp_bedrock_uce_mem_msg_s cache_cmd_li;
   bp_bedrock_cce_mem_msg_s cache_cmd;
@@ -137,12 +137,12 @@ module bp_unicore
   bp_bedrock_uce_mem_msg_s cache_resp_lo;
   bp_bedrock_cce_mem_msg_s cache_resp;
   logic cache_resp_v_lo, cache_resp_yumi_li;
-  assign cache_cmd = {header: cache_cmd_li.header
-                     ,data: {'0,cache_cmd_li.data}
-                     };
-  assign cache_resp_lo = {header: cache_resp.header
-                         ,data: cache_resp.data[0+:uce_mem_data_width_lp]
-                         };
+  assign cache_cmd = '{header: cache_cmd_li.header
+                      ,data: {'0,cache_cmd_li.data}
+                      };
+  assign cache_resp_lo = '{header: cache_resp.header
+                          ,data: cache_resp.data[0+:uce_mem_data_width_lp]
+                          };
 
   bp_bedrock_uce_mem_msg_s loopback_cmd_li;
   bp_bedrock_xce_mem_msg_s loopback_cmd;
@@ -150,12 +150,12 @@ module bp_unicore
   bp_bedrock_uce_mem_msg_s loopback_resp_lo;
   bp_bedrock_xce_mem_msg_s loopback_resp;
   logic loopback_resp_v_lo, loopback_resp_yumi_li;
-  assign loopback_cmd = {header: loopback_cmd_li.header
-                        ,data: loopback_cmd_li.data[0+:dword_width_p]
-                        };
-  assign loopback_resp_lo = {header: loopback_resp.header
-                            ,data: {'0,loopback_resp.data}
-                            };
+  assign loopback_cmd = '{header: loopback_cmd_li.header
+                         ,data: loopback_cmd_li.data[0+:dword_width_p]
+                         };
+  assign loopback_resp_lo = '{header: loopback_resp.header
+                             ,data: {'0,loopback_resp.data}
+                             };
 
   bp_cfg_bus_s cfg_bus_lo;
   bp_fe_queue_s fe_queue_li, fe_queue_lo;

--- a/bp_top/src/v/bp_unicore.v
+++ b/bp_top/src/v/bp_unicore.v
@@ -115,7 +115,7 @@ module bp_unicore
                     ,data: cfg_cmd_li.data[0+:dword_width_p]
                     };
   assign cfg_resp_lo = '{header: cfg_resp.header
-                        ,data: {'0,cfg_resp.data}
+                        ,data: {uce_mem_data_width_lp/dword_width_p{cfg_resp.data}}
                         };
 
   bp_bedrock_uce_mem_msg_s clint_cmd_li;
@@ -128,7 +128,7 @@ module bp_unicore
                       ,data: clint_cmd_li.data[0+:dword_width_p]
                       };
   assign clint_resp_lo = '{header: clint_resp.header
-                          ,data: {'0,clint_resp.data}
+                          ,data: {uce_mem_data_width_lp/dword_width_p{clint_resp.data}}
                           };
 
   bp_bedrock_uce_mem_msg_s cache_cmd_li;
@@ -138,7 +138,7 @@ module bp_unicore
   bp_bedrock_cce_mem_msg_s cache_resp;
   logic cache_resp_v_lo, cache_resp_yumi_li;
   assign cache_cmd = '{header: cache_cmd_li.header
-                      ,data: {'0,cache_cmd_li.data}
+                      ,data: {cce_block_width_p/uce_mem_data_width_lp{cache_cmd_li.data}}
                       };
   assign cache_resp_lo = '{header: cache_resp.header
                           ,data: cache_resp.data[0+:uce_mem_data_width_lp]
@@ -154,7 +154,7 @@ module bp_unicore
                          ,data: loopback_cmd_li.data[0+:dword_width_p]
                          };
   assign loopback_resp_lo = '{header: loopback_resp.header
-                             ,data: {'0,loopback_resp.data}
+                             ,data: {uce_mem_data_width_lp/dword_width_p{loopback_resp.data}}
                              };
 
   bp_cfg_bus_s cfg_bus_lo;

--- a/bp_top/test/common/bp_nonsynth_cache_tracer.v
+++ b/bp_top/test/common/bp_nonsynth_cache_tracer.v
@@ -77,7 +77,7 @@ module bp_nonsynth_cache_tracer
    
    // tag and data mem read counter
    , input                                                 tag_mem_v_i
-   , input [icache_assoc_p-1:0]                            data_mem_v_i
+   , input [assoc_p-1:0]                                   data_mem_v_i
    );
 
   `declare_bp_cache_service_if(paddr_width_p, ptag_width_p, sets_p, assoc_p, dword_width_p, block_width_p, fill_width_p, cache);

--- a/bp_top/test/common/bp_nonsynth_if_verif.v
+++ b/bp_top/test/common/bp_nonsynth_if_verif.v
@@ -63,8 +63,8 @@ initial
     $fatal("Error: Must have <= 1 column of streaming accelerators");
   if (cac_x_dim_p > 1)
     $fatal("Error: Must have <= 1 column of coherent accelerators");
-  if (!((dcache_block_width_p == icache_block_width_p) && (dcache_block_width_p ==  acache_block_width_p)))
-    $fatal("Error: We don't currently support different block widths");
+  if (multicore_p == 1 && !((dcache_block_width_p == icache_block_width_p) && (dcache_block_width_p ==  acache_block_width_p)))
+    $fatal("Error: We don't currently support different block widths for multicore configurations");
   if ((cce_block_width_p == 256) && (dcache_assoc_p == 8 || icache_assoc_p == 8))
     $fatal("Error: We can't maintain 64-bit dwords with a 256-bit cache block size and 8-way cache associativity");
   if ((cce_block_width_p == 128) && (dcache_assoc_p == 4 || dcache_assoc_p == 8 || icache_assoc_p == 4 || icache_assoc_p == 8))

--- a/bp_top/test/common/bp_nonsynth_if_verif.v
+++ b/bp_top/test/common/bp_nonsynth_if_verif.v
@@ -63,6 +63,8 @@ initial
     $fatal("Error: Must have <= 1 column of streaming accelerators");
   if (cac_x_dim_p > 1)
     $fatal("Error: Must have <= 1 column of coherent accelerators");
+  if (!((dcache_block_width_p == icache_block_width_p) && (dcache_block_width_p ==  acache_block_width_p)))
+    $fatal("Error: We don't currently support different block widths");
   if ((cce_block_width_p == 256) && (dcache_assoc_p == 8 || icache_assoc_p == 8))
     $fatal("Error: We can't maintain 64-bit dwords with a 256-bit cache block size and 8-way cache associativity");
   if ((cce_block_width_p == 128) && (dcache_assoc_p == 4 || dcache_assoc_p == 8 || icache_assoc_p == 4 || icache_assoc_p == 8))

--- a/bp_top/test/tb/bp_tethered/Makefile.cfgs
+++ b/bp_top/test/tb/bp_tethered/Makefile.cfgs
@@ -27,6 +27,7 @@ e_bp_multicore_1_bootrom_cfg_cores      := 1
 e_bp_multicore_1_cfg_cores              := 1
 
 e_bp_unicore_writethrough_cfg_cores     := 1
+e_bp_unicore_l1_hetero_cfg_cores        := 1
 e_bp_unicore_l1_medium_cfg_cores        := 1
 e_bp_unicore_l1_small_cfg_cores         := 1
 e_bp_unicore_no_l2_cfg_cores            := 1

--- a/bp_top/test/tb/bp_tethered/Makefile.cfgs
+++ b/bp_top/test/tb/bp_tethered/Makefile.cfgs
@@ -27,6 +27,7 @@ e_bp_multicore_1_bootrom_cfg_cores      := 1
 e_bp_multicore_1_cfg_cores              := 1
 
 e_bp_unicore_writethrough_cfg_cores     := 1
+e_bp_unicore_l1_wide_cfg_cores          := 1
 e_bp_unicore_l1_hetero_cfg_cores        := 1
 e_bp_unicore_l1_medium_cfg_cores        := 1
 e_bp_unicore_l1_small_cfg_cores         := 1

--- a/ci/weird_config.sh
+++ b/ci/weird_config.sh
@@ -30,7 +30,6 @@ cfgs=(\
     "e_bp_multicore_8_cfg"
     "e_bp_multicore_6_cce_ucode_cfg"
     "e_bp_multicore_6_cfg"
-    "e_bp_multicore_4_accelerator_cfg"
     "e_bp_multicore_4_cce_ucode_cfg"
     "e_bp_multicore_4_cfg"
     "e_bp_multicore_3_cce_ucode_cfg"

--- a/ci/weird_config.sh
+++ b/ci/weird_config.sh
@@ -45,6 +45,7 @@ cfgs=(\
 
     "e_bp_unicore_writethrough_cfg"
     "e_bp_unicore_no_l2_cfg"
+    "e_bp_unicore_l1_wide_cfg"
     "e_bp_unicore_l1_hetero_cfg"
     "e_bp_unicore_l1_medium_cfg"
     "e_bp_unicore_l1_small_cfg"

--- a/ci/weird_config.sh
+++ b/ci/weird_config.sh
@@ -45,6 +45,7 @@ cfgs=(\
 
     "e_bp_unicore_writethrough_cfg"
     "e_bp_unicore_no_l2_cfg"
+    "e_bp_unicore_l1_hetero_cfg"
     "e_bp_unicore_l1_medium_cfg"
     "e_bp_unicore_l1_small_cfg"
     "e_bp_unicore_cfg"


### PR DESCRIPTION
This PR adds a fix for the l1_medium and l1_small cache configs that were found to be broken. A new l1_tiny config will follow in a future PR as well. 

The main reason for these configs to break was that we currently strongly require all caches - I$, D$ and A$ (Accelerator cache) to have the same parameters (the blockwidth specifically). 