### PR TITLE
Adding AMO subop types and cache req metadata updates

### DIFF
--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -740,29 +740,30 @@ module bp_be_dcache
         cache_req_cast_o.msg_type = e_miss_store;
       else if (store_miss_tv)
         cache_req_cast_o.msg_type = e_miss_store;
-      else if (wt_req)
-        cache_req_cast_o.msg_type = e_wt_store;
       else if (uncached_load_req)
         cache_req_cast_o.msg_type = e_uc_load;
-      else if (uncached_store_req)
-        cache_req_cast_o.msg_type = e_uc_store;
       else if (fencei_req)
         cache_req_cast_o.msg_type = e_cache_flush;
+      else if (uncached_store_req | wt_req)
+        begin
+          cache_req_cast_o.msg_type = e_uc_store;
+          cache_req_cast_o.subop = e_req_amoswap;
+        end
       else
         begin
+          cache_req_cast_o.msg_type = e_uc_store;
           unique casez (decode_tv_r.amo_subop)
-            e_dcache_subop_lr     : cache_req_cast_o.msg_type = e_amo_lr;
-            e_dcache_subop_sc     : cache_req_cast_o.msg_type = e_amo_sc;
-            e_dcache_subop_amoswap: cache_req_cast_o.msg_type = e_amo_swap;
-            e_dcache_subop_amoadd : cache_req_cast_o.msg_type = e_amo_add;
-            e_dcache_subop_amoxor : cache_req_cast_o.msg_type = e_amo_xor;
-            e_dcache_subop_amoand : cache_req_cast_o.msg_type = e_amo_and;
-            e_dcache_subop_amoor  : cache_req_cast_o.msg_type = e_amo_or;
-            e_dcache_subop_amomin : cache_req_cast_o.msg_type = e_amo_min;
-            e_dcache_subop_amomax : cache_req_cast_o.msg_type = e_amo_max;
-            e_dcache_subop_amominu: cache_req_cast_o.msg_type = e_amo_minu;
-            //e_dcache_subop_amomaxu
-            default               : cache_req_cast_o.msg_type = e_amo_maxu;
+            e_dcache_subop_lr     : cache_req_cast_o.subop = e_req_amolr;
+            e_dcache_subop_sc     : cache_req_cast_o.subop = e_req_amosc;
+            e_dcache_subop_amoadd : cache_req_cast_o.subop = e_req_amoadd;
+            e_dcache_subop_amoxor : cache_req_cast_o.subop = e_req_amoxor;
+            e_dcache_subop_amoand : cache_req_cast_o.subop = e_req_amoand;
+            e_dcache_subop_amoor  : cache_req_cast_o.subop = e_req_amoor;
+            e_dcache_subop_amomin : cache_req_cast_o.subop = e_req_amomin;
+            e_dcache_subop_amomax : cache_req_cast_o.subop = e_req_amomax;
+            e_dcache_subop_amominu: cache_req_cast_o.subop = e_req_amominu;
+            e_dcache_subop_amomaxu: cache_req_cast_o.subop = e_req_amomaxu;
+            default : cache_req_cast_o.subop = e_req_amoswap;
           endcase
         end
     end
@@ -780,7 +781,9 @@ module bp_be_dcache
      ,.data_o(cache_req_metadata_v_o)
      );
 
-  assign cache_req_metadata_cast_o.repl_way = lru_way_li;
+  // TODO: Send hit way on non misses. fencei?
+  assign cache_req_metadata_cast_o.hit_or_repl_way = lru_way_li;
+  assign cache_req_metadata_cast_o.hit_not_repl    = 1'b0;
   assign cache_req_metadata_cast_o.dirty = stat_mem_data_lo.dirty[lru_way_li];
 
   /////////////////////////////////////////////////////////////////////////////

--- a/bp_common/src/include/bp_common_bedrock_if.svh
+++ b/bp_common/src/include/bp_common_bedrock_if.svh
@@ -60,6 +60,7 @@
       logic [payload_width_mp-1:0]                 payload;                                 \
       bp_bedrock_msg_size_e                        size;                                    \
       logic [addr_width_mp-1:0]                    addr;                                    \
+      bp_bedrock_wr_subop_e                        subop;                                   \
       bp_bedrock_msg_u                             msg_type;                                \
     } bp_bedrock_``name_mp``_msg_header_s;                                                  \
                                                                                             \
@@ -157,7 +158,7 @@
    */
 
   `define bp_bedrock_msg_header_width(addr_width_mp, payload_width_mp) \
-    ($bits(bp_bedrock_msg_u)+addr_width_mp+$bits(bp_bedrock_msg_size_e)+payload_width_mp)
+    ($bits(bp_bedrock_msg_u)+$bits(bp_bedrock_wr_subop_e)+addr_width_mp+$bits(bp_bedrock_msg_size_e)+payload_width_mp)
 
   `define bp_bedrock_msg_width(addr_width_mp, payload_width_mp, data_width_mp) \
     (`bp_bedrock_msg_header_width(addr_width_mp, payload_width_mp)+data_width_mp)

--- a/bp_common/src/include/bp_common_bedrock_if.svh
+++ b/bp_common/src/include/bp_common_bedrock_if.svh
@@ -88,6 +88,7 @@
     {                                                                                  \
       logic [`BSG_SAFE_CLOG2(lce_assoc_mp)-1:0]    lru_way_id;                         \
       bp_bedrock_req_non_excl_e                    non_exclusive;                      \
+      bp_bedrock_wr_subop_e                        subop;                              \
       logic [lce_id_width_mp-1:0]                  src_id;                             \
       logic [cce_id_width_mp-1:0]                  dst_id;                             \
     } bp_bedrock_``name_mp``_req_payload_s;                                            \
@@ -129,7 +130,7 @@
    */
 
   `define bp_bedrock_req_payload_width(lce_id_width_mp, cce_id_width_mp, lce_assoc_mp) \
-    (cce_id_width_mp+lce_id_width_mp+$bits(bp_bedrock_req_non_excl_e)+`BSG_SAFE_CLOG2(lce_assoc_mp))
+    (cce_id_width_mp+lce_id_width_mp+$bits(bp_bedrock_req_non_excl_e)+$bits(bp_bedrock_wr_subop_e)+`BSG_SAFE_CLOG2(lce_assoc_mp))
 
   `define bp_bedrock_cmd_payload_width(lce_id_width_mp, cce_id_width_mp, lce_assoc_mp) \
     ((2*lce_id_width_mp)+cce_id_width_mp+(2*`BSG_SAFE_CLOG2(lce_assoc_mp))+(2*$bits(bp_coh_states_e)))

--- a/bp_common/src/include/bp_common_bedrock_pkgdef.svh
+++ b/bp_common/src/include/bp_common_bedrock_pkgdef.svh
@@ -58,8 +58,29 @@
     ,e_bedrock_req_wr        = 4'b0001 // Write-miss
     ,e_bedrock_req_uc_rd     = 4'b0010 // Uncached Read-miss
     ,e_bedrock_req_uc_wr     = 4'b0011 // Uncached Write-miss
+    ,e_bedrock_req_amo       = 4'b0100 // AMO
     // 4'b0100 - 4'b1111 reserved / custom
   } bp_bedrock_req_type_e;
+
+  /*
+   * bp_bedrock_wr_subop_e specifies the type of store
+   */
+  typedef enum logic [3:0]
+  {
+      e_store             = 4'b0000
+      ,e_amo_lr           = 4'b0001
+      ,e_amo_sc           = 4'b0010
+      ,e_amo_swap         = 4'b0011
+      ,e_amo_add          = 4'b0100
+      ,e_amo_xor          = 4'b0101
+      ,e_amo_and          = 4'b0110
+      ,e_amo_or           = 4'b0111
+      ,e_amo_min          = 4'b1000
+      ,e_amo_max          = 4'b1001
+      ,e_amo_minu         = 4'b1010
+      ,e_amo_maxu         = 4'b1011
+  } bp_bedrock_wr_subop_e;
+
 
   /*
    * bp_bedrock_cmd_type_e defines the various commands that an CCE may issue to an LCE

--- a/bp_common/src/include/bp_common_bedrock_pkgdef.svh
+++ b/bp_common/src/include/bp_common_bedrock_pkgdef.svh
@@ -45,6 +45,7 @@
     ,e_bedrock_mem_uc_rd   = 4'b0010  // Uncached load (uncached in L2/LLC)
     ,e_bedrock_mem_uc_wr   = 4'b0011  // Uncached store (uncached in L2/LLC)
     ,e_bedrock_mem_pre     = 4'b0100  // Pre-fetch block request from CCE, fill into L2/LLC if able
+    ,e_bedrock_mem_amo     = 4'b0101  // Atomic operation in L2/LLC
     // 4'b0101 - 4'b1111 reserved // custom
   } bp_bedrock_mem_type_e;
 
@@ -67,18 +68,17 @@
    */
   typedef enum logic [3:0]
   {
-      e_store             = 4'b0000
-      ,e_amo_lr           = 4'b0001
-      ,e_amo_sc           = 4'b0010
-      ,e_amo_swap         = 4'b0011
-      ,e_amo_add          = 4'b0100
-      ,e_amo_xor          = 4'b0101
-      ,e_amo_and          = 4'b0110
-      ,e_amo_or           = 4'b0111
-      ,e_amo_min          = 4'b1000
-      ,e_amo_max          = 4'b1001
-      ,e_amo_minu         = 4'b1010
-      ,e_amo_maxu         = 4'b1011
+      e_bedrock_amoswap          = 4'b0000
+      ,e_bedrock_amolr           = 4'b0001
+      ,e_bedrock_amosc           = 4'b0010
+      ,e_bedrock_amoadd          = 4'b0011
+      ,e_bedrock_amoxor          = 4'b0100
+      ,e_bedrock_amoand          = 4'b0101
+      ,e_bedrock_amoor           = 4'b0110
+      ,e_bedrock_amomin          = 4'b0111
+      ,e_bedrock_amomax          = 4'b1000
+      ,e_bedrock_amominu         = 4'b1001
+      ,e_bedrock_amomaxu         = 4'b1010
   } bp_bedrock_wr_subop_e;
 
 

--- a/bp_common/src/include/bp_common_cache_engine_if.svh
+++ b/bp_common/src/include/bp_common_cache_engine_if.svh
@@ -5,26 +5,15 @@
 `ifndef BP_COMMON_CACHE_ENGINE_SVH
 `define BP_COMMON_CACHE_ENGINE_SVH
 
-  typedef enum logic [4:0]
+  typedef enum logic [3:0]
   {
-    e_miss_load         = 5'b00000
-    ,e_miss_store       = 5'b00001
-    ,e_uc_load          = 5'b00010
-    ,e_uc_store         = 5'b00011
-    ,e_wt_store         = 5'b00100
-    ,e_cache_flush      = 5'b00101
-    ,e_cache_clear      = 5'b00110
-    ,e_amo_lr           = 5'b00111
-    ,e_amo_sc           = 5'b01000
-    ,e_amo_swap         = 5'b01001
-    ,e_amo_add          = 5'b01010
-    ,e_amo_xor          = 5'b01011
-    ,e_amo_and          = 5'b01100
-    ,e_amo_or           = 5'b01101
-    ,e_amo_min          = 5'b01110
-    ,e_amo_max          = 5'b01111
-    ,e_amo_minu         = 5'b10000
-    ,e_amo_maxu         = 5'b10001
+    e_miss_load         = 4'b0000
+    ,e_miss_store       = 4'b0001
+    ,e_uc_load          = 4'b0010
+    ,e_uc_store         = 4'b0011
+    ,e_cache_flush      = 4'b0101
+    ,e_cache_clear      = 4'b0110
+    ,e_amo              = 4'b0111
   } bp_cache_req_msg_type_e;
 
   typedef enum logic [2:0]
@@ -38,6 +27,21 @@
     ,e_size_64B  = 3'b110
   } bp_cache_req_size_e;
 
+  typedef enum logic [3:0]
+  {
+    e_req_amoswap  = 4'b0000
+    ,e_req_amolr   = 4'b0001
+    ,e_req_amosc   = 4'b0010
+    ,e_req_amoadd  = 4'b0011
+    ,e_req_amoxor  = 4'b0100
+    ,e_req_amoand  = 4'b0101
+    ,e_req_amoor   = 4'b0110
+    ,e_req_amomin  = 4'b0111
+    ,e_req_amomax  = 4'b1000
+    ,e_req_amominu = 4'b1001
+    ,e_req_amomaxu = 4'b1010
+  } bp_cache_req_wr_subop_e;
+
   `define declare_bp_cache_req_s(data_width_mp, paddr_width_mp, cache_name_mp) \
     typedef struct packed                             \
     {                                                 \
@@ -45,20 +49,22 @@
       bp_cache_req_size_e size;                       \
       logic [paddr_width_mp-1:0] addr;                \
       bp_cache_req_msg_type_e msg_type;               \
+      bp_cache_req_wr_subop_e subop;                  \
     }  bp_``cache_name_mp``_req_s
 
   `define bp_cache_req_width(data_width_mp, paddr_width_mp) \
-    (data_width_mp+$bits(bp_cache_req_size_e) +paddr_width_mp+$bits(bp_cache_req_msg_type_e))
+    (data_width_mp+$bits(bp_cache_req_size_e)+paddr_width_mp+$bits(bp_cache_req_msg_type_e)+$bits(bp_cache_req_wr_subop_e))
 
   `define declare_bp_cache_req_metadata_s(ways_mp, cache_name_mp) \
-    typedef struct packed                              \
-    {                                                  \
-      logic [`BSG_SAFE_CLOG2(ways_mp)-1:0] repl_way;   \
-      logic dirty;                                     \
+    typedef struct packed                                   \
+    {                                                       \
+      logic [`BSG_SAFE_CLOG2(ways_mp)-1:0] hit_or_repl_way; \
+      logic hit_not_repl;                                   \
+      logic dirty;                                          \
     }  bp_``cache_name_mp``_req_metadata_s
 
   `define bp_cache_req_metadata_width(ways_mp) \
-    (`BSG_SAFE_CLOG2(ways_mp)+1)
+    (`BSG_SAFE_CLOG2(ways_mp)+2)
 
     typedef enum logic [1:0]
     {// write cache block

--- a/bp_common/src/include/bp_common_cache_engine_if.svh
+++ b/bp_common/src/include/bp_common_cache_engine_if.svh
@@ -45,6 +45,7 @@
   `define declare_bp_cache_req_s(data_width_mp, paddr_width_mp, cache_name_mp) \
     typedef struct packed                             \
     {                                                 \
+      logic hit;                                      \
       logic [data_width_mp-1:0] data;                 \
       bp_cache_req_size_e size;                       \
       logic [paddr_width_mp-1:0] addr;                \
@@ -53,18 +54,17 @@
     }  bp_``cache_name_mp``_req_s
 
   `define bp_cache_req_width(data_width_mp, paddr_width_mp) \
-    (data_width_mp+$bits(bp_cache_req_size_e)+paddr_width_mp+$bits(bp_cache_req_msg_type_e)+$bits(bp_cache_req_wr_subop_e))
+    (1+data_width_mp+$bits(bp_cache_req_size_e)+paddr_width_mp+$bits(bp_cache_req_msg_type_e)+$bits(bp_cache_req_wr_subop_e))
 
   `define declare_bp_cache_req_metadata_s(ways_mp, cache_name_mp) \
     typedef struct packed                                   \
     {                                                       \
       logic [`BSG_SAFE_CLOG2(ways_mp)-1:0] hit_or_repl_way; \
-      logic hit_not_repl;                                   \
       logic dirty;                                          \
     }  bp_``cache_name_mp``_req_metadata_s
 
   `define bp_cache_req_metadata_width(ways_mp) \
-    (`BSG_SAFE_CLOG2(ways_mp)+2)
+    (`BSG_SAFE_CLOG2(ways_mp)+1)
 
     typedef enum logic [1:0]
     {// write cache block

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -388,6 +388,7 @@ module bp_fe_icache
    '{addr     : paddr_tv_r
      ,size    : cached_req ? block_req_size : uncached_req_size
      ,msg_type: cached_req ? e_miss_load : uncached_req ? e_uc_load : e_cache_clear
+     ,subop   : e_req_amoswap
      ,data    : '0
      };
 
@@ -420,8 +421,10 @@ module bp_fe_icache
      ,.addr_o(way_invalid_index)
      );
 
+  // TODO: Does hit way matter for I$?
   // invalid way takes priority over LRU way
-  assign cache_req_metadata_cast_o.repl_way = invalid_exist ? way_invalid_index : lru_encode;
+  assign cache_req_metadata_cast_o.hit_or_repl_way = invalid_exist ? way_invalid_index : lru_encode;
+  assign cache_req_metadata_cast_o.hit_not_repl = 1'b0;
   assign cache_req_metadata_cast_o.dirty = '0;
 
   /////////////////////////////////////////////////////////////////////////////

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -283,6 +283,7 @@ module bp_fe_icache
      ,.w_i(stat_mem_w_li)
      ,.data_o(stat_mem_data_lo.lru)
      );
+  assign stat_mem_data_lo.dirty = '0;
 
   /////////////////////////////////////////////////////////////////////////////
   // TV stage
@@ -331,6 +332,16 @@ module bp_fe_icache
                ,bank_sel_one_hot_tv_r, way_v_tv_r, hit_v_tv_r, cached_hit_tv_r, uncached_hit_tv_r
                ,fencei_op_tv_r, uncached_op_tv_r, cached_op_tv_r
                })
+     );
+
+
+  logic [lg_icache_assoc_lp-1:0] hit_index_tv;
+  bsg_encode_one_hot
+   #(.width_p(assoc_p), .lo_to_hi_p(1))
+   hit_index_encoder
+    (.i(hit_v_tv_r)
+     ,.addr_o(hit_index_tv)
+     ,.v_o()
      );
 
   // One-hot data muxing
@@ -390,6 +401,7 @@ module bp_fe_icache
      ,msg_type: cached_req ? e_miss_load : uncached_req ? e_uc_load : e_cache_clear
      ,subop   : e_req_amoswap
      ,data    : '0
+     ,hit     : cached_hit_tv_r
      };
 
   // The cache pipeline is designed to always send metadata a cycle after the request
@@ -421,10 +433,18 @@ module bp_fe_icache
      ,.addr_o(way_invalid_index)
      );
 
-  // TODO: Does hit way matter for I$?
-  // invalid way takes priority over LRU way
-  assign cache_req_metadata_cast_o.hit_or_repl_way = invalid_exist ? way_invalid_index : lru_encode;
-  assign cache_req_metadata_cast_o.hit_not_repl = 1'b0;
+  logic metadata_hit_r;
+  logic [lg_icache_assoc_lp-1:0] metadata_hit_index_r;
+  bsg_dff
+   #(.width_p(1+lg_icache_assoc_lp))
+   cached_hit_reg
+    (.clk_i(clk_i)
+     ,.data_i({cached_hit_tv_r, hit_index_tv})
+     ,.data_o({metadata_hit_r, metadata_hit_index_r})
+     );
+
+  wire [assoc_p-1:0] hit_or_repl_way = metadata_hit_r ? metadata_hit_index_r : lru_encode;
+  assign cache_req_metadata_cast_o.hit_or_repl_way = hit_or_repl_way;
   assign cache_req_metadata_cast_o.dirty = '0;
 
   /////////////////////////////////////////////////////////////////////////////
@@ -625,15 +645,6 @@ module bp_fe_icache
     ? paddr_tv_r[block_offset_width_lp+:sindex_width_lp]
     : stat_mem_pkt_cast_i.index;
 
-  logic [lg_icache_assoc_lp-1:0] hit_index_tv;
-  bsg_encode_one_hot
-   #(.width_p(assoc_p), .lo_to_hi_p(1))
-   hit_index_encoder
-    (.i(hit_v_tv_r)
-     ,.addr_o(hit_index_tv)
-     ,.v_o()
-     );
-
   logic [`BSG_SAFE_MINUS(assoc_p, 2):0] lru_decode_data_lo, lru_decode_mask_lo;
   bsg_lru_pseudo_tree_decode
    #(.ways_p(assoc_p))
@@ -646,7 +657,7 @@ module bp_fe_icache
   assign stat_mem_data_li.lru = stat_mem_fast_write ? lru_decode_data_lo : '0;
   assign stat_mem_mask_li.lru = stat_mem_fast_write ? lru_decode_mask_lo : '1;
 
-  assign stat_mem_o = {stat_mem_data_lo.lru, assoc_p'(0)};
+  assign stat_mem_o = stat_mem_data_lo;
 
   ///////////////////////////
   // Uncached data storage
@@ -680,4 +691,3 @@ module bp_fe_icache
   //synopsys translate_on
 
 endmodule
-

--- a/bp_me/src/v/cache/bp_me_cache_slice.sv
+++ b/bp_me/src/v/cache/bp_me_cache_slice.sv
@@ -126,6 +126,7 @@ module bp_me_cache_slice
   `declare_bp_bedrock_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce);
   `bp_cast_o(bp_bedrock_cce_mem_msg_header_s, mem_cmd_header);
   assign mem_cmd_header_cast_o = '{msg_type : dma_pkt_lo.write_not_read ? e_bedrock_mem_wr : e_bedrock_mem_rd
+                                   ,subop   : e_bedrock_amoswap
                                    ,size    : mem_cmd_block_size
                                    ,addr    : dma_pkt_lo.addr
                                    ,payload : '0

--- a/bp_me/src/v/lce/bp_lce_req.sv
+++ b/bp_me/src/v/lce/bp_lce_req.sv
@@ -251,7 +251,7 @@ module bp_lce_req
           ? e_bedrock_req_rd
           : e_bedrock_req_wr;
 
-        lce_req_payload.lru_way_id = lg_lce_assoc_lp'(cache_req_metadata_r.repl_way);
+        lce_req_payload.lru_way_id = lg_lce_assoc_lp'(cache_req_metadata_r.hit_or_repl_way);
         lce_req_payload.non_exclusive = (cache_req_r.msg_type == e_miss_load)
           ? (non_excl_reads_p == 1)
             ? e_bedrock_req_non_excl

--- a/bp_top/src/v/bp_clint_slice.sv
+++ b/bp_top/src/v/bp_clint_slice.sv
@@ -168,6 +168,7 @@ bp_bedrock_xce_mem_msg_s mem_resp_lo;
 assign mem_resp_lo =
   '{header : '{
     msg_type       : mem_cmd_lo.header.msg_type
+    ,subop         : e_bedrock_amoswap
     ,addr          : mem_cmd_lo.header.addr
     ,payload       : mem_cmd_lo.header.payload
     ,size          : mem_cmd_lo.header.size

--- a/bp_top/test/common/bp_nonsynth_cache_tracer.sv
+++ b/bp_top/test/common/bp_nonsynth_cache_tracer.sv
@@ -142,8 +142,6 @@ module bp_nonsynth_cache_tracer
       op = "[load]";
     else if (cache_req_v_o & cache_req_cast_o.msg_type == e_uc_load)
       op = "[uncached load]";
-    else if (cache_req_v_o & cache_req_cast_o.msg_type == e_wt_store)
-      op = "[writethrough store]";
     else if (cache_req_v_o & cache_req_cast_o.msg_type == e_uc_store)
       op = "[uncached store]";
     else if (cache_req_v_o & cache_req_cast_o.msg_type == e_cache_flush)
@@ -208,7 +206,7 @@ module bp_nonsynth_cache_tracer
       end
 
       if (cache_req_metadata_v_o)
-        $fwrite(file, "[%t] lru_way: %x dirty: %x \n", $time, cache_req_metadata_cast_o.repl_way, cache_req_metadata_cast_o.dirty);
+        $fwrite(file, "[%t] lru_way: %x dirty: %x \n", $time, cache_req_metadata_cast_o.hit_or_repl_way, cache_req_metadata_cast_o.dirty);
 
       if (cache_req_complete_i)
         $fwrite(file, "[%t] Cache request completed \n", $time);


### PR DESCRIPTION
This PR adds AMO subop types and cache req metadata changes needed for L2 atomic support. I believe it has no functional changes as currently written.