### PR TITLE
Adding replay on full FE cmd

### DIFF
--- a/bp_be/src/include/bp_be_ctl_pkgdef.svh
+++ b/bp_be/src/include/bp_be_ctl_pkgdef.svh
@@ -245,6 +245,7 @@
     logic itlb_fill;
     logic dtlb_fill;
     logic _interrupt;
+    logic cmd_full;
   }  bp_be_exception_s;
 
   typedef struct packed

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -461,7 +461,7 @@ module bp_be_calculator_top
 
           exc_stage_n[2].exc.dcache_miss        |= pipe_mem_dcache_miss_lo;
           exc_stage_n[2].spec.fencei            |= pipe_mem_fencei_lo;
-          exc_stage_n[2].exc.cmd_full           |= |exc_stage_r[2].exc & cmd_full_n_i;
+          exc_stage_n[2].exc.cmd_full           |= |{exc_stage_r[2].exc, exc_stage_r[2].spec} & cmd_full_n_i;
     end
 
   // Exception pipeline

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -48,6 +48,7 @@ module bp_be_calculator_top
   , output logic                                    ptw_busy_o
   , output logic                                    replay_pending_o
   , output logic [decode_info_width_lp-1:0]         decode_info_o
+  , input                                           cmd_full_n_i
 
   , output logic [commit_pkt_width_lp-1:0]          commit_pkt_o
   , output logic [branch_pkt_width_lp-1:0]          br_pkt_o
@@ -460,6 +461,7 @@ module bp_be_calculator_top
 
           exc_stage_n[2].exc.dcache_miss        |= pipe_mem_dcache_miss_lo;
           exc_stage_n[2].spec.fencei            |= pipe_mem_fencei_lo;
+          exc_stage_n[2].exc.cmd_full           |= |exc_stage_r[2].exc & cmd_full_n_i;
     end
 
   // Exception pipeline

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
@@ -147,6 +147,7 @@ module bp_be_pipe_sys
       retire_instr_r  <= retire_ninstr_r;
     end
 
+  wire instret_li = retire_v_i & ~|retire_exception_i;
   assign retire_pkt =
     '{v          : retire_v_i
       ,queue_v   : retire_queue_v_i
@@ -157,7 +158,7 @@ module bp_be_pipe_sys
       ,instr     : retire_instr_r
       // Could do a preemptive onehot decode here
       ,exception : retire_v_i ? retire_exception_i : '0
-      ,special   : retire_v_i ? retire_special_i   : '0
+      ,special   : instret_li ? retire_special_i   : '0
       };
 
 endmodule

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
@@ -28,38 +28,38 @@ module bp_be_pipe_sys
    , localparam trans_info_width_lp   = `bp_be_trans_info_width(ptag_width_p)
    , localparam wb_pkt_width_lp       = `bp_be_wb_pkt_width(vaddr_width_p)
    )
-  (input                                  clk_i
-   , input                                reset_i
+  (input                                     clk_i
+   , input                                   reset_i
 
-   , input [cfg_bus_width_lp-1:0]         cfg_bus_i
+   , input [cfg_bus_width_lp-1:0]            cfg_bus_i
 
-   , input [dispatch_pkt_width_lp-1:0]    reservation_i
-   , input                                flush_i
+   , input [dispatch_pkt_width_lp-1:0]       reservation_i
+   , input                                   flush_i
 
-   , input                                retire_v_i
-   , input                                retire_queue_v_i
-   , input [dpath_width_gp-1:0]           retire_data_i
-   , input [exception_width_lp-1:0]       retire_exception_i
-   , input [special_width_lp-1:0]         retire_special_i
+   , input                                   retire_v_i
+   , input                                   retire_queue_v_i
+   , input [dpath_width_gp-1:0]              retire_data_i
+   , input [exception_width_lp-1:0]          retire_exception_i
+   , input [special_width_lp-1:0]            retire_special_i
 
-   , output logic [dpath_width_gp-1:0]    data_o
-   , output logic                         satp_o
-   , output logic                         illegal_instr_o
-   , output logic                         v_o
+   , output logic [dpath_width_gp-1:0]       data_o
+   , output logic                            satp_o
+   , output logic                            illegal_instr_o
+   , output logic                            v_o
 
-   , input [wb_pkt_width_lp-1:0]          iwb_pkt_i
-   , input [wb_pkt_width_lp-1:0]          fwb_pkt_i
-   , output [commit_pkt_width_lp-1:0]     commit_pkt_o
+   , input [wb_pkt_width_lp-1:0]             iwb_pkt_i
+   , input [wb_pkt_width_lp-1:0]             fwb_pkt_i
+   , output logic [commit_pkt_width_lp-1:0]  commit_pkt_o
 
-   , input                                timer_irq_i
-   , input                                software_irq_i
-   , input                                external_irq_i
-   , output logic                         irq_pending_o
-   , output logic                         irq_waiting_o
+   , input                                   timer_irq_i
+   , input                                   software_irq_i
+   , input                                   external_irq_i
+   , output logic                            irq_pending_o
+   , output logic                            irq_waiting_o
 
-   , output [decode_info_width_lp-1:0]    decode_info_o
-   , output [trans_info_width_lp-1:0]     trans_info_o
-   , output rv64_frm_e                    frm_dyn_o
+   , output logic [decode_info_width_lp-1:0] decode_info_o
+   , output logic [trans_info_width_lp-1:0]  trans_info_o
+   , output rv64_frm_e                       frm_dyn_o
    );
 
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);

--- a/bp_be/src/v/bp_be_checker/bp_be_cmd_queue.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_cmd_queue.sv
@@ -1,0 +1,74 @@
+
+`include "bp_common_defines.svh"
+`include "bp_be_defines.svh"
+
+module bp_be_cmd_queue
+ import bp_common_pkg::*;
+ import bp_be_pkg::*;
+ #(parameter bp_params_e bp_params_p = e_bp_multicore_1_cfg
+   `declare_bp_proc_params(bp_params_p)
+   `declare_bp_core_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
+   , localparam ptr_width_lp = `BSG_SAFE_CLOG2(fe_cmd_fifo_els_p)
+   )
+  (input                                clk_i
+   , input                              reset_i
+
+   , input [fe_cmd_width_lp-1:0]        fe_cmd_i
+   , input                              fe_cmd_v_i
+   , output logic                       fe_cmd_ready_o
+
+   , output logic [fe_cmd_width_lp-1:0] fe_cmd_o
+   , output logic                       fe_cmd_v_o
+   , input                              fe_cmd_yumi_i
+
+   , output logic                       empty_o
+   , output logic                       full_n_o
+   , output logic                       full_r_o
+   );
+
+  `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
+
+  wire enq = fe_cmd_ready_o & fe_cmd_v_i;
+  wire deq = fe_cmd_yumi_i;
+
+  logic [ptr_width_lp-1:0] wptr_r, rptr_n, rptr_r;
+  logic full_lo, empty_lo;
+  bsg_fifo_tracker
+   #(.els_p(fe_cmd_fifo_els_p))
+   ft
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.enq_i(enq)
+     ,.deq_i(deq)
+     ,.wptr_r_o(wptr_r)
+     ,.rptr_r_o(rptr_r)
+     ,.rptr_n_o(rptr_n)
+     ,.full_o(full_lo)
+     ,.empty_o(empty_lo)
+     );
+
+  bsg_mem_1r1w
+   #(.width_p($bits(bp_fe_cmd_s)), .els_p(fe_cmd_fifo_els_p))
+   fifo_mem
+    (.w_clk_i(clk_i)
+     ,.w_reset_i(reset_i)
+     ,.w_v_i(enq)
+     ,.w_addr_i(wptr_r)
+     ,.w_data_i(fe_cmd_i)
+     ,.r_v_i(fe_cmd_v_o)
+     ,.r_addr_i(rptr_r)
+     ,.r_data_o(fe_cmd_o)
+     );
+
+  assign fe_cmd_ready_o = ~full_lo;
+  assign fe_cmd_v_o     = ~empty_lo;
+
+  wire almost_full = (rptr_r == wptr_r-1'b1);
+
+  assign empty_o  = empty_lo;
+  assign full_r_o = full_lo;
+  assign full_n_o = almost_full & enq & ~deq;
+
+endmodule
+

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -34,7 +34,7 @@ module bp_be_detector
 
    // Dependency information
    , input [isd_status_width_lp-1:0]   isd_status_i
-   , input                             fe_cmd_full_i
+   , input                             cmd_full_i
    , input                             credits_full_i
    , input                             credits_empty_i
    , input                             long_ready_i
@@ -218,7 +218,7 @@ module bp_be_detector
       mem_in_pipe_v      = (dep_status_r[0].mem_v) | (dep_status_r[1].mem_v);
       fence_haz_v        = (isd_status_cast_i.fence_v & (~credits_empty_i | mem_in_pipe_v))
                            | (isd_status_cast_i.mem_v & credits_full_i);
-      cmd_haz_v          = fe_cmd_full_i;
+      cmd_haz_v          = cmd_full_i;
 
       fflags_haz_v = isd_status_cast_i.csr_w_v
                      & ((dep_status_r[0].fflags_w_v)

--- a/bp_be/src/v/bp_be_checker/bp_be_director.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.sv
@@ -38,12 +38,14 @@ module bp_be_director
    , output logic                       poison_isd_o
    , output logic                       suppress_iss_o
    , input                              irq_waiting_i
+   , output logic                       cmd_empty_o
+   , output logic                       cmd_full_n_o
+   , output logic                       cmd_full_r_o
 
    // FE-BE interface
    , output logic [fe_cmd_width_lp-1:0] fe_cmd_o
    , output logic                       fe_cmd_v_o
    , input                              fe_cmd_yumi_i
-   , output logic                       fe_cmd_full_o
 
    , input [branch_pkt_width_lp-1:0]    br_pkt_i
    , input [commit_pkt_width_lp-1:0]    commit_pkt_i
@@ -264,24 +266,24 @@ module bp_be_director
         end
     end
 
-  bsg_fifo_1r1w_small
-   #(.width_p(fe_cmd_width_lp)
-     ,.els_p(fe_cmd_fifo_els_p)
-     ,.ready_THEN_valid_p(1)
-     )
+  bp_be_cmd_queue
+   #(.bp_params_p(bp_params_p))
    fe_cmd_fifo
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.data_i(fe_cmd_li)
-     ,.v_i(fe_cmd_v_li)
-     ,.ready_o(fe_cmd_ready_lo)
+     ,.fe_cmd_i(fe_cmd_li)
+     ,.fe_cmd_v_i(fe_cmd_v_li)
+     ,.fe_cmd_ready_o(fe_cmd_ready_lo)
 
-     ,.data_o(fe_cmd_o)
-     ,.v_o(fe_cmd_v_o)
-     ,.yumi_i(fe_cmd_yumi_i)
+     ,.fe_cmd_o(fe_cmd_o)
+     ,.fe_cmd_v_o(fe_cmd_v_o)
+     ,.fe_cmd_yumi_i(fe_cmd_yumi_i)
+
+     ,.empty_o(cmd_empty_o)
+     ,.full_n_o(cmd_full_n_o)
+     ,.full_r_o(cmd_full_r_o)
      );
-  assign fe_cmd_full_o = ~fe_cmd_ready_lo;
 
 endmodule
 

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -93,7 +93,7 @@ module bp_be_top
   logic poison_isd_lo, suppress_iss_lo;
   logic waiting_for_irq_lo;
 
-  logic fe_cmd_full_lo;
+  logic cmd_full_n_lo, cmd_full_r_lo, cmd_empty_lo;
   logic mem_ready_lo, long_ready_lo, ptw_busy_lo;
 
   bp_be_director
@@ -110,11 +110,13 @@ module bp_be_top
      ,.fe_cmd_o(fe_cmd_o)
      ,.fe_cmd_v_o(fe_cmd_v_o)
      ,.fe_cmd_yumi_i(fe_cmd_yumi_i)
-     ,.fe_cmd_full_o(fe_cmd_full_lo)
 
      ,.suppress_iss_o(suppress_iss_lo)
      ,.poison_isd_o(poison_isd_lo)
      ,.irq_waiting_i(irq_waiting_lo)
+     ,.cmd_empty_o()
+     ,.cmd_full_n_o(cmd_full_n_lo)
+     ,.cmd_full_r_o(cmd_full_r_lo)
 
      ,.br_pkt_i(br_pkt)
      ,.commit_pkt_i(commit_pkt)
@@ -129,7 +131,7 @@ module bp_be_top
      ,.cfg_bus_i(cfg_bus_i)
 
      ,.isd_status_i(isd_status)
-     ,.fe_cmd_full_i(fe_cmd_full_lo)
+     ,.cmd_full_i(cmd_full_r_lo)
      ,.credits_full_i(cache_req_credits_full_i)
      ,.credits_empty_i(cache_req_credits_empty_i)
      ,.mem_ready_i(mem_ready_lo)
@@ -225,6 +227,7 @@ module bp_be_top
      ,.irq_pending_o(irq_pending_lo)
      ,.irq_waiting_o(irq_waiting_lo)
      ,.replay_pending_o(replay_pending_lo)
+     ,.cmd_full_n_i(cmd_full_n_lo)
      );
 
 endmodule

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -194,6 +194,7 @@ $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_sys.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_ptw.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_rec_to_fp.sv
 # Checker
+$BP_BE_DIR/src/v/bp_be_checker/bp_be_cmd_queue.sv
 $BP_BE_DIR/src/v/bp_be_checker/bp_be_detector.sv
 $BP_BE_DIR/src/v/bp_be_checker/bp_be_director.sv
 $BP_BE_DIR/src/v/bp_be_checker/bp_be_instr_decoder.sv


### PR DESCRIPTION
Replays exceptions and special instructions before they commit, if the FE cmd queue is full. This is necessary if the FE applies any back pressure.  Currently, we provision enough space in the fifo such that it cannot fill by construction, but this approach is more flexible.

fixes #443 