### PR TITLE
Blocks interrupts on pending cache replay

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -45,11 +45,12 @@ module bp_be_calculator_top
   , output logic                                    long_ready_o
   , output logic                                    mem_ready_o
   , output logic                                    ptw_busy_o
+  , output logic                                    replay_pending_o
 
-  , output [commit_pkt_width_lp-1:0]                commit_pkt_o
-  , output [branch_pkt_width_lp-1:0]                br_pkt_o
-  , output [wb_pkt_width_lp-1:0]                    iwb_pkt_o
-  , output [wb_pkt_width_lp-1:0]                    fwb_pkt_o
+  , output logic [commit_pkt_width_lp-1:0]          commit_pkt_o
+  , output logic [branch_pkt_width_lp-1:0]          br_pkt_o
+  , output logic [wb_pkt_width_lp-1:0]              iwb_pkt_o
+  , output logic [wb_pkt_width_lp-1:0]              fwb_pkt_o
 
   , input                                           timer_irq_i
   , input                                           software_irq_i
@@ -324,6 +325,7 @@ module bp_be_calculator_top
      ,.final_v_o(pipe_mem_final_data_lo_v)
 
      ,.trans_info_i(trans_info_lo)
+     ,.replay_pending_o(replay_pending_o)
      );
 
   // Floating point pipe: 4/5 cycle latency

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -58,6 +58,7 @@ module bp_be_pipe_mem
    , output logic                         final_v_o
 
    , input [trans_info_width_lp-1:0]      trans_info_i
+   , output logic                         replay_pending_o
 
    // D$-LCE Interface
    // signals to LCE
@@ -258,6 +259,7 @@ module bp_be_pipe_mem
       ,.final_v_o(dcache_final_v)
 
       ,.flush_i(flush_i)
+      ,.replay_pending_o(replay_pending_o)
 
       // D$-LCE Interface
       ,.cache_req_o(cache_req_cast_o)

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -41,10 +41,11 @@ module bp_be_detector
    , input                             mem_ready_i
    , input                             ptw_busy_i
    , input                             irq_pending_i
+   , input                             replay_pending_i
 
    // Pipeline control signals from the checker to the calculator
-   , output                            chk_dispatch_v_o
-   , output                            chk_interrupt_v_o
+   , output logic                      chk_dispatch_v_o
+   , output logic                      chk_interrupt_v_o
    , input [dispatch_pkt_width_lp-1:0] dispatch_pkt_i
    , input [commit_pkt_width_lp-1:0]   commit_pkt_i
    , input [wb_pkt_width_lp-1:0]       iwb_pkt_i
@@ -278,7 +279,7 @@ module bp_be_detector
   // Generate calculator control signals
   assign chk_dispatch_v_o  = ~(control_haz_v | data_haz_v | struct_haz_v) & ~irq_pending_i;
   // TODO: Inject into pipeline rather than "happening" at EX3
-  assign chk_interrupt_v_o = irq_pending_i & ~cfg_bus_cast_i.freeze & ~ptw_busy_i & ~dep_status_r[2].instr_v;
+  assign chk_interrupt_v_o = irq_pending_i & ~replay_pending_i & ~cfg_bus_cast_i.freeze & ~ptw_busy_i & ~dep_status_r[2].instr_v;
 
   always_comb
     begin

--- a/bp_be/src/v/bp_be_checker/bp_be_director.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.sv
@@ -240,19 +240,6 @@ module bp_be_director
 
           fe_cmd_v_li = fe_cmd_ready_lo;
         end
-      else if (commit_pkt.exception | commit_pkt._interrupt)
-        begin
-          fe_cmd_pc_redirect_operands = '0;
-
-          fe_cmd_li.opcode                                 = e_op_pc_redirection;
-          fe_cmd_li.vaddr                                  = commit_pkt.npc;
-          fe_cmd_pc_redirect_operands.subopcode            = e_subop_trap;
-          fe_cmd_pc_redirect_operands.priv                 = commit_pkt.priv_n;
-          fe_cmd_pc_redirect_operands.translation_en       = commit_pkt.translation_en_n;
-          fe_cmd_li.operands.pc_redirect_operands          = fe_cmd_pc_redirect_operands;
-
-          fe_cmd_v_li = fe_cmd_ready_lo;
-        end
       else if (isd_status_cast_i.v & npc_mismatch_v)
         begin
           fe_cmd_pc_redirect_operands = '0;

--- a/bp_be/src/v/bp_be_checker/bp_be_director.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.sv
@@ -240,6 +240,19 @@ module bp_be_director
 
           fe_cmd_v_li = fe_cmd_ready_lo;
         end
+      else if (commit_pkt.exception | commit_pkt._interrupt)
+        begin
+          fe_cmd_pc_redirect_operands = '0;
+
+          fe_cmd_li.opcode                                 = e_op_pc_redirection;
+          fe_cmd_li.vaddr                                  = commit_pkt.npc;
+          fe_cmd_pc_redirect_operands.subopcode            = e_subop_trap;
+          fe_cmd_pc_redirect_operands.priv                 = commit_pkt.priv_n;
+          fe_cmd_pc_redirect_operands.translation_en       = commit_pkt.translation_en_n;
+          fe_cmd_li.operands.pc_redirect_operands          = fe_cmd_pc_redirect_operands;
+
+          fe_cmd_v_li = fe_cmd_ready_lo;
+        end
       else if (isd_status_cast_i.v & npc_mismatch_v)
         begin
           fe_cmd_pc_redirect_operands = '0;

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -81,7 +81,7 @@ module bp_be_top
   bp_be_ptw_miss_pkt_s ptw_miss_pkt;
 
   logic chk_dispatch_v, chk_interrupt_v;
-  logic irq_pending_lo, irq_waiting_lo;
+  logic irq_pending_lo, irq_waiting_lo, replay_pending_lo;
 
   bp_be_commit_pkt_s commit_pkt;
   bp_be_wb_pkt_s iwb_pkt, fwb_pkt;
@@ -135,6 +135,7 @@ module bp_be_top
      ,.long_ready_i(long_ready_lo)
      ,.ptw_busy_i(ptw_busy_lo)
      ,.irq_pending_i(irq_pending_lo)
+     ,.replay_pending_i(replay_pending_lo)
 
      ,.chk_dispatch_v_o(chk_dispatch_v)
      ,.chk_interrupt_v_o(chk_interrupt_v)
@@ -220,6 +221,8 @@ module bp_be_top
      ,.interrupt_v_i(chk_interrupt_v)
      ,.irq_pending_o(irq_pending_lo)
      ,.irq_waiting_o(irq_waiting_lo)
+     ,.replay_pending_o(replay_pending_lo)
      );
 
 endmodule
+


### PR DESCRIPTION
This PR blocks interrupts while there's a cache replay being performed. This is necessary for making sure that uncached operations are not repeated, which can break things in non-idempotent remote memory space.  Slight penalty for interrupt responsiveness, definitely a bandaid fix until we get non-blocking loads