### PR TITLE
FPGA Signal Alignment Bug

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_fp_to_rec.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_fp_to_rec.sv
@@ -57,7 +57,7 @@ module bp_be_fp_to_rec
 
   assign sp2dp_rec = '{sign  : sp_rec.sign
                        ,exp  : special ? {exp_code, adjusted_exp[0+:dp_exp_width_gp-2]} : adjusted_exp
-                       ,fract: sp_rec.fract << (dp_sig_width_gp-sp_sig_width_gp)
+                       ,fract: {sp_rec.fract, (dp_sig_width_gp-sp_sig_width_gp)'(0)}
                        };
 
   wire nanbox_v_li = &raw_i[word_width_p+:word_width_p];

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_aux.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_aux.sv
@@ -335,7 +335,7 @@ module bp_be_pipe_aux
 
   assign d2s2d_final = '{sign  : d2s_round.sign
                          ,exp  : special ? {exp_code, adjusted_exp[0+:dp_exp_width_gp-2]} : adjusted_exp
-                         ,fract: d2s_round.fract << (dp_sig_width_gp-sp_sig_width_gp)
+                         ,fract: {d2s_round.fract, (dp_sig_width_gp-sp_sig_width_gp)'(0)}
                          };
 
   // SP->DP conversion is a NOP, except for canonicalizing NaNs

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_fma.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_fma.sv
@@ -180,7 +180,7 @@ module bp_be_pipe_fma
 
   assign fma_sp2dp_final = '{sign  : fma_sp_final.sign
                              ,exp  : special ? {exp_code, adjusted_exp[0+:dp_exp_width_gp-2]} : adjusted_exp
-                             ,fract: fma_sp_final.fract << (dp_sig_width_gp-sp_sig_width_gp)
+                             ,fract: {fma_sp_final.fract, (dp_sig_width_gp-sp_sig_width_gp)'(0)}
                              };
 
   assign fma_result = '{sp_not_dp: decode.ops_v, rec: decode.ops_v ? fma_sp2dp_final : fma_dp_final};

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
@@ -180,7 +180,7 @@ module bp_be_pipe_long
 
   assign fdivsqrt_sp2dp_final = '{sign  : fdivsqrt_sp_final.sign
                                   ,exp  : special ? {exp_code, adjusted_exp[0+:dp_exp_width_gp-2]} : adjusted_exp
-                                  ,fract: fdivsqrt_sp_final.fract << (dp_sig_width_gp-sp_sig_width_gp)
+                                  ,fract: {fdivsqrt_sp_final.fract, (dp_sig_width_gp-sp_sig_width_gp)'(0)}
                                   };
 
   logic opw_v_r, ops_v_r;

--- a/bp_be/src/v/bp_be_calculator/bp_be_rec_to_fp.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_rec_to_fp.sv
@@ -26,7 +26,7 @@ module bp_be_rec_to_fp
 
   assign dp2sp_rec = '{sign  : dp_rec.sign
                        ,exp  : special ? {exp_code, adjusted_exp[0+:sp_exp_width_gp-2]} : adjusted_exp
-                       ,fract: dp_rec.fract >> (dp_sig_width_gp-sp_sig_width_gp)
+                       ,fract: dp_rec.fract[dp_sig_width_gp-2:dp_sig_width_gp-sp_sig_width_gp]
                        };
 
   logic [word_width_p-1:0] sp_raw_lo;


### PR DESCRIPTION
On Vivado, this bug causes the fraction part of the result to be all-zeros when converting between single and double precision floating-point numbers.