### PR TITLE
Harden predictors

### DIFF
--- a/bp_common/src/include/bp_common_aviary_pkg.vh
+++ b/bp_common/src/include/bp_common_aviary_pkg.vh
@@ -29,7 +29,7 @@ package bp_common_aviary_pkg;
       ,boot_pc       : dram_base_addr_gp
       ,boot_in_debug : 0
 
-      ,branch_metadata_fwd_width: 35
+      ,branch_metadata_fwd_width: 37
       ,btb_tag_width            : 10
       ,btb_idx_width            : 6
       ,bht_idx_width            : 9

--- a/bp_fe/src/include/bp_fe_defines.vh
+++ b/bp_fe/src/include/bp_fe_defines.vh
@@ -35,7 +35,6 @@
 `define declare_bp_fe_branch_metadata_fwd_s(btb_tag_width_mp, btb_idx_width_mp, bht_idx_width_mp, ghist_width_mp) \
   typedef struct packed                                                                         \
   {                                                                                             \
-    logic                           pred_taken;                                                 \
     logic                           is_br;                                                      \
     logic                           is_jal;                                                     \
     logic                           is_jalr;                                                    \
@@ -47,6 +46,7 @@
     logic [btb_tag_width_mp-1:0]    btb_tag;                                                    \
     logic [btb_idx_width_mp-1:0]    btb_idx;                                                    \
     logic [bht_idx_width_mp-1:0]    bht_idx;                                                    \
+    logic [1:0]                     bht_val;                                                    \
     logic [ghist_width_mp-1:0]      ghist;                                                      \
   }  bp_fe_branch_metadata_fwd_s;
 
@@ -55,7 +55,7 @@
   {                                 \
     logic v;                        \
     logic btb;                      \
-    logic bht;                      \
+    logic [1:0] bht;                \
     logic ret;                      \
     logic ovr;                      \
     logic taken;                    \
@@ -68,7 +68,7 @@
   (vaddr_width_mp + 5)
 
 `define bp_fe_pc_gen_stage_width(vaddr_width_mp, ghist_width_mp) \
-  (6 + vaddr_width_mp + ghist_width_mp)
+  (7 + vaddr_width_mp + ghist_width_mp)
 
 `endif
 

--- a/bp_fe/src/v/bp_fe_bht.v
+++ b/bp_fe/src/v/bp_fe_bht.v
@@ -7,79 +7,108 @@
  * the positive regime, the BHT predicts "taken"; if the counter value is in the
  * negative regime, the BHT predicts "not taken". The implementation of BHT is
  * native to this design.
-*/
+ * 2-bit saturating counter(high_bit:prediction direction,low_bit:strong/weak prediction)
+ */
 module bp_fe_bht
  import bp_fe_pkg::*; 
- #(parameter vaddr_width_p = "inv"
+ #(parameter vaddr_width_p     = "inv"
    , parameter bht_idx_width_p = "inv"
 
-   , parameter debug_p             = 0
-
-   , localparam els_lp             = 2**bht_idx_width_p
-   , localparam saturation_size_lp = 2
+   , localparam els_lp = 2**bht_idx_width_p
    )
   (input                         clk_i
    , input                       reset_i
     
    , input                       w_v_i
    , input [bht_idx_width_p-1:0] idx_w_i
+   , input [1:0]                 val_i
    , input                       correct_i
  
    , input                       r_v_i   
    , input [bht_idx_width_p-1:0] idx_r_i
-
-   , output                      predict_o
+   , output [1:0]                val_o
    );
 
-logic [els_lp-1:0][saturation_size_lp-1:0] mem;
+  // Initialization state machine
+  enum logic [1:0] {e_reset, e_clear, e_run} state_n, state_r;
+  wire is_reset = (state_r == e_reset);
+  wire is_clear = (state_r == e_clear);
+  wire is_run   = (state_r == e_run);
 
-logic [bht_idx_width_p-1:0] idx_r_r;
-logic r_v_r;
-bsg_dff
- #(.width_p(1+bht_idx_width_p))
- read_reg
-  (.clk_i(clk_i)
+  localparam bht_els_lp = 2**bht_idx_width_p;
+  localparam bht_init_lp = 2'b10;
+  logic [`BSG_WIDTH(bht_els_lp)-1:0] init_cnt;
+  bsg_counter_clear_up
+   #(.max_val_p(bht_els_lp), .init_val_p(0))
+   init_counter
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
 
-   ,.data_i({r_v_i, idx_r_i})
-   ,.data_o({r_v_r, idx_r_r})
-   );
-assign predict_o = r_v_r ? mem[idx_r_r][1] : `BSG_UNDEFINED_IN_SIM(1'b0);
+     ,.clear_i(1'b0)
+     ,.up_i(is_clear)
+     ,.count_o(init_cnt)
+     );
+  wire finished_init = (init_cnt == bht_els_lp-1'b1);
 
-//2-bit saturating counter(high_bit:prediction direction,low_bit:strong/weak prediction)
-always_ff @(posedge clk_i) 
-  if (reset_i) 
-    mem <= '{default:2'b01};
-  else if (w_v_i & correct_i)
-    mem[idx_w_i] <= {mem[idx_w_i][1], 1'b0};
-  else if (w_v_i & ~correct_i)
-    mem[idx_w_i] <= {mem[idx_w_i][1]^mem[idx_w_i][0], 1'b1};
+  always_comb
+    case (state_r)
+      e_clear: state_n = finished_init ? e_run : e_clear;
+      e_run  : state_n = e_run;
+      // e_reset
+      default: state_n = e_clear;
+    endcase
 
+  //synopsys sync_set_reset "reset_i"
+  always_ff @(posedge clk_i)
+    if (reset_i)
+      state_r <= e_reset;
+    else
+      state_r <= state_n;
 
-//synopsys translate_off
-logic [bht_idx_width_p-1:0] idx_w_r;
-logic correct_r, w_v_r;
-bsg_dff
- #(.width_p(2+bht_idx_width_p))
- write_reg
-  (.clk_i(clk_i)
+  /* TODO: We should fold this tall, narrow RAM */
+  wire                          w_v_li = is_clear | w_v_i;
+  wire [bht_idx_width_p-1:0] w_addr_li = is_clear ? init_cnt : idx_w_i;
+  wire [1:0]                 w_data_li = is_clear ? bht_init_lp : correct_i ? {val_i[1], 1'b0} : {val_i[1]^val_i[0], 1'b1};
 
-   ,.data_i({correct_i, w_v_i, idx_w_i})
-   ,.data_o({correct_r, w_v_r, idx_w_r})
-   );
+  wire                          r_v_li = r_v_i;
+  wire [bht_idx_width_p-1:0] r_addr_li = idx_r_i;
+  logic [1:0] r_data_lo;
+  bsg_mem_1r1w_sync
+   #(.width_p(2), .els_p(2**bht_idx_width_p))
+   bht_mem
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+ 
+     ,.w_v_i(w_v_li)
+     ,.w_addr_i(w_addr_li)
+     ,.w_data_i(w_data_li)
+ 
+     ,.r_v_i(r_v_li)
+     ,.r_addr_i(r_addr_li)
+     ,.r_data_o(r_data_lo)
+     );
 
-if (debug_p)
-  begin
-     always_ff @(negedge clk_i)
-       begin
-         if (w_v_r | r_v_r)
-	       $write("v=%b c=%b W[%h] (=%b); v=%b R[%h] (=%b) p=%b ",w_v_r,correct_r,idx_w_r,mem[idx_w_r],r_v_r,idx_r_r,mem[idx_r_r],predict_o);
+  logic r_v_r;
+  bsg_dff_reset
+   #(.width_p(1))
+   r_v_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
 
-	  if (w_v_r & ~correct_r)
-	    $write("X\n");
-	  else if (w_v_r | r_v_r)
-	    $write("\n");
-       end
-end // if (debug_p)
-//synopsys translate_on 
+     ,.data_i(r_v_i)
+     ,.data_o(r_v_r)
+     );
+
+  bsg_dff_reset_en_bypass
+   #(.width_p(2))
+   bypass_reg
+   (.clk_i(clk_i)
+    ,.reset_i(reset_i) 
+    ,.en_i(r_v_r)
+
+    ,.data_i(r_data_lo)
+    ,.data_o(val_o)
+    );
 
 endmodule
+

--- a/bp_fe/src/v/bp_fe_bht.v
+++ b/bp_fe/src/v/bp_fe_bht.v
@@ -36,7 +36,7 @@ module bp_fe_bht
   wire is_run   = (state_r == e_run);
 
   localparam bht_els_lp = 2**bht_idx_width_p;
-  localparam bht_init_lp = 2'b10;
+  localparam bht_init_lp = 2'b01;
   logic [`BSG_WIDTH(bht_els_lp)-1:0] init_cnt;
   bsg_counter_clear_up
    #(.max_val_p(bht_els_lp), .init_val_p(0))

--- a/bp_fe/src/v/bp_fe_btb.v
+++ b/bp_fe/src/v/bp_fe_btb.v
@@ -88,7 +88,7 @@ module bp_fe_btb
   bp_btb_entry_s tag_mem_data_li;
   wire                          tag_mem_w_v_li = is_clear | w_v_i;
   wire [btb_idx_width_p-1:0] tag_mem_w_addr_li = is_clear ? init_cnt : w_idx_i;
-  assign tag_mem_data_li = (is_clear | w_clr_i) ? '0 : '{v: 1'b1, jmp: w_jmp_i, tag: w_tag_i, tgt: br_tgt_i};
+  assign tag_mem_data_li = (is_clear | (w_v_i & w_clr_i)) ? '0 : '{v: 1'b1, jmp: w_jmp_i, tag: w_tag_i, tgt: br_tgt_i};
 
   bp_btb_entry_s tag_mem_data_lo;
   wire                           tag_mem_r_v_li = r_v_i;
@@ -144,7 +144,7 @@ module bp_fe_btb
      );
 
   assign br_tgt_v_o   = tag_mem_data_bypass_lo.v & (tag_mem_data_bypass_lo.tag == r_tag_r);
-  assign br_tgt_jmp_o = tag_mem_data_bypass_lo.jmp;
+  assign br_tgt_jmp_o = tag_mem_data_bypass_lo.v & tag_mem_data_bypass_lo.jmp;
   assign br_tgt_o     = tag_mem_data_bypass_lo.tgt;
 
 

--- a/bp_fe/src/v/bp_fe_btb.v
+++ b/bp_fe/src/v/bp_fe_btb.v
@@ -143,8 +143,8 @@ module bp_fe_btb
      ,.data_o(tag_mem_data_bypass_lo)
      );
 
-  assign br_tgt_v_o   = tag_mem_data_bypass_lo.v & (tag_mem_data_bypass_lo.tag == r_tag_r);
-  assign br_tgt_jmp_o = tag_mem_data_bypass_lo.v & tag_mem_data_bypass_lo.jmp;
+  assign br_tgt_v_o   = r_v_r & (tag_mem_data_bypass_lo.tag == r_tag_r);
+  assign br_tgt_jmp_o = r_v_r & tag_mem_data_bypass_lo.v & tag_mem_data_bypass_lo.jmp;
   assign br_tgt_o     = tag_mem_data_bypass_lo.tgt;
 
 

--- a/bp_fe/src/v/bp_fe_btb.v
+++ b/bp_fe/src/v/bp_fe_btb.v
@@ -1,30 +1,26 @@
 /*
  * bp_fe_btb.v
- * 
+ *
  * Branch Target Buffer (BTB) stores the addresses of the branch targets and the
  * corresponding branch sites. Branch happens from the branch sites to the branch
- * targets. In order to save the logic sizes, the BTB is designed to have limited 
- * entries for storing the branch sites, branch target pairs. The implementation 
+ * targets. In order to save the logic sizes, the BTB is designed to have limited
+ * entries for storing the branch sites, branch target pairs. The implementation
  * uses the bsg_mem_1rw_sync_synth RAM design.
  *
  * Notes:
- *   BTB writes are prioritized over BTB reads, since they come on redirections and therefore 
+ *   BTB writes are prioritized over BTB reads, since they come on redirections and therefore
  *     the BTB read is most likely for an erroneous instruction, anyway.
  */
+
 module bp_fe_btb
  import bp_fe_pkg::*;
  import bp_common_rv64_pkg::*;
- #(parameter vaddr_width_p = "inv"
+ #(parameter vaddr_width_p     = "inv"
    , parameter btb_tag_width_p = "inv"
    , parameter btb_idx_width_p = "inv"
-
-   , localparam debug_p = 0
-
-   , localparam btb_offset_width_lp = 2 // bottom 2 bits are unused without compressed branches
-                                        // TODO: Should be a parameterizable struct
-   ) 
+   )
   (input                          clk_i
-   , input                        reset_i 
+   , input                        reset_i
 
    // Synchronous read
    , input [vaddr_width_p-1:0]    r_addr_i
@@ -33,6 +29,7 @@ module bp_fe_btb
    , output                       br_tgt_v_o
    , output                       br_tgt_jmp_o
 
+   // Synchronous write
    , input                        w_v_i
    , input                        w_clr_i
    , input                        w_jmp_i
@@ -41,99 +38,115 @@ module bp_fe_btb
    , input [vaddr_width_p-1:0]    br_tgt_i
    );
 
-localparam btb_els_lp = 2**btb_idx_width_p;
+  ///////////////////////
+  // Initialization state machine
+  enum logic [1:0] {e_reset, e_clear, e_run} state_n, state_r;
+  wire is_reset = (state_r == e_reset);
+  wire is_clear = (state_r == e_clear);
+  wire is_run   = (state_r == e_run);
 
-logic [btb_tag_width_p-1:0] tag_mem_li, tag_mem_lo;
-logic [btb_idx_width_p-1:0] tag_mem_addr_li;
-logic                       tag_mem_v_lo;
+  localparam btb_els_lp = 2**btb_idx_width_p;
+  logic [`BSG_WIDTH(btb_els_lp)-1:0] init_cnt;
+  bsg_counter_clear_up
+   #(.max_val_p(btb_els_lp), .init_val_p(0))
+   init_counter
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
 
-logic [vaddr_width_p-1:0]   tgt_mem_li, tgt_mem_lo;
-logic [btb_idx_width_p-1:0] tgt_mem_addr_li;
-logic                       tag_jmp_lo;
-   
-logic [btb_tag_width_p-1:0] w_tag_n, w_tag_r;
-logic [btb_tag_width_p-1:0] r_tag_n, r_tag_r;
-logic [btb_idx_width_p-1:0] r_idx_n, r_idx_r;
-logic                       r_v_r;
+     ,.clear_i(1'b0)
+     ,.up_i(is_clear)
+     ,.count_o(init_cnt)
+     );
+  wire finished_init = (init_cnt == btb_els_lp-1'b1);
 
-assign tag_mem_li      = w_tag_i; 
-assign tgt_mem_li      = br_tgt_i[0+:vaddr_width_p];
-                            
-logic [btb_els_lp-1:0] v_r, v_n;
-    
-bsg_mem_1r1w_sync
- #(.width_p(1+btb_tag_width_p+vaddr_width_p)
-   ,.els_p(btb_els_lp)
-   )
- tag_mem
-  (.clk_i(clk_i)
-   ,.reset_i(reset_i)
- 
+  always_comb
+    case (state_r)
+      e_clear: state_n = finished_init ? e_run : e_clear;
+      e_run  : state_n = e_run;
+      // e_reset
+      default: state_n = e_clear;
+    endcase
 
-   ,.w_v_i(w_v_i & ~w_clr_i)
-   ,.w_addr_i(w_idx_i)
-   ,.w_data_i({w_jmp_i, tag_mem_li, tgt_mem_li})
-
-   ,.r_v_i(r_v_i)
-   ,.r_addr_i(r_addr_i[btb_offset_width_lp+:btb_idx_width_p])
-   ,.r_data_o({tag_jmp_lo, tag_mem_lo, tgt_mem_lo})
-   );
-
-
-assign tag_mem_v_lo = v_r[r_idx_r];
-assign br_tgt_o   = tgt_mem_lo;
-assign br_tgt_v_o = tag_mem_v_lo & r_v_r & (tag_mem_lo == r_tag_r);
-assign br_tgt_jmp_o = tag_mem_v_lo & tag_jmp_lo;
-
-always_ff @(posedge clk_i)
-  begin
+  //synopsys sync_set_reset "reset_i"
+  always_ff @(posedge clk_i)
     if (reset_i)
-      begin
-        r_v_r <= '0;
-        r_tag_r <= '0;
-        r_idx_r <= '0;
-      end
+      state_r <= e_reset;
     else
-      begin
-        r_v_r <= r_v_i;
-        r_tag_r <= r_addr_i[btb_offset_width_lp+btb_idx_width_p+:btb_tag_width_p];
-        r_idx_r <= r_addr_i[btb_offset_width_lp+:btb_idx_width_p];
-      end
-    
-      if (reset_i)
-        v_r <= '0;
-      else if (w_v_i & w_clr_i)
-        v_r[w_idx_i] <= 1'b0;
-      else if (w_v_i & ~w_clr_i)
-        v_r[w_idx_i] <= 1'b1;
-  end
+      state_r <= state_n;
 
-if (debug_p)
-  always_ff @(negedge clk_i)
-    begin
-      if (w_v_i & ~w_clr_i)
-        begin
-          $display("[BTB] WRITE INDEX: %x TAG: %x TARGET: %x"
-                   , tag_mem_addr_li
-                   , tag_mem_li
-                   , tgt_mem_li
-                   );
-        end
-      if (w_v_i & w_clr_i)
-        begin
-          $display("[BTB] CLEAR INDEX: %x TAG: %x"
-                   , tag_mem_addr_li
-                   , tag_mem_li
-                   );
-        end
-      if (br_tgt_v_o)
-        begin
-          $display("[BTB] READ INDEX: %x TAG: %x TARGET: %x"
-                   , r_idx_r
-                   , r_tag_r
-                   , br_tgt_o
-                   );
-        end
-    end
+  typedef struct packed
+  {
+    logic                       v;
+    logic                       jmp;
+    logic [btb_tag_width_p-1:0] tag;
+    logic [vaddr_width_p-1:0]   tgt;
+  }  bp_btb_entry_s;
+
+  wire [btb_idx_width_p-1:0] r_idx_li = r_addr_i[2+:btb_idx_width_p];
+  wire [btb_tag_width_p-1:0] r_tag_li = r_addr_i[2+btb_idx_width_p+:btb_tag_width_p];
+
+  bp_btb_entry_s tag_mem_data_li;
+  wire                          tag_mem_w_v_li = is_clear | w_v_i;
+  wire [btb_idx_width_p-1:0] tag_mem_w_addr_li = is_clear ? init_cnt : w_idx_i;
+  assign tag_mem_data_li = (is_clear | w_clr_i) ? '0 : '{v: 1'b1, jmp: w_jmp_i, tag: w_tag_i, tgt: br_tgt_i};
+
+  bp_btb_entry_s tag_mem_data_lo;
+  wire                           tag_mem_r_v_li = r_v_i;
+  wire [btb_idx_width_p-1:0]  tag_mem_r_addr_li = r_idx_li;
+  bsg_mem_1r1w_sync
+   #(.width_p($bits(bp_btb_entry_s)), .els_p(btb_els_lp))
+   tag_mem
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.w_v_i(tag_mem_w_v_li)
+     ,.w_addr_i(tag_mem_w_addr_li)
+     ,.w_data_i(tag_mem_data_li)
+
+     ,.r_v_i(tag_mem_r_v_li)
+     ,.r_addr_i(tag_mem_r_addr_li)
+     ,.r_data_o(tag_mem_data_lo)
+     );
+
+  logic [btb_tag_width_p-1:0] r_tag_r;
+  bsg_dff_reset_en
+   #(.width_p(btb_tag_width_p))
+   tag_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.en_i(r_v_i)
+
+     ,.data_i(r_tag_li)
+     ,.data_o(r_tag_r)
+     );
+
+  logic r_v_r;
+  bsg_dff_reset
+   #(.width_p(1))
+   r_v_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.data_i(r_v_i)
+     ,.data_o(r_v_r)
+     );
+
+  bp_btb_entry_s tag_mem_data_bypass_lo;
+  bsg_dff_reset_en_bypass
+   #(.width_p($bits(bp_btb_entry_s)))
+   btb_bypass_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.en_i(r_v_r)
+
+     ,.data_i(tag_mem_data_lo)
+     ,.data_o(tag_mem_data_bypass_lo)
+     );
+
+  assign br_tgt_v_o   = tag_mem_data_bypass_lo.v & (tag_mem_data_bypass_lo.tag == r_tag_r);
+  assign br_tgt_jmp_o = tag_mem_data_bypass_lo.jmp;
+  assign br_tgt_o     = tag_mem_data_bypass_lo.tgt;
+
 
 endmodule
+

--- a/bp_fe/src/v/bp_fe_pc_gen.v
+++ b/bp_fe/src/v/bp_fe_pc_gen.v
@@ -221,16 +221,16 @@ bsg_dff_reset
    ,.data_o(ghistory_r)
    );
 
-logic bht_pred_lo;
+logic [1:0] bht_val_lo;
 logic [vaddr_width_p-1:0] return_addr_n, return_addr_r;
-wire btb_taken = btb_br_tgt_v_lo & (bht_pred_lo | btb_br_tgt_jmp_lo);
+wire btb_taken = btb_br_tgt_v_lo & (bht_val_lo[1] | btb_br_tgt_jmp_lo);
 always_comb
   begin
     pc_gen_stage_n[0]            = '0;
     pc_gen_stage_n[0].v          = fetch_v;
     pc_gen_stage_n[0].taken      = ovr_taken | btb_taken | ovr_ret;
     pc_gen_stage_n[0].btb        = btb_br_tgt_v_lo;
-    pc_gen_stage_n[0].bht        = bht_pred_lo;
+    pc_gen_stage_n[0].bht        = bht_val_lo;
     pc_gen_stage_n[0].ret        = ovr_ret;
     pc_gen_stage_n[0].ovr        = ovr_taken;
     pc_gen_stage_n[0].ghist      = ghistory_n;
@@ -242,7 +242,7 @@ always_comb
       begin
         pc_gen_stage_n[0].taken = br_res_taken;
         pc_gen_stage_n[0].btb = fe_cmd_branch_metadata.src_btb;
-        pc_gen_stage_n[0].bht = '0; // Does not come from metadata
+        pc_gen_stage_n[0].bht = fe_cmd_branch_metadata.bht_val;
         pc_gen_stage_n[0].ret = fe_cmd_branch_metadata.src_ret;
         pc_gen_stage_n[0].ovr = '0; // Does not come from metadata
         pc_gen_stage_n[0].pc = fe_cmd_cast_i.vaddr;
@@ -303,8 +303,7 @@ always_ff @(posedge clk_i)
 
 bp_fe_branch_metadata_fwd_s fe_queue_cast_o_branch_metadata;
 assign fe_queue_cast_o_branch_metadata =
-  '{pred_taken: pc_gen_stage_r[1].taken | is_jalr // We can't predict target, but jalr are always taken
-    ,src_btb  : pc_gen_stage_r[1].btb
+  '{src_btb   : pc_gen_stage_r[1].btb
     ,src_ret  : pc_gen_stage_r[1].ret
     ,src_ovr  : pc_gen_stage_r[1].ovr
     ,ghist    : pc_gen_stage_r[1].ghist
@@ -316,6 +315,7 @@ assign fe_queue_cast_o_branch_metadata =
     ,btb_tag  : btb_tag_site
     ,btb_idx  : btb_idx_site
     ,bht_idx  : bht_idx_site
+    ,bht_val  : pc_gen_stage_r[1].bht
     ,default  : '0
     };
 
@@ -350,7 +350,6 @@ bp_fe_btb
 //
 // Direct bimodal
 wire [bht_idx_width_p-1:0] bht_idx_r_li = pc_gen_stage_n[0].pc[2+:bht_idx_width_p] ^ pc_gen_stage_n[0].ghist;
-
 bp_fe_bht
  #(.vaddr_width_p(vaddr_width_p)
    ,.bht_idx_width_p(bht_idx_width_p+ghist_width_p)
@@ -361,11 +360,12 @@ bp_fe_bht
 
    ,.r_v_i(pc_gen_stage_n[0].v)
    ,.idx_r_i({pc_gen_stage_n[0].pc[2+:bht_idx_width_p], pc_gen_stage_n[0].ghist})
-   ,.predict_o(bht_pred_lo)
+   ,.val_o(bht_val_lo)
 
    ,.w_v_i((br_miss_v | attaboy_v) & fe_cmd_branch_metadata.is_br & fe_cmd_yumi_o)
    ,.idx_w_i({fe_cmd_branch_metadata.bht_idx, fe_cmd_branch_metadata.ghist})
    ,.correct_i(attaboy_v)
+   ,.val_i(fe_cmd_branch_metadata.bht_val)
    );
 
 `declare_bp_fe_instr_scan_s(vaddr_width_p)
@@ -386,7 +386,7 @@ assign is_ret       = fe_queue_v_o & scan_instr.ret;
 wire btb_miss_ras   = ~pc_gen_stage_r[0].btb | (pc_gen_stage_r[0].pc != return_addr_r);
 wire btb_miss_br    = ~pc_gen_stage_r[0].btb | (pc_gen_stage_r[0].pc != br_target);
 assign ovr_ret      = btb_miss_ras & is_ret;
-assign ovr_taken    = btb_miss_br & ((is_br & pc_gen_stage_r[0].bht) | is_jal);
+assign ovr_taken    = btb_miss_br & ((is_br & pc_gen_stage_r[0].bht[1]) | is_jal);
 assign br_target    = pc_gen_stage_r[1].pc + scan_instr.imm;
 
 assign return_addr_n = pc_gen_stage_r[1].pc + vaddr_width_p'(4);


### PR DESCRIPTION
- Absorbs valids into BTB RAM
- Converts BHT to 1r1w_sync
- Adds initialization FSMs to BHT and BTB
- Makes BHT updates idempotent, fixes #286 