### PR TITLE
Non-replay D$

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 variables:
-  GIT_STRATEGY: fetch
+  GIT_STRATEGY: clone
   GIT_SUBMODULE_STRATEGY: none
 
 ## CI Stages:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 variables:
-  GIT_STRATEGY: clone
+  GIT_STRATEGY: fetch
   GIT_SUBMODULE_STRATEGY: none
 
 ## CI Stages:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - be_dev_dcachetemptemptmep
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/bp_be/src/include/bp_be_ctl_pkgdef.svh
+++ b/bp_be/src/include/bp_be_ctl_pkgdef.svh
@@ -239,9 +239,9 @@
     // BP "exceptions"
     logic itlb_miss;
     logic icache_miss;
+    logic dcache_fail;
     logic dtlb_load_miss;
     logic dtlb_store_miss;
-    logic dcache_miss;
     logic fencei_dirty;
     logic itlb_fill;
     logic dtlb_fill;
@@ -251,6 +251,7 @@
 
   typedef struct packed
   {
+    logic dcache_miss;
     logic fencei_clean;
     logic sfence_vma;
     logic dbreak;

--- a/bp_be/src/include/bp_be_defines.svh
+++ b/bp_be/src/include/bp_be_defines.svh
@@ -154,7 +154,6 @@
       logic                           dcache_miss;                                                 \
       logic                           itlb_fill_v;                                                 \
       logic                           dtlb_fill_v;                                                 \
-      logic                           rollback;                                                    \
     }  bp_be_commit_pkt_s;                                                                         \
                                                                                                    \
     typedef struct packed                                                                          \
@@ -246,7 +245,7 @@
     (paddr_width_mp - page_offset_width_gp + 7)
 
   `define bp_be_commit_pkt_width(vaddr_width_mp, paddr_width_mp) \
-    (3 + `bp_be_pte_leaf_width(paddr_width_mp) +  3*vaddr_width_mp + instr_width_gp + rv64_priv_width_gp + 16)
+    (3 + `bp_be_pte_leaf_width(paddr_width_mp) +  3*vaddr_width_mp + instr_width_gp + rv64_priv_width_gp + 15)
 
   `define bp_be_wb_pkt_width(vaddr_width_mp) \
     (3                                                                                             \

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -459,10 +459,10 @@ module bp_be_calculator_top
           exc_stage_n[3].v                      &= commit_pkt_cast_o.instret;
 
           exc_stage_n[0].queue_v                 = reservation_n.queue_v;
-          exc_stage_n[0].queue_v                &= ~commit_pkt_cast_o.rollback;
-          exc_stage_n[1].queue_v                &= ~commit_pkt_cast_o.rollback;
-          exc_stage_n[2].queue_v                &= ~commit_pkt_cast_o.rollback;
-          exc_stage_n[3].queue_v                &= ~commit_pkt_cast_o.rollback;
+          exc_stage_n[0].queue_v                &= ~commit_pkt_cast_o.npc_w_v;
+          exc_stage_n[1].queue_v                &= ~commit_pkt_cast_o.npc_w_v;
+          exc_stage_n[2].queue_v                &= ~commit_pkt_cast_o.npc_w_v;
+          exc_stage_n[3].queue_v                &= ~commit_pkt_cast_o.npc_w_v;
 
           exc_stage_n[0].spec                   |= reservation_n.special;
           exc_stage_n[0].exc                    |= reservation_n.exception;

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -637,7 +637,7 @@ module bp_be_csr
   assign commit_pkt_cast_o.icache_miss      = retire_pkt_cast_i.exception.icache_miss;
   assign commit_pkt_cast_o.dtlb_store_miss  = retire_pkt_cast_i.exception.dtlb_store_miss;
   assign commit_pkt_cast_o.dtlb_load_miss   = retire_pkt_cast_i.exception.dtlb_load_miss;
-  assign commit_pkt_cast_o.dcache_miss      = retire_pkt_cast_i.exception.dcache_miss;;
+  assign commit_pkt_cast_o.dcache_miss      = retire_pkt_cast_i.special.dcache_miss;
   assign commit_pkt_cast_o.itlb_fill_v      = retire_pkt_cast_i.exception.itlb_fill;
   assign commit_pkt_cast_o.dtlb_fill_v      = retire_pkt_cast_i.exception.dtlb_fill;
   assign commit_pkt_cast_o.rollback         = |retire_pkt_cast_i.exception;

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -617,7 +617,7 @@ module bp_be_csr
   assign csr_data_o = dword_width_gp'(csr_data_lo);
 
   assign commit_pkt_cast_o.npc_w_v          = |{retire_pkt_cast_i.special, retire_pkt_cast_i.exception};
-  assign commit_pkt_cast_o.queue_v          = retire_pkt_cast_i.queue_v;
+  assign commit_pkt_cast_o.queue_v          = retire_pkt_cast_i.queue_v & ~|retire_pkt_cast_i.exception;
   assign commit_pkt_cast_o.instret          = retire_pkt_cast_i.instret;
   assign commit_pkt_cast_o.pc               = apc_r;
   assign commit_pkt_cast_o.npc              = apc_n;
@@ -640,7 +640,6 @@ module bp_be_csr
   assign commit_pkt_cast_o.dcache_miss      = retire_pkt_cast_i.special.dcache_miss;
   assign commit_pkt_cast_o.itlb_fill_v      = retire_pkt_cast_i.exception.itlb_fill;
   assign commit_pkt_cast_o.dtlb_fill_v      = retire_pkt_cast_i.exception.dtlb_fill;
-  assign commit_pkt_cast_o.rollback         = |retire_pkt_cast_i.exception;
 
   assign trans_info_cast_o.priv_mode = priv_mode_r;
   assign trans_info_cast_o.satp_ppn  = satp_lo.ppn;

--- a/bp_be/src/v/bp_be_calculator/bp_be_ptw.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_ptw.sv
@@ -197,7 +197,7 @@ module bp_be_ptw
                              ? (page_fault_v
                                 ? eIdle
                                 : (pte_is_leaf ? eWriteBack : eSendLoad))
-                             : eSendLoad);
+                             : eRecvLoad);
       eWriteBack: state_n = eIdle;
       default: state_n = eIdle;
     endcase

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -219,7 +219,7 @@ module bp_be_detector
                            & (dep_status_r[3].fma_fwb_v);
 
       mem_in_pipe_v      = dep_status_r[0].mem_v | dep_status_r[1].mem_v | dep_status_r[2].mem_v;
-      fence_haz_v        = (isd_status_cast_i.fence_v & (~credits_empty_i | mem_in_pipe_v))
+      fence_haz_v        = (isd_status_cast_i.fence_v & (~credits_empty_i | mem_in_pipe_v | ~mem_ready_i))
                            | (isd_status_cast_i.mem_v & credits_full_i);
       cmd_haz_v          = cmd_full_i;
 

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -70,7 +70,7 @@ module bp_be_scheduler
   bp_fe_queue_s fe_queue_lo;
   logic fe_queue_v_lo, fe_queue_yumi_li;
   wire fe_queue_clr_li  = suppress_iss_i;
-  wire fe_queue_deq_li  = commit_pkt_cast_i.queue_v & ~commit_pkt_cast_i.rollback;
+  wire fe_queue_deq_li  = commit_pkt_cast_i.queue_v;
   wire fe_queue_roll_li = commit_pkt_cast_i.rollback;
   bp_be_issue_pkt_s preissue_pkt, issue_pkt;
   bp_be_issue_queue

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -71,7 +71,7 @@ module bp_be_scheduler
   logic fe_queue_v_lo, fe_queue_yumi_li;
   wire fe_queue_clr_li  = suppress_iss_i;
   wire fe_queue_deq_li  = commit_pkt_cast_i.queue_v;
-  wire fe_queue_roll_li = commit_pkt_cast_i.rollback;
+  wire fe_queue_roll_li = commit_pkt_cast_i.npc_w_v;
   bp_be_issue_pkt_s preissue_pkt, issue_pkt;
   bp_be_issue_queue
    #(.bp_params_p(bp_params_p))

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -827,7 +827,7 @@ module bp_be_dcache
   wire nonblocking_req     = uncached_store_req | wt_req;
 
   assign cache_req_v_o = is_req
-    | (~flush_i & v_tv_r & (|{cached_req, fencei_req, l2_amo_req, uncached_load_req, uncached_store_req, wt_req}));
+    | (is_ready & v_tv_r & ~flush_i & (|{cached_req, fencei_req, l2_amo_req, uncached_load_req, uncached_store_req, wt_req}));
 
   always_comb
     begin

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -82,7 +82,7 @@ module bp_be_top
   bp_be_ptw_miss_pkt_s ptw_miss_pkt;
 
   logic dispatch_v, interrupt_v;
-  logic irq_pending_lo, irq_waiting_lo, replay_pending_lo;
+  logic irq_pending_lo, irq_waiting_lo;
 
   bp_be_commit_pkt_s commit_pkt;
   bp_be_ptw_fill_pkt_s ptw_fill_pkt;
@@ -139,7 +139,6 @@ module bp_be_top
      ,.long_ready_i(long_ready_lo)
      ,.ptw_busy_i(ptw_busy_lo)
      ,.irq_pending_i(irq_pending_lo)
-     ,.replay_pending_i(replay_pending_lo)
 
      ,.dispatch_v_o(dispatch_v)
      ,.interrupt_v_o(interrupt_v)
@@ -228,7 +227,6 @@ module bp_be_top
      ,.external_irq_i(external_irq_i)
      ,.irq_pending_o(irq_pending_lo)
      ,.irq_waiting_o(irq_waiting_lo)
-     ,.replay_pending_o(replay_pending_lo)
      ,.cmd_full_n_i(cmd_full_n_lo)
      );
 

--- a/bp_be/test/tb/bp_be_dcache/testbench.sv
+++ b/bp_be/test/tb/bp_be_dcache/testbench.sv
@@ -309,11 +309,13 @@ module testbench
        ,.sc_op_tv_r(decode_tv_r.sc_op)
        ,.sc_success(sc_success_tv)
 
-       ,.cache_req_v_o(cache_req_v_o)
+       ,.cache_req_yumi_i(cache_req_yumi_i)
        ,.cache_req_o(cache_req_o)
        ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
        ,.cache_req_metadata_o(cache_req_metadata_o)
        ,.cache_req_complete_i(cache_req_complete_i)
+       ,.cache_req_critical_tag_i(cache_req_critical_tag_i)
+       ,.cache_req_critical_data_i(cache_req_critical_data_i)
 
        ,.v_o(early_v_o)
        ,.load_data(early_data_o[0+:65])

--- a/bp_fe/test/tb/bp_fe_icache/testbench.sv
+++ b/bp_fe/test/tb/bp_fe_icache/testbench.sv
@@ -282,10 +282,12 @@ module testbench
       ,.sc_success(1'b0)
 
       ,.cache_req_o(cache_req_o)
-      ,.cache_req_v_o(cache_req_v_o)
+      ,.cache_req_yumi_i(cache_req_yumi_i)
       ,.cache_req_metadata_o(cache_req_metadata_o)
       ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
       ,.cache_req_complete_i(cache_req_complete_i)
+      ,.cache_req_critical_data_i(cache_req_critical_data_i)
+      ,.cache_req_critical_data_i(cache_req_critical_data_i)
 
       ,.wt_req()
 

--- a/bp_me/src/v/lce/bp_lce_cmd.sv
+++ b/bp_me/src/v/lce/bp_lce_cmd.sv
@@ -423,8 +423,8 @@ module bp_lce_cmd
 
               // TODO: This is sufficient for the critical signal when only
               //   line width fills
-              cache_req_critical_tag_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
-              cache_req_critical_data_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+              cache_req_critical_tag_o = tag_mem_pkt_yumi_i;
+              cache_req_critical_data_o = data_mem_pkt_yumi_i;
 
               // send coherence ack after updating tag and data memories
               state_n = (tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i)
@@ -442,6 +442,8 @@ module bp_lce_cmd
               tag_mem_pkt.tag = lce_cmd_addr_tag;
               tag_mem_pkt.opcode = e_cache_tag_mem_set_state;
               tag_mem_pkt_v_o = lce_cmd_v_i;
+
+              cache_req_critical_tag_o = tag_mem_pkt_yumi_i;
 
               state_n = tag_mem_pkt_yumi_i
                         ? e_coh_ack
@@ -556,6 +558,7 @@ module bp_lce_cmd
 
               lce_cmd_yumi_o = data_mem_pkt_yumi_i;
 
+              cache_req_critical_tag_o = lce_cmd_yumi_o;
               cache_req_critical_data_o = lce_cmd_yumi_o;
               cache_req_complete_o = lce_cmd_yumi_o;
             end

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -358,13 +358,15 @@ module testbench
            ,.sc_op_tv_r(decode_tv_r.sc_op)
            ,.sc_success(sc_success_tv)
 
-           ,.cache_req_v_o(cache_req_v_o)
+           ,.cache_req_yumi_i(cache_req_yumi_i)
            ,.cache_req_o(cache_req_o)
 
            ,.cache_req_metadata_o(cache_req_metadata_o)
            ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
 
            ,.cache_req_complete_i(cache_req_complete_i)
+           ,.cache_req_critical_tag_i(cache_req_critical_tag_i)
+           ,.cache_req_critical_data_i(cache_req_critical_data_i)
 
            ,.v_o(early_v_o)
            ,.load_data(early_data_o[0+:65])
@@ -410,13 +412,15 @@ module testbench
            ,.sc_op_tv_r(1'b0)
            ,.sc_success(1'b0)
 
-           ,.cache_req_v_o(cache_req_v_o)
+           ,.cache_req_yumi_i(cache_req_yumi_i)
            ,.cache_req_o(cache_req_o)
 
            ,.cache_req_metadata_o(cache_req_metadata_o)
            ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
 
            ,.cache_req_complete_i(cache_req_complete_i)
+           ,.cache_req_critical_tag_i(cache_req_critical_tag_i)
+           ,.cache_req_critical_data_i(cache_req_critical_data_i)
 
            ,.v_o(data_v_o)
            ,.load_data(65'(data_o))

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -495,7 +495,7 @@ module testbench
 
            ,.dtlb_miss(be.calculator.pipe_mem.dtlb_miss_v)
            ,.dcache_miss(~be.calculator.pipe_mem.dcache.ready_o)
-           ,.dcache_rollback(be.scheduler.commit_pkt_cast_i.rollback)
+           ,.dcache_rollback(be.scheduler.commit_pkt_cast_i.npc_w_v)
            ,.long_haz(be.detector.long_haz_v)
            ,.exception(be.director.commit_pkt_cast_i.exception)
            ,.eret(be.director.commit_pkt_cast_i.eret)


### PR DESCRIPTION
This PR adds D$ operation to the scoreboard, so that cache misses do not block the pipeline. This is nice for performance, but necessary for non-idempotent remote atomic or uncached operations