### PR TITLE
Tiny Instruction Cache

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,8 +18,8 @@
 
 [submodule "external/basejump_stl"]
   path = external/basejump_stl
-  url = https://github.com/sripathi-muralitharan/basejump_stl.git
-  branch = bsg_pe_fix_width_1
+  url = https://github.com/bespoke-silicon-group/basejump_stl.git
+  branch = master
   ignore = dirty
 
 [submodule "bp_common/test/src/riscv-tests"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,7 +19,7 @@
 [submodule "external/basejump_stl"]
   path = external/basejump_stl
   url = https://github.com/sripathi-muralitharan/basejump_stl.git
-  branch = bsg_safe_minus
+  branch = bsg_pe_fix_width_1
   ignore = dirty
 
 [submodule "bp_common/test/src/riscv-tests"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -18,8 +18,8 @@
 
 [submodule "external/basejump_stl"]
   path = external/basejump_stl
-  url = https://github.com/bespoke-silicon-group/basejump_stl.git
-  branch = master
+  url = https://github.com/sripathi-muralitharan/basejump_stl.git
+  branch = bsg_safe_minus
   ignore = dirty
 
 [submodule "bp_common/test/src/riscv-tests"]

--- a/bp_common/src/include/bp_common_aviary_pkg.sv
+++ b/bp_common/src/include/bp_common_aviary_pkg.sv
@@ -152,6 +152,22 @@ package bp_common_aviary_pkg;
                         ,bp_unicore_cfg_p
                         );
 
+  localparam bp_proc_param_s bp_unicore_l1_tiny_override_p =
+    '{icache_sets         : 64
+      ,icache_assoc       : 1
+      ,icache_block_width : 512
+      ,icache_fill_width  : 512
+      ,dcache_sets        : 64
+      ,dcache_assoc       : 8
+      ,dcache_block_width : 512
+      ,dcache_fill_width  : 512
+      ,default : "inv"
+      };
+  `bp_aviary_derive_cfg(bp_unicore_l1_tiny_cfg_p
+                        ,bp_unicore_l1_tiny_override_p
+                        ,bp_unicore_cfg_p
+                        );
+
   localparam bp_proc_param_s bp_unicore_l1_hetero_override_p =
     '{icache_sets         : 256
       ,icache_assoc       : 2
@@ -588,6 +604,7 @@ package bp_common_aviary_pkg;
     ,bp_unicore_writethrough_cfg_p
     ,bp_unicore_l1_wide_cfg_p
     ,bp_unicore_l1_hetero_cfg_p
+    ,bp_unicore_l1_tiny_cfg_p
     ,bp_unicore_l1_small_cfg_p
     ,bp_unicore_l1_medium_cfg_p
     ,bp_unicore_no_l2_cfg_p
@@ -605,42 +622,43 @@ package bp_common_aviary_pkg;
   typedef enum bit [lg_max_cfgs-1:0]
   {
     // Various testing config
-    e_bp_multicore_cce_ucode_half_cfg       = 34
-    ,e_bp_multicore_half_cfg                = 33
-    ,e_bp_unicore_half_cfg                  = 32
+    e_bp_multicore_cce_ucode_half_cfg       = 35
+    ,e_bp_multicore_half_cfg                = 34
+    ,e_bp_unicore_half_cfg                  = 33
 
     // Accelerator configurations
-    ,e_bp_multicore_1_accelerator_cfg       = 31
+    ,e_bp_multicore_1_accelerator_cfg       = 32
 
     // Ucode configurations
-    ,e_bp_multicore_16_cce_ucode_cfg        = 30
-    ,e_bp_multicore_12_cce_ucode_cfg        = 29
-    ,e_bp_multicore_8_cce_ucode_cfg         = 28
-    ,e_bp_multicore_6_cce_ucode_cfg         = 27
-    ,e_bp_multicore_4_cce_ucode_cfg         = 26
-    ,e_bp_multicore_3_cce_ucode_cfg         = 25
-    ,e_bp_multicore_2_cce_ucode_cfg         = 24
-    ,e_bp_multicore_1_cce_ucode_bootrom_cfg = 23
-    ,e_bp_multicore_1_cce_ucode_cfg         = 22
+    ,e_bp_multicore_16_cce_ucode_cfg        = 31
+    ,e_bp_multicore_12_cce_ucode_cfg        = 30
+    ,e_bp_multicore_8_cce_ucode_cfg         = 29
+    ,e_bp_multicore_6_cce_ucode_cfg         = 28
+    ,e_bp_multicore_4_cce_ucode_cfg         = 27
+    ,e_bp_multicore_3_cce_ucode_cfg         = 26
+    ,e_bp_multicore_2_cce_ucode_cfg         = 25
+    ,e_bp_multicore_1_cce_ucode_bootrom_cfg = 24
+    ,e_bp_multicore_1_cce_ucode_cfg         = 23
 
     // Multicore configurations
-    ,e_bp_multicore_16_cfg                  = 21
-    ,e_bp_multicore_12_cfg                  = 20
-    ,e_bp_multicore_8_cfg                   = 19
-    ,e_bp_multicore_6_cfg                   = 18
-    ,e_bp_multicore_4_cfg                   = 17
-    ,e_bp_multicore_3_cfg                   = 16
-    ,e_bp_multicore_2_cfg                   = 15
-    ,e_bp_multicore_1_l1_small_cfg          = 14
-    ,e_bp_multicore_1_l1_medium_cfg         = 13
-    ,e_bp_multicore_1_no_l2_cfg             = 12
-    ,e_bp_multicore_1_bootrom_cfg           = 11
-    ,e_bp_multicore_1_cfg                   = 10
+    ,e_bp_multicore_16_cfg                  = 22
+    ,e_bp_multicore_12_cfg                  = 21
+    ,e_bp_multicore_8_cfg                   = 20
+    ,e_bp_multicore_6_cfg                   = 19
+    ,e_bp_multicore_4_cfg                   = 18
+    ,e_bp_multicore_3_cfg                   = 17
+    ,e_bp_multicore_2_cfg                   = 16
+    ,e_bp_multicore_1_l1_small_cfg          = 15
+    ,e_bp_multicore_1_l1_medium_cfg         = 14
+    ,e_bp_multicore_1_no_l2_cfg             = 13
+    ,e_bp_multicore_1_bootrom_cfg           = 12
+    ,e_bp_multicore_1_cfg                   = 11
 
     // Unicore configurations
-    ,e_bp_unicore_writethrough_cfg          = 9
-    ,e_bp_unicore_l1_wide_cfg               = 8
-    ,e_bp_unicore_l1_hetero_cfg             = 7
+    ,e_bp_unicore_writethrough_cfg          = 10
+    ,e_bp_unicore_l1_wide_cfg               = 9
+    ,e_bp_unicore_l1_hetero_cfg             = 8
+    ,e_bp_unicore_l1_tiny_cfg               = 7
     ,e_bp_unicore_l1_small_cfg              = 6
     ,e_bp_unicore_l1_medium_cfg             = 5
     ,e_bp_unicore_no_l2_cfg                 = 4

--- a/bp_common/src/include/bp_common_cache_engine_if.svh
+++ b/bp_common/src/include/bp_common_cache_engine_if.svh
@@ -156,12 +156,12 @@ typedef enum logic [1:0] {
 
 `define declare_bp_cache_stat_info_s(ways_mp, cache_name_mp)  \
   typedef struct packed {                 \
-    logic [ways_mp-2:0] lru;              \
+    logic [`BSG_MAX(ways_mp-2, 0):0] lru; \
     logic [ways_mp-1:0] dirty;            \
   } bp_``cache_name_mp``_stat_info_s
 
 `define bp_cache_stat_info_width(ways_mp) \
-  (2*ways_mp-1)
+  (`BSG_MAX(2, (2*ways_mp-1)))
 
 `define declare_bp_cache_engine_if(addr_width_mp, tag_width_mp, sets_mp, ways_mp, req_data_width_mp, block_data_width_mp, fill_width_mp, cache_name_mp) \
   `declare_bp_cache_req_s(req_data_width_mp, addr_width_mp, cache_name_mp);                              \

--- a/bp_common/src/include/bp_common_cache_engine_if.svh
+++ b/bp_common/src/include/bp_common_cache_engine_if.svh
@@ -156,12 +156,13 @@ typedef enum logic [1:0] {
 
 `define declare_bp_cache_stat_info_s(ways_mp, cache_name_mp)  \
   typedef struct packed {                 \
-    logic [`BSG_MAX(ways_mp-2, 0):0] lru; \
+    logic [`BSG_SAFE_MINUS(ways_mp, 2):0] lru; \
     logic [ways_mp-1:0] dirty;            \
   } bp_``cache_name_mp``_stat_info_s
 
+// Direct mapped caches need 2-bits in the stat info
 `define bp_cache_stat_info_width(ways_mp) \
-  (`BSG_MAX(2, (2*ways_mp-1)))
+  (`BSG_MAX(2,2*ways_mp-1))
 
 `define declare_bp_cache_engine_if(addr_width_mp, tag_width_mp, sets_mp, ways_mp, req_data_width_mp, block_data_width_mp, fill_width_mp, cache_name_mp) \
   `declare_bp_cache_req_s(req_data_width_mp, addr_width_mp, cache_name_mp);                              \

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -295,7 +295,7 @@ module bp_fe_icache
   logic [lg_icache_assoc_lp-1:0] lru_encode;
 
   bsg_mem_1rw_sync_mask_write_bit #(
-    .width_p(icache_assoc_p-1)
+    .width_p(`BSG_MAX(2, icache_assoc_p)-1)
     ,.els_p(icache_sets_p)
   ) stat_mem (
     .clk_i(clk_i)

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -40,6 +40,7 @@ module bp_fe_icache
     , localparam byte_offset_width_lp=`BSG_SAFE_CLOG2(bank_width_lp >> 3)
     // Two kinds of bank offsets to handle indexing and memory instantion respectively for a direct-mapped cache. 
     // They boil down to the same thing for a set associative cache
+    // TODO: Check PR review comment
     , localparam bank_offset_width_lp = `BSG_SAFE_CLOG2(icache_assoc_p)
     , localparam mem_bank_offset_width_lp = $clog2(icache_assoc_p)
     , localparam index_width_lp=`BSG_SAFE_CLOG2(icache_sets_p)
@@ -308,10 +309,8 @@ module bp_fe_icache
     ,.data_o(stat_mem_data_lo.lru)
   );
 
-  // For direct-mapped the LRU bits are unused. Constant propagation will
-  // remove the LRU-specific modules
   bsg_lru_pseudo_tree_encode #(
-    .ways_p(`BSG_MAX(2, icache_assoc_p))
+    .ways_p(icache_assoc_p)
   ) lru_encoder (
     .lru_i(stat_mem_data_lo.lru)
     ,.way_id_o(lru_encode)
@@ -631,7 +630,7 @@ module bp_fe_icache
      );
 
   bsg_lru_pseudo_tree_decode #(
-     .ways_p(`BSG_MAX(2, icache_assoc_p))
+     .ways_p(icache_assoc_p)
   ) lru_decode (
      .way_id_i(hit_index_tv)
      ,.data_o(lru_decode_data_lo)

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -24,6 +24,9 @@ module bp_fe_top
    , localparam mem_bank_offset_width_lp= $clog2(icache_assoc_p)
    , localparam index_width_lp=`BSG_SAFE_CLOG2(icache_sets_p)
    , localparam block_offset_width_lp=(mem_bank_offset_width_lp+byte_offset_width_lp)
+
+
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
    )
   (input                                              clk_i
    , input                                            reset_i

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -21,11 +21,9 @@ module bp_fe_top
    , localparam data_mem_mask_width_lp=(bank_width_lp >> 3)
    , localparam byte_offset_width_lp=`BSG_SAFE_CLOG2(bank_width_lp >> 3)
    , localparam bank_offset_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)
+   , localparam mem_bank_offset_width_lp= $clog2(icache_assoc_p)
    , localparam index_width_lp=`BSG_SAFE_CLOG2(icache_sets_p)
-   , localparam block_offset_width_lp=(bank_offset_width_lp+byte_offset_width_lp)
-   , localparam ptag_width_lp=(paddr_width_p-bp_page_offset_width_gp)
-
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
+   , localparam block_offset_width_lp=(mem_bank_offset_width_lp+byte_offset_width_lp)
    )
   (input                                              clk_i
    , input                                            reset_i

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -20,10 +20,9 @@ module bp_fe_top
    , localparam num_dwords_per_bank_lp = bank_width_lp / dword_width_p
    , localparam data_mem_mask_width_lp=(bank_width_lp >> 3)
    , localparam byte_offset_width_lp=`BSG_SAFE_CLOG2(bank_width_lp >> 3)
-   , localparam bank_offset_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)
-   , localparam mem_bank_offset_width_lp= $clog2(icache_assoc_p)
+   , localparam bank_offset_width_lp=$clog2(icache_assoc_p)
    , localparam index_width_lp=`BSG_SAFE_CLOG2(icache_sets_p)
-   , localparam block_offset_width_lp=(mem_bank_offset_width_lp+byte_offset_width_lp)
+   , localparam block_offset_width_lp=(bank_offset_width_lp+byte_offset_width_lp)
 
 
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -15,16 +15,6 @@ module bp_fe_top
    `declare_bp_core_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ptag_width_p, icache_sets_p, icache_assoc_p, dword_width_p, icache_block_width_p, icache_fill_width_p, icache)
 
-   , localparam way_id_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)
-   , localparam bank_width_lp = icache_block_width_p / icache_assoc_p
-   , localparam num_dwords_per_bank_lp = bank_width_lp / dword_width_p
-   , localparam data_mem_mask_width_lp=(bank_width_lp >> 3)
-   , localparam byte_offset_width_lp=`BSG_SAFE_CLOG2(bank_width_lp >> 3)
-   , localparam bank_offset_width_lp=$clog2(icache_assoc_p)
-   , localparam index_width_lp=`BSG_SAFE_CLOG2(icache_sets_p)
-   , localparam block_offset_width_lp=(bank_offset_width_lp+byte_offset_width_lp)
-
-
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, cce_pc_width_p, cce_instr_width_p)
    )
   (input                                              clk_i

--- a/bp_fe/test/tb/bp_fe_icache/Makefile.params
+++ b/bp_fe/test/tb/bp_fe_icache/Makefile.params
@@ -2,7 +2,6 @@ CCE_TRACE_P    ?= 0
 LCE_TRACE_P    ?= 0
 DRAM_TRACE_P   ?= 0
 ICACHE_TRACE_P ?= 0
-RANDOM_YUMI_P  ?= 0
 UCE_P          ?= 0
 
 export DRAM_PKG ?= bsg_dramsim3_hbm2_4gb_x128_pkg
@@ -17,7 +16,6 @@ export TB_PARAMS  = -pvalue+uce_p=$(UCE_P) \
                     -pvalue+lce_trace_p=$(LCE_TRACE_P)   \
                     -pvalue+dram_trace_p=$(DRAM_TRACE_P) \
                     -pvalue+icache_trace_p=$(ICACHE_TRACE_P) \
-                    -pvalue+random_yumi_p=$(RANDOM_YUMI_P) \
                     -pvalue+dram_fixed_latency_p=$(DRAM_FIXED_LATENCY)
 
 export DUT_DEFINES =

--- a/bp_me/src/v/cce/bp_uce.sv
+++ b/bp_me/src/v/cce/bp_uce.sv
@@ -297,7 +297,10 @@ module bp_uce
   if (fill_size_in_bank_lp == 1)
     begin
       assign bank_index =  mem_cmd_cnt;
-      assign fill_index_shift = mem_resp_cast_i.header.addr[byte_offset_width_lp+:bank_offset_width_lp];
+      // Setting fill_index_shift to zero for direct-mapped caches since there aren't any opportunities for iterative filling as well as no data memory banks
+      assign fill_index_shift = (assoc_p > 1) 
+                                  ? mem_resp_cast_i.header.addr[byte_offset_width_lp+:bank_offset_width_lp]
+                                  : '0;
     end
   else
     begin

--- a/bp_me/src/v/lce/bp_lce.sv
+++ b/bp_me/src/v/lce/bp_lce.sv
@@ -79,7 +79,7 @@ module bp_lce
     , output logic                                   stat_mem_pkt_v_o
     , output logic [cache_stat_mem_pkt_width_lp-1:0] stat_mem_pkt_o
     , input                                          stat_mem_pkt_yumi_i
-    , input [stat_info_width_lp-1:0]                 stat_mem_i
+    , input [cache_stat_info_width_lp-1:0]           stat_mem_i
 
     // LCE-CCE interface
     // Req: ready->valid

--- a/bp_top/test/tb/bp_tethered/Makefile.cfgs
+++ b/bp_top/test/tb/bp_tethered/Makefile.cfgs
@@ -29,6 +29,7 @@ e_bp_multicore_1_cfg_cores              := 1
 e_bp_unicore_writethrough_cfg_cores     := 1
 e_bp_unicore_l1_wide_cfg_cores          := 1
 e_bp_unicore_l1_hetero_cfg_cores        := 1
+e_bp_unicore_l1_tiny_cfg_cores          := 1
 e_bp_unicore_l1_medium_cfg_cores        := 1
 e_bp_unicore_l1_small_cfg_cores         := 1
 e_bp_unicore_no_l2_cfg_cores            := 1

--- a/ci/weird_config.sh
+++ b/ci/weird_config.sh
@@ -46,6 +46,7 @@ cfgs=(\
     "e_bp_unicore_no_l2_cfg"
     "e_bp_unicore_l1_wide_cfg"
     "e_bp_unicore_l1_hetero_cfg"
+    "e_bp_unicore_l1_tiny_cfg"
     "e_bp_unicore_l1_medium_cfg"
     "e_bp_unicore_l1_small_cfg"
     "e_bp_unicore_cfg"


### PR DESCRIPTION
This PR adds support for a tiny cache - 4KB and a corresponding tiny config (reflects only the tiny icache changes) that is supported only in the UCE. 

A similar change for the D$ will soon follow in a future PR.