### PR TITLE
WFI

### DIFF
--- a/bp_be/src/include/bp_be_defines.svh
+++ b/bp_be/src/include/bp_be_defines.svh
@@ -129,6 +129,7 @@
       logic                           fencei;                                                      \
       logic                           sfence;                                                      \
       logic                           satp;                                                        \
+      logic                           wfi;                                                         \
       logic                           itlb_miss;                                                   \
       logic                           icache_miss;                                                 \
       logic                           dtlb_store_miss;                                             \
@@ -210,7 +211,7 @@
     (paddr_width_mp - page_offset_width_gp + 6)
 
   `define bp_be_commit_pkt_width(vaddr_width_mp, paddr_width_mp) \
-    (3 + `bp_be_pte_leaf_width(paddr_width_mp) +  3*vaddr_width_mp + instr_width_gp + rv64_priv_width_gp + 16)
+    (3 + `bp_be_pte_leaf_width(paddr_width_mp) +  3*vaddr_width_mp + instr_width_gp + rv64_priv_width_gp + 17)
 
   `define bp_be_wb_pkt_width(vaddr_width_mp) \
     (3                                                                                             \

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -41,10 +41,10 @@ module bp_be_calculator_top
   // Calculator - Checker interface
   , input [dispatch_pkt_width_lp-1:0]               dispatch_pkt_i
 
-  , output                                          fpu_en_o
-  , output                                          long_ready_o
-  , output                                          mem_ready_o
-  , output                                          ptw_busy_o
+  , output logic                                    fpu_en_o
+  , output logic                                    long_ready_o
+  , output logic                                    mem_ready_o
+  , output logic                                    ptw_busy_o
 
   , output [commit_pkt_width_lp-1:0]                commit_pkt_o
   , output [branch_pkt_width_lp-1:0]                br_pkt_o
@@ -54,6 +54,7 @@ module bp_be_calculator_top
   , input                                           timer_irq_i
   , input                                           software_irq_i
   , input                                           external_irq_i
+  , output logic                                    irq_waiting_o
   , output logic                                    irq_pending_o
   , input                                           interrupt_v_i
 
@@ -219,6 +220,7 @@ module bp_be_calculator_top
      ,.software_irq_i(software_irq_i)
      ,.external_irq_i(external_irq_i)
      ,.irq_pending_o(irq_pending_o)
+     ,.irq_waiting_o(irq_waiting_o)
      ,.interrupt_v_i(interrupt_v_i)
 
      ,.data_o(pipe_sys_data_lo)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
@@ -54,6 +54,7 @@ module bp_be_pipe_sys
    , input                                software_irq_i
    , input                                external_irq_i
    , output logic                         irq_pending_o
+   , output logic                         irq_waiting_o
    , input                                interrupt_v_i
 
    , output [trans_info_width_lp-1:0]     trans_info_o
@@ -162,6 +163,7 @@ module bp_be_pipe_sys
      ,.software_irq_i(software_irq_i)
      ,.external_irq_i(external_irq_i)
      ,.irq_pending_o(irq_pending_o)
+     ,.irq_waiting_o(irq_waiting_o)
      ,.interrupt_v_i(interrupt_v_i)
 
      ,.commit_pkt_o(commit_pkt)

--- a/bp_be/src/v/bp_be_checker/bp_be_director.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.sv
@@ -27,25 +27,26 @@ module bp_be_director
    , localparam branch_pkt_width_lp = `bp_be_branch_pkt_width(vaddr_width_p)
    , localparam commit_pkt_width_lp = `bp_be_commit_pkt_width(vaddr_width_p, paddr_width_p)
    )
-  (input                              clk_i
-   , input                            reset_i
+  (input                                clk_i
+   , input                              reset_i
 
-   , input [cfg_bus_width_lp-1:0]     cfg_bus_i
+   , input [cfg_bus_width_lp-1:0]       cfg_bus_i
 
    // Dependency information
-   , input [isd_status_width_lp-1:0]  isd_status_i
-   , output [vaddr_width_p-1:0]       expected_npc_o
-   , output                           poison_isd_o
-   , output                           suppress_iss_o
+   , input [isd_status_width_lp-1:0]    isd_status_i
+   , output logic [vaddr_width_p-1:0]   expected_npc_o
+   , output logic                       poison_isd_o
+   , output logic                       suppress_iss_o
+   , input                              irq_waiting_i
 
    // FE-BE interface
-   , output [fe_cmd_width_lp-1:0]     fe_cmd_o
-   , output                           fe_cmd_v_o
-   , input                            fe_cmd_yumi_i
-   , output                           fe_cmd_full_o
+   , output logic [fe_cmd_width_lp-1:0] fe_cmd_o
+   , output logic                       fe_cmd_v_o
+   , input                              fe_cmd_yumi_i
+   , output logic                       fe_cmd_full_o
 
-   , input [branch_pkt_width_lp-1:0]   br_pkt_i
-   , input [commit_pkt_width_lp-1:0]   commit_pkt_i
+   , input [branch_pkt_width_lp-1:0]    br_pkt_i
+   , input [commit_pkt_width_lp-1:0]    commit_pkt_i
    );
 
   // Declare parameterized structures
@@ -72,8 +73,11 @@ module bp_be_director
   logic [vaddr_width_p-1:0]               npc_n, npc_r, pc_r;
   logic                                   npc_mismatch_v;
 
-  // Logic for handling coming out of reset
-  enum logic [1:0] {e_reset, e_boot, e_run, e_fence} state_n, state_r;
+  enum logic [2:0] {e_reset, e_boot, e_run, e_fence, e_wfi} state_n, state_r;
+  wire is_reset = (state_r == e_reset);
+  wire is_boot  = (state_r == e_boot);
+  wire is_fence = (state_r == e_fence);
+  wire is_wfi   = (state_r == e_wfi);
 
   // Module instantiations
   // Update the NPC on a valid instruction in ex1 or upon commit
@@ -120,8 +124,9 @@ module bp_be_director
       unique casez (state_r)
         e_reset : state_n = cfg_bus_cast_i.freeze ? e_reset : e_boot;
         e_boot  : state_n = fe_cmd_v_li ? e_run : e_boot;
-        e_run   : state_n = cfg_bus_cast_i.freeze ? e_reset : fe_cmd_nonattaboy_v ? e_fence : e_run;
+        e_run   : state_n = commit_pkt.wfi ? e_wfi : fe_cmd_nonattaboy_v ? e_fence : e_run;
         e_fence : state_n = suppress_iss_o ? e_fence : e_run;
+        e_wfi   : state_n = fe_cmd_nonattaboy_v ? e_fence : e_wfi;
         default : state_n = e_reset;
       endcase
     end
@@ -135,7 +140,7 @@ module bp_be_director
         state_r <= state_n;
       end
 
-  assign suppress_iss_o  = (state_r == e_fence) & fe_cmd_v_o;
+  assign suppress_iss_o  = ((state_r == e_fence) & fe_cmd_v_o) || (state_r == e_wfi);
 
   always_comb
     begin : fe_cmd_adapter
@@ -188,6 +193,13 @@ module bp_be_director
 
           fe_cmd_v_li = fe_cmd_ready_lo;
         end
+      else if (commit_pkt.wfi)
+        begin
+          fe_cmd_li.opcode = e_op_wait;
+          fe_cmd_li.vaddr  = commit_pkt.npc;
+
+          fe_cmd_v_li = fe_cmd_ready_lo;
+        end
       else if (commit_pkt.fencei)
         begin
           fe_cmd_li.opcode = e_op_icache_fence;
@@ -215,7 +227,7 @@ module bp_be_director
 
           fe_cmd_v_li = fe_cmd_ready_lo;
         end
-      else if (commit_pkt.exception | commit_pkt._interrupt)
+      else if (commit_pkt.exception | commit_pkt._interrupt | (is_wfi & irq_waiting_i))
         begin
           fe_cmd_pc_redirect_operands = '0;
 

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -81,7 +81,7 @@ module bp_be_top
   bp_be_ptw_miss_pkt_s ptw_miss_pkt;
 
   logic chk_dispatch_v, chk_interrupt_v;
-  logic irq_pending_lo;
+  logic irq_pending_lo, irq_waiting_lo;
 
   bp_be_commit_pkt_s commit_pkt;
   bp_be_wb_pkt_s iwb_pkt, fwb_pkt;
@@ -89,6 +89,7 @@ module bp_be_top
   bp_be_isd_status_s isd_status;
   logic [vaddr_width_p-1:0] expected_npc_lo;
   logic poison_isd_lo, suppress_iss_lo;
+  logic waiting_for_irq_lo;
 
   logic fpu_en_lo;
   logic fe_cmd_full_lo;
@@ -112,6 +113,7 @@ module bp_be_top
 
      ,.suppress_iss_o(suppress_iss_lo)
      ,.poison_isd_o(poison_isd_lo)
+     ,.irq_waiting_i(irq_waiting_lo)
 
      ,.br_pkt_i(br_pkt)
      ,.commit_pkt_i(commit_pkt)
@@ -217,6 +219,7 @@ module bp_be_top
      ,.external_irq_i(external_irq_i)
      ,.interrupt_v_i(chk_interrupt_v)
      ,.irq_pending_o(irq_pending_lo)
+     ,.irq_waiting_o(irq_waiting_lo)
      );
 
 endmodule

--- a/bp_common/src/include/bp_common_core_pkgdef.svh
+++ b/bp_common/src/include/bp_common_core_pkgdef.svh
@@ -47,6 +47,7 @@
     ,e_op_icache_fence         = 4
     ,e_op_itlb_fill_response   = 5
     ,e_op_itlb_fence           = 6
+    ,e_op_wait                 = 7
   } bp_fe_command_queue_opcodes_e;
 
   /*

--- a/bp_common/test/src/perch/start.S
+++ b/bp_common/test/src/perch/start.S
@@ -21,6 +21,11 @@ _start:
    la x1, bp_mtvec_handler
    csrw mtvec, x1
 
+/* Enable FPU */
+   li a0, 0x00006000 & (0x00006000 >> 1);
+   csrs mstatus, a0;
+   csrwi fcsr, 0
+
 /* 0 all registers */
     addi x1,  x0, 0
     /* x2 is the sp which we set, so don't zero */

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -128,6 +128,7 @@ module bp_fe_top
   wire itlb_fill_v       = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_itlb_fill_response);
   wire icache_fence_v    = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_icache_fence);
   wire itlb_fence_v      = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_itlb_fence);
+  wire wait_v            = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_wait);
   wire attaboy_v         = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_attaboy);
   wire cmd_nonattaboy_v  = fe_cmd_v_i & (fe_cmd_cast_i.opcode != e_op_attaboy);
 

--- a/bp_top/test/common/bp_nonsynth_watchdog.sv
+++ b/bp_top/test/common/bp_nonsynth_watchdog.sv
@@ -18,6 +18,7 @@ module bp_nonsynth_watchdog
     , input                                   reset_i
 
     , input                                   freeze_i
+    , input                                   wfi_i
 
     , input [`BSG_SAFE_CLOG2(num_core_p)-1:0] mhartid_i
 
@@ -42,7 +43,7 @@ module bp_nonsynth_watchdog
    #(.max_val_p(timeout_cycles_p), .init_val_p(0))
    stall_counter
     (.clk_i(clk_i)
-     ,.reset_i(reset_i | freeze_i)
+     ,.reset_i(reset_i | freeze_i | wfi_i)
 
      ,.clear_i(npc_change)
      ,.up_i(1'b1)

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -244,6 +244,7 @@ module testbench
           (.clk_i(clk_i)
            ,.reset_i(reset_i)
            ,.freeze_i(calculator.pipe_sys.csr.cfg_bus_cast_i.freeze)
+           ,.wfi_i(director.is_wfi)
 
            ,.mhartid_i(calculator.pipe_sys.csr.cfg_bus_cast_i.core_id)
 


### PR DESCRIPTION
This PR adds support for the WFI instruction.  Upon WFI, it freezes the BE sets the FE to the wait state, until an interrupt is taken.

Dependent on https://github.com/black-parrot/bp_tests/pull/7

This PR is mostly functional. However, we also need to add a case for an interrupt occuring while interrupts are globally disabled. This should wake the processor, despite it being frozen. I'm holding off adding that bit until #745 is merged, because interrupt behavior is changing substantially.

@zaazad It should be sufficient to run accelerator tests, provided you don't rely on this behavior