### PR TITLE
Adding a compile time check for cache parameter conditions

### DIFF
--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -189,12 +189,6 @@ module bp_be_dcache
   assign addr_index = dcache_pkt.page_offset[block_offset_width_lp+:index_width_lp];
   assign addr_bank_offset = dcache_pkt.page_offset[byte_offset_width_lp+:bank_offset_width_lp];
  
-  generate // dcache parameter check in compile time
-  if ( (dcache_block_width_p/dcache_assoc_p) < dword_width_p || dcache_fill_width_p > dcache_block_width_p )begin
-    $error("ERROR: The dcache supports multi-cycle fill/eviction with the following constraints: - bank_width = block_width / assoc >= dword_width and fill_width = N*bank_width <= block_width. Please adjust the parameters according to these conditions and recompile");
-  end
-  endgenerate
- 
   // TL stage
   //
   logic v_tl_r; // valid bit
@@ -1289,6 +1283,10 @@ module bp_be_dcache
   assign stat_mem_o = stat_mem_data_lo;
 
   // synopsys translate_off
+  if ( (dcache_block_width_p/dcache_assoc_p) < dword_width_p || dcache_fill_width_p > dcache_block_width_p ) begin // dcache parameter check in compile time
+    $error("ERROR: The dcache supports multi-cycle fill/eviction with the following constraints: - bank_width = block_width / assoc >= dword_width and fill_width = N*bank_width <= block_width. Please adjust the parameters according to these conditions and recompile");
+  end
+ 
   always_ff @ (posedge clk_i) begin
     if (v_tv_r) begin
       assert($countones(load_hit_tl) <= 1)

--- a/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
+++ b/bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v
@@ -188,7 +188,13 @@ module bp_be_dcache
 
   assign addr_index = dcache_pkt.page_offset[block_offset_width_lp+:index_width_lp];
   assign addr_bank_offset = dcache_pkt.page_offset[byte_offset_width_lp+:bank_offset_width_lp];
-
+ 
+  generate // dcache parameter check in compile time
+  if ( (dcache_block_width_p/dcache_assoc_p) < dword_width_p || dcache_fill_width_p > dcache_block_width_p )begin
+    $error("ERROR: The dcache supports multi-cycle fill/eviction with the following constraints: - bank_width = block_width / assoc >= dword_width and fill_width = N*bank_width <= block_width. Please adjust the parameters according to these conditions and recompile");
+  end
+  endgenerate
+ 
   // TL stage
   //
   logic v_tl_r; // valid bit


### PR DESCRIPTION
As mentioned in the comments, cache parameters should satisfy the following conditions. 
The dcache supports multi-cycle fill/eviction with the following constraints:
- bank_width = block_width / assoc >= dword_width
- fill_width = N*bank_width <= block_width
But whenever an incorrect set of parameters are used, it will result in a compilation error(in verilator). 
To resolve this issue, one option is to edit the parameters such that it won't result in a compile error even when the conditions are not met. Other option is to introduce a compile time check of these conditions. 
This PR is for the second option, to communicate the cause of this error to the user, the above compile time check can be used. (Because generate blocks are resolved at compile time).