### PR TITLE
Reshaping BHT

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_ctl.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_ctl.sv
@@ -76,8 +76,8 @@ module bp_be_pipe_ctl
   assign v_o      = reservation.v & reservation.decode.pipe_ctl_v;
 
   assign br_pkt.v         = reservation.v & reservation.queue_v & ~flush_i;
-  assign br_pkt.branch    = reservation.v & reservation.queue_v & reservation.decode.pipe_ctl_v;
-  assign br_pkt.btaken    = reservation.v & reservation.queue_v & reservation.decode.pipe_ctl_v & btaken;
+  assign br_pkt.branch    = br_pkt.v & reservation.decode.pipe_ctl_v;
+  assign br_pkt.btaken    = br_pkt.v & reservation.decode.pipe_ctl_v & btaken;
   assign br_pkt.npc       = btaken ? {taken_tgt[vaddr_width_p-1:1], 1'b0} : ntaken_tgt;
 
 endmodule

--- a/bp_common/src/v/bsg_mem_1r1w_sync_mask_write_bit_reshape.v
+++ b/bp_common/src/v/bsg_mem_1r1w_sync_mask_write_bit_reshape.v
@@ -56,7 +56,6 @@ module bsg_mem_1r1w_sync_mask_write_bit_reshape #(parameter skinny_width_p=-1
       assign fat_w_offset = w_addr_i[0+:offset_width_lp];
       assign fat_r_offset = r_addr_i[0+:offset_width_lp];
 
-      logic [offset_width_lp-1:0] fat_r_offset_r;
       bsg_dff_reset
        #(.width_p(offset_width_lp))
        fat_r_offset_reg
@@ -69,8 +68,8 @@ module bsg_mem_1r1w_sync_mask_write_bit_reshape #(parameter skinny_width_p=-1
     end
 
   logic rw_same_fat_addr;
-  wire drop_read = rw_same_fat_addr & (drop_write_not_read_p == 0);
-  wire drop_write = rw_same_fat_addr & (drop_write_not_read_p == 1);
+  wire drop_read = w_v_i & rw_same_fat_addr & (drop_write_not_read_p == 0);
+  wire drop_write = r_v_i & rw_same_fat_addr & (drop_write_not_read_p == 1);
 
   wire                            fat_w_v_li = w_v_i & ~drop_write;
   wire [fat_width_p-1:0]       fat_w_mask_li = w_mask_i << (fat_w_offset*skinny_width_p);
@@ -80,7 +79,7 @@ module bsg_mem_1r1w_sync_mask_write_bit_reshape #(parameter skinny_width_p=-1
   wire                            fat_r_v_li = r_v_i & ~drop_read;
   wire [fat_addr_width_lp-1:0] fat_r_addr_li = r_addr_i[offset_width_lp+:fat_addr_width_lp];
 
-  assign rw_same_fat_addr = r_v_i & w_v_i & (fat_r_addr_li == fat_w_addr_li);
+  assign rw_same_fat_addr = (fat_r_addr_li == fat_w_addr_li);
 
   logic [fat_width_p-1:0] fat_r_data_lo;
   bsg_mem_1r1w_sync_mask_write_bit

--- a/bp_common/src/v/bsg_mem_1r1w_sync_mask_write_bit_reshape.v
+++ b/bp_common/src/v/bsg_mem_1r1w_sync_mask_write_bit_reshape.v
@@ -1,0 +1,141 @@
+
+//
+// This module fattens a skinny bitmasked RAM to a more PD-friendly wider ram
+// It does so by 'folding' the RAM like so:
+// [aa]
+// [bb]
+// [cc]      [bbaa]    
+// [dd]  ->  [ddcc] -> [ddccbbaa]
+// [ee]  ->  [ffee] -> [hhggffee]
+// [ff]      [hhgg]
+// [gg]
+// [hh]
+//
+//
+module bsg_mem_1r1w_sync_mask_write_bit_reshape #(parameter skinny_width_p=-1
+                                                  , parameter skinny_els_p=-1
+                                                  , parameter skinny_addr_width_lp=`BSG_SAFE_CLOG2(skinny_els_p)
+
+                                                  , parameter fat_width_p=-1
+                                                  , parameter fat_els_p=-1
+                                                  , parameter fat_addr_width_lp=`BSG_SAFE_CLOG2(fat_els_p)
+
+                                                  // We must drop one of the requests during
+                                                  //   a silent conflict, this parameter
+                                                  //   dictates which one
+                                                  , parameter drop_write_not_read_p = 0
+
+                                                  , parameter debug_lp = 0
+                                                  )
+   (input   clk_i
+    , input reset_i
+
+    , input                             w_v_i
+    , input [skinny_width_p-1:0]        w_mask_i
+    , input [skinny_addr_width_lp-1:0]  w_addr_i
+    , input [skinny_width_p-1:0]        w_data_i
+
+    , input                             r_v_i
+    , input [skinny_addr_width_lp-1:0]  r_addr_i
+    , output logic [skinny_width_p-1:0] r_data_o
+
+    // This is a same cycle signal that there was a read/write conflict
+    , output logic                      conflict_o
+    );
+
+  localparam offset_width_lp = $clog2(fat_width_p/skinny_width_p);
+  logic [`BSG_SAFE_MINUS(offset_width_lp,1):0] fat_w_offset, fat_r_offset, fat_r_offset_r;
+  if (skinny_width_p == fat_width_p)
+    begin : ident
+      assign fat_w_offset = '0;
+      assign fat_r_offset = '0;
+      assign fat_r_offset_r = '0;
+    end
+  else
+    begin : nident
+      assign fat_w_offset = w_addr_i[0+:offset_width_lp];
+      assign fat_r_offset = r_addr_i[0+:offset_width_lp];
+
+      logic [offset_width_lp-1:0] fat_r_offset_r;
+      bsg_dff_reset
+       #(.width_p(offset_width_lp))
+       fat_r_offset_reg
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+
+         ,.data_i(fat_r_offset)
+         ,.data_o(fat_r_offset_r)
+         );
+    end
+
+  logic rw_same_fat_addr;
+  wire drop_read = rw_same_fat_addr & (drop_write_not_read_p == 0);
+  wire drop_write = rw_same_fat_addr & (drop_write_not_read_p == 1);
+
+  wire                            fat_w_v_li = w_v_i & ~drop_write;
+  wire [fat_width_p-1:0]       fat_w_mask_li = w_mask_i << (fat_w_offset*skinny_width_p);
+  wire [fat_addr_width_lp-1:0] fat_w_addr_li = w_addr_i[offset_width_lp+:fat_addr_width_lp];
+  wire [fat_width_p-1:0]       fat_w_data_li = w_data_i << (fat_w_offset*skinny_width_p);
+
+  wire                            fat_r_v_li = r_v_i & ~drop_read;
+  wire [fat_addr_width_lp-1:0] fat_r_addr_li = r_addr_i[offset_width_lp+:fat_addr_width_lp];
+
+  assign rw_same_fat_addr = r_v_i & w_v_i & (fat_r_addr_li == fat_w_addr_li);
+
+  logic [fat_width_p-1:0] fat_r_data_lo;
+  bsg_mem_1r1w_sync_mask_write_bit
+   #(.width_p(fat_width_p), .els_p(fat_els_p))
+   fat_mem
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.w_v_i(fat_w_v_li)
+     ,.w_mask_i(fat_w_mask_li)
+     ,.w_addr_i(fat_w_addr_li)
+     ,.w_data_i(fat_w_data_li)
+
+     ,.r_v_i(fat_r_v_li)
+     ,.r_addr_i(fat_r_addr_li)
+     ,.r_data_o(fat_r_data_lo)
+     );
+
+  bsg_mux
+   #(.width_p(skinny_width_p), .els_p(fat_width_p/skinny_width_p))
+   data_mux
+    (.data_i(fat_r_data_lo)
+     ,.sel_i(fat_r_offset_r)
+     ,.data_o(r_data_o)
+     );
+
+  assign conflict_o = drop_read | drop_write;
+
+  //synopsys translate_off
+  initial
+    begin
+      assert (fat_width_p % skinny_width_p == 0) else $error("%m Fat width must be multiple of skinny width");
+      assert (skinny_els_p % fat_els_p == 0) else $error("%m Skinny els must be a multiple of fat els");
+    end
+
+  logic r_v_r;
+  logic [skinny_addr_width_lp-1:0] skinny_r_addr_r;
+  logic [fat_addr_width_lp-1:0] fat_r_addr_r;
+
+  bsg_dff
+   #(.width_p(1+skinny_addr_width_lp+fat_addr_width_lp))
+   read_reg
+    (.clk_i(clk_i)
+     ,.data_i({r_v_i, r_addr_i, fat_r_addr_li})
+     ,.data_o({r_v_r, skinny_r_addr_r, fat_r_addr_r})
+     );
+
+  if (debug_lp)
+    always_ff @(negedge clk_i)
+      begin
+        if (w_v_i)
+            $display("%t [WRITE] Skinny[%x] = %b, WMASK: %b; Fat[%x] = %b, WMASK: %b", $time, w_addr_i, w_data_i, w_mask_i, fat_w_addr_li, fat_w_data_li, fat_w_mask_li);
+        if (r_v_r)
+            $display("%t [READ] Skinny[%x]: %b; Fat[%x]: %b", $time, skinny_r_addr_r, r_data_o, fat_r_addr_r, fat_r_data_lo);
+      end
+  //synopsys translate_on
+   
+endmodule

--- a/bp_common/syn/Makefile.vcs
+++ b/bp_common/syn/Makefile.vcs
@@ -71,7 +71,7 @@ $(BUILD_DIR)/simv: $(BUILD_COLLATERAL)
 	-@tail -n3 $(BUILD_LOG) > $(BUILD_REPORT)
 	-@test -s $(BUILD_ERROR) && echo "FAILED" >> $(BUILD_REPORT) || rm $(BUILD_ERROR)
 
-build_dump.v: VCS_BUILD_OPTS += -debug_all
+build_dump.v: VCS_BUILD_OPTS += -debug_pp
 build_dump.v: VCS_BUILD_OPTS += +vcs+vcdpluson
 build_dump.v: VCS_BUILD_OPTS += +vcs+vcdplusautoflushon
 build_dump.v: build.v

--- a/bp_common/syn/Makefile.vcs
+++ b/bp_common/syn/Makefile.vcs
@@ -71,7 +71,7 @@ $(BUILD_DIR)/simv: $(BUILD_COLLATERAL)
 	-@tail -n3 $(BUILD_LOG) > $(BUILD_REPORT)
 	-@test -s $(BUILD_ERROR) && echo "FAILED" >> $(BUILD_REPORT) || rm $(BUILD_ERROR)
 
-build_dump.v: VCS_BUILD_OPTS += -debug_pp
+build_dump.v: VCS_BUILD_OPTS += -debug_all
 build_dump.v: VCS_BUILD_OPTS += +vcs+vcdpluson
 build_dump.v: VCS_BUILD_OPTS += +vcs+vcdplusautoflushon
 build_dump.v: build.v

--- a/bp_fe/src/v/bp_fe_bht.sv
+++ b/bp_fe/src/v/bp_fe_bht.sv
@@ -26,10 +26,11 @@ module bp_fe_bht
    , input [bht_idx_width_p-1:0] idx_w_i
    , input [1:0]                 val_i
    , input                       correct_i
+   , output logic                w_yumi_o
 
    , input                       r_v_i
    , input [bht_idx_width_p-1:0] idx_r_i
-   , output [1:0]                val_o
+   , output logic [1:0]          val_o
    );
 
   // Initialization state machine
@@ -68,15 +69,11 @@ module bp_fe_bht
     else
       state_r <= state_n;
 
-  /* TODO: We should fold this tall, narrow RAM */
   wire                          w_v_li = is_clear | w_v_i;
   wire [bht_idx_width_p-1:0] w_addr_li = is_clear ? init_cnt : idx_w_i;
   wire [1:0]                 w_data_li = is_clear ? bht_init_lp : correct_i ? {val_i[1], 1'b0} : {val_i[1]^val_i[0], 1'b1};
 
-  // We could technically forward, but instead we'll bank the memory in
-  //   the future, so won't waste effort here
-  wire                    rw_same_addr = r_v_i & w_v_i & (w_addr_li == idx_r_i);
-  wire                          r_v_li = r_v_i & ~rw_same_addr;
+  wire                          r_v_li = r_v_i;
   wire [bht_idx_width_p-1:0] r_addr_li = idx_r_i;
   logic [1:0] r_data_lo;
   logic conflict_lo;
@@ -102,6 +99,7 @@ module bp_fe_bht
 
      ,.conflict_o(conflict_lo)
      );
+  assign w_yumi_o = w_v_i & ~conflict_lo;
 
   logic r_v_r;
   bsg_dff_reset

--- a/bp_fe/src/v/bp_fe_bht.sv
+++ b/bp_fe/src/v/bp_fe_bht.sv
@@ -13,23 +13,24 @@
 `include "bp_fe_defines.svh"
 
 module bp_fe_bht
+ import bp_common_pkg::*;
  import bp_fe_pkg::*;
- #(parameter vaddr_width_p     = "inv"
-   , parameter bht_idx_width_p = "inv"
+ #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+   `declare_bp_proc_params(bp_params_p)
 
-   , localparam els_lp = 2**bht_idx_width_p
+   , localparam idx_width_lp = bht_idx_width_p+ghist_width_p
    )
   (input                         clk_i
    , input                       reset_i
 
    , input                       w_v_i
-   , input [bht_idx_width_p-1:0] idx_w_i
+   , input [idx_width_lp-1:0]    idx_w_i
    , input [1:0]                 val_i
    , input                       correct_i
    , output logic                w_yumi_o
 
    , input                       r_v_i
-   , input [bht_idx_width_p-1:0] idx_r_i
+   , input [idx_width_lp-1:0]    idx_r_i
    , output logic [1:0]          val_o
    );
 
@@ -39,7 +40,7 @@ module bp_fe_bht
   wire is_clear = (state_r == e_clear);
   wire is_run   = (state_r == e_run);
 
-  localparam bht_els_lp = 2**bht_idx_width_p;
+  localparam bht_els_lp = 2**idx_width_lp;
   localparam bht_init_lp = 2'b01;
   logic [`BSG_WIDTH(bht_els_lp)-1:0] init_cnt;
   bsg_counter_clear_up
@@ -69,19 +70,19 @@ module bp_fe_bht
     else
       state_r <= state_n;
 
-  wire                          w_v_li = is_clear | w_v_i;
-  wire [bht_idx_width_p-1:0] w_addr_li = is_clear ? init_cnt : idx_w_i;
-  wire [1:0]                 w_data_li = is_clear ? bht_init_lp : correct_i ? {val_i[1], 1'b0} : {val_i[1]^val_i[0], 1'b1};
+  wire                       w_v_li = is_clear | w_v_i;
+  wire [idx_width_lp-1:0] w_addr_li = is_clear ? init_cnt : idx_w_i;
+  wire [1:0]              w_data_li = is_clear ? bht_init_lp : correct_i ? {val_i[1], 1'b0} : {val_i[1]^val_i[0], 1'b1};
 
-  wire                          r_v_li = r_v_i;
-  wire [bht_idx_width_p-1:0] r_addr_li = idx_r_i;
+  wire                       r_v_li = r_v_i;
+  wire [idx_width_lp-1:0] r_addr_li = idx_r_i;
   logic [1:0] r_data_lo;
   logic conflict_lo;
   bsg_mem_1r1w_sync_mask_write_bit_reshape
    #(.skinny_width_p(2)
-     ,.skinny_els_p(2**bht_idx_width_p)
+     ,.skinny_els_p(2**idx_width_lp)
      ,.fat_width_p(2)
-     ,.fat_els_p(2**bht_idx_width_p)
+     ,.fat_els_p(2**idx_width_lp)
      ,.drop_write_not_read_p(1)
      )
    bht_mem

--- a/bp_fe/src/v/bp_fe_bht.sv
+++ b/bp_fe/src/v/bp_fe_bht.sv
@@ -23,6 +23,8 @@ module bp_fe_bht
   (input                         clk_i
    , input                       reset_i
 
+   , output logic                init_done_o
+
    , input                       w_v_i
    , input [idx_width_lp-1:0]    idx_w_i
    , input [1:0]                 val_i
@@ -39,6 +41,8 @@ module bp_fe_bht
   wire is_reset = (state_r == e_reset);
   wire is_clear = (state_r == e_clear);
   wire is_run   = (state_r == e_run);
+
+  assign init_done_o = is_run;
 
   localparam bht_els_lp = 2**idx_width_lp;
   localparam bht_init_lp = 2'b01;

--- a/bp_fe/src/v/bp_fe_bht.sv
+++ b/bp_fe/src/v/bp_fe_bht.sv
@@ -78,11 +78,14 @@ module bp_fe_bht
   wire [idx_width_lp-1:0] r_addr_li = idx_r_i;
   logic [1:0] r_data_lo;
   logic conflict_lo;
+  // 64 is a reasonable value, but there's an optimization space here
+  localparam fat_width_lp = 64;
+  localparam skinny_width_lp = 2;
   bsg_mem_1r1w_sync_mask_write_bit_reshape
-   #(.skinny_width_p(2)
-     ,.skinny_els_p(2**idx_width_lp)
-     ,.fat_width_p(2)
-     ,.fat_els_p(2**idx_width_lp)
+   #(.skinny_width_p(skinny_width_lp)
+     ,.skinny_els_p(bht_els_lp)
+     ,.fat_width_p(fat_width_lp)
+     ,.fat_els_p(bht_els_lp/(fat_width_lp/skinny_width_lp))
      ,.drop_write_not_read_p(1)
      )
    bht_mem
@@ -100,7 +103,7 @@ module bp_fe_bht
 
      ,.conflict_o(conflict_lo)
      );
-  assign w_yumi_o = w_v_i & ~conflict_lo;
+  assign w_yumi_o = is_run & w_v_i & ~conflict_lo;
 
   logic r_v_r;
   bsg_dff_reset

--- a/bp_fe/src/v/bp_fe_bht.sv
+++ b/bp_fe/src/v/bp_fe_bht.sv
@@ -79,19 +79,28 @@ module bp_fe_bht
   wire                          r_v_li = r_v_i & ~rw_same_addr;
   wire [bht_idx_width_p-1:0] r_addr_li = idx_r_i;
   logic [1:0] r_data_lo;
-  bsg_mem_1r1w_sync
-   #(.width_p(2), .els_p(2**bht_idx_width_p))
+  logic conflict_lo;
+  bsg_mem_1r1w_sync_mask_write_bit_reshape
+   #(.skinny_width_p(2)
+     ,.skinny_els_p(2**bht_idx_width_p)
+     ,.fat_width_p(2)
+     ,.fat_els_p(2**bht_idx_width_p)
+     ,.drop_write_not_read_p(1)
+     )
    bht_mem
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
      ,.w_v_i(w_v_li)
+     ,.w_mask_i('1)
      ,.w_addr_i(w_addr_li)
      ,.w_data_i(w_data_li)
 
      ,.r_v_i(r_v_li)
      ,.r_addr_i(r_addr_li)
      ,.r_data_o(r_data_lo)
+
+     ,.conflict_o(conflict_lo)
      );
 
   logic r_v_r;

--- a/bp_fe/src/v/bp_fe_btb.sv
+++ b/bp_fe/src/v/bp_fe_btb.sv
@@ -24,6 +24,8 @@ module bp_fe_btb
   (input                              clk_i
    , input                            reset_i
 
+   , output logic                     init_done_o
+
    // Synchronous read
    , input [vaddr_width_p-1:0]        r_addr_i
    , input                            r_v_i
@@ -47,6 +49,8 @@ module bp_fe_btb
   wire is_reset = (state_r == e_reset);
   wire is_clear = (state_r == e_clear);
   wire is_run   = (state_r == e_run);
+
+  assign init_done_o = is_run;
 
   localparam btb_els_lp = 2**btb_idx_width_p;
   logic [`BSG_WIDTH(btb_els_lp)-1:0] init_cnt;

--- a/bp_fe/src/v/bp_fe_btb.sv
+++ b/bp_fe/src/v/bp_fe_btb.sv
@@ -21,23 +21,24 @@ module bp_fe_btb
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
    )
-  (input                          clk_i
-   , input                        reset_i
+  (input                              clk_i
+   , input                            reset_i
 
    // Synchronous read
-   , input [vaddr_width_p-1:0]    r_addr_i
-   , input                        r_v_i
-   , output [vaddr_width_p-1:0]   br_tgt_o
-   , output                       br_tgt_v_o
-   , output                       br_tgt_jmp_o
+   , input [vaddr_width_p-1:0]        r_addr_i
+   , input                            r_v_i
+   , output logic [vaddr_width_p-1:0] br_tgt_o
+   , output logic                     br_tgt_v_o
+   , output logic                     br_tgt_jmp_o
 
    // Synchronous write
-   , input                        w_v_i
-   , input                        w_clr_i
-   , input                        w_jmp_i
-   , input [btb_tag_width_p-1:0]  w_tag_i
-   , input [btb_idx_width_p-1:0]  w_idx_i
-   , input [vaddr_width_p-1:0]    br_tgt_i
+   , input                            w_v_i
+   , input                            w_clr_i
+   , input                            w_jmp_i
+   , input [btb_tag_width_p-1:0]      w_tag_i
+   , input [btb_idx_width_p-1:0]      w_idx_i
+   , input [vaddr_width_p-1:0]        br_tgt_i
+   , output logic                     w_yumi_o
    );
 
   ///////////////////////
@@ -88,15 +89,13 @@ module bp_fe_btb
   wire [btb_tag_width_p-1:0] r_tag_li = r_addr_i[2+btb_idx_width_p+:btb_tag_width_p];
 
   bp_btb_entry_s tag_mem_data_li;
-  wire                          tag_mem_w_v_li = is_clear | w_v_i;
+  wire rw_same_addr = r_v_i & w_v_i & (r_idx_li == w_idx_i);
+  wire                          tag_mem_w_v_li = is_clear | (w_v_i & ~rw_same_addr);
   wire [btb_idx_width_p-1:0] tag_mem_w_addr_li = is_clear ? init_cnt : w_idx_i;
   assign tag_mem_data_li = (is_clear | (w_v_i & w_clr_i)) ? '0 : '{v: 1'b1, jmp: w_jmp_i, tag: w_tag_i, tgt: br_tgt_i};
 
-  // We could technically forward, but instead we'll bank the memory in
-  //   the future, so won't waste effort here
-  wire rw_same_addr = r_v_i & w_v_i & (r_idx_li == w_idx_i);
   bp_btb_entry_s tag_mem_data_lo;
-  wire                           tag_mem_r_v_li = r_v_i & ~rw_same_addr;
+  wire                           tag_mem_r_v_li = r_v_i;
   wire [btb_idx_width_p-1:0]  tag_mem_r_addr_li = r_idx_li;
   bsg_mem_1r1w_sync
    #(.width_p($bits(bp_btb_entry_s)), .els_p(btb_els_lp))
@@ -112,6 +111,7 @@ module bp_fe_btb
      ,.r_addr_i(tag_mem_r_addr_li)
      ,.r_data_o(tag_mem_data_lo)
      );
+  assign w_yumi_o = is_run & w_v_i & ~rw_same_addr;
 
   logic [btb_tag_width_p-1:0] r_tag_r;
   bsg_dff_reset_en

--- a/bp_fe/src/v/bp_fe_btb.sv
+++ b/bp_fe/src/v/bp_fe_btb.sv
@@ -16,10 +16,10 @@
 `include "bp_fe_defines.svh"
 
 module bp_fe_btb
+ import bp_common_pkg::*;
  import bp_fe_pkg::*;
- #(parameter vaddr_width_p     = "inv"
-   , parameter btb_tag_width_p = "inv"
-   , parameter btb_idx_width_p = "inv"
+ #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+   `declare_bp_proc_params(bp_params_p)
    )
   (input                          clk_i
    , input                        reset_i

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -149,12 +149,13 @@ module bp_fe_pc_gen
   wire [bht_idx_width_p+ghist_width_p-1:0] bht_idx_r_li =
     {next_pc_o[2+:bht_idx_width_p], pred_if1_n.ghist};
   wire bht_w_v_li =
-    (redirect_br_v_i & redirect_br_metadata_fwd.is_br) | (attaboy_yumi_o & attaboy_br_metadata_fwd.is_br);
+    (redirect_br_v_i & redirect_br_metadata_fwd.is_br) | (attaboy_v_i & attaboy_br_metadata_fwd.is_br);
   wire [bht_idx_width_p+ghist_width_p-1:0] bht_idx_w_li = redirect_br_v_i
     ? {redirect_br_metadata_fwd.bht_idx, redirect_br_metadata_fwd.ghist}
     : {attaboy_br_metadata_fwd.bht_idx, attaboy_br_metadata_fwd.ghist};
   wire [1:0] bht_val_li = redirect_br_v_i ? redirect_br_metadata_fwd.bht_val : attaboy_br_metadata_fwd.bht_val;
   logic [1:0] bht_val_lo;
+  logic bht_w_yumi_lo;
   bp_fe_bht
    #(.vaddr_width_p(vaddr_width_p)
      ,.bht_idx_width_p(bht_idx_width_p+ghist_width_p)
@@ -171,6 +172,7 @@ module bp_fe_pc_gen
      ,.idx_w_i(bht_idx_w_li)
      ,.correct_i(attaboy_yumi_o)
      ,.val_i(bht_val_li)
+     ,.w_yumi_o(bht_w_yumi_lo)
      );
   assign btb_taken = btb_br_tgt_v_lo & (bht_val_lo[1] | btb_br_tgt_jmp_lo);
 
@@ -188,7 +190,7 @@ module bp_fe_pc_gen
      );
   assign ras_tgt_lo = return_addr_r;
 
-  assign attaboy_yumi_o = attaboy_v_i & ~redirect_br_v_i;
+  assign attaboy_yumi_o = attaboy_v_i & ~redirect_br_v_i & ~(bht_w_v_li & ~bht_w_yumi_lo);
 
   /////////////////
   // IF2

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -112,7 +112,7 @@ module bp_fe_pc_gen
   wire btb_r_v_li = next_pc_yumi_i & ~ovr_taken & ~ovr_ret;
   wire btb_w_v_li = (redirect_br_v_i & redirect_br_taken_i)
     | (redirect_br_v_i & redirect_br_nonbr_i & redirect_br_metadata_fwd.src_btb)
-    | (attaboy_yumi_o & attaboy_taken_i & ~attaboy_br_metadata_fwd.src_btb);
+    | (attaboy_v_i & attaboy_taken_i & ~attaboy_br_metadata_fwd.src_btb);
   wire btb_clr_li = redirect_br_v_i & redirect_br_nonbr_i & redirect_br_metadata_fwd.src_btb;
   wire btb_jmp_li = redirect_br_v_i ? (redirect_br_metadata_fwd.is_jal | redirect_br_metadata_fwd.is_jalr) : (attaboy_br_metadata_fwd.is_jal | attaboy_br_metadata_fwd.is_jalr);
   wire [btb_tag_width_p-1:0] btb_tag_li = redirect_br_v_i ? redirect_br_metadata_fwd.btb_tag : attaboy_br_metadata_fwd.btb_tag;
@@ -121,11 +121,9 @@ module bp_fe_pc_gen
 
   logic btb_br_tgt_v_lo;
   logic btb_br_tgt_jmp_lo;
+  logic btb_w_yumi_lo;
   bp_fe_btb
-   #(.vaddr_width_p(vaddr_width_p)
-     ,.btb_tag_width_p(btb_tag_width_p)
-     ,.btb_idx_width_p(btb_idx_width_p)
-     )
+   #(.bp_params_p(bp_params_p))
    btb
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
@@ -142,6 +140,7 @@ module bp_fe_pc_gen
      ,.w_tag_i(btb_tag_li)
      ,.w_idx_i(btb_idx_li)
      ,.br_tgt_i(btb_tgt_li)
+     ,.w_yumi_o(btb_w_yumi_lo)
      );
 
   // BHT
@@ -157,10 +156,8 @@ module bp_fe_pc_gen
   logic [1:0] bht_val_lo;
   logic bht_w_yumi_lo;
   bp_fe_bht
-   #(.vaddr_width_p(vaddr_width_p)
-     ,.bht_idx_width_p(bht_idx_width_p+ghist_width_p)
-     )
-   bp_fe_bht
+   #(.bp_params_p(bp_params_p))
+   bht
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
@@ -190,7 +187,7 @@ module bp_fe_pc_gen
      );
   assign ras_tgt_lo = return_addr_r;
 
-  assign attaboy_yumi_o = attaboy_v_i & ~redirect_br_v_i & ~(bht_w_v_li & ~bht_w_yumi_lo);
+  assign attaboy_yumi_o = attaboy_v_i & ~(bht_w_v_li & ~bht_w_yumi_lo) & ~(btb_w_v_li & ~btb_w_yumi_lo);
 
   /////////////////
   // IF2

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -19,6 +19,8 @@ module bp_fe_pc_gen
   (input                                             clk_i
    , input                                           reset_i
 
+   , output logic                                    init_done_o
+
    , input                                           redirect_v_i
    , input [vaddr_width_p-1:0]                       redirect_pc_i
    , input                                           redirect_br_v_i
@@ -32,7 +34,7 @@ module bp_fe_pc_gen
 
    , output logic                                    ovr_o
 
-   , input [instr_width_gp-1:0]                       fetch_i
+   , input [instr_width_gp-1:0]                      fetch_i
    , input                                           fetch_instr_v_i
    , input                                           fetch_exception_v_i
    , output logic [branch_metadata_fwd_width_p-1:0]  fetch_br_metadata_fwd_o
@@ -119,6 +121,7 @@ module bp_fe_pc_gen
   wire [btb_idx_width_p-1:0] btb_idx_li = redirect_br_v_i ? redirect_br_metadata_fwd.btb_idx : attaboy_br_metadata_fwd.btb_idx;
   wire [vaddr_width_p-1:0]   btb_tgt_li = redirect_br_v_i ? redirect_pc_i : attaboy_pc_i;
 
+  logic btb_init_done_lo;
   logic btb_br_tgt_v_lo;
   logic btb_br_tgt_jmp_lo;
   logic btb_w_yumi_lo;
@@ -127,6 +130,8 @@ module bp_fe_pc_gen
    btb
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
+
+     ,.init_done_o(btb_init_done_lo)
 
      ,.r_addr_i(next_pc_o)
      ,.r_v_i(btb_r_v_li)
@@ -155,11 +160,14 @@ module bp_fe_pc_gen
   wire [1:0] bht_val_li = redirect_br_v_i ? redirect_br_metadata_fwd.bht_val : attaboy_br_metadata_fwd.bht_val;
   logic [1:0] bht_val_lo;
   logic bht_w_yumi_lo;
+  logic bht_init_done_lo;
   bp_fe_bht
    #(.bp_params_p(bp_params_p))
    bht
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
+
+     ,.init_done_o(bht_init_done_lo)
 
      ,.r_v_i(bht_r_v_li)
      ,.idx_r_i(bht_idx_r_li)
@@ -271,6 +279,8 @@ module bp_fe_pc_gen
      ,.data_i(ghistory_n)
      ,.data_o(ghistory_r)
      );
+
+  assign init_done_o = bht_init_done_lo & btb_init_done_lo;
 
 endmodule
 

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -76,6 +76,7 @@ module bp_fe_top
   wire is_run   = (state_r == e_run);
   wire is_stall = (state_r == e_stall);
 
+  logic pc_gen_init_done_lo;
   logic redirect_v_li;
   logic [vaddr_width_p-1:0] redirect_pc_li;
   logic redirect_br_v_li, redirect_br_taken_li, redirect_br_ntaken_li, redirect_br_nonbr_li;
@@ -95,6 +96,8 @@ module bp_fe_top
    pc_gen
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
+
+     ,.init_done_o(pc_gen_init_done_lo)
 
      ,.redirect_v_i(redirect_v_li)
      ,.redirect_pc_i(redirect_pc_li)
@@ -342,7 +345,7 @@ module bp_fe_top
   assign icache_poison_tl = ovr_lo | fe_exception_v | queue_miss | cmd_nonattaboy_v;
   assign icache_poison_tv = fe_exception_v | cmd_nonattaboy_v;
 
-  assign fe_cmd_yumi_o = cmd_nonattaboy_v | attaboy_yumi_lo;
+  assign fe_cmd_yumi_o = pc_gen_init_done_lo & (cmd_nonattaboy_v | attaboy_yumi_lo);
   assign next_pc_yumi_li = (state_n == e_run);
 
   assign fetch_instr_v_li     = fe_queue_v_o & fe_instr_v;

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -73,6 +73,8 @@ $BASEJUMP_STL_DIR/bsg_mem/bsg_cam_1r1w_tag_array.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_one_hot.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_sync.v
+$BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.v
+$BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_synth.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_sync_synth.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_synth.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync.v
@@ -175,6 +177,7 @@ $HARDFLOAT_DIR/source/RISCV/HardFloat_specialize.v
 # Common files
 $BP_COMMON_DIR/src/v/bsg_fifo_1r1w_rolly.sv
 $BP_COMMON_DIR/src/v/bsg_bus_pack.sv
+$BP_COMMON_DIR/src/v/bsg_mem_1r1w_sync_mask_write_bit_reshape.v
 $BP_COMMON_DIR/src/v/bp_mmu.sv
 $BP_COMMON_DIR/src/v/bp_pma.sv
 $BP_COMMON_DIR/src/v/bp_tlb.sv


### PR DESCRIPTION
- Adds a memory reshaping module
- Reshapes BHT to 64-bit wide
- Adds conflict-based back-pressure in bht and btb
- Fixes a hidden X in the br_pkt exposed by these metadata changes

depends on #772 to prevent deadlock