### PR TITLE
Adding full tag info to the cache service interface

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v
@@ -79,7 +79,7 @@ module bp_be_calculator_top
   , input tag_mem_pkt_v_i
   , input [dcache_tag_mem_pkt_width_lp-1:0] tag_mem_pkt_i
   , output logic tag_mem_pkt_yumi_o
-  , output logic [ptag_width_p-1:0] tag_mem_o
+  , output logic [dcache_tag_info_width_lp-1:0] tag_mem_o
 
   // stat_mem
   , input stat_mem_pkt_v_i

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.v
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.v
@@ -81,7 +81,7 @@ module bp_be_pipe_mem
    , input tag_mem_pkt_v_i
    , input [dcache_tag_mem_pkt_width_lp-1:0] tag_mem_pkt_i
    , output logic tag_mem_pkt_yumi_o
-   , output logic [ptag_width_p-1:0] tag_mem_o
+   , output logic [dcache_tag_info_width_lp-1:0] tag_mem_o
 
    // stat_mem
    , input stat_mem_pkt_v_i

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -155,7 +155,7 @@ module bp_be_dcache
     , input tag_mem_pkt_v_i
     , input [dcache_tag_mem_pkt_width_lp-1:0] tag_mem_pkt_i
     , output logic tag_mem_pkt_yumi_o
-    , output logic [ptag_width_p-1:0] tag_mem_o
+    , output logic [dcache_tag_info_width_lp-1:0] tag_mem_o
 
     // stat_mem
     , input stat_mem_pkt_v_i
@@ -1269,7 +1269,7 @@ module bp_be_dcache
     end
   end
 
-  assign tag_mem_o =  tag_mem_data_lo[tag_mem_pkt_way_r].tag;
+  assign tag_mem_o =  tag_mem_data_lo[tag_mem_pkt_way_r];
 
   assign tag_mem_pkt_yumi_o = ~tl_we & tag_mem_pkt_v;
 

--- a/bp_be/src/v/bp_be_top.v
+++ b/bp_be/src/v/bp_be_top.v
@@ -59,7 +59,7 @@ module bp_be_top
    // tag_mem
    , input                                           tag_mem_pkt_v_i
    , input [dcache_tag_mem_pkt_width_lp-1:0]         tag_mem_pkt_i
-   , output logic [ptag_width_p-1:0]                 tag_mem_o
+   , output logic [dcache_tag_info_width_lp-1:0]     tag_mem_o
    , output logic                                    tag_mem_pkt_yumi_o
 
    // stat_mem

--- a/bp_be/test/tb/bp_be_dcache/testbench.v
+++ b/bp_be/test/tb/bp_be_dcache/testbench.v
@@ -102,6 +102,7 @@ module testbench
   always_comb begin
     if(counter == 16'd65535) begin
       $display("FAIL: Timeout");
+      $finish();
     end
   end
 

--- a/bp_be/test/tb/bp_be_dcache/wrapper.v
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.v
@@ -26,13 +26,11 @@ module wrapper
 
    , localparam cfg_bus_width_lp= `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
    , localparam block_size_in_words_lp=dcache_assoc_p
-   , localparam ptag_width_lp=(paddr_width_p-bp_page_offset_width_gp)
    , localparam way_id_width_lp=`BSG_SAFE_CLOG2(dcache_assoc_p)
 
    , localparam wg_per_cce_lp = (lce_sets_p / num_cce_p)
 
    , localparam dcache_pkt_width_lp=`bp_be_dcache_pkt_width(page_offset_width_p,dpath_width_p)
-   , localparam tag_info_width_lp=`bp_be_dcache_tag_info_width(ptag_width_lp)
 
    , localparam lce_cce_req_packet_width_lp = `bsg_wormhole_concentrator_packet_width(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_req_msg_width_lp)
    , localparam lce_cce_req_packet_hdr_width_lp = (lce_cce_req_packet_width_lp-cce_block_width_p)
@@ -46,7 +44,7 @@ module wrapper
    , input [num_caches_p-1:0]                          v_i
    , output logic [num_caches_p-1:0]                   ready_o
 
-   , input [num_caches_p-1:0][ptag_width_lp-1:0]       ptag_i
+   , input [num_caches_p-1:0][ptag_width_p-1:0]        ptag_i
    , input [num_caches_p-1:0]                          uncached_i
 
    , output logic [num_caches_p-1:0][dword_width_p-1:0]data_o
@@ -69,7 +67,7 @@ module wrapper
    logic [num_caches_p-1:0] rolly_uncached_lo;
    logic [num_caches_p-1:0] rolly_v_lo, rolly_yumi_li;
    bp_be_dcache_pkt_s [num_caches_p-1:0] rolly_dcache_pkt_lo;
-   logic [num_caches_p-1:0][ptag_width_lp-1:0] rolly_ptag_lo;
+   logic [num_caches_p-1:0][ptag_width_p-1:0] rolly_ptag_lo;
 
    // D$ - LCE Interface signals
    // Miss, Management Interfaces
@@ -86,13 +84,13 @@ module wrapper
    logic [num_caches_p-1:0][dcache_tag_mem_pkt_width_lp-1:0] tag_mem_pkt_lo;
    logic [num_caches_p-1:0][dcache_stat_mem_pkt_width_lp-1:0] stat_mem_pkt_lo;
    logic [num_caches_p-1:0][dcache_block_width_p-1:0] data_mem_lo;
-   logic [num_caches_p-1:0][ptag_width_lp-1:0] tag_mem_lo;
+   logic [num_caches_p-1:0][ptag_width_p-1:0] tag_mem_lo;
    logic [num_caches_p-1:0][dcache_stat_info_width_lp-1:0] stat_mem_lo;
 
    // Credits
    logic [num_caches_p-1:0] credits_full_lo, credits_empty_lo;
 
-   logic [num_caches_p-1:0][ptag_width_lp-1:0] rolly_ptag_r;
+   logic [num_caches_p-1:0][ptag_width_p-1:0] rolly_ptag_r;
    logic [num_caches_p-1:0] rolly_uncached_r;
    logic [num_caches_p-1:0] is_store, is_store_rr, dcache_v_rr, poison_li;
 
@@ -148,7 +146,7 @@ module wrapper
    for (genvar i = 0; i < num_caches_p; i++)
      begin : cache
        bsg_fifo_1r1w_rolly
-       #(.width_p(dcache_pkt_width_lp+ptag_width_lp+1)
+       #(.width_p(dcache_pkt_width_lp+ptag_width_p+1)
         ,.els_p(8))
         rolly
         (.clk_i(clk_i)
@@ -169,7 +167,7 @@ module wrapper
        assign rolly_yumi_li[i] = rolly_v_lo[i] & dcache_ready_lo[i];
 
        bsg_dff_reset
-        #(.width_p(1+ptag_width_lp)
+        #(.width_p(1+ptag_width_p)
          ,.reset_val_p(0)
         )
         ptag_dff

--- a/bp_common/src/include/bp_common_cache_service_if.vh
+++ b/bp_common/src/include/bp_common_cache_service_if.vh
@@ -135,6 +135,15 @@ typedef enum logic [1:0] {
 `define bp_cache_tag_mem_pkt_width(sets_mp, ways_mp, tag_width_mp) \
   (`BSG_SAFE_CLOG2(sets_mp)+`BSG_SAFE_CLOG2(ways_mp)+$bits(bp_coh_states_e)+tag_width_mp+`bp_cache_tag_mem_opcode_width)
 
+`define declare_bp_cache_tag_info_s(tag_width_mp, cache_name_mp) \
+  typedef struct packed {                                                 \
+    logic [$bits(bp_coh_states_e)-1:0] state;                             \
+    logic [tag_width_mp-1:0]           tag;                               \
+  }  bp_``cache_name_mp``_tag_info_s;
+
+`define bp_cache_tag_info_width(tag_width_mp) \
+  ($bits(bp_coh_states_e)+tag_width_mp)
+
 `define declare_bp_cache_stat_mem_pkt_s(sets_mp, ways_mp, cache_name_mp)  \
   typedef struct packed {                                                 \
     logic [`BSG_SAFE_CLOG2(sets_mp)-1:0]    index;                        \
@@ -159,6 +168,7 @@ typedef enum logic [1:0] {
   `declare_bp_cache_req_metadata_s(ways_mp, cache_name_mp);                                              \
   `declare_bp_cache_data_mem_pkt_s(sets_mp, ways_mp, block_data_width_mp, fill_width_mp, cache_name_mp); \
   `declare_bp_cache_tag_mem_pkt_s(sets_mp, ways_mp, tag_width_mp, cache_name_mp);                        \
+  `declare_bp_cache_tag_info_s(tag_width_mp, cache_name_mp);                                             \
   `declare_bp_cache_stat_mem_pkt_s(sets_mp, ways_mp, cache_name_mp);                                     \
   `declare_bp_cache_stat_info_s(ways_mp, cache_name_mp)
 
@@ -168,6 +178,7 @@ typedef enum logic [1:0] {
   , localparam ``cache_name_mp``_req_metadata_width_lp = `bp_cache_req_metadata_width(ways_mp)                                         \
   , localparam ``cache_name_mp``_data_mem_pkt_width_lp=`bp_cache_data_mem_pkt_width(sets_mp,ways_mp,block_data_width_mp,fill_width_mp) \
   , localparam ``cache_name_mp``_tag_mem_pkt_width_lp=`bp_cache_tag_mem_pkt_width(sets_mp,ways_mp,tag_width_mp)                        \
+  , localparam ``cache_name_mp``_tag_info_width_lp=`bp_cache_tag_info_width(tag_width_mp)                                              \
   , localparam ``cache_name_mp``_stat_mem_pkt_width_lp=`bp_cache_stat_mem_pkt_width(sets_mp,ways_mp)                                   \
   , localparam ``cache_name_mp``_stat_info_width_lp=`bp_cache_stat_info_width(ways_mp)
 

--- a/bp_me/src/v/cce/bp_uce.v
+++ b/bp_me/src/v/cce/bp_uce.v
@@ -60,7 +60,7 @@ module bp_uce
     , output logic [cache_tag_mem_pkt_width_lp-1:0]  tag_mem_pkt_o
     , output logic                                   tag_mem_pkt_v_o
     , input                                          tag_mem_pkt_yumi_i
-    , input [ptag_width_p-1:0]                       tag_mem_i
+    , input [cache_tag_info_width_lp-1:0]            tag_mem_i
 
     , output logic [cache_data_mem_pkt_width_lp-1:0] data_mem_pkt_o
     , output logic                                   data_mem_pkt_v_o
@@ -203,9 +203,9 @@ module bp_uce
      ,.data_o(dirty_tag_v_r)
      );
 
-  logic [ptag_width_p-1:0] dirty_tag_r;
+  bp_cache_tag_info_s dirty_tag_r;
   bsg_dff_en
-   #(.width_p(ptag_width_p))
+   #(.width_p($bits(bp_cache_tag_info_s)))
    dirty_tag_reg
     (.clk_i(tag_mem_clk)
 
@@ -525,7 +525,7 @@ module bp_uce
         e_flush_write:
           begin
             mem_cmd_cast_o.header.msg_type = e_bedrock_mem_wr;
-            mem_cmd_cast_o.header.addr     = {dirty_tag_r, index_cnt, bank_index, byte_offset_width_lp'(0)};
+            mem_cmd_cast_o.header.addr     = {dirty_tag_r.tag, index_cnt, bank_index, byte_offset_width_lp'(0)};
             mem_cmd_cast_o.header.size     = block_msg_size_lp;
             mem_cmd_cast_payload.lce_id    = lce_id_i;
             mem_cmd_cast_o.header.payload = mem_cmd_cast_payload;
@@ -668,7 +668,7 @@ module bp_uce
         e_writeback_write_req:
           begin
             mem_cmd_cast_o.header.msg_type = e_bedrock_mem_wr;
-            mem_cmd_cast_o.header.addr     = {dirty_tag_r, cache_req_r.addr[block_offset_width_lp+:index_width_lp], bank_index, byte_offset_width_lp'(0)};
+            mem_cmd_cast_o.header.addr     = {dirty_tag_r.tag, cache_req_r.addr[block_offset_width_lp+:index_width_lp], bank_index, byte_offset_width_lp'(0)};
             mem_cmd_cast_o.header.size     = block_msg_size_lp;
             mem_cmd_cast_payload.lce_id    = lce_id_i;
             mem_cmd_cast_o.header.payload = mem_cmd_cast_payload;

--- a/bp_me/src/v/lce/bp_lce.v
+++ b/bp_me/src/v/lce/bp_lce.v
@@ -70,7 +70,7 @@ module bp_lce
     , output logic                                   tag_mem_pkt_v_o
     , output logic [cache_tag_mem_pkt_width_lp-1:0]  tag_mem_pkt_o
     , input                                          tag_mem_pkt_yumi_i
-    , input [ptag_width_p-1:0]                       tag_mem_i
+    , input [cache_tag_info_width_lp-1:0]            tag_mem_i
 
     , output logic                                   stat_mem_pkt_v_o
     , output logic [cache_stat_mem_pkt_width_lp-1:0] stat_mem_pkt_o

--- a/bp_me/src/v/lce/bp_lce_cmd.v
+++ b/bp_me/src/v/lce/bp_lce_cmd.v
@@ -81,7 +81,7 @@ module bp_lce_cmd
     , output logic                                   tag_mem_pkt_v_o
     , output logic [cache_tag_mem_pkt_width_lp-1:0]  tag_mem_pkt_o
     , input                                          tag_mem_pkt_yumi_i
-    , input [ptag_width_p-1:0]                      tag_mem_i
+    , input [cache_tag_info_width_lp-1:0]            tag_mem_i
 
     , output logic                                   stat_mem_pkt_v_o
     , output logic [cache_stat_mem_pkt_width_lp-1:0] stat_mem_pkt_o


### PR DESCRIPTION
- Adds tag info to the cache service struct
- Updates this struct in cache engines

Not used for anything right now, but enables extra state (coherence or otherwise) to be stored in the tag, useful for certain classes of cache engine. For instance, a system where true tags are stored in L1 rather than shadow tags.