### PR TITLE
Adding bp_finish at the end of test

### DIFF
--- a/bp_common/test/src/demos/src/sample.c
+++ b/bp_common/test/src/demos/src/sample.c
@@ -23,5 +23,6 @@ int main(int arc, char** argv) {
   bp_cprint(' ');
   bp_cprint(' ' + core_id);
 
+  bp_finish(0);
   return 0;
 }


### PR DESCRIPTION
The test is hanging at the end of runtime due to missing   bp_finish(0);. Adding this will make it terminate correctly.