### PR TITLE
Adding scoreboards for idiv and fdiv

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,7 +83,7 @@ update-cache: &update-cache-manual
     - me_dev
     - top_dev
     - sw_dev
-    - me_dev_fix_ci
+    - be_dev_project_scoreboarding
   before_script:
     - echo "Forcefully updating submodules"
     - git submodule update --init --force

--- a/bp_be/src/include/bp_be_internal_if_defines.svh
+++ b/bp_be/src/include/bp_be_internal_if_defines.svh
@@ -82,6 +82,9 @@
     logic [rv64_reg_addr_width_gp-1:0]       isd_rs2_addr;                                         \
     logic                                    isd_frs3_v;                                           \
     logic [rv64_reg_addr_width_gp-1:0]       isd_rs3_addr;                                         \
+    logic [rv64_reg_addr_width_gp-1:0]       isd_rd_addr;                                          \
+    logic                                    isd_iwb_v;                                            \
+    logic                                    isd_fwb_v;                                            \
   }  bp_be_isd_status_s;                                                                           \
                                                                                                    \
   typedef struct packed                                                                            \
@@ -169,7 +172,7 @@
    )
 
 `define bp_be_isd_status_width(vaddr_width_mp, branch_metadata_fwd_width_mp) \
-  (1 + vaddr_width_mp + branch_metadata_fwd_width_mp + 9 + 3*rv64_reg_addr_width_gp)
+  (1 + vaddr_width_mp + branch_metadata_fwd_width_mp + 11 + 4*rv64_reg_addr_width_gp)
 
 `define bp_be_dep_status_width \
   (15 + rv64_reg_addr_width_gp)

--- a/bp_be/src/include/bp_be_internal_if_defines.svh
+++ b/bp_be/src/include/bp_be_internal_if_defines.svh
@@ -67,24 +67,24 @@
                                                                                                    \
   typedef struct packed                                                                            \
   {                                                                                                \
-    logic                                    isd_v;                                                \
-    logic [vaddr_width_mp-1:0]               isd_pc;                                               \
-    logic [branch_metadata_fwd_width_mp-1:0] isd_branch_metadata_fwd;                              \
-    logic                                    isd_fence_v;                                          \
-    logic                                    isd_mem_v;                                            \
-    logic                                    isd_long_v;                                           \
-    logic                                    isd_csr_v;                                            \
-    logic                                    isd_irs1_v;                                           \
-    logic                                    isd_frs1_v;                                           \
-    logic [rv64_reg_addr_width_gp-1:0]       isd_rs1_addr;                                         \
-    logic                                    isd_irs2_v;                                           \
-    logic                                    isd_frs2_v;                                           \
-    logic [rv64_reg_addr_width_gp-1:0]       isd_rs2_addr;                                         \
-    logic                                    isd_frs3_v;                                           \
-    logic [rv64_reg_addr_width_gp-1:0]       isd_rs3_addr;                                         \
-    logic [rv64_reg_addr_width_gp-1:0]       isd_rd_addr;                                          \
-    logic                                    isd_iwb_v;                                            \
-    logic                                    isd_fwb_v;                                            \
+    logic                                    v;                                                    \
+    logic [vaddr_width_mp-1:0]               pc;                                                   \
+    logic [branch_metadata_fwd_width_mp-1:0] branch_metadata_fwd;                                  \
+    logic                                    fence_v;                                              \
+    logic                                    mem_v;                                                \
+    logic                                    long_v;                                               \
+    logic                                    csr_v;                                                \
+    logic                                    irs1_v;                                               \
+    logic                                    frs1_v;                                               \
+    logic [rv64_reg_addr_width_gp-1:0]       rs1_addr;                                             \
+    logic                                    irs2_v;                                               \
+    logic                                    frs2_v;                                               \
+    logic [rv64_reg_addr_width_gp-1:0]       rs2_addr;                                             \
+    logic                                    frs3_v;                                               \
+    logic [rv64_reg_addr_width_gp-1:0]       rs3_addr;                                             \
+    logic [rv64_reg_addr_width_gp-1:0]       rd_addr;                                              \
+    logic                                    iwb_v;                                                \
+    logic                                    fwb_v;                                                \
   }  bp_be_isd_status_s;                                                                           \
                                                                                                    \
   typedef struct packed                                                                            \

--- a/bp_be/src/include/bp_be_internal_if_defines.svh
+++ b/bp_be/src/include/bp_be_internal_if_defines.svh
@@ -119,6 +119,7 @@
   {                                                                                                \
     logic                        ird_w_v;                                                          \
     logic                        frd_w_v;                                                          \
+    logic                        late;                                                             \
     logic [reg_addr_width_p-1:0] rd_addr;                                                          \
     logic [dpath_width_p-1:0]    rd_data;                                                          \
     logic                        fflags_w_v;                                                       \
@@ -184,7 +185,7 @@
   (3 + 2 * vaddr_width_mp + instr_width_p + rv64_priv_width_gp + 9)
 
 `define bp_be_wb_pkt_width(vaddr_width_mp) \
-  (2                                                                                               \
+  (3                                                                                               \
    + reg_addr_width_p                                                                              \
    + dpath_width_p                                                                                 \
    + 1                                                                                             \

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -310,8 +310,7 @@ module bp_be_calculator_top
      ,.cfg_bus_i(cfg_bus_i)
 
      ,.ready_o(pipe_sys_ready_lo)
-     ,.pipe_mem_ready_i(pipe_mem_ready_lo)
-     ,.pipe_long_ready_i(pipe_long_ready_lo)
+     ,.ptw_busy_i(ptw_busy_o)
 
      ,.reservation_i(reservation_r)
      ,.flush_i(flush_i)

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -47,6 +47,7 @@ module bp_be_calculator_top
   , output                                          long_ready_o
   , output                                          mem_ready_o
   , output                                          sys_ready_o
+  , output                                          ptw_busy_o
 
   , output [ptw_fill_pkt_width_lp-1:0]              ptw_fill_pkt_o
   , output [commit_pkt_width_lp-1:0]                commit_pkt_o
@@ -255,6 +256,7 @@ module bp_be_calculator_top
 
      ,.ptw_miss_pkt_i(ptw_miss_pkt)
      ,.ptw_fill_pkt_o(ptw_fill_pkt)
+     ,.ptw_busy_o(ptw_busy_o)
 
      ,.cache_req_o(cache_req_o)
      ,.cache_req_v_o(cache_req_v_o)

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -122,7 +122,7 @@ module bp_be_calculator_top
   logic pipe_mem_store_page_fault_lo;
 
   logic pipe_ctl_data_lo_v, pipe_int_data_lo_v, pipe_aux_data_lo_v, pipe_mem_early_data_lo_v, pipe_mem_final_data_lo_v, pipe_sys_data_lo_v, pipe_mul_data_lo_v, pipe_fma_data_lo_v;
-  logic pipe_long_idata_lo_v, pipe_long_fdata_lo_v;
+  logic pipe_long_idata_lo_v, pipe_long_idata_lo_yumi, pipe_long_fdata_lo_v, pipe_long_fdata_lo_yumi;
   logic [dpath_width_p-1:0] pipe_ctl_data_lo, pipe_int_data_lo, pipe_aux_data_lo, pipe_mem_early_data_lo, pipe_mem_final_data_lo, pipe_sys_data_lo, pipe_mul_data_lo, pipe_fma_data_lo;
   rv64_fflags_s pipe_aux_fflags_lo, pipe_fma_fflags_lo;
 
@@ -371,9 +371,11 @@ module bp_be_calculator_top
 
      ,.iwb_pkt_o(long_iwb_pkt)
      ,.iwb_v_o(pipe_long_idata_lo_v)
+     ,.iwb_yumi_i(pipe_long_idata_lo_yumi)
 
      ,.fwb_pkt_o(long_fwb_pkt)
      ,.fwb_v_o(pipe_long_fdata_lo_v)
+     ,.fwb_yumi_i(pipe_long_fdata_lo_yumi)
      );
 
   // If a pipeline has completed an instruction (pipe_xxx_v), then mux in the calculated result.
@@ -489,8 +491,11 @@ module bp_be_calculator_top
      ,.data_o(exc_stage_r)
      );
 
-  assign iwb_pkt_o = pipe_long_idata_lo_v ? long_iwb_pkt : comp_stage_r[4];
-  assign fwb_pkt_o = pipe_long_fdata_lo_v ? long_fwb_pkt : comp_stage_r[5];
+  assign pipe_long_idata_lo_yumi = pipe_long_idata_lo_v & ~comp_stage_r[4].ird_w_v;
+  assign pipe_long_fdata_lo_yumi = pipe_long_fdata_lo_v & ~comp_stage_r[5].frd_w_v & ~comp_stage_r[5].fflags_w_v;
+
+  assign iwb_pkt_o = pipe_long_idata_lo_yumi ? long_iwb_pkt : comp_stage_r[4];
+  assign fwb_pkt_o = pipe_long_fdata_lo_yumi ? long_fwb_pkt : comp_stage_r[5];
 
   assign mem_ready_o  = pipe_mem_ready_lo;
   assign long_ready_o = pipe_long_ready_lo;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
@@ -20,9 +20,11 @@ module bp_be_pipe_long
 
    , output [wb_pkt_width_lp-1:0]      iwb_pkt_o
    , output                            iwb_v_o
+   , input                             iwb_yumi_i
 
    , output [wb_pkt_width_lp-1:0]      fwb_pkt_o
    , output                            fwb_v_o
+   , input                             fwb_yumi_i
    );
 
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
@@ -72,7 +74,7 @@ module bp_be_pipe_long
      ,.quotient_o(quotient_lo)
      ,.remainder_o(remainder_lo)
      ,.v_o(idiv_v_lo)
-     // Immediately ack, since the data stays safe until the next incoming division
+     // Immediately ack, since the data stays done until the next incoming division
      ,.yumi_i(idiv_v_lo)
      );
 
@@ -125,6 +127,47 @@ module bp_be_pipe_long
      ,.out_sig(fdivsqrt_out_sig)
      );
 
+  logic opw_v_r, ops_v_r;
+  bp_be_fu_op_s fu_op_r;
+  logic [reg_addr_width_p-1:0] rd_addr_r;
+  rv64_frm_e frm_r;
+  bsg_dff_reset_en
+   #(.width_p($bits(rv64_frm_e)+reg_addr_width_p+$bits(bp_be_fu_op_s)+2))
+   wb_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.en_i(v_li)
+
+     ,.data_i({frm_li, instr.rd_addr, decode.fu_op, decode.opw_v, decode.ops_v})
+     ,.data_o({frm_r, rd_addr_r, fu_op_r, opw_v_r, ops_v_r})
+     );
+
+  logic [2:0] hazard_cnt;
+  wire idiv_safe = (hazard_cnt == 3);
+  wire fdiv_safe = (hazard_cnt == 4);
+  bsg_counter_clear_up
+   #(.max_val_p(4), .init_val_p(0))
+   hazard_counter
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.clear_i(v_li)
+     ,.up_i(rd_w_v_r & ~idiv_safe & ~fdiv_safe)
+     ,.count_o(hazard_cnt)
+     );
+
+  logic idiv_done_v_r, fdiv_done_v_r, rd_w_v_r;
+  bsg_dff_reset_set_clear
+   #(.width_p(3))
+   wb_v_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.set_i({idiv_v_lo, fdivsqrt_v_lo, v_li})
+     ,.clear_i({v_li, v_li, (iwb_yumi_i | fwb_yumi_i)})
+     ,.data_o({idiv_done_v_r, fdiv_done_v_r, rd_w_v_r})
+     );
+
   logic [dp_rec_width_gp-1:0] fdivsqrt_dp_final;
   rv64_fflags_s fdivsqrt_dp_fflags;
   roundAnyRawFNToRecFN
@@ -143,7 +186,7 @@ module bp_be_pipe_long
      ,.in_sign(fdivsqrt_out_sign)
      ,.in_sExp(fdivsqrt_out_sexp)
      ,.in_sig(fdivsqrt_out_sig)
-     ,.roundingMode(frm_li)
+     ,.roundingMode(frm_r)
      ,.out(fdivsqrt_dp_final)
      ,.exceptionFlags(fdivsqrt_dp_fflags)
      );
@@ -166,13 +209,18 @@ module bp_be_pipe_long
      ,.in_sign(fdivsqrt_out_sign)
      ,.in_sExp(fdivsqrt_out_sexp)
      ,.in_sig(fdivsqrt_out_sig)
-     ,.roundingMode(frm_li)
+     ,.roundingMode(frm_r)
      ,.out(fdivsqrt_sp_final)
      ,.exceptionFlags(fdivsqrt_sp_fflags)
      );
 
   localparam bias_adj_lp = (1 << dp_exp_width_gp) - (1 << sp_exp_width_gp);
   bp_hardfloat_rec_dp_s fdivsqrt_sp2dp_final;
+
+  bp_be_fp_reg_s fdivsqrt_result;
+  rv64_fflags_s fdivsqrt_fflags;
+  assign fdivsqrt_result = '{sp_not_dp: ops_v_r, rec: ops_v_r ? fdivsqrt_sp2dp_final : fdivsqrt_dp_final};
+  assign fdivsqrt_fflags = ops_v_r ? fdivsqrt_sp_fflags : fdivsqrt_dp_fflags;
 
   wire [dp_exp_width_gp:0] adjusted_exp = fdivsqrt_sp_final.exp + bias_adj_lp;
   wire [2:0]                   exp_code = fdivsqrt_sp_final.exp[sp_exp_width_gp-:3];
@@ -182,26 +230,6 @@ module bp_be_pipe_long
                                   ,exp  : special ? {exp_code, adjusted_exp[0+:dp_exp_width_gp-2]} : adjusted_exp
                                   ,fract: fdivsqrt_sp_final.fract << (dp_sig_width_gp-sp_sig_width_gp)
                                   };
-
-  logic opw_v_r, ops_v_r;
-  bp_be_fu_op_s fu_op_r;
-  logic [reg_addr_width_p-1:0] rd_addr_r;
-  logic rd_w_v_r;
-  bsg_dff_reset_en
-   #(.width_p(1+reg_addr_width_p+$bits(bp_be_fu_op_s)+2))
-   wb_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-     ,.en_i(v_li | (iwb_v_o | fwb_v_o))
-
-     ,.data_i({v_li, instr.rd_addr, decode.fu_op, decode.opw_v, decode.ops_v})
-     ,.data_o({rd_w_v_r, rd_addr_r, fu_op_r, opw_v_r, ops_v_r})
-     );
-
-  bp_be_fp_reg_s fdivsqrt_result;
-  rv64_fflags_s fdivsqrt_fflags;
-  assign fdivsqrt_result = '{sp_not_dp: ops_v_r, rec: ops_v_r ? fdivsqrt_sp2dp_final : fdivsqrt_dp_final};
-  assign fdivsqrt_fflags = ops_v_r ? fdivsqrt_sp_fflags : fdivsqrt_dp_fflags;
 
   logic [dword_width_p-1:0] rd_data_lo;
   always_comb
@@ -219,19 +247,21 @@ module bp_be_pipe_long
 
   assign iwb_pkt.ird_w_v    = rd_w_v_r;
   assign iwb_pkt.frd_w_v    = 1'b0;
+  assign iwb_pkt.late       = 1'b1;
   assign iwb_pkt.rd_addr    = rd_addr_r;
   assign iwb_pkt.rd_data    = rd_data_lo;
   assign iwb_pkt.fflags_w_v = 1'b0;
   assign iwb_pkt.fflags     = '0;
-  assign iwb_v_o = idiv_v_lo & rd_w_v_r;
+  assign iwb_v_o = idiv_safe & idiv_done_v_r & rd_w_v_r;
 
   assign fwb_pkt.ird_w_v    = 1'b0;
   assign fwb_pkt.frd_w_v    = rd_w_v_r;
+  assign fwb_pkt.late       = 1'b1;
   assign fwb_pkt.rd_addr    = rd_addr_r;
   assign fwb_pkt.rd_data    = fdivsqrt_result;
   assign fwb_pkt.fflags_w_v = 1'b1;
   assign fwb_pkt.fflags     = fdivsqrt_fflags;
-  assign fwb_v_o = fdivsqrt_v_lo & rd_w_v_r;
+  assign fwb_v_o = fdiv_safe & fdiv_done_v_r & rd_w_v_r;
 
 endmodule
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
@@ -191,7 +191,7 @@ module bp_be_pipe_long
    #(.width_p(1+reg_addr_width_p+$bits(bp_be_fu_op_s)+2))
    wb_reg
     (.clk_i(clk_i)
-     ,.reset_i(reset_i | flush_i)
+     ,.reset_i(reset_i)
      ,.en_i(v_li | (iwb_v_o | fwb_v_o))
 
      ,.data_i({v_li, instr.rd_addr, decode.fu_op, decode.opw_v, decode.ops_v})

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
@@ -74,8 +74,7 @@ module bp_be_pipe_long
      ,.quotient_o(quotient_lo)
      ,.remainder_o(remainder_lo)
      ,.v_o(idiv_v_lo)
-     // Immediately ack, since the data stays done until the next incoming division
-     ,.yumi_i(idiv_v_lo)
+     ,.yumi_i(idiv_v_lo & iwb_yumi_i)
      );
 
   bp_be_fp_reg_s frs1, frs2;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
@@ -142,20 +142,6 @@ module bp_be_pipe_long
      ,.data_o({frm_r, rd_addr_r, fu_op_r, opw_v_r, ops_v_r})
      );
 
-  logic [2:0] hazard_cnt;
-  wire idiv_safe = (hazard_cnt == 3);
-  wire fdiv_safe = (hazard_cnt == 4);
-  bsg_counter_clear_up
-   #(.max_val_p(4), .init_val_p(0))
-   hazard_counter
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.clear_i(v_li)
-     ,.up_i(rd_w_v_r & ~idiv_safe & ~fdiv_safe)
-     ,.count_o(hazard_cnt)
-     );
-
   logic idiv_done_v_r, fdiv_done_v_r, rd_w_v_r;
   bsg_dff_reset_set_clear
    #(.width_p(3))
@@ -166,6 +152,20 @@ module bp_be_pipe_long
      ,.set_i({idiv_v_lo, fdivsqrt_v_lo, v_li})
      ,.clear_i({v_li, v_li, (iwb_yumi_i | fwb_yumi_i)})
      ,.data_o({idiv_done_v_r, fdiv_done_v_r, rd_w_v_r})
+     );
+
+  logic [2:0] hazard_cnt;
+  wire idiv_safe = (hazard_cnt > 2);
+  wire fdiv_safe = (hazard_cnt > 3);
+  bsg_counter_clear_up
+   #(.max_val_p(4), .init_val_p(0))
+   hazard_counter
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.clear_i(v_li)
+     ,.up_i(rd_w_v_r & ~fdiv_safe)
+     ,.count_o(hazard_cnt)
      );
 
   logic [dp_rec_width_gp-1:0] fdivsqrt_dp_final;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -40,6 +40,7 @@ module bp_be_pipe_mem
 
    , input [ptw_miss_pkt_width_lp-1:0]    ptw_miss_pkt_i
    , output [ptw_fill_pkt_width_lp-1:0]   ptw_fill_pkt_o
+   , output logic                         ptw_busy_o
 
    , output logic                         tlb_miss_v_o
    , output logic                         cache_miss_v_o
@@ -322,7 +323,8 @@ module bp_be_pipe_mem
   assign store_misaligned_v_o   = store_misaligned_v;
   assign load_misaligned_v_o    = load_misaligned_v;
 
-  assign ready_o                = dcache_ready_lo & ~ptw_busy;
+  assign ready_o                = dcache_ready_lo;
+  assign ptw_busy_o             = ptw_busy;
   assign early_data_o           = dcache_early_data;
   assign final_data_o           = dcache_final_data;
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
@@ -35,8 +35,7 @@ module bp_be_pipe_sys
    , input                                flush_i
 
    , output                               ready_o
-   , input                                pipe_mem_ready_i
-   , input                                pipe_long_ready_i
+   , input                                ptw_busy_i
 
    , input                                commit_v_i
    , input                                commit_queue_v_i
@@ -206,7 +205,7 @@ module bp_be_pipe_sys
      ,.fpu_en_o(fpu_en_o)
      );
 
-  assign interrupt_v_li   = interrupt_ready_lo & pipe_mem_ready_i & pipe_long_ready_i & ~commit_v_i;
+  assign interrupt_v_li   = interrupt_ready_lo & ~ptw_busy_i & ~commit_v_i;
 
   always_ff @(posedge clk_i)
     begin

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -37,6 +37,7 @@ module bp_be_detector
    , input                             long_ready_i
    , input                             mem_ready_i
    , input                             sys_ready_i
+   , input                             ptw_busy_i
 
    // Pipeline control signals from the checker to the calculator
    , output                            chk_dispatch_v_o
@@ -138,96 +139,96 @@ module bp_be_detector
       //   can be handled through forwarding
       for(integer i = 0; i < 4; i++)
         begin
-          rs1_match_vector[i] = (isd_status_cast_i.isd_rs1_addr == dep_status_r[i].rd_addr);
-          rs2_match_vector[i] = (isd_status_cast_i.isd_rs2_addr == dep_status_r[i].rd_addr);
-          rs3_match_vector[i] = (isd_status_cast_i.isd_rs3_addr == dep_status_r[i].rd_addr);
+          rs1_match_vector[i] = (isd_status_cast_i.rs1_addr == dep_status_r[i].rd_addr);
+          rs2_match_vector[i] = (isd_status_cast_i.rs2_addr == dep_status_r[i].rd_addr);
+          rs3_match_vector[i] = (isd_status_cast_i.rs3_addr == dep_status_r[i].rd_addr);
         end
 
       // Detect scoreboard hazards
-      irs1_sb_raw_haz_v = (isd_status_cast_i.isd_irs1_v & irs_match_lo[0])
-                          & (isd_status_cast_i.isd_rs1_addr != '0);
+      irs1_sb_raw_haz_v = (isd_status_cast_i.irs1_v & irs_match_lo[0])
+                          & (isd_status_cast_i.rs1_addr != '0);
 
-      irs2_sb_raw_haz_v = (isd_status_cast_i.isd_irs2_v & irs_match_lo[1])
-                          & (isd_status_cast_i.isd_rs2_addr != '0);
+      irs2_sb_raw_haz_v = (isd_status_cast_i.irs2_v & irs_match_lo[1])
+                          & (isd_status_cast_i.rs2_addr != '0);
 
-      ird_sb_waw_haz_v = (isd_status_cast_i.isd_iwb_v & ird_match_lo)
-                         & (isd_status_cast_i.isd_rd_addr != '0);
+      ird_sb_waw_haz_v = (isd_status_cast_i.iwb_v & ird_match_lo)
+                         & (isd_status_cast_i.rd_addr != '0);
 
-      frs1_sb_raw_haz_v = (isd_status_cast_i.isd_frs1_v & frs_match_lo[0]);
-      frs2_sb_raw_haz_v = (isd_status_cast_i.isd_frs2_v & frs_match_lo[1]);
-      frs3_sb_raw_haz_v = (isd_status_cast_i.isd_frs3_v & frs_match_lo[2]);
+      frs1_sb_raw_haz_v = (isd_status_cast_i.frs1_v & frs_match_lo[0]);
+      frs2_sb_raw_haz_v = (isd_status_cast_i.frs2_v & frs_match_lo[1]);
+      frs3_sb_raw_haz_v = (isd_status_cast_i.frs3_v & frs_match_lo[2]);
 
-      frd_sb_waw_haz_v = (isd_status_cast_i.isd_fwb_v & frd_match_lo);
+      frd_sb_waw_haz_v = (isd_status_cast_i.fwb_v & frd_match_lo);
 
       // Detect integer and float data hazards for EX1
-      irs1_data_haz_v[0] = (isd_status_cast_i.isd_irs1_v & rs1_match_vector[0])
-                           & (isd_status_cast_i.isd_rs1_addr != '0)
+      irs1_data_haz_v[0] = (isd_status_cast_i.irs1_v & rs1_match_vector[0])
+                           & (isd_status_cast_i.rs1_addr != '0)
                            & (dep_status_r[0].aux_iwb_v | dep_status_r[0].mul_iwb_v | dep_status_r[0].emem_iwb_v | dep_status_r[0].fmem_iwb_v);
 
-      irs2_data_haz_v[0] = (isd_status_cast_i.isd_irs2_v & rs2_match_vector[0])
-                           & (isd_status_cast_i.isd_rs2_addr != '0)
+      irs2_data_haz_v[0] = (isd_status_cast_i.irs2_v & rs2_match_vector[0])
+                           & (isd_status_cast_i.rs2_addr != '0)
                            & (dep_status_r[0].aux_iwb_v | dep_status_r[0].mul_iwb_v | dep_status_r[0].emem_iwb_v | dep_status_r[0].fmem_iwb_v);
 
-      frs1_data_haz_v[0] = (isd_status_cast_i.isd_frs1_v & rs1_match_vector[0])
+      frs1_data_haz_v[0] = (isd_status_cast_i.frs1_v & rs1_match_vector[0])
                            & (dep_status_r[0].aux_fwb_v | dep_status_r[0].emem_fwb_v | dep_status_r[0].fmem_fwb_v | dep_status_r[0].fma_fwb_v);
 
-      frs2_data_haz_v[0] = (isd_status_cast_i.isd_frs2_v & rs2_match_vector[0])
+      frs2_data_haz_v[0] = (isd_status_cast_i.frs2_v & rs2_match_vector[0])
                            & (dep_status_r[0].aux_fwb_v | dep_status_r[0].emem_fwb_v | dep_status_r[0].fmem_fwb_v | dep_status_r[0].fma_fwb_v);
 
-      frs3_data_haz_v[0] = (isd_status_cast_i.isd_frs3_v & rs3_match_vector[0])
+      frs3_data_haz_v[0] = (isd_status_cast_i.frs3_v & rs3_match_vector[0])
                            & (dep_status_r[0].aux_fwb_v | dep_status_r[0].emem_fwb_v | dep_status_r[0].fmem_fwb_v | dep_status_r[0].fma_fwb_v);
 
       // Detect integer and float data hazards for EX2
-      irs1_data_haz_v[1] = (isd_status_cast_i.isd_irs1_v & rs1_match_vector[1])
-                           & (isd_status_cast_i.isd_rs1_addr != '0)
+      irs1_data_haz_v[1] = (isd_status_cast_i.irs1_v & rs1_match_vector[1])
+                           & (isd_status_cast_i.rs1_addr != '0)
                            & (dep_status_r[1].fmem_iwb_v | dep_status_r[1].mul_iwb_v);
 
-      irs2_data_haz_v[1] = (isd_status_cast_i.isd_irs2_v & rs2_match_vector[1])
-                           & (isd_status_cast_i.isd_rs2_addr != '0)
+      irs2_data_haz_v[1] = (isd_status_cast_i.irs2_v & rs2_match_vector[1])
+                           & (isd_status_cast_i.rs2_addr != '0)
                            & (dep_status_r[1].fmem_iwb_v | dep_status_r[1].mul_iwb_v);
 
-      frs1_data_haz_v[1] = (isd_status_cast_i.isd_frs1_v & rs1_match_vector[1])
+      frs1_data_haz_v[1] = (isd_status_cast_i.frs1_v & rs1_match_vector[1])
                            & (dep_status_r[1].fmem_fwb_v | dep_status_r[1].fma_fwb_v);
 
-      frs2_data_haz_v[1] = (isd_status_cast_i.isd_frs2_v & rs2_match_vector[1])
+      frs2_data_haz_v[1] = (isd_status_cast_i.frs2_v & rs2_match_vector[1])
                            & (dep_status_r[1].fmem_fwb_v | dep_status_r[1].fma_fwb_v);
 
-      frs3_data_haz_v[1] = (isd_status_cast_i.isd_frs3_v & rs3_match_vector[1])
+      frs3_data_haz_v[1] = (isd_status_cast_i.frs3_v & rs3_match_vector[1])
                            & (dep_status_r[1].fmem_fwb_v | dep_status_r[1].fma_fwb_v);
 
-      irs1_data_haz_v[2] = (isd_status_cast_i.isd_irs1_v & rs1_match_vector[2])
-                           & (isd_status_cast_i.isd_rs1_addr != '0)
+      irs1_data_haz_v[2] = (isd_status_cast_i.irs1_v & rs1_match_vector[2])
+                           & (isd_status_cast_i.rs1_addr != '0)
                            & (dep_status_r[2].mul_iwb_v);
 
-      irs2_data_haz_v[2] = (isd_status_cast_i.isd_irs2_v & rs2_match_vector[2])
-                           & (isd_status_cast_i.isd_rs2_addr != '0)
+      irs2_data_haz_v[2] = (isd_status_cast_i.irs2_v & rs2_match_vector[2])
+                           & (isd_status_cast_i.rs2_addr != '0)
                            & (dep_status_r[2].mul_iwb_v);
 
-      frs1_data_haz_v[2] = (isd_status_cast_i.isd_frs1_v & rs1_match_vector[2])
+      frs1_data_haz_v[2] = (isd_status_cast_i.frs1_v & rs1_match_vector[2])
                            & (dep_status_r[2].fma_fwb_v);
 
-      frs2_data_haz_v[2] = (isd_status_cast_i.isd_frs2_v & rs2_match_vector[2])
+      frs2_data_haz_v[2] = (isd_status_cast_i.frs2_v & rs2_match_vector[2])
                            & (dep_status_r[2].fma_fwb_v);
 
-      frs3_data_haz_v[2] = (isd_status_cast_i.isd_frs3_v & rs3_match_vector[2])
+      frs3_data_haz_v[2] = (isd_status_cast_i.frs3_v & rs3_match_vector[2])
                            & (dep_status_r[2].fma_fwb_v);
 
       irs1_data_haz_v[3] = '0;
       irs2_data_haz_v[3] = '0;
 
-      frs1_data_haz_v[3] = (isd_status_cast_i.isd_frs1_v & rs1_match_vector[3])
+      frs1_data_haz_v[3] = (isd_status_cast_i.frs1_v & rs1_match_vector[3])
                            & (dep_status_r[3].fma_fwb_v);
 
-      frs2_data_haz_v[3] = (isd_status_cast_i.isd_frs2_v & rs2_match_vector[3])
+      frs2_data_haz_v[3] = (isd_status_cast_i.frs2_v & rs2_match_vector[3])
                            & (dep_status_r[3].fma_fwb_v);
 
-      frs3_data_haz_v[3] = (isd_status_cast_i.isd_frs3_v & rs3_match_vector[3])
+      frs3_data_haz_v[3] = (isd_status_cast_i.frs3_v & rs3_match_vector[3])
                            & (dep_status_r[3].fma_fwb_v);
 
       mem_in_pipe_v      = (dep_status_r[0].mem_v)
                            | (dep_status_r[1].mem_v);
-      fence_haz_v        = (isd_status_cast_i.isd_fence_v & (~credits_empty_i | mem_in_pipe_v))
-                           | (isd_status_cast_i.isd_mem_v & credits_full_i);
+      fence_haz_v        = (isd_status_cast_i.fence_v & (~credits_empty_i | mem_in_pipe_v))
+                           | (isd_status_cast_i.mem_v & credits_full_i);
       queue_haz_v        = fe_cmd_full_i;
 
       // Conservatively serialize on csr operations.  Could change to only write operations
@@ -236,7 +237,7 @@ module bp_be_detector
                            | (dep_status_r[2].csr_v);
 
       // This is overly conservative, should add an explicit fflags dependency checker
-      csr_haz_v = isd_status_cast_i.isd_csr_v
+      csr_haz_v = isd_status_cast_i.csr_v
                   & ((dep_status_r[0].fflags_w_v)
                      | (dep_status_r[1].fflags_w_v)
                      | (dep_status_r[2].fflags_w_v)
@@ -246,7 +247,7 @@ module bp_be_detector
       //   executing instructions on trap, and only pause on dependency in
       //   EX4, rather than any instruction. Most likely not a huge
       //   performance problem at the moment.
-      long_haz_v = isd_status_cast_i.isd_long_v
+      long_haz_v = isd_status_cast_i.long_v
                    & ((dep_status_r[0].instr_v)
                       | (dep_status_r[1].instr_v)
                       | (dep_status_r[2].instr_v)
@@ -268,12 +269,10 @@ module bp_be_detector
 
       // Combine all structural hazard information
       struct_haz_v = cfg_bus_cast_i.freeze
-      // We block on mmu not ready even on not memory instructions, because it means there's an
-      //   operation being performed asynchronously (such as a page fault)
-      //   but, we should really explictly track the PTW
-                     | ~mem_ready_i
+                     | ptw_busy_i
                      | ~sys_ready_i
-                     | (~long_ready_i & dispatch_pkt.decode.pipe_long_v)
+                     | (~mem_ready_i & isd_status_cast_i.mem_v)
+                     | (~long_ready_i & isd_status_cast_i.long_v)
                      | queue_haz_v;
     end
 

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -73,7 +73,7 @@ module bp_be_detector
   logic [3:0] frs1_data_haz_v , frs2_data_haz_v, frs3_data_haz_v;
   logic [3:0] rs1_match_vector, rs2_match_vector, rs3_match_vector;
 
-  bp_be_dep_status_s [6:0] dep_status_r;
+  bp_be_dep_status_s [3:0] dep_status_r;
 
   logic fence_haz_v, queue_haz_v, serial_haz_v;
   logic data_haz_v, control_haz_v, struct_haz_v;
@@ -91,7 +91,7 @@ module bp_be_detector
   logic [1:0] irs_match_lo;
   logic       ird_match_lo;
   wire score_int_v_li = (dispatch_pkt.v & ~dispatch_pkt.poison) & dispatch_pkt.decode.late_iwb_v;
-  wire clear_int_v_li = iwb_pkt.ird_w_v;
+  wire clear_int_v_li = iwb_pkt.ird_w_v & iwb_pkt.late;
   bp_be_scoreboard
    #(.bp_params_p(bp_params_p), .num_rs_p(2))
    int_scoreboard
@@ -113,7 +113,7 @@ module bp_be_detector
   logic [2:0] frs_match_lo;
   logic       frd_match_lo;
   wire score_fp_v_li = (dispatch_pkt.v & ~dispatch_pkt.poison) & dispatch_pkt.decode.late_fwb_v;
-  wire clear_fp_v_li = fwb_pkt.frd_w_v;
+  wire clear_fp_v_li = fwb_pkt.frd_w_v & fwb_pkt.late;
   bp_be_scoreboard
    #(.bp_params_p(bp_params_p), .num_rs_p(3))
    fp_scoreboard
@@ -251,10 +251,6 @@ module bp_be_detector
                    & ((dep_status_r[0].instr_v)
                       | (dep_status_r[1].instr_v)
                       | (dep_status_r[2].instr_v)
-                      | (dep_status_r[3].instr_v)
-                      | (dep_status_r[4].instr_v)
-                      | (dep_status_r[5].instr_v)
-                      | (dep_status_r[6].instr_v)
                       );
 
       control_haz_v = fence_haz_v | serial_haz_v | csr_haz_v | long_haz_v;
@@ -306,7 +302,7 @@ module bp_be_detector
   always_ff @(posedge clk_i)
     begin
       dep_status_r[0]   <= (dispatch_pkt.v & ~dispatch_pkt.poison) ? dep_status_n : '0;
-      dep_status_r[6:1] <= dep_status_r[5:0];
+      dep_status_r[3:1] <= dep_status_r[2:0];
     end
 
 endmodule

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -73,7 +73,7 @@ module bp_be_detector
   logic [3:0] frs1_data_haz_v , frs2_data_haz_v, frs3_data_haz_v;
   logic [3:0] rs1_match_vector, rs2_match_vector, rs3_match_vector;
 
-  bp_be_dep_status_s [4:0] dep_status_r;
+  bp_be_dep_status_s [6:0] dep_status_r;
 
   logic fence_haz_v, queue_haz_v, serial_haz_v;
   logic data_haz_v, control_haz_v, struct_haz_v;
@@ -253,6 +253,8 @@ module bp_be_detector
                       | (dep_status_r[2].instr_v)
                       | (dep_status_r[3].instr_v)
                       | (dep_status_r[4].instr_v)
+                      | (dep_status_r[5].instr_v)
+                      | (dep_status_r[6].instr_v)
                       );
 
       control_haz_v = fence_haz_v | serial_haz_v | csr_haz_v | long_haz_v;
@@ -304,7 +306,7 @@ module bp_be_detector
   always_ff @(posedge clk_i)
     begin
       dep_status_r[0]   <= (dispatch_pkt.v & ~dispatch_pkt.poison) ? dep_status_n : '0;
-      dep_status_r[4:1] <= dep_status_r[3:0];
+      dep_status_r[6:1] <= dep_status_r[5:0];
     end
 
 endmodule

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -72,7 +72,7 @@ module bp_be_detector
   logic [3:0] frs1_data_haz_v , frs2_data_haz_v, frs3_data_haz_v;
   logic [3:0] rs1_match_vector, rs2_match_vector, rs3_match_vector;
 
-  bp_be_dep_status_s [3:0] dep_status_r;
+  bp_be_dep_status_s [4:0] dep_status_r;
 
   logic fence_haz_v, queue_haz_v, serial_haz_v;
   logic data_haz_v, control_haz_v, struct_haz_v;
@@ -242,10 +242,16 @@ module bp_be_detector
                      | (dep_status_r[2].fflags_w_v)
                      );
 
+      // TODO: This is pessimistic. Could instead flush currently
+      //   executing instructions on trap, and only pause on dependency in
+      //   EX4, rather than any instruction. Most likely not a huge
+      //   performance problem at the moment.
       long_haz_v = isd_status_cast_i.isd_long_v
                    & ((dep_status_r[0].instr_v)
                       | (dep_status_r[1].instr_v)
                       | (dep_status_r[2].instr_v)
+                      | (dep_status_r[3].instr_v)
+                      | (dep_status_r[4].instr_v)
                       );
 
       control_haz_v = fence_haz_v | serial_haz_v | csr_haz_v | long_haz_v;
@@ -299,7 +305,7 @@ module bp_be_detector
   always_ff @(posedge clk_i)
     begin
       dep_status_r[0]   <= (dispatch_pkt.v & ~dispatch_pkt.poison) ? dep_status_n : '0;
-      dep_status_r[3:1] <= dep_status_r[2:0];
+      dep_status_r[4:1] <= dep_status_r[3:0];
     end
 
 endmodule

--- a/bp_be/src/v/bp_be_checker/bp_be_issue_queue.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_issue_queue.sv
@@ -155,6 +155,7 @@ module bp_be_issue_queue
       issue_pkt_li.mem_v = instr.opcode inside {`RV64_FLOAD_OP, `RV64_FSTORE_OP
                                                 ,`RV64_LOAD_OP, `RV64_STORE_OP
                                                 ,`RV64_AMO_OP, `RV64_SYSTEM_OP
+                                                ,`RV64_MISC_MEM_OP
                                                 };
       issue_pkt_li.fence_v = instr inside {`RV64_FENCE, `RV64_FENCE_I, `RV64_SFENCE_VMA};
       issue_pkt_li.long_v = instr inside {`RV64_DIV, `RV64_DIVU, `RV64_DIVW, `RV64_DIVUW

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -56,7 +56,7 @@ module bp_be_scheduler
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 
   // Cast input and output ports
-  bp_be_isd_status_s isd_status;
+  bp_be_isd_status_s isd_status_cast_o;
   rv64_instr_s       instr;
   bp_be_commit_pkt_s commit_pkt;
   bp_be_wb_pkt_s     iwb_pkt, fwb_pkt;
@@ -64,7 +64,7 @@ module bp_be_scheduler
   bp_fe_queue_s fe_queue_lo;
   logic fe_queue_v_lo, fe_queue_yumi_li;
 
-  assign isd_status_o    = isd_status;
+  assign isd_status_o    = isd_status_cast_o;
   assign instr           = fe_queue_lo.msg.fetch.instr;
   assign commit_pkt      = commit_pkt_i;
   assign iwb_pkt         = iwb_pkt_i;
@@ -153,24 +153,24 @@ module bp_be_scheduler
   always_comb
     begin
       // Calculator status ISD stage
-      isd_status.isd_v        = fe_queue_yumi_li;
-      isd_status.isd_pc       = fe_queue_lo.msg.fetch.pc;
-      isd_status.isd_branch_metadata_fwd = fe_queue_lo.msg.fetch.branch_metadata_fwd;
-      isd_status.isd_fence_v  = fe_queue_v_lo & issue_pkt.fence_v;
-      isd_status.isd_csr_v    = fe_queue_v_lo & issue_pkt.csr_v;
-      isd_status.isd_mem_v    = fe_queue_v_lo & issue_pkt.mem_v;
-      isd_status.isd_long_v   = fe_queue_v_lo & issue_pkt.long_v;
-      isd_status.isd_irs1_v   = fe_queue_v_lo & issue_pkt.irs1_v;
-      isd_status.isd_frs1_v   = fe_queue_v_lo & issue_pkt.frs1_v;
-      isd_status.isd_rs1_addr = instr.t.fmatype.rs1_addr;
-      isd_status.isd_irs2_v   = fe_queue_v_lo & issue_pkt.irs2_v;
-      isd_status.isd_frs2_v   = fe_queue_v_lo & issue_pkt.frs2_v;
-      isd_status.isd_rs2_addr = instr.t.fmatype.rs2_addr;
-      isd_status.isd_frs3_v   = fe_queue_v_lo & issue_pkt.frs3_v;
-      isd_status.isd_rs3_addr = instr.t.fmatype.rs3_addr;
-      isd_status.isd_rd_addr  = instr.t.fmatype.rd_addr;
-      isd_status.isd_iwb_v    = decoded.irf_w_v;
-      isd_status.isd_fwb_v    = decoded.frf_w_v;
+      isd_status_cast_o.v        = fe_queue_yumi_li;
+      isd_status_cast_o.pc       = fe_queue_lo.msg.fetch.pc;
+      isd_status_cast_o.branch_metadata_fwd = fe_queue_lo.msg.fetch.branch_metadata_fwd;
+      isd_status_cast_o.fence_v  = fe_queue_v_lo & issue_pkt.fence_v;
+      isd_status_cast_o.csr_v    = fe_queue_v_lo & issue_pkt.csr_v;
+      isd_status_cast_o.mem_v    = fe_queue_v_lo & issue_pkt.mem_v;
+      isd_status_cast_o.long_v   = fe_queue_v_lo & issue_pkt.long_v;
+      isd_status_cast_o.irs1_v   = fe_queue_v_lo & issue_pkt.irs1_v;
+      isd_status_cast_o.frs1_v   = fe_queue_v_lo & issue_pkt.frs1_v;
+      isd_status_cast_o.rs1_addr = instr.t.fmatype.rs1_addr;
+      isd_status_cast_o.irs2_v   = fe_queue_v_lo & issue_pkt.irs2_v;
+      isd_status_cast_o.frs2_v   = fe_queue_v_lo & issue_pkt.frs2_v;
+      isd_status_cast_o.rs2_addr = instr.t.fmatype.rs2_addr;
+      isd_status_cast_o.frs3_v   = fe_queue_v_lo & issue_pkt.frs3_v;
+      isd_status_cast_o.rs3_addr = instr.t.fmatype.rs3_addr;
+      isd_status_cast_o.rd_addr  = instr.t.fmatype.rd_addr;
+      isd_status_cast_o.iwb_v    = decoded.irf_w_v;
+      isd_status_cast_o.fwb_v    = decoded.frf_w_v;
 
       // Form dispatch packet
       dispatch_pkt.v        = fe_queue_yumi_li;

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -168,6 +168,9 @@ module bp_be_scheduler
       isd_status.isd_rs2_addr = instr.t.fmatype.rs2_addr;
       isd_status.isd_frs3_v   = fe_queue_v_lo & issue_pkt.frs3_v;
       isd_status.isd_rs3_addr = instr.t.fmatype.rs3_addr;
+      isd_status.isd_rd_addr  = instr.t.fmatype.rd_addr;
+      isd_status.isd_iwb_v    = decoded.irf_w_v;
+      isd_status.isd_fwb_v    = decoded.frf_w_v;
 
       // Form dispatch packet
       dispatch_pkt.v        = fe_queue_yumi_li;

--- a/bp_be/src/v/bp_be_checker/bp_be_scoreboard.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scoreboard.sv
@@ -1,0 +1,66 @@
+
+module bp_be_scoreboard
+ import bp_common_pkg::*;
+ import bp_common_aviary_pkg::*;
+ import bp_be_pkg::*;
+ #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+   `declare_bp_proc_params(bp_params_p)
+
+   , parameter num_rs_p = "inv"
+   )
+  (input                                        clk_i
+   , input                                      reset_i
+ 
+   , input                                      score_v_i
+   , input [reg_addr_width_p-1:0]               score_rd_i
+
+   , input                                      clear_v_i
+   , input [reg_addr_width_p-1:0]               clear_rd_i
+
+   , input [num_rs_p-1:0][reg_addr_width_p-1:0] rs_i
+   , input               [reg_addr_width_p-1:0] rd_i
+
+   , output logic [num_rs_p-1:0]                rs_match_o
+   , output logic                               rd_match_o
+   );
+
+  localparam rf_els_lp = 2**reg_addr_width_p;
+  logic [rf_els_lp-1:0] scoreboard_r;
+
+  logic [rf_els_lp-1:0] score_onehot_li;
+  bsg_decode_with_v
+   #(.num_out_p(rf_els_lp))
+   score_decode
+    (.i(score_rd_i)
+     ,.v_i(score_v_i)
+     ,.o(score_onehot_li)
+     );
+
+  logic [rf_els_lp-1:0] clear_onehot_li;
+  bsg_decode_with_v
+   #(.num_out_p(rf_els_lp))
+   clear_decode
+    (.i(clear_rd_i)
+     ,.v_i(clear_v_i)
+     ,.o(clear_onehot_li)
+     );
+
+  bsg_dff_reset_set_clear
+   #(.width_p(rf_els_lp))
+   scoreboard_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.set_i(score_onehot_li)
+     ,.clear_i(clear_onehot_li)
+     ,.data_o(scoreboard_r)
+     );
+
+  for (genvar i = 0; i < num_rs_p; i++)
+    begin : rs
+      assign rs_match_o[i] = scoreboard_r[rs_i[i]];
+    end
+  assign rd_match_o = scoreboard_r[rd_i];
+
+endmodule
+

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -94,8 +94,7 @@ module bp_be_top
 
   logic fpu_en_lo;
   logic fe_cmd_full_lo;
-  logic mem_ready_lo, long_ready_lo, sys_ready_lo;
-
+  logic mem_ready_lo, long_ready_lo, sys_ready_lo, ptw_busy_lo;
 
   logic flush;
   bp_be_director
@@ -138,6 +137,7 @@ module bp_be_top
      ,.mem_ready_i(mem_ready_lo)
      ,.long_ready_i(long_ready_lo)
      ,.sys_ready_i(sys_ready_lo)
+     ,.ptw_busy_i(ptw_busy_lo)
 
      ,.chk_dispatch_v_o(chk_dispatch_v)
      ,.dispatch_pkt_i(dispatch_pkt)
@@ -185,6 +185,7 @@ module bp_be_top
      ,.mem_ready_o(mem_ready_lo)
      ,.long_ready_o(long_ready_lo)
      ,.sys_ready_o(sys_ready_lo)
+     ,.ptw_busy_o(ptw_busy_lo)
 
      ,.ptw_fill_pkt_o(ptw_fill_pkt)
 

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -141,6 +141,8 @@ module bp_be_top
 
      ,.chk_dispatch_v_o(chk_dispatch_v)
      ,.dispatch_pkt_i(dispatch_pkt)
+     ,.iwb_pkt_i(iwb_pkt)
+     ,.fwb_pkt_i(fwb_pkt)
      );
 
   bp_be_scheduler

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -203,6 +203,7 @@ $BP_BE_DIR/src/v/bp_be_checker/bp_be_instr_decoder.sv
 $BP_BE_DIR/src/v/bp_be_checker/bp_be_issue_queue.sv
 $BP_BE_DIR/src/v/bp_be_checker/bp_be_regfile.sv
 $BP_BE_DIR/src/v/bp_be_checker/bp_be_scheduler.sv
+$BP_BE_DIR/src/v/bp_be_checker/bp_be_scoreboard.sv
 # MMU
 $BP_BE_DIR/src/v/bp_be_dcache/bp_be_dcache.sv
 $BP_BE_DIR/src/v/bp_be_dcache/bp_be_dcache_decoder.sv

--- a/bp_top/test/common/bp_nonsynth_cosim.sv
+++ b/bp_top/test/common/bp_nonsynth_cosim.sv
@@ -66,13 +66,14 @@ module bp_nonsynth_cosim
 
   logic                     commit_v_r;
   logic [vaddr_width_p-1:0] commit_pc_r;
-  logic [instr_width_p-1:0] commit_instr_r;
+  rv64_instr_fmatype_s      commit_instr, commit_instr_r;
   logic                     commit_ird_w_v_r;
   logic                     commit_frd_w_v_r;
   logic                     trap_v_r;
   logic [dword_width_p-1:0] cause_r;
   logic                     is_debug_mode_r;
   logic commit_fifo_v_lo, commit_fifo_yumi_li;
+  assign commit_instr = commit_instr_i;
   wire commit_ird_w_v_li = commit_v_i & (decode_r.irf_w_v | decode_r.late_iwb_v);
   wire commit_frd_w_v_li = commit_v_i & (decode_r.frf_w_v | decode_r.late_fwb_v);
   bsg_fifo_1r1w_small
@@ -90,61 +91,70 @@ module bp_nonsynth_cosim
      ,.yumi_i(commit_fifo_yumi_li)
      );
 
-  logic [reg_addr_width_p-1:0] iwb_addr_r;
-  logic [dword_width_p-1:0] iwb_data_r;
-  logic ird_fifo_v_lo, ird_fifo_yumi_li;
-  bsg_fifo_1r1w_small
-   #(.width_p(reg_addr_width_p+dword_width_p), .els_p(8))
-   ird_fifo
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+  localparam rf_els_lp = 2**reg_addr_width_p;
+  logic [rf_els_lp-1:0][dword_width_p-1:0] ird_data_r;
+  bp_be_fp_reg_s [rf_els_lp-1:0] frd_data_r;
+  logic [rf_els_lp-1:0] iwb_v_r, frd_fifo_v_lo;
+  logic [rf_els_lp-1:0][dword_width_p-1:0] frd_raw_li;
 
-     ,.data_i({ird_addr_i, ird_data_i[0+:dword_width_p]})
-     ,.v_i(ird_w_v_i)
-     ,.ready_o()
+  for (genvar i = 0; i < rf_els_lp; i++)
+    begin : iwb
+      wire fill       = ird_w_v_i & (ird_addr_i == i);
+      wire deallocate = commit_ird_w_v_r & (commit_instr_r.rd_addr == i) & commit_fifo_yumi_li;
+      bsg_fifo_1r1w_small
+        #(.width_p(dword_width_p), .els_p(16))
+        ird_fifo
+         (.clk_i(clk_i)
+          ,.reset_i(reset_i)
 
-     ,.data_o({iwb_addr_r, iwb_data_r})
-     ,.v_o(ird_fifo_v_lo)
-     ,.yumi_i(ird_fifo_yumi_li)
-     );
+          ,.data_i(ird_data_i[0+:dword_width_p])
+          ,.v_i(fill)
+          ,.ready_o()
 
-  logic [reg_addr_width_p-1:0] frd_addr_r;
-  bp_be_fp_reg_s frd_data_r;
-  logic frd_fifo_v_lo, frd_fifo_yumi_li;
-  bsg_fifo_1r1w_small
-   #(.width_p(reg_addr_width_p+dpath_width_p), .els_p(8))
-   frd_fifo
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+          ,.data_o(ird_data_r[i])
+          ,.v_o(iwb_v_r[i])
+          ,.yumi_i(deallocate)
+          );
+    end
 
-     ,.data_i({frd_addr_i, frd_data_i})
-     ,.v_i(frd_w_v_i)
-     ,.ready_o()
+  for (genvar i = 0; i < rf_els_lp; i++)
+    begin : fwb
+      wire fill       = frd_w_v_i & (frd_addr_i == i);
+      wire deallocate = commit_frd_w_v_r & (commit_instr_r.rd_addr == i) & commit_fifo_yumi_li;
+      bsg_fifo_1r1w_small
+        #(.width_p(dpath_width_p), .els_p(16))
+        ird_fifo
+         (.clk_i(clk_i)
+          ,.reset_i(reset_i)
 
-     ,.data_o({frd_addr_r, frd_data_r})
-     ,.v_o(frd_fifo_v_lo)
-     ,.yumi_i(frd_fifo_yumi_li)
-     );
+          ,.data_i(frd_data_i)
+          ,.v_i(fill)
+          ,.ready_o()
 
-  // The control bits control tininess, which is fixed in RISC-V
-  wire [`floatControlWidth-1:0] control_li = `flControl_default;
+          ,.data_o(frd_data_r[i])
+          ,.v_o(frd_fifo_v_lo[i])
+          ,.yumi_i(deallocate)
+          );
 
-  logic [dword_width_p-1:0] frd_raw_li;
-  bp_be_rec_to_fp
-   #(.bp_params_p(bp_params_p))
-   debug_fp
-    (.rec_i(frd_data_r.rec)
+      // The control bits control tininess, which is fixed in RISC-V
+      wire [`floatControlWidth-1:0] control_li = `flControl_default;
 
-     ,.raw_sp_not_dp_i(frd_data_r.sp_not_dp)
-     ,.raw_o(frd_raw_li)
-     );
+      bp_be_rec_to_fp
+       #(.bp_params_p(bp_params_p))
+       debug_fp
+        (.rec_i(frd_data_r[i].rec)
 
-  assign ird_fifo_yumi_li = ird_fifo_v_lo & commit_ird_w_v_r;
-  assign frd_fifo_yumi_li = frd_fifo_v_lo & commit_frd_w_v_r;
+         ,.raw_sp_not_dp_i(frd_data_r[i].sp_not_dp)
+         ,.raw_o(frd_raw_li[i])
+         );
+    end
+
   assign commit_fifo_yumi_li = commit_fifo_v_lo & ((~commit_ird_w_v_r & ~commit_frd_w_v_r)
-                                                   | (commit_ird_w_v_r & ird_fifo_v_lo)
-                                                   | (commit_frd_w_v_r & frd_fifo_v_lo)
+                                                   | (commit_ird_w_v_r & iwb_v_r[commit_instr_r.rd_addr])
+                                                   | (commit_frd_w_v_r & frd_fifo_v_lo[commit_instr_r.rd_addr])
                                                    );
+  assign commit_ird_li = commit_fifo_v_lo & (commit_ird_w_v_r & iwb_v_r[commit_instr_r.rd_addr]);
+  assign commit_frd_li = commit_fifo_v_lo & (commit_frd_w_v_r & frd_fifo_v_lo[commit_instr_r.rd_addr]);
 
   logic [`BSG_SAFE_CLOG2(max_instr_lp+1)-1:0] instr_cnt;
   bsg_counter_clear_up
@@ -180,7 +190,7 @@ module bp_nonsynth_cosim
         dromajo_trap(mhartid_i, cause_r);
       end
     else if (cosim_en_i & commit_fifo_yumi_li & commit_v_r & ~is_debug_mode_r & commit_pc_r != '0)
-      if (dromajo_step(mhartid_i, 64'($signed(commit_pc_r)), commit_instr_r, frd_fifo_yumi_li ? frd_raw_li : iwb_data_r))
+      if (dromajo_step(mhartid_i, 64'($signed(commit_pc_r)), commit_instr_r, commit_frd_li ? frd_raw_li[commit_instr_r.rd_addr] : ird_data_r[commit_instr_r.rd_addr]))
         begin
           $display("COSIM_FAIL");
           $finish();


### PR DESCRIPTION
Adds an integer and floating point scoreboard. For now, only used for IDIV and FDIV.  Expected minor performance improvements.

Before merging, need to figure out how to adjust cosim module to see in-order writebacks.  Most like need to reorder them in the non-synth module.

Partially in support of #718 
