### PR TITLE
Hotfixes for cosim

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -687,7 +687,8 @@ module bp_be_csr
 
   assign trans_info_cast_o.priv_mode = priv_mode_r;
   assign trans_info_cast_o.satp_ppn  = satp_lo.ppn;
-  assign trans_info_cast_o.translation_en = translation_en_r | (mstatus_lo.mprv & (mstatus_lo.mpp < `PRIV_MODE_M) & (satp_lo.mode == 4'd8));
+  assign trans_info_cast_o.translation_en = translation_en_r
+    | ((~is_debug_mode | dcsr_lo.mprven) & mstatus_lo.mprv & (mstatus_lo.mpp < `PRIV_MODE_M) & (satp_lo.mode == 4'd8));
   assign trans_info_cast_o.mstatus_sum = mstatus_lo.sum;
   assign trans_info_cast_o.mstatus_mxr = mstatus_lo.mxr;
 

--- a/bp_common/src/include/bp_common_csr_defines.svh
+++ b/bp_common/src/include/bp_common_csr_defines.svh
@@ -991,7 +991,7 @@ typedef struct packed
     ,stopcount: 1'b0                  \
     ,stoptime : 1'b0                  \
     ,cause    : data_comp_mp.cause    \
-    ,mprven   : 1'b1                  \
+    ,mprven   : 1'b0                  \
     ,nmip     : 1'b0                  \
     ,step     : data_comp_mp.step     \
     ,prv      : data_comp_mp.prv      \

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -241,7 +241,7 @@ module testbench
 
        ,.mhartid_i(calculator.pipe_sys.csr.cfg_bus_cast_i.core_id)
 
-       ,.npc_i(director.npc_r)
+       ,.npc_i(calculator.pipe_sys.csr.apc_r)
        ,.instret_i(calculator.commit_pkt.instret)
        );
 


### PR DESCRIPTION
- MPRVEN initial value should be 0, since we want to disable translation during debug mode
- disable mprv-based translation during debug mode
- Also small fix to watchdog timer, which should better detect "hardware idle loops"