### PR TITLE
Remove Buffering in lite to stream modules

### DIFF
--- a/bp_me/src/v/cache/bp_me_cache_slice.sv
+++ b/bp_me/src/v/cache/bp_me_cache_slice.sv
@@ -91,7 +91,7 @@ module bp_me_cache_slice
 
     ,.in_msg_header_i(mem_header_li)
     ,.in_msg_data_i(mem_data_li)
-    ,.in_msg_v_i(mem_ready_lo & mem_v_li)
+    ,.in_msg_v_i(mem_v_li)
     ,.in_msg_ready_and_o(mem_ready_lo)
     ,.in_msg_last_i(mem_last_li)
 

--- a/bp_me/src/v/wormhole/bp_lite_to_stream.sv
+++ b/bp_me/src/v/wormhole/bp_lite_to_stream.sv
@@ -1,5 +1,5 @@
 
-module bp_lite_to_stream
+module bp_lite_to_stream_bypass
  import bp_common_pkg::*;
  import bp_common_aviary_pkg::*;
  import bp_me_pkg::*;
@@ -40,59 +40,78 @@ module bp_lite_to_stream
   `declare_bp_bedrock_if(paddr_width_p, payload_width_p, out_data_width_p, lce_id_width_p, lce_assoc_p, out);
 
   bp_bedrock_in_msg_s msg_cast_i;
-  bp_bedrock_in_msg_header_s msg_header_cast_i;
   assign msg_cast_i = in_msg_i;
-  assign msg_header_cast_i = msg_cast_i.header;
 
   localparam in_data_bytes_lp = in_data_width_p/8;
   localparam out_data_bytes_lp = out_data_width_p/8;
   localparam stream_words_lp = in_data_width_p/out_data_width_p;
   localparam stream_offset_width_lp = `BSG_SAFE_CLOG2(out_data_bytes_lp);
 
-  bp_bedrock_in_msg_header_s header_lo;
-  logic msg_v_lo, msg_yumi_li;
-  bsg_one_fifo
+  bp_bedrock_in_msg_header_s in_msg_header_lo;
+  logic [in_data_width_p-1:0] in_msg_data_lo;
+  // Hold the data and header for multi-cycle streaming
+  bsg_dff_en_bypass
    #(.width_p($bits(bp_bedrock_in_msg_header_s)))
-   header_fifo
+   header_reg
     (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+    ,.en_i(in_msg_v_i)
+    ,.data_i(msg_cast_i.header)
+    ,.data_o(in_msg_header_lo)
+    );
 
-     ,.data_i(msg_cast_i.header)
-     ,.ready_o(in_msg_ready_and_o)
-     ,.v_i(in_msg_v_i)
+  bsg_dff_en_bypass
+   #(.width_p(in_data_width_p))
+   data_reg
+    (.clk_i(clk_i)
+    ,.en_i(in_msg_v_i)
+    ,.data_i(msg_cast_i.data)
+    ,.data_o(in_msg_data_lo)
+    );
 
-     ,.data_o(header_lo)
-     ,.v_o(msg_v_lo)
-     ,.yumi_i(msg_yumi_li)
-     );
+  logic streaming_r, stream_clear;
+  bsg_dff_reset_set_clear
+   #(.width_p(1)
+   ,.clear_over_set_p(1))
+    streaming_reg
+    (.clk_i(clk_i)
+    ,.reset_i(reset_i)
+    ,.set_i(in_msg_v_i)
+    ,.clear_i(stream_clear)
+    ,.data_o(streaming_r)
+    );
 
-  wire has_data = payload_mask_p[msg_header_cast_i.msg_type];
+  assign in_msg_ready_and_o = out_msg_ready_and_i & ~streaming_r;
+
+  wire has_data = payload_mask_p[in_msg_header_lo.msg_type];
   localparam data_len_width_lp = `BSG_SAFE_CLOG2(stream_words_lp);
   wire [data_len_width_lp-1:0] num_stream_cmds = has_data
-    ? `BSG_MAX(((1'b1 << msg_cast_i.header.size) / out_data_bytes_lp), 1'b1)
+    ? `BSG_MAX(((1'b1 << in_msg_header_lo.size) / out_data_bytes_lp), 1'b1)
     : 1'b1;
-  logic [out_data_width_p-1:0] data_lo;
-  bsg_parallel_in_serial_out_dynamic
-   #(.width_p(out_data_width_p), .max_els_p(stream_words_lp))
-   piso
+  
+  logic first_lo;
+  bsg_parallel_in_serial_out_passthrough_dynamic
+   #(.width_p(out_data_width_p)
+   ,.max_els_p(stream_words_lp))
+   piso_passthrough
     (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+    ,.reset_i(reset_i)
 
-     ,.data_i(msg_cast_i.data)
-     ,.len_i(num_stream_cmds - 1'b1)
-     ,.v_i(in_msg_v_i)
+    // data_i and v_i should hold during the entire transcation
+    ,.data_i(in_msg_data_lo)
+    ,.v_i(in_msg_v_i | streaming_r)
+    ,.ready_and_o(/* unused */)
+    ,.len_i(num_stream_cmds - 1'b1)
 
-     ,.data_o(out_msg_data_o)
-     ,.v_o(out_msg_v_o)
-     ,.yumi_i(out_msg_ready_and_i & out_msg_v_o)
-
-     // We rely on the header fifo to handle ready/valid handshaking
-     ,.len_v_o(/* Unused */)
-     ,.ready_o(/* Unused */)
-     );
+    ,.data_o(out_msg_data_o)
+    ,.v_o(out_msg_v_o)
+    ,.ready_and_i(out_msg_ready_and_i)
+    ,.first_o(first_lo)  
+    );
 
   // We wouldn't need this counter if we could peek into the PISO...
-  logic [data_len_width_lp-1:0] first_cnt, last_cnt, last_cnt_r, current_cnt;
+  logic [data_len_width_lp-1:0] first_cnt, last_cnt, last_cnt_r, current_cnt, stream_cnt;
+  logic cnt_up;
+  assign cnt_up = out_msg_ready_and_i & out_msg_v_o;
   bsg_counter_set_en
    #(.max_val_p(stream_words_lp-1), .reset_val_p(0))
    data_counter
@@ -100,11 +119,11 @@ module bp_lite_to_stream
      ,.reset_i(reset_i)
 
      ,.set_i(in_msg_v_i)
-     ,.en_i(out_msg_ready_and_i & out_msg_v_o)
-     ,.val_i(first_cnt)
+     ,.en_i(cnt_up)
+     ,.val_i(first_cnt + cnt_up)
      ,.count_o(current_cnt)
      );
-  assign first_cnt = msg_cast_i.header.addr[stream_offset_width_lp+:data_len_width_lp];
+  assign first_cnt = in_msg_header_lo.addr[stream_offset_width_lp+:data_len_width_lp];
   assign last_cnt = first_cnt + num_stream_cmds - 1'b1;
   bsg_dff_en_bypass
    #(.width_p(data_len_width_lp))
@@ -115,21 +134,23 @@ module bp_lite_to_stream
     ,.data_o(last_cnt_r)
     );
   
-  wire cnt_done = (current_cnt == last_cnt_r);
+  assign stream_cnt = first_lo ? first_cnt : current_cnt;
+  wire cnt_done = (stream_cnt == last_cnt_r);
 
   bp_bedrock_out_msg_header_s msg_header_cast_o;
   assign out_msg_header_o = msg_header_cast_o;
+
   always_comb
     begin
       // Autoincrement address
-      msg_header_cast_o = header_lo;
-      msg_header_cast_o.addr = {header_lo.addr[paddr_width_p-1:stream_offset_width_lp+data_len_width_lp]
-                                ,current_cnt
-                                ,header_lo.addr[0+:stream_offset_width_lp]
+      msg_header_cast_o = in_msg_header_lo;
+      msg_header_cast_o.addr = {in_msg_header_lo.addr[paddr_width_p-1:stream_offset_width_lp+data_len_width_lp]
+                                ,stream_cnt
+                                ,in_msg_header_lo.addr[0+:stream_offset_width_lp]
                                 };
     end
   assign out_msg_last_o = out_msg_v_o & cnt_done;
-  assign msg_yumi_li = cnt_done & out_msg_ready_and_i & out_msg_v_o;
+  assign stream_clear = cnt_done & cnt_up;
 
   //synopsys translate_off
   initial

--- a/bp_me/src/v/wormhole/bp_lite_to_stream.sv
+++ b/bp_me/src/v/wormhole/bp_lite_to_stream.sv
@@ -1,5 +1,5 @@
 
-module bp_lite_to_stream_bypass
+module bp_lite_to_stream
  import bp_common_pkg::*;
  import bp_common_aviary_pkg::*;
  import bp_me_pkg::*;

--- a/bp_me/src/v/wormhole/bp_lite_to_stream.sv
+++ b/bp_me/src/v/wormhole/bp_lite_to_stream.sv
@@ -54,7 +54,7 @@ module bp_lite_to_stream
    #(.width_p($bits(bp_bedrock_in_msg_header_s)))
    header_reg
     (.clk_i(clk_i)
-    ,.en_i(in_msg_v_i)
+    ,.en_i(in_msg_ready_and_o & in_msg_v_i)
     ,.data_i(msg_cast_i.header)
     ,.data_o(in_msg_header_lo)
     );
@@ -63,7 +63,7 @@ module bp_lite_to_stream
    #(.width_p(in_data_width_p))
    data_reg
     (.clk_i(clk_i)
-    ,.en_i(in_msg_v_i)
+    ,.en_i(in_msg_ready_and_o & in_msg_v_i)
     ,.data_i(msg_cast_i.data)
     ,.data_o(in_msg_data_lo)
     );

--- a/bp_me/src/v/wormhole/bp_stream_to_lite.sv
+++ b/bp_me/src/v/wormhole/bp_stream_to_lite.sv
@@ -46,7 +46,6 @@ module bp_stream_to_lite
 
   bp_bedrock_in_msg_header_s in_msg_header_lo;
   logic [in_data_width_p-1:0] in_msg_data_lo;
-  logic streaming_r, stream_clear;
   bsg_dff_en_bypass
    #(.width_p($bits(bp_bedrock_in_msg_header_s)))
    header_reg
@@ -63,17 +62,6 @@ module bp_stream_to_lite
     ,.en_i(in_msg_v_i)
     ,.data_i(in_msg_data_i)
     ,.data_o(in_msg_data_lo)
-    );
-
-  bsg_dff_reset_set_clear
-   #(.width_p(1)
-   ,.clear_over_set_p(1))
-    streaming_reg
-    (.clk_i(clk_i)
-    ,.reset_i(reset_i)
-    ,.set_i(in_msg_v_i)
-    ,.clear_i(stream_clear)
-    ,.data_o(streaming_r)
     );
 
   wire has_data = payload_mask_p[in_msg_header_lo.msg_type];
@@ -100,7 +88,7 @@ module bp_stream_to_lite
     ,.ready_and_i(out_msg_ready_and_i)
     ,.first_o(/* unused */)
     );
-  assign stream_clear = in_msg_last_i & out_msg_v_o & out_msg_ready_and_i;
+  wire unused = in_msg_last_i; // counter in the sipo tracks the progress
 
   bp_bedrock_out_msg_s msg_cast_o;
   assign msg_cast_o = '{header: in_msg_header_lo, data: sipo_data_lo};

--- a/bp_me/src/v/wormhole/bp_stream_to_lite.sv
+++ b/bp_me/src/v/wormhole/bp_stream_to_lite.sv
@@ -45,14 +45,30 @@ module bp_stream_to_lite
   localparam stream_offset_width_lp = `BSG_SAFE_CLOG2(out_data_bytes_lp);
 
   bp_bedrock_in_msg_header_s in_msg_header_lo;
+  logic streaming_r, stream_clear;
+  // Accept no header when
+  // 1. SIPO is not ready (We should keep the corresponding header for the waiting data)
+  // 2. In streaming state (We want to latch the header with critical address) 
   bsg_dff_en_bypass
    #(.width_p($bits(bp_bedrock_in_msg_header_s)))
    header_reg
     (.clk_i(clk_i)
-    ,.en_i(in_msg_v_i)
+    ,.en_i(in_msg_ready_and_o & in_msg_v_i & ~streaming_r)
     ,.data_i(in_msg_header_i)
     ,.data_o(in_msg_header_lo)
     );
+
+  bsg_dff_reset_set_clear
+   #(.width_p(1)
+   ,.clear_over_set_p(1))
+    streaming_reg
+    (.clk_i(clk_i)
+    ,.reset_i(reset_i)
+    ,.set_i(in_msg_v_i)
+    ,.clear_i(stream_clear)
+    ,.data_o(streaming_r)
+    );
+  assign stream_clear = in_msg_last_i & out_msg_v_o & out_msg_ready_and_i;
 
   wire has_data = payload_mask_p[in_msg_header_lo.msg_type];
   localparam data_len_width_lp = `BSG_SAFE_CLOG2(stream_words_lp);
@@ -78,7 +94,6 @@ module bp_stream_to_lite
     ,.ready_and_i(out_msg_ready_and_i)
     ,.first_o(/* unused */)
     );
-  wire unused = in_msg_last_i; // counter in the sipo tracks the progress
 
   bp_bedrock_out_msg_s msg_cast_o;
   assign msg_cast_o = '{header: in_msg_header_lo, data: sipo_data_lo};

--- a/bp_me/src/v/wormhole/bp_stream_to_lite.sv
+++ b/bp_me/src/v/wormhole/bp_stream_to_lite.sv
@@ -1,5 +1,5 @@
 
-module bp_stream_to_lite_bypass
+module bp_stream_to_lite
  import bp_common_pkg::*;
  import bp_common_aviary_pkg::*;
  import bp_me_pkg::*;

--- a/bp_me/src/v/wormhole/bp_stream_to_lite.sv
+++ b/bp_me/src/v/wormhole/bp_stream_to_lite.sv
@@ -45,7 +45,6 @@ module bp_stream_to_lite
   localparam stream_offset_width_lp = `BSG_SAFE_CLOG2(out_data_bytes_lp);
 
   bp_bedrock_in_msg_header_s in_msg_header_lo;
-  logic [in_data_width_p-1:0] in_msg_data_lo;
   bsg_dff_en_bypass
    #(.width_p($bits(bp_bedrock_in_msg_header_s)))
    header_reg
@@ -53,15 +52,6 @@ module bp_stream_to_lite
     ,.en_i(in_msg_v_i)
     ,.data_i(in_msg_header_i)
     ,.data_o(in_msg_header_lo)
-    );
-
-  bsg_dff_en_bypass
-   #(.width_p(in_data_width_p))
-   data_reg
-    (.clk_i(clk_i)
-    ,.en_i(in_msg_v_i)
-    ,.data_i(in_msg_data_i)
-    ,.data_o(in_msg_data_lo)
     );
 
   wire has_data = payload_mask_p[in_msg_header_lo.msg_type];
@@ -78,7 +68,7 @@ module bp_stream_to_lite
     (.clk_i(clk_i)
     ,.reset_i(reset_i)
 
-    ,.data_i(in_msg_data_lo)
+    ,.data_i(in_msg_data_i)
     ,.v_i(in_msg_v_i)
     ,.ready_and_o(in_msg_ready_and_o)
     ,.len_i(num_stream_cmds-1'b1)

--- a/bp_me/src/v/wormhole/bp_stream_to_lite.sv
+++ b/bp_me/src/v/wormhole/bp_stream_to_lite.sv
@@ -91,7 +91,7 @@ module bp_stream_to_lite
     ,.reset_i(reset_i)
 
     ,.data_i(in_msg_data_lo)
-    ,.v_i(in_msg_v_i | streaming_r)
+    ,.v_i(in_msg_v_i)
     ,.ready_and_o(in_msg_ready_and_o)
     ,.len_i(num_stream_cmds-1'b1)
    

--- a/bp_me/src/v/wormhole/bp_stream_to_lite.sv
+++ b/bp_me/src/v/wormhole/bp_stream_to_lite.sv
@@ -1,5 +1,5 @@
 
-module bp_stream_to_lite
+module bp_stream_to_lite_bypass
  import bp_common_pkg::*;
  import bp_common_aviary_pkg::*;
  import bp_me_pkg::*;
@@ -44,57 +44,66 @@ module bp_stream_to_lite
   localparam stream_words_lp = out_data_width_p/in_data_width_p;
   localparam stream_offset_width_lp = `BSG_SAFE_CLOG2(out_data_bytes_lp);
 
-  bp_bedrock_in_msg_header_s header_lo;
-  bsg_one_fifo
+  bp_bedrock_in_msg_header_s in_msg_header_lo;
+  logic [in_data_width_p-1:0] in_msg_data_lo;
+  logic streaming_r, stream_clear;
+  bsg_dff_en_bypass
    #(.width_p($bits(bp_bedrock_in_msg_header_s)))
-   header_fifo
+   header_reg
     (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+    ,.en_i(in_msg_v_i)
+    ,.data_i(in_msg_header_i)
+    ,.data_o(in_msg_header_lo)
+    );
 
-     ,.data_i(in_msg_header_i)
-     // We ready on ready/and failing on the stream after the first
-     ,.v_i(in_msg_v_i)
+  bsg_dff_en_bypass
+   #(.width_p(in_data_width_p))
+   data_reg
+    (.clk_i(clk_i)
+    ,.en_i(in_msg_v_i)
+    ,.data_i(in_msg_data_i)
+    ,.data_o(in_msg_data_lo)
+    );
 
-     ,.data_o(header_lo)
-     ,.yumi_i(out_msg_ready_and_i & out_msg_v_o)
+  bsg_dff_reset_set_clear
+   #(.width_p(1)
+   ,.clear_over_set_p(1))
+    streaming_reg
+    (.clk_i(clk_i)
+    ,.reset_i(reset_i)
+    ,.set_i(in_msg_v_i)
+    ,.clear_i(stream_clear)
+    ,.data_o(streaming_r)
+    );
 
-     // We use the sipo ready/valid
-     ,.ready_o(/* Unused */)
-     ,.v_o(/* Unused */)
-     );
-
-  bp_bedrock_in_msg_header_s msg_header_cast_i;
-  assign msg_header_cast_i = in_msg_header_i;
-  wire has_data = payload_mask_p[msg_header_cast_i.msg_type];
+  wire has_data = payload_mask_p[in_msg_header_lo.msg_type];
   localparam data_len_width_lp = `BSG_SAFE_CLOG2(stream_words_lp);
   wire [data_len_width_lp-1:0] num_stream_cmds = has_data
-    ? `BSG_MAX(((1'b1 << msg_header_cast_i.size) / in_data_bytes_lp), 1'b1)
+    ? `BSG_MAX(((1'b1 << in_msg_header_lo.size) / in_data_bytes_lp), 1'b1)
     : 1'b1;
-  logic [out_data_width_p-1:0] data_lo;
-  logic data_ready_lo, len_ready_lo;
-  bsg_serial_in_parallel_out_dynamic
-   #(.width_p(in_data_width_p), .max_els_p(stream_words_lp))
-   sipo
+
+  logic [out_data_width_p-1:0] sipo_data_lo;
+  bsg_serial_in_parallel_out_passthrough_dynamic
+   #(.width_p(in_data_width_p)
+   ,.max_els_p(stream_words_lp))
+   sipo_passthrough
     (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+    ,.reset_i(reset_i)
 
-     ,.data_i(in_msg_data_i)
-     ,.len_i(num_stream_cmds-1'b1)
-     ,.ready_o(in_msg_ready_and_o)
-     ,.v_i(in_msg_v_i)
-
-     ,.data_o(data_lo)
-     ,.v_o(out_msg_v_o)
-     ,.yumi_i(out_msg_ready_and_i & out_msg_v_o)
-
-     // We rely on fifo ready signal
-     ,.len_ready_o(/* Unused */)
-     );
-
-  wire unused = &{in_msg_last_i};
+    ,.data_i(in_msg_data_lo)
+    ,.v_i(in_msg_v_i | streaming_r)
+    ,.ready_and_o(in_msg_ready_and_o)
+    ,.len_i(num_stream_cmds-1'b1)
+   
+    ,.data_o(sipo_data_lo)
+    ,.v_o(out_msg_v_o)
+    ,.ready_and_i(out_msg_ready_and_i)
+    ,.first_o(/* unused */)
+    );
+  assign stream_clear = in_msg_last_i & out_msg_v_o & out_msg_ready_and_i;
 
   bp_bedrock_out_msg_s msg_cast_o;
-  assign msg_cast_o = '{header: header_lo, data: data_lo};
+  assign msg_cast_o = '{header: in_msg_header_lo, data: sipo_data_lo};
   assign out_msg_o = msg_cast_o;
 
   //synopsys translate_off
@@ -109,7 +118,7 @@ module bp_stream_to_lite
   always_ff @(negedge clk_i)
     begin
     //  if (in_msg_v_i)
-    //    $display("[%t] Stream received: %p %x", $time, msg_header_cast_i, in_msg_data_i);
+    //    $display("[%t] Stream received: %p %x", $time, in_msg_header_i, in_msg_data_i);
 
     //  if (out_msg_ready_and_i & out_msg_v_o)
     //    $display("[%t] Msg sent: %p", $time, msg_cast_o);

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -66,6 +66,7 @@ $BASEJUMP_STL_DIR/bsg_dataflow/bsg_one_fifo.v
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_parallel_in_serial_out.v
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_parallel_in_serial_out_dynamic.v
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_parallel_in_serial_out_passthrough.v
+$BASEJUMP_STL_DIR/bsg_dataflow/bsg_parallel_in_serial_out_passthrough_dynamic.v
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_round_robin_1_to_n.v
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_round_robin_2_to_2.v
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_round_robin_n_to_1.v
@@ -73,6 +74,7 @@ $BASEJUMP_STL_DIR/bsg_dataflow/bsg_serial_in_parallel_out.v
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_serial_in_parallel_out_dynamic.v
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_serial_in_parallel_out_full.v
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_serial_in_parallel_out_passthrough.v
+$BASEJUMP_STL_DIR/bsg_dataflow/bsg_serial_in_parallel_out_passthrough_dynamic.v
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_shift_reg.v
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_two_fifo.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_cam_1r1w.v


### PR DESCRIPTION
This PR is aimed at fixing issue #730.

In current design of lite to stream modules, header and data buffers account for a majority of area consumption. Also, a bubble is introduced between consecutive requests, which is very inefficient, especially for uncached requests.

This PR replaces the header fifo with bypass registers, and make use of the sipo/piso_passthrough_dynamic to hold the data. These changes not only reduce the area consumption of the conversion modules, but also eliminate the bubbles between consecutive requests and improve the performance.