### PR TITLE
[WIP] PTW Injection

### DIFF
--- a/bp_be/src/include/bp_be_ctl_pkgdef.svh
+++ b/bp_be/src/include/bp_be_ctl_pkgdef.svh
@@ -194,6 +194,7 @@
   typedef struct packed
   {
     logic                             v;
+    logic                             queue_v;
 
     logic                             pipe_ctl_v;
     logic                             pipe_int_v;
@@ -223,13 +224,15 @@
     bp_be_src2_e                      src2_sel;
     bp_be_baddr_e                     baddr_sel;
 
+
+    logic                             _interrupt;
     logic                             itlb_miss;
     logic                             icache_miss;
     logic                             instr_access_fault;
     logic                             instr_page_fault;
+    logic                             load_page_fault;
+    logic                             store_page_fault;
     logic                             illegal_instr;
-    logic                             ebreak;
-    logic                             ecall;
   }  bp_be_decode_s;
 
   typedef struct packed
@@ -237,7 +240,9 @@
     logic store_page_fault;
     logic load_page_fault;
     logic instr_page_fault;
-    logic ecall;
+    logic ecall_m;
+    logic ecall_s;
+    logic ecall_u;
     logic store_access_fault;
     logic store_misaligned;
     logic load_access_fault;
@@ -246,16 +251,23 @@
     logic illegal_instr;
     logic instr_access_fault;
     logic instr_misaligned;
+    logic _interrupt;
   }  bp_be_exception_s;
 
   typedef struct packed
   {
     logic itlb_miss;
     logic icache_miss;
-    logic dtlb_load_miss;
     logic dtlb_store_miss;
+    logic dtlb_load_miss;
     logic dcache_miss;
     logic fencei_v;
+    logic satp_v;
+    logic sfence_v;
+    logic sret_v;
+    logic mret_v;
+    logic dret_v;
+    logic dbreak;
   }  bp_be_special_s;
 
   typedef struct packed

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -246,15 +246,12 @@ module bp_be_detector
                       | (dep_status_r[2].instr_v)
                       );
 
-      //// Conservatively serialize on csr operations.  Could change to only write operations
-      //csr_haz_v     = isd_status_cast_i.csr_v
-      //                & ((dep_status_r[0].instr_v)
-      //                   | (dep_status_r[1].instr_v)
-      //                   | (dep_status_r[2].instr_v)
-      //                   );
-
-      // When CSRs are in EX3, serialize...
-      csr_haz_v     = dep_status_r[0].csr_v | dep_status_r[1].csr_v | dep_status_r[2].csr_v;
+      // Conservatively serialize on csr operations.  Could change to only write operations
+      csr_haz_v     = isd_status_cast_i.csr_v
+                      & ((dep_status_r[0].instr_v)
+                         | (dep_status_r[1].instr_v)
+                         | (dep_status_r[2].instr_v)
+                         );
 
       control_haz_v = fence_haz_v | csr_haz_v | fflags_haz_v | long_haz_v;
 
@@ -279,7 +276,7 @@ module bp_be_detector
   // Generate calculator control signals
   assign chk_dispatch_v_o  = ~(control_haz_v | data_haz_v | struct_haz_v) & ~irq_pending_i;
   // TODO: Inject into pipeline rather than "happening" at EX3
-  assign chk_interrupt_v_o = irq_pending_i & ~cfg_bus_cast_i.freeze & ~ptw_busy_i & ~dep_status_r[2].instr_v;
+  assign chk_interrupt_v_o = irq_pending_i & ~cfg_bus_cast_i.freeze & ~ptw_busy_i;
 
   always_comb
     begin

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -85,10 +85,11 @@ module bp_be_top
 
   bp_be_commit_pkt_s commit_pkt;
   bp_be_wb_pkt_s iwb_pkt, fwb_pkt;
+  bp_be_ptw_fill_pkt_s ptw_fill_pkt;
 
   bp_be_isd_status_s isd_status;
   logic [vaddr_width_p-1:0] expected_npc_lo;
-  logic poison_isd_lo, suppress_iss_lo;
+  logic poison_isd_lo, suppress_iss_lo, irq_pending_lo;
 
   logic fpu_en_lo;
   logic fe_cmd_full_lo;
@@ -152,6 +153,7 @@ module bp_be_top
      ,.expected_npc_i(expected_npc_lo)
      ,.poison_isd_i(poison_isd_lo)
      ,.dispatch_v_i(chk_dispatch_v)
+     ,.interrupt_v_i(chk_interrupt_v)
      ,.suppress_iss_i(suppress_iss_lo)
      ,.fpu_en_i(fpu_en_lo)
 
@@ -162,6 +164,7 @@ module bp_be_top
      ,.dispatch_pkt_o(dispatch_pkt)
 
      ,.commit_pkt_i(commit_pkt)
+     ,.ptw_fill_pkt_i(ptw_fill_pkt)
      ,.iwb_pkt_i(iwb_pkt)
      ,.fwb_pkt_i(fwb_pkt)
      );
@@ -183,6 +186,7 @@ module bp_be_top
 
      ,.br_pkt_o(br_pkt)
      ,.commit_pkt_o(commit_pkt)
+     ,.ptw_fill_pkt_o(ptw_fill_pkt)
      ,.iwb_pkt_o(iwb_pkt)
      ,.fwb_pkt_o(fwb_pkt)
 
@@ -215,7 +219,6 @@ module bp_be_top
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)
      ,.external_irq_i(external_irq_i)
-     ,.interrupt_v_i(chk_interrupt_v)
      ,.irq_pending_o(irq_pending_lo)
      );
 


### PR DESCRIPTION
- Injecting PTW exceptions into pipeline instead of out-of-band
- Injecting interrupts into pipeline instead of out-of-band
- Decouples CSR illegal access from trap
- Moves CSR access into EX1 (saves a bunch of unnecessary pipe registers)
- splits BE redirects into exceptions and special instructions