### PR TITLE
Fixes non-idempotency in the I$

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -178,6 +178,7 @@ module bp_be_pipe_mem
      ,.sum_i(trans_info.mstatus_sum)
      ,.trans_en_i(trans_info.translation_en)
      ,.uncached_mode_i((cfg_bus.dcache_mode == e_lce_mode_uncached))
+     ,.nonspec_mode_i((cfg_bus.dcache_mode == e_lce_mode_nonspec))
      ,.domain_mask_i(cfg_bus.domain_mask)
 
      ,.w_v_i(dtlb_w_v)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -194,6 +194,7 @@ module bp_be_pipe_mem
      ,.r_ptag_o(dtlb_ptag_lo)
      ,.r_miss_o(dtlb_miss_v)
      ,.r_uncached_o(dcache_uncached)
+     ,.r_nonidem_o(/* All D$ misses are non-speculative */)
      ,.r_instr_access_fault_o()
      ,.r_load_access_fault_o(load_access_fault_v)
      ,.r_store_access_fault_o(store_access_fault_v)

--- a/bp_common/src/include/bp_common_cfg_bus_pkgdef.svh
+++ b/bp_common/src/include/bp_common_cfg_bus_pkgdef.svh
@@ -2,9 +2,15 @@
 `ifndef BP_COMMON_CFG_BUS_PKGDEF_SVH
 `define BP_COMMON_CFG_BUS_PKGDEF_SVH
 
-  typedef enum logic {
+  // LCE Operating Mode
+  // e_lce_mode_uncached: Cache treats all requests as uncached
+  // e_lce_mode_normal: Cache acts normally
+  // e_lce_mode_nonspec: Cache acts mostly normally, but will not send a speculative miss
+  typedef enum logic [1:0]
+  {
     e_lce_mode_uncached = 0
     ,e_lce_mode_normal  = 1
+    ,e_lce_mode_nonspec = 2
   } bp_lce_mode_e;
 
   // CCE Operating Mode
@@ -42,7 +48,6 @@
   localparam cfg_reg_dcache_mode_gp    = 'h0043;
   localparam cfg_reg_cce_id_gp         = 'h0080;
   localparam cfg_reg_cce_mode_gp       = 'h0081;
-  localparam cfg_reg_num_lce_gp        = 'h0082;
   localparam cfg_mem_base_cce_ucode_gp = 'h8000;
 
 `endif

--- a/bp_common/src/v/bp_mmu.sv
+++ b/bp_common/src/v/bp_mmu.sv
@@ -21,6 +21,7 @@ module bp_mmu
    , input                                            trans_en_i
    , input                                            sum_i
    , input                                            uncached_mode_i
+   , input                                            nonspec_mode_i
    , input [domain_width_p-1:0]                       domain_mask_i
 
    , input                                            w_v_i
@@ -128,6 +129,8 @@ module bp_mmu
 
      ,.ptag_v_i(ptag_v_lo)
      ,.ptag_i(ptag_lo)
+     ,.uncached_mode_i(uncached_mode_i)
+     ,.nonspec_mode_i(nonspec_mode_i)
 
      ,.uncached_o(ptag_uncached_lo)
      ,.nonidem_o(ptag_nonidem_lo)
@@ -135,16 +138,14 @@ module bp_mmu
 
   // Fault if higher bits of eaddr do not match vaddr MSB
   wire eaddr_fault_v = ~&r_etag_r[etag_width_p-1:vtag_width_p-1] & |r_etag_r[etag_width_p-1:vtag_width_p-1];
-  // Fault if in uncached mode but access is not for an uncached address
-  wire mode_fault_v  = (uncached_mode_i & ~r_uncached_o);
   // Fault if domain bit is not enabled and we're accessing that domain
   wire domain_fault_v = (r_instr_r & ptag_lo[ptag_width_p-1-:domain_width_p] != '0)
     || (ptag_lo[ptag_width_p-1-:domain_width_p] & ~domain_mask_i);
 
   // Access faults
-  wire instr_access_fault_v = r_instr_r & (mode_fault_v | domain_fault_v);
-  wire load_access_fault_v  = r_load_r  & (mode_fault_v | domain_fault_v);
-  wire store_access_fault_v = r_store_r & (mode_fault_v | domain_fault_v);
+  wire instr_access_fault_v = r_instr_r & domain_fault_v;
+  wire load_access_fault_v  = r_load_r  & domain_fault_v;
+  wire store_access_fault_v = r_store_r & domain_fault_v;
   wire any_access_fault_v   = |{instr_access_fault_v, load_access_fault_v, store_access_fault_v};
 
   // Page faults

--- a/bp_common/src/v/bp_mmu.sv
+++ b/bp_common/src/v/bp_mmu.sv
@@ -37,6 +37,7 @@ module bp_mmu
    , output logic [ptag_width_p-1:0]                  r_ptag_o
    , output logic                                     r_miss_o
    , output logic                                     r_uncached_o
+   , output logic                                     r_nonidem_o
    , output logic                                     r_instr_access_fault_o
    , output logic                                     r_load_access_fault_o
    , output logic                                     r_store_access_fault_o
@@ -118,7 +119,7 @@ module bp_mmu
 
   wire ptag_v_lo                  = tlb_v_lo;
   wire [ptag_width_p-1:0] ptag_lo = tlb_entry_lo.ptag;
-  logic ptag_uncached_lo;
+  logic ptag_uncached_lo, ptag_nonidem_lo;
   bp_pma
    #(.bp_params_p(bp_params_p))
    pma
@@ -129,6 +130,7 @@ module bp_mmu
      ,.ptag_i(ptag_lo)
 
      ,.uncached_o(ptag_uncached_lo)
+     ,.nonidem_o(ptag_nonidem_lo)
      );
 
   // Fault if higher bits of eaddr do not match vaddr MSB
@@ -161,6 +163,7 @@ module bp_mmu
   assign r_ptag_o                = ptag_lo;
   assign r_miss_o                = r_v_r & ~tlb_v_lo;
   assign r_uncached_o            = r_v_r & tlb_v_lo & ptag_uncached_lo;
+  assign r_nonidem_o             = r_v_r & tlb_v_lo & ptag_nonidem_lo;
   assign r_instr_access_fault_o  = r_v_r & tlb_v_lo & instr_access_fault_v;
   assign r_load_access_fault_o   = r_v_r & tlb_v_lo & load_access_fault_v;
   assign r_store_access_fault_o  = r_v_r & tlb_v_lo & store_access_fault_v;

--- a/bp_common/src/v/bp_pma.sv
+++ b/bp_common/src/v/bp_pma.sv
@@ -12,13 +12,15 @@ module bp_pma
    , input                        ptag_v_i
    , input [ptag_width_p-1:0]     ptag_i
 
-   , output                       uncached_o
+   , output logic                 uncached_o
+   , output logic                 nonidem_o
    );
 
   wire is_local_addr = (ptag_i < (dram_base_addr_gp >> page_offset_width_gp));
   wire is_io_addr    = (ptag_i[ptag_width_p-1-:domain_width_p] != '0);
 
   assign uncached_o = ptag_v_i & (is_local_addr | is_io_addr);
+  assign nonidem_o = ptag_v_i & (is_io_addr);
 
 endmodule
 

--- a/bp_common/src/v/bp_pma.sv
+++ b/bp_common/src/v/bp_pma.sv
@@ -11,6 +11,8 @@ module bp_pma
 
    , input                        ptag_v_i
    , input [ptag_width_p-1:0]     ptag_i
+   , input                        uncached_mode_i
+   , input                        nonspec_mode_i
 
    , output logic                 uncached_o
    , output logic                 nonidem_o
@@ -19,8 +21,10 @@ module bp_pma
   wire is_local_addr = (ptag_i < (dram_base_addr_gp >> page_offset_width_gp));
   wire is_io_addr    = (ptag_i[ptag_width_p-1-:domain_width_p] != '0);
 
-  assign uncached_o = ptag_v_i & (is_local_addr | is_io_addr);
-  assign nonidem_o = ptag_v_i & (is_io_addr);
+  assign uncached_o = ptag_v_i & (is_local_addr | is_io_addr | uncached_mode_i);
+  // For now, uncached mode also means non-idempotency. Will reevaluate if we need
+  //   a high-performance, unsafe, uncached mode
+  assign nonidem_o  = ptag_v_i & (is_io_addr | uncached_mode_i | nonspec_mode_i);
 
 endmodule
 

--- a/bp_fe/src/include/bp_fe_icache_pkgdef.svh
+++ b/bp_fe/src/include/bp_fe_icache_pkgdef.svh
@@ -5,6 +5,7 @@
   {
     e_icache_fetch
     ,e_icache_fencei
+    ,e_icache_fill
   } bp_fe_icache_op_e;
 
 `endif

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -67,8 +67,9 @@ module bp_fe_icache
 
    // Cycle 2: "Tag Verify"
    // Data (or miss result) comes out of the cache
-   , output [instr_width_gp-1:0]                      data_o
-   , output                                           data_v_o
+   , output logic [instr_width_gp-1:0]                data_o
+   , output logic                                     data_v_o
+   , output logic                                     miss_v_o
    , input                                            poison_tv_i
 
    // Cache Engine Interface
@@ -89,7 +90,7 @@ module bp_fe_icache
    , input                                            data_mem_pkt_v_i
    , input [icache_data_mem_pkt_width_lp-1:0]         data_mem_pkt_i
    , output logic                                     data_mem_pkt_yumi_o
-   , output logic [block_width_p-1:0]          data_mem_o
+   , output logic [block_width_p-1:0]                 data_mem_o
 
    , input                                            tag_mem_pkt_v_i
    , input [icache_tag_mem_pkt_width_lp-1:0]          tag_mem_pkt_i
@@ -121,7 +122,7 @@ module bp_fe_icache
   localparam fill_size_in_bank_lp   = fill_width_p / bank_width_lp;
 
   // State machine declaration
-  enum logic [1:0] {e_ready, e_miss, e_recover} state_n, state_r;
+  enum logic [1:0] {e_ready, e_miss} state_n, state_r;
   wire is_ready   = (state_r == e_ready);
   wire is_miss    = (state_r == e_miss);
 
@@ -139,8 +140,9 @@ module bp_fe_icache
   `declare_bp_fe_icache_pkt_s(vaddr_width_p);
   `bp_cast_i(bp_fe_icache_pkt_s, icache_pkt);
 
-  wire is_fetch = (icache_pkt_cast_i.op == e_icache_fetch);
-  wire is_fencei = (icache_pkt_cast_i.op == e_icache_fencei);
+  wire is_fetch  = (icache_pkt_cast_i.op inside {e_icache_fetch, e_icache_fill});
+  wire is_fencei = (icache_pkt_cast_i.op inside {e_icache_fencei});
+  wire is_fill   = (icache_pkt_cast_i.op inside {e_icache_fill});
 
   wire [vaddr_width_p-1:0]   vaddr       = icache_pkt_cast_i.vaddr;
   wire [vtag_width_p-1:0]    vaddr_vtag  = vaddr[block_offset_width_lp+sindex_width_lp+:vtag_width_p];
@@ -151,18 +153,15 @@ module bp_fe_icache
   // Tag Mem Storage
   ///////////////////////////
   `bp_cast_i(bp_icache_tag_mem_pkt_s, tag_mem_pkt);
-  logic                                     tag_mem_v_li;
-  logic                                     tag_mem_w_li;
-  logic [sindex_width_lp-1:0]               tag_mem_addr_li;
+  logic                              tag_mem_v_li;
+  logic                              tag_mem_w_li;
+  logic [sindex_width_lp-1:0]        tag_mem_addr_li;
   bp_icache_tag_info_s [assoc_p-1:0] tag_mem_w_mask_li;
   bp_icache_tag_info_s [assoc_p-1:0] tag_mem_data_li;
   bp_icache_tag_info_s [assoc_p-1:0] tag_mem_data_lo;
 
   bsg_mem_1rw_sync_mask_write_bit
-   #(.width_p(assoc_p*($bits(bp_icache_tag_info_s)))
-     ,.els_p(sets_p)
-     ,.latch_last_read_p(1)
-     )
+   #(.width_p(assoc_p*($bits(bp_icache_tag_info_s))), .els_p(sets_p), .latch_last_read_p(1))
    tag_mem
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
@@ -187,11 +186,7 @@ module bp_fe_icache
 
   for (genvar bank = 0; bank < assoc_p; bank++)
     begin: data_mems
-      bsg_mem_1rw_sync
-       #(.width_p(bank_width_lp)
-         ,.els_p(sets_p*assoc_p)
-         ,.latch_last_read_p(1)
-         )
+      bsg_mem_1rw_sync #(.width_p(bank_width_lp), .els_p(sets_p*assoc_p), .latch_last_read_p(1))
        data_mem
         (.clk_i(clk_i)
          ,.reset_i(reset_i)
@@ -207,7 +202,7 @@ module bp_fe_icache
   // TL stage
   /////////////////////////////////////////////////////////////////////////////
   logic [vaddr_width_p-1:0] vaddr_tl_r;
-  logic fetch_op_tl_r, fencei_op_tl_r;
+  logic fill_op_tl_r, fetch_op_tl_r, fencei_op_tl_r;
 
   // Valid when we accept new data, clear when we advance to tv
   assign tl_we = ready_o & v_i & ~cache_req_yumi_i;
@@ -225,13 +220,13 @@ module bp_fe_icache
 
   // Save stage information
   bsg_dff_reset_en
-   #(.width_p(vaddr_width_p+2))
+   #(.width_p(vaddr_width_p+3))
    tl_stage_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
      ,.en_i(tl_we)
-     ,.data_i({vaddr, is_fetch, is_fencei})
-     ,.data_o({vaddr_tl_r, fetch_op_tl_r, fencei_op_tl_r})
+     ,.data_i({vaddr, is_fill, is_fetch, is_fencei})
+     ,.data_o({vaddr_tl_r, fill_op_tl_r, fetch_op_tl_r, fencei_op_tl_r})
      );
 
   wire [paddr_width_p-1:0]         paddr_tl = {ptag_i, vaddr_tl_r[0+:page_offset_width_gp]};
@@ -269,10 +264,7 @@ module bp_fe_icache
   bp_icache_stat_info_s       stat_mem_data_lo;
 
   bsg_mem_1rw_sync_mask_write_bit
-   #(.width_p(assoc_p-1)
-     ,.els_p(sets_p)
-     ,.latch_last_read_p(1)
-     )
+   #(.width_p(assoc_p-1), .els_p(sets_p), .latch_last_read_p(1))
    stat_mem
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
@@ -287,11 +279,11 @@ module bp_fe_icache
   /////////////////////////////////////////////////////////////////////////////
   // TV stage
   /////////////////////////////////////////////////////////////////////////////
-  logic [paddr_width_p-1:0]                     paddr_tv_r;
+  logic [paddr_width_p-1:0]              paddr_tv_r;
   logic [assoc_p-1:0]                    bank_sel_one_hot_tv_r;
   logic [assoc_p-1:0]                    way_v_tv_r, hit_v_tv_r;
-  logic                                         cached_hit_tv_r, uncached_hit_tv_r;
-  logic                                         fencei_op_tv_r, uncached_op_tv_r, cached_op_tv_r;
+  logic                                  cached_hit_tv_r, uncached_hit_tv_r;
+  logic                                  fill_op_tv_r, fencei_op_tv_r, uncached_op_tv_r, cached_op_tv_r;
   logic [assoc_p-1:0][bank_width_lp-1:0] ld_data_tv_r;
 
   // fence.i does not check tags
@@ -319,17 +311,17 @@ module bp_fe_icache
      );
 
   bsg_dff_en
-   #(.width_p(paddr_width_p+3*assoc_p+5))
+   #(.width_p(paddr_width_p+3*assoc_p+6))
    tv_stage_reg
     (.clk_i(clk_i)
      ,.en_i(tv_we)
      ,.data_i({paddr_tl
                ,bank_sel_one_hot_tl, way_v_tl, hit_v_tl, cached_hit_tl, uncached_hit_tl
-               ,fencei_op_tl_r, fetch_uncached_tl, fetch_cached_tl
+               ,fill_op_tl_r, fencei_op_tl_r, fetch_uncached_tl, fetch_cached_tl
                })
      ,.data_o({paddr_tv_r
                ,bank_sel_one_hot_tv_r, way_v_tv_r, hit_v_tv_r, cached_hit_tv_r, uncached_hit_tv_r
-               ,fencei_op_tv_r, uncached_op_tv_r, cached_op_tv_r
+               ,fill_op_tv_r, fencei_op_tv_r, uncached_op_tv_r, cached_op_tv_r
                })
      );
 
@@ -345,9 +337,7 @@ module bp_fe_icache
 
   logic [bank_width_lp-1:0] ld_data_way_picked;
   bsg_mux_one_hot
-   #(.width_p(bank_width_lp)
-     ,.els_p(assoc_p)
-     )
+   #(.width_p(bank_width_lp), .els_p(assoc_p))
    data_set_select_mux
     (.data_i(ld_data_tv_r)
      ,.sel_one_hot_i(ld_data_way_select)
@@ -356,9 +346,7 @@ module bp_fe_icache
 
   logic [instr_width_gp-1:0] final_data;
   bsg_mux
-   #(.width_p(instr_width_gp)
-     ,.els_p(num_words_per_bank_lp)
-     )
+   #(.width_p(instr_width_gp), .els_p(num_words_per_bank_lp))
    dword_select_mux
     (.data_i(ld_data_way_picked)
      ,.sel_i(paddr_tv_r[2+:`BSG_SAFE_CLOG2(num_words_per_bank_lp)])
@@ -369,6 +357,7 @@ module bp_fe_icache
   assign data_v_o = v_tv_r & ((uncached_op_tv_r & uncached_hit_tv_r)
                               | (cached_op_tv_r & cached_hit_tv_r)
                               );
+  assign miss_v_o = v_tv_r & ~fill_op_tv_r & ~data_v_o;
 
   /////////////////////////////////////////////////////////////////////////////
   // Slow Path
@@ -379,8 +368,8 @@ module bp_fe_icache
   localparam bp_cache_req_size_e block_req_size = bp_cache_req_size_e'(`BSG_SAFE_CLOG2(block_width_p/8));
   localparam bp_cache_req_size_e uncached_req_size = e_size_4B;
 
-  wire cached_req   = v_tv_r & cached_op_tv_r & ~cached_hit_tv_r;
-  wire uncached_req = v_tv_r & uncached_op_tv_r & ~uncached_hit_tv_r;
+  wire cached_req   = v_tv_r & cached_op_tv_r & fill_op_tv_r & ~cached_hit_tv_r;
+  wire uncached_req = v_tv_r & uncached_op_tv_r & fill_op_tv_r & ~uncached_hit_tv_r;
   wire fencei_req   = v_tv_r & fencei_op_tv_r & !coherent_p;
 
   assign cache_req_v_o = |{uncached_req, cached_req, fencei_req} & ~poison_tv_i;

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -230,6 +230,7 @@ module bp_fe_top
      // Supervisor use of user memory is always disabled for immu
      ,.sum_i('0)
      ,.uncached_mode_i((cfg_bus_cast_i.icache_mode == e_lce_mode_uncached))
+     ,.nonspec_mode_i((cfg_bus_cast_i.icache_mode == e_lce_mode_nonspec))
      ,.domain_mask_i(cfg_bus_cast_i.domain_mask)
 
      ,.w_v_i(itlb_fill_v)

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -207,7 +207,7 @@ module bp_fe_top
   assign attaboy_pc_li              = fe_cmd_cast_i.vaddr;
 
   logic instr_access_fault_v, instr_page_fault_v;
-  logic ptag_v_li, ptag_uncached_li, ptag_miss_li;
+  logic ptag_v_li, ptag_uncached_li, ptag_nonidem_li, ptag_miss_li;
   logic [ptag_width_p-1:0] ptag_li;
 
   bp_pte_leaf_s w_tlb_entry_li;
@@ -246,6 +246,7 @@ module bp_fe_top
      ,.r_ptag_o(ptag_li)
      ,.r_miss_o(ptag_miss_li)
      ,.r_uncached_o(ptag_uncached_li)
+     ,.r_nonidem_o(ptag_nonidem_li)
      ,.r_instr_access_fault_o(instr_access_fault_v)
      ,.r_load_access_fault_o()
      ,.r_store_access_fault_o()
@@ -257,7 +258,6 @@ module bp_fe_top
   `declare_bp_fe_icache_pkt_s(vaddr_width_p);
   bp_fe_icache_pkt_s icache_pkt;
   assign icache_pkt = '{vaddr: next_pc_lo
-                        //,op  : icache_fence_v ? e_icache_fencei : e_icache_fill
                         ,op  : icache_fence_v ? e_icache_fencei : icache_fill_response_v ? e_icache_fill : e_icache_fetch
                         };
   // TODO: Should only ack icache fence when icache_ready
@@ -280,6 +280,7 @@ module bp_fe_top
      ,.ptag_i(ptag_li)
      ,.ptag_v_i(ptag_v_li)
      ,.uncached_i(ptag_uncached_li)
+     ,.nonidem_i(ptag_nonidem_li)
      ,.poison_tl_i(icache_poison_tl)
 
      ,.data_o(icache_data_lo)

--- a/bp_fe/test/tb/bp_fe_icache/testbench.sv
+++ b/bp_fe/test/tb/bp_fe_icache/testbench.sv
@@ -71,9 +71,10 @@ module testbench
     cfg_bus_cast_li.cce_mode = e_cce_mode_normal;
   end
 
-  assign ptag_li = trace_data_lo[0+:(ptag_width_p)];
-  assign vaddr_li = trace_data_lo[ptag_width_p+:vaddr_width_p];
-  assign uncached_li = trace_data_lo[(ptag_width_p+vaddr_width_p)+:1];
+  assign ptag_li       = trace_data_lo[0+:(ptag_width_p)];
+  assign vaddr_li      = trace_data_lo[ptag_width_p+:vaddr_width_p];
+  assign uncached_li   = trace_data_lo[(ptag_width_p+vaddr_width_p)+:1];
+  assign nonidem_li    = '0;
   assign trace_yumi_li = trace_v_lo & dut_ready_lo;
 
   // Trace replay
@@ -179,6 +180,7 @@ module testbench
      ,.ptag_v_i(trace_v_lo)
 
      ,.uncached_i(uncached_li)
+     ,.nonidem_i(nonidem_li)
      ,.data_o(icache_data_lo)
      ,.data_v_o(icache_data_v_lo)
 

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -40,6 +40,7 @@ module wrapper
    , input                                   ptag_v_i
 
    , input                                   uncached_i
+   , input                                   nonidem_i
 
    , output [instr_width_gp-1:0]             data_o
    , output                                  data_v_o
@@ -83,6 +84,7 @@ module wrapper
   // Rolly fifo signals
   logic [ptag_width_p-1:0] rolly_ptag_lo;
   logic [vaddr_width_p-1:0] rolly_vaddr_lo;
+  logic rolly_nonidem_lo;
   logic rolly_uncached_lo;
   logic rolly_v_lo;
   logic rolly_yumi_li;
@@ -92,7 +94,7 @@ module wrapper
   logic rollback_li, rolly_yumi_rr;
 
   bsg_fifo_1r1w_rolly
-   #(.width_p(vaddr_width_p+ptag_width_p+1), .els_p(8))
+   #(.width_p(vaddr_width_p+ptag_width_p+2), .els_p(8))
    rolly_icache
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
@@ -101,11 +103,11 @@ module wrapper
      ,.deq_v_i(data_v_o)
      ,.roll_v_i(rollback_li)
 
-     ,.data_i({uncached_i, vaddr_i, ptag_i})
+     ,.data_i({non_idem_i, uncached_i, vaddr_i, ptag_i})
      ,.v_i(vaddr_v_i)
      ,.ready_o(vaddr_ready_o)
 
-     ,.data_o({rolly_uncached_lo, rolly_vaddr_lo, rolly_ptag_lo})
+     ,.data_o({rolly_nonidem_lo, rolly_uncached_lo, rolly_vaddr_lo, rolly_ptag_lo})
      ,.v_o(rolly_v_lo)
      ,.yumi_i(rolly_yumi_li)
      );
@@ -131,15 +133,15 @@ module wrapper
      ,.data_o(rolly_ptag_r)
      );
 
-  logic ptag_v_r, uncached_r;
+  logic ptag_v_r, uncached_r, nonidem_r;
   bsg_dff_reset
    #(.width_p(2))
    ptag_v_dff
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.data_i({rolly_uncached_lo, rolly_v_lo})
-     ,.data_o({uncached_r, ptag_v_r})
+     ,.data_i({rolly_nonidem_lo, rolly_uncached_lo, rolly_v_lo})
+     ,.data_o({rolly_nonidem_r, uncached_r, ptag_v_r})
      );
 
    logic icache_v_rr, poison_li;
@@ -178,6 +180,7 @@ module wrapper
      ,.ptag_i(rolly_ptag_r)
      ,.ptag_v_i(ptag_v_r)
      ,.uncached_i(uncached_r)
+     ,.nonidem_i(nonidem_r)
      ,.poison_tl_i(poison_li)
 
      ,.data_o(data_o)

--- a/bp_me/src/v/lce/bp_lce_req.sv
+++ b/bp_me/src/v/lce/bp_lce_req.sv
@@ -214,7 +214,7 @@ module bp_lce_req
           unique case (cache_req.msg_type)
             e_miss_store
             ,e_miss_load: begin
-              cache_req_yumi_o = cache_req_v_i & (lce_mode_i == e_lce_mode_normal) & sync_done_i;
+              cache_req_yumi_o = cache_req_v_i & (lce_mode_i inside {e_lce_mode_normal, e_lce_mode_nonspec}) & sync_done_i;
               state_n = cache_req_yumi_o ? e_send_cached_req : e_ready;
             end
             e_uc_store: begin


### PR DESCRIPTION
- Adds fetch and fill ops to the I$
- Adds a nonidempotency PMA (tied to off-chip space currently)
- Adds a mode where all I$ misses are treated as speculative
- Minor modification to LCE to support both modes