### PR TITLE
Minor fixes to memory management in D$

### DIFF
--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -835,7 +835,7 @@ module bp_be_dcache
       else if (fencei_req)
         cache_req_cast_o.msg_type = e_cache_flush;
       else if (l2_amo_req)
-        cache_req_cast_o.msg_type = e_amo;
+        cache_req_cast_o.msg_type = e_uc_amo;
       else if (uncached_load_req)
         cache_req_cast_o.msg_type = e_uc_load;
       else if (uncached_store_req)

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -902,7 +902,7 @@ module bp_be_dcache
   ///////////////////////////
   // Tag Mem Control
   ///////////////////////////
-  wire tag_mem_fast_read = (tl_we & ~decode_lo.fencei_op & ~decode_lo.l2_op);
+  wire tag_mem_fast_read = (tl_we & ~decode_lo.fencei_op);
   wire tag_mem_slow_read = tag_mem_pkt_yumi_o & (tag_mem_pkt_cast_i.opcode == e_cache_tag_mem_read);
   wire tag_mem_slow_write = tag_mem_pkt_yumi_o & (tag_mem_pkt_cast_i.opcode != e_cache_tag_mem_read);
   // TODO: This will produce spurious invalidations if flush_i goes high while this invalidation is occuring
@@ -1045,6 +1045,7 @@ module bp_be_dcache
         ? {num_dwords_per_bank_lp{wbuf_entry_out.data}}
         : data_mem_pkt_data_li[i];
     end
+  // TODO: Can accept wbuf on non-reading data mems
   assign wbuf_yumi_li = wbuf_v_lo & ~|data_mem_fast_read;
 
   // As an optimization, we could snoop the data_mem_pkt to see if there are any matching entries
@@ -1053,7 +1054,7 @@ module bp_be_dcache
   // A similar scheme could be adopted for a non-blocking version, where we snoop the bank
   assign data_mem_pkt_yumi_o = (data_mem_pkt_cast_i.opcode == e_cache_data_mem_uncached)
                                ? ~cache_lock & data_mem_pkt_v_i
-                               : ~cache_lock & data_mem_pkt_v_i & ~(decode_lo.load_op & tl_we) & ~wbuf_v_lo & ~wbuf_v_li;
+                               : ~cache_lock & data_mem_pkt_v_i & ~|data_mem_fast_read & ~wbuf_v_lo & ~wbuf_v_li;
 
 
   logic [lg_dcache_assoc_lp-1:0] data_mem_pkt_way_r;
@@ -1078,7 +1079,7 @@ module bp_be_dcache
   // Stat Mem Control
   ///////////////////////////
   wire stat_mem_fast_read = ~flush_i & ((v_tv_r & ~early_v_o) | (v_tv_r & load_hit_tv & uncached_op_tv_r));
-  wire stat_mem_fast_write = ~flush_i & (v_tv_r & early_v_o & ~uncached_op_tv_r);
+  wire stat_mem_fast_write = ~flush_i & (v_tv_r & early_v_o & cached_op_tv_r);
   wire stat_mem_slow_write = stat_mem_pkt_yumi_o & (stat_mem_pkt_cast_i.opcode != e_cache_stat_mem_read);
   wire stat_mem_slow_read  = stat_mem_pkt_yumi_o & (stat_mem_pkt_cast_i.opcode == e_cache_stat_mem_read);
   assign stat_mem_v_li = stat_mem_fast_read | stat_mem_fast_write
@@ -1087,7 +1088,7 @@ module bp_be_dcache
   assign stat_mem_addr_li = (stat_mem_fast_write | stat_mem_fast_read)
     ? paddr_tv_r[block_offset_width_lp+:sindex_width_lp]
     : stat_mem_pkt_cast_i.index;
-  assign stat_mem_pkt_yumi_o = ~(v_tv_r & ~uncached_op_tv_r) & ~cache_lock & stat_mem_pkt_v_i;
+  assign stat_mem_pkt_yumi_o = ~cache_lock & stat_mem_pkt_v_i & ~stat_mem_fast_read & ~stat_mem_fast_write;
 
   logic [`BSG_SAFE_MINUS(assoc_p, 2):0] lru_decode_data_lo;
   logic [`BSG_SAFE_MINUS(assoc_p, 2):0] lru_decode_mask_lo;
@@ -1120,7 +1121,7 @@ module bp_be_dcache
       //   1) If dirty bit is set, we force a miss and send off a flush request to the CE
       //   2) If dirty bit is not set, we do not send a request and simply return valid flush.
       //        The CSR unit is now responsible for sending the clear request to the I$.
-      wire set_dirty = wbuf_v_li;
+      wire set_dirty = wbuf_v_li & ~flush_i;
       wire clear_dirty = (is_fence & cache_req_complete_i);
       bsg_dff_reset_set_clear
        #(.width_p(1))

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -812,6 +812,7 @@ module bp_be_dcache
       unique casez ({decode_tv_r.amo_op, decode_tv_r.amo_subop})
         {1'b1, e_dcache_subop_lr     }: cache_req_cast_o.subop = e_req_amolr;
         {1'b1, e_dcache_subop_sc     }: cache_req_cast_o.subop = e_req_amosc;
+        {1'b1, e_dcache_subop_amoswap}: cache_req_cast_o.subop = e_req_amoswap;
         {1'b1, e_dcache_subop_amoadd }: cache_req_cast_o.subop = e_req_amoadd;
         {1'b1, e_dcache_subop_amoxor }: cache_req_cast_o.subop = e_req_amoxor;
         {1'b1, e_dcache_subop_amoand }: cache_req_cast_o.subop = e_req_amoand;
@@ -820,7 +821,7 @@ module bp_be_dcache
         {1'b1, e_dcache_subop_amomax }: cache_req_cast_o.subop = e_req_amomax;
         {1'b1, e_dcache_subop_amominu}: cache_req_cast_o.subop = e_req_amominu;
         {1'b1, e_dcache_subop_amomaxu}: cache_req_cast_o.subop = e_req_amomaxu;
-        default: cache_req_cast_o.subop = e_req_amoswap;
+        default: cache_req_cast_o.subop = e_req_store;
       endcase
 
       if (load_miss_tv)

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -779,7 +779,7 @@ module bp_be_dcache
   wire wt_req             = v_tv_r & decode_tv_r.store_op & ~sc_fail & ~uncached_op_tv_r & (writethrough_p == 1);
   wire l2_amo_req         = v_tv_r & decode_tv_r.l2_op & ~uncached_pending_r;
 
-  assign cache_req_v_o = ~flush_i & |{cached_req, uncached_load_req, uncached_store_req, fencei_req, l2_amo_req, wt_req};
+  assign cache_req_v_o = ~flush_i & |{cached_req, uncached_load_req, fencei_req, uncached_store_req, wt_req, l2_amo_req};
 
   always_comb
     begin
@@ -822,7 +822,7 @@ module bp_be_dcache
         end
       else
         begin
-          cache_req_cast_o.msg_type = e_uc_store;
+          cache_req_cast_o.msg_type = (decode_tv_r.rd_addr == '0) ? e_uc_store : e_amo;
           unique casez (decode_tv_r.amo_subop)
             e_dcache_subop_lr     : cache_req_cast_o.subop = e_req_amolr;
             e_dcache_subop_sc     : cache_req_cast_o.subop = e_req_amosc;

--- a/bp_common/src/include/bp_common_bedrock_if.svh
+++ b/bp_common/src/include/bp_common_bedrock_if.svh
@@ -60,6 +60,7 @@
       logic [payload_width_mp-1:0]                 payload;                                 \
       bp_bedrock_msg_size_e                        size;                                    \
       logic [addr_width_mp-1:0]                    addr;                                    \
+      bp_bedrock_wr_subop_e                        subop;                                   \
       bp_bedrock_msg_u                             msg_type;                                \
     } bp_bedrock_``name_mp``_msg_header_s;                                                  \
                                                                                             \
@@ -157,7 +158,7 @@
    */
 
   `define bp_bedrock_msg_header_width(addr_width_mp, payload_width_mp) \
-    ($bits(bp_bedrock_msg_u)+addr_width_mp+$bits(bp_bedrock_msg_size_e)+payload_width_mp)
+    ($bits(bp_bedrock_msg_u)+$bits(bp_bedrock_wr_subop_e)+addr_width_mp+$bits(bp_bedrock_msg_size_e)+payload_width_mp)
 
   `define bp_bedrock_msg_width(addr_width_mp, payload_width_mp, data_width_mp) \
     (`bp_bedrock_msg_header_width(addr_width_mp, payload_width_mp)+data_width_mp)
@@ -183,18 +184,26 @@
 
   `define declare_bp_bedrock_lce_if(addr_width_mp, data_width_mp, lce_id_width_mp, cce_id_width_mp, lce_assoc_mp, name_mp) \
     `declare_bp_bedrock_lce_payload_s(lce_id_width_mp, cce_id_width_mp, lce_assoc_mp, name_mp);                            \
-    `declare_bp_bedrock_msg_s(addr_width_mp, ``name_mp``_req_payload_width_lp, data_width_mp, ``name_mp``_req); \
-    `declare_bp_bedrock_msg_s(addr_width_mp, ``name_mp``_cmd_payload_width_lp, data_width_mp, ``name_mp``_cmd); \
-    `declare_bp_bedrock_msg_s(addr_width_mp, ``name_mp``_resp_payload_width_lp, data_width_mp, ``name_mp``_resp)
+    `declare_bp_bedrock_msg_s(addr_width_mp, $bits(bp_bedrock_``name_mp``_req_payload_s), data_width_mp, ``name_mp``_req); \
+    `declare_bp_bedrock_msg_s(addr_width_mp, $bits(bp_bedrock_``name_mp``_cmd_payload_s), data_width_mp, ``name_mp``_cmd); \
+    `declare_bp_bedrock_msg_s(addr_width_mp, $bits(bp_bedrock_``name_mp``_resp_payload_s), data_width_mp, ``name_mp``_resp);
 
   `define declare_bp_bedrock_mem_if_widths(addr_width_mp, data_width_mp, lce_id_width_mp, lce_assoc_mp, name_mp)       \
     `declare_bp_bedrock_mem_payload_width(lce_id_width_mp, lce_assoc_mp, name_mp)                                      \
     `declare_bp_bedrock_msg_header_width(addr_width_mp, ``name_mp``_mem_payload_width_lp, ``name_mp``_mem)  \
     `declare_bp_bedrock_msg_width(addr_width_mp, ``name_mp``_mem_payload_width_lp, data_width_mp, ``name_mp``_mem)
 
+  `define declare_bp_bedrock_if_widths(addr_width_mp, payload_width_mp, data_width_mp, lce_id_width_mp, lce_assoc_mp, name_mp) \
+    , localparam ``name_mp``_msg_payload_width_lp = payload_width_mp                                                   \
+    `declare_bp_bedrock_msg_header_width(addr_width_mp, ``name_mp``_msg_payload_width_lp, ``name_mp``)                 \
+    `declare_bp_bedrock_msg_width(addr_width_mp, ``name_mp``_msg_payload_width_lp, data_width_mp, ``name_mp``)
+
   `define declare_bp_bedrock_mem_if(addr_width_mp, data_width_mp, lce_id_width_mp, lce_assoc_mp, name_mp) \
-    `declare_bp_bedrock_mem_payload_s(lce_id_width_mp, lce_assoc_mp, name_mp); \
-    `declare_bp_bedrock_msg_s(addr_width_mp, ``name_mp``_mem_payload_width_lp, data_width_mp, ``name_mp``_mem)
+    `declare_bp_bedrock_mem_payload_s(lce_id_width_mp, lce_assoc_mp, name_mp);                                         \
+    `declare_bp_bedrock_msg_s(addr_width_mp, $bits(bp_bedrock_``name_mp``_mem_payload_s), data_width_mp, ``name_mp``_mem);
+
+  `define declare_bp_bedrock_if(addr_width_mp, payload_width_mp, data_width_mp, lce_id_width_mp, lce_assoc_mp, name_mp) \
+    `declare_bp_bedrock_msg_s(addr_width_mp, payload_width_mp, data_width_mp, ``name_mp``);
 
 `endif
 

--- a/bp_common/src/include/bp_common_bedrock_pkgdef.svh
+++ b/bp_common/src/include/bp_common_bedrock_pkgdef.svh
@@ -68,17 +68,18 @@
    */
   typedef enum logic [3:0]
   {
-      e_bedrock_amoswap          = 4'b0000
+      e_bedrock_store            = 4'b0000
       ,e_bedrock_amolr           = 4'b0001
       ,e_bedrock_amosc           = 4'b0010
-      ,e_bedrock_amoadd          = 4'b0011
-      ,e_bedrock_amoxor          = 4'b0100
-      ,e_bedrock_amoand          = 4'b0101
-      ,e_bedrock_amoor           = 4'b0110
-      ,e_bedrock_amomin          = 4'b0111
-      ,e_bedrock_amomax          = 4'b1000
-      ,e_bedrock_amominu         = 4'b1001
-      ,e_bedrock_amomaxu         = 4'b1010
+      ,e_bedrock_amoswap         = 4'b0011
+      ,e_bedrock_amoadd          = 4'b0100
+      ,e_bedrock_amoxor          = 4'b0101
+      ,e_bedrock_amoand          = 4'b0110
+      ,e_bedrock_amoor           = 4'b0111
+      ,e_bedrock_amomin          = 4'b1000
+      ,e_bedrock_amomax          = 4'b1001
+      ,e_bedrock_amominu         = 4'b1010
+      ,e_bedrock_amomaxu         = 4'b1011
   } bp_bedrock_wr_subop_e;
 
 

--- a/bp_common/src/include/bp_common_bedrock_pkgdef.svh
+++ b/bp_common/src/include/bp_common_bedrock_pkgdef.svh
@@ -55,31 +55,34 @@
    */
   typedef enum logic [3:0]
   {
-    e_bedrock_req_rd         = 4'b0000 // Read-miss
-    ,e_bedrock_req_wr        = 4'b0001 // Write-miss
-    ,e_bedrock_req_uc_rd     = 4'b0010 // Uncached Read-miss
-    ,e_bedrock_req_uc_wr     = 4'b0011 // Uncached Write-miss
-    ,e_bedrock_req_amo       = 4'b0100 // AMO
+    e_bedrock_req_rd_miss    = 4'b0000 // Read-miss
+    ,e_bedrock_req_wr_miss   = 4'b0001 // Write-miss
+    ,e_bedrock_req_uc_rd     = 4'b0010 // Uncached Read
+    ,e_bedrock_req_uc_wr     = 4'b0011 // Uncached Write
+    ,e_bedrock_req_uc_amo    = 4'b0100 // AMO
     // 4'b0100 - 4'b1111 reserved / custom
   } bp_bedrock_req_type_e;
 
   /*
    * bp_bedrock_wr_subop_e specifies the type of store
+   * Valid only for
+   * req: e_bedrock_req_uc_wr, e_bedrock_req_uc_amo
+   * mem_cmd: e_bedrock_mem_uc_wr, e_bedrock_mem_amo
    */
   typedef enum logic [3:0]
   {
-      e_bedrock_store            = 4'b0000
-      ,e_bedrock_amolr           = 4'b0001
-      ,e_bedrock_amosc           = 4'b0010
-      ,e_bedrock_amoswap         = 4'b0011
-      ,e_bedrock_amoadd          = 4'b0100
-      ,e_bedrock_amoxor          = 4'b0101
-      ,e_bedrock_amoand          = 4'b0110
-      ,e_bedrock_amoor           = 4'b0111
-      ,e_bedrock_amomin          = 4'b1000
-      ,e_bedrock_amomax          = 4'b1001
-      ,e_bedrock_amominu         = 4'b1010
-      ,e_bedrock_amomaxu         = 4'b1011
+    e_bedrock_store            = 4'b0000
+    ,e_bedrock_amolr           = 4'b0001
+    ,e_bedrock_amosc           = 4'b0010
+    ,e_bedrock_amoswap         = 4'b0011
+    ,e_bedrock_amoadd          = 4'b0100
+    ,e_bedrock_amoxor          = 4'b0101
+    ,e_bedrock_amoand          = 4'b0110
+    ,e_bedrock_amoor           = 4'b0111
+    ,e_bedrock_amomin          = 4'b1000
+    ,e_bedrock_amomax          = 4'b1001
+    ,e_bedrock_amominu         = 4'b1010
+    ,e_bedrock_amomaxu         = 4'b1011
   } bp_bedrock_wr_subop_e;
 
 

--- a/bp_common/src/include/bp_common_bedrock_pkgdef.svh
+++ b/bp_common/src/include/bp_common_bedrock_pkgdef.svh
@@ -45,6 +45,7 @@
     ,e_bedrock_mem_uc_rd   = 4'b0010  // Uncached load (uncached in L2/LLC)
     ,e_bedrock_mem_uc_wr   = 4'b0011  // Uncached store (uncached in L2/LLC)
     ,e_bedrock_mem_pre     = 4'b0100  // Pre-fetch block request from CCE, fill into L2/LLC if able
+    ,e_bedrock_mem_amo     = 4'b0101  // Atomic operation in L2/LLC
     // 4'b0101 - 4'b1111 reserved // custom
   } bp_bedrock_mem_type_e;
 
@@ -67,18 +68,17 @@
    */
   typedef enum logic [3:0]
   {
-      e_store             = 4'b0000
-      ,e_amo_lr           = 4'b0001
-      ,e_amo_sc           = 4'b0010
-      ,e_amo_swap         = 4'b0011
-      ,e_amo_add          = 4'b0100
-      ,e_amo_xor          = 4'b0101
-      ,e_amo_and          = 4'b0110
-      ,e_amo_or           = 4'b0111
-      ,e_amo_min          = 4'b1000
-      ,e_amo_max          = 4'b1001
-      ,e_amo_minu         = 4'b1010
-      ,e_amo_maxu         = 4'b1011
+      e_bedrock_amoswap          = 4'b0000
+      ,e_bedrock_amolr           = 4'b0001
+      ,e_bedrock_amosc           = 4'b0010
+      ,e_bedrock_amoadd          = 4'b0011
+      ,e_bedrock_amoxor          = 4'b0100
+      ,e_bedrock_amoand          = 4'b0101
+      ,e_bedrock_amoor           = 4'b0110
+      ,e_bedrock_amomin          = 4'b0111
+      ,e_bedrock_amomax          = 4'b1000
+      ,e_bedrock_amominu         = 4'b1001
+      ,e_bedrock_amomaxu         = 4'b1010
   } bp_bedrock_wr_subop_e;
 
 

--- a/bp_common/src/include/bp_common_cache_engine_pkgdef.svh
+++ b/bp_common/src/include/bp_common_cache_engine_pkgdef.svh
@@ -6,12 +6,12 @@
   {
     e_miss_load         = 4'b0000
     ,e_miss_store       = 4'b0001
-    ,e_uc_load          = 4'b0010
-    ,e_uc_store         = 4'b0011
-    ,e_wt_store         = 4'b0100
-    ,e_cache_flush      = 4'b0101
-    ,e_cache_clear      = 4'b0110
-    ,e_amo              = 4'b0111
+    ,e_wt_store         = 4'b0010
+    ,e_uc_load          = 4'b0011
+    ,e_uc_store         = 4'b0100
+    ,e_uc_amo           = 4'b0101
+    ,e_cache_flush      = 4'b0110
+    ,e_cache_clear      = 4'b0111
   } bp_cache_req_msg_type_e;
 
   typedef enum logic [2:0]
@@ -25,6 +25,7 @@
     ,e_size_64B  = 3'b110
   } bp_cache_req_size_e;
 
+  // Relevant for uc_store and uc_amo
   typedef enum logic [3:0]
   {
     // Return value of e_req_store is undefined, clients should not

--- a/bp_common/src/include/bp_common_cache_engine_pkgdef.svh
+++ b/bp_common/src/include/bp_common_cache_engine_pkgdef.svh
@@ -8,6 +8,7 @@
     ,e_miss_store       = 4'b0001
     ,e_uc_load          = 4'b0010
     ,e_uc_store         = 4'b0011
+    ,e_wt_store         = 4'b0100
     ,e_cache_flush      = 4'b0101
     ,e_cache_clear      = 4'b0110
     ,e_amo              = 4'b0111
@@ -26,6 +27,8 @@
 
   typedef enum logic [3:0]
   {
+    // Return value of e_req_store is undefined, clients should not
+    //   depend on it being zero
     e_req_store    = 4'b0000
     ,e_req_amolr   = 4'b0001
     ,e_req_amosc   = 4'b0010

--- a/bp_common/src/include/bp_common_cache_engine_pkgdef.svh
+++ b/bp_common/src/include/bp_common_cache_engine_pkgdef.svh
@@ -26,17 +26,18 @@
 
   typedef enum logic [3:0]
   {
-    e_req_amoswap  = 4'b0000
+    e_req_store    = 4'b0000
     ,e_req_amolr   = 4'b0001
     ,e_req_amosc   = 4'b0010
-    ,e_req_amoadd  = 4'b0011
-    ,e_req_amoxor  = 4'b0100
-    ,e_req_amoand  = 4'b0101
-    ,e_req_amoor   = 4'b0110
-    ,e_req_amomin  = 4'b0111
-    ,e_req_amomax  = 4'b1000
-    ,e_req_amominu = 4'b1001
-    ,e_req_amomaxu = 4'b1010
+    ,e_req_amoswap = 4'b0011
+    ,e_req_amoadd  = 4'b0100
+    ,e_req_amoxor  = 4'b0101
+    ,e_req_amoand  = 4'b0110
+    ,e_req_amoor   = 4'b0111
+    ,e_req_amomin  = 4'b1000
+    ,e_req_amomax  = 4'b1001
+    ,e_req_amominu = 4'b1010
+    ,e_req_amomaxu = 4'b1011
   } bp_cache_req_wr_subop_e;
 
 `endif

--- a/bp_me/src/v/cache/bp_me_cache_slice.sv
+++ b/bp_me/src/v/cache/bp_me_cache_slice.sv
@@ -126,7 +126,7 @@ module bp_me_cache_slice
   `declare_bp_bedrock_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce);
   `bp_cast_o(bp_bedrock_cce_mem_msg_header_s, mem_cmd_header);
   assign mem_cmd_header_cast_o = '{msg_type : dma_pkt_lo.write_not_read ? e_bedrock_mem_wr : e_bedrock_mem_rd
-                                   ,subop   : e_bedrock_amoswap
+                                   ,subop   : e_bedrock_store
                                    ,size    : mem_cmd_block_size
                                    ,addr    : dma_pkt_lo.addr
                                    ,payload : '0

--- a/bp_me/src/v/cache/bp_me_cache_slice.sv
+++ b/bp_me/src/v/cache/bp_me_cache_slice.sv
@@ -126,6 +126,7 @@ module bp_me_cache_slice
   `declare_bp_bedrock_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce);
   `bp_cast_o(bp_bedrock_cce_mem_msg_header_s, mem_cmd_header);
   assign mem_cmd_header_cast_o = '{msg_type : dma_pkt_lo.write_not_read ? e_bedrock_mem_wr : e_bedrock_mem_rd
+                                   ,subop   : e_bedrock_amoswap
                                    ,size    : mem_cmd_block_size
                                    ,addr    : dma_pkt_lo.addr
                                    ,payload : '0

--- a/bp_me/src/v/cce/bp_cce_fsm.sv
+++ b/bp_me/src/v/cce/bp_cce_fsm.sv
@@ -278,8 +278,8 @@ module bp_cce_fsm
     if (~reset_i) begin
       // Cacheable requests must target cacheable memory
       assert(!(lce_req_v_i && ~req_pma_coherent_addr_lo
-               && ((lce_req.header.msg_type.req == e_bedrock_req_rd)
-                   || (lce_req.header.msg_type.req == e_bedrock_req_wr))
+               && ((lce_req.header.msg_type.req == e_bedrock_req_rd_miss)
+                   || (lce_req.header.msg_type.req == e_bedrock_req_wr_miss))
               )
             ) else
       $error("CCE PMA violation - cacheable requests must target cacheable memory");
@@ -850,8 +850,8 @@ module bp_cce_fsm
         // cached requests will stall on the input port
         end else if (lce_req_v_i) begin
           // cached requests not allowed, go to error state and stall
-          if ((lce_req.header.msg_type.req == e_bedrock_req_rd)
-              | (lce_req.header.msg_type.req == e_bedrock_req_wr)) begin
+          if ((lce_req.header.msg_type.req == e_bedrock_req_rd_miss)
+              | (lce_req.header.msg_type.req == e_bedrock_req_wr_miss)) begin
               state_n = e_error;
 
           // uncached load/store
@@ -934,13 +934,13 @@ module bp_cce_fsm
           mshr_n.lce_id = lce_req_payload.src_id;
           state_n = e_error;
           // cached request
-          if (lce_req.header.msg_type.req == e_bedrock_req_rd
-              | lce_req.header.msg_type.req == e_bedrock_req_wr) begin
+          if (lce_req.header.msg_type.req == e_bedrock_req_rd_miss
+              | lce_req.header.msg_type.req == e_bedrock_req_wr_miss) begin
 
             mshr_n.paddr = lce_req.header.addr;
             mshr_n.msg_size = lce_req.header.size;
             mshr_n.lru_way_id = lce_req_payload.lru_way_id;
-            mshr_n.flags[e_opd_rqf] = (lce_req.header.msg_type.req == e_bedrock_req_wr);
+            mshr_n.flags[e_opd_rqf] = (lce_req.header.msg_type.req == e_bedrock_req_wr_miss);
             mshr_n.flags[e_opd_nerf] = lce_req_payload.non_exclusive;
 
             // query PMA for coherence property - it is a violation for a cached request

--- a/bp_me/src/v/cce/bp_cce_reg.sv
+++ b/bp_me/src/v/cce/bp_cce_reg.sv
@@ -126,8 +126,8 @@ module bp_cce_reg
     if (~reset_i) begin
       // Cacheable requests must target cacheable memory
       assert(!(lce_req_v_i && ~req_pma_coherent_addr_lo
-               && ((lce_req_hdr.msg_type.req == e_bedrock_req_rd)
-                   || (lce_req_hdr.msg_type.req == e_bedrock_req_wr))
+               && ((lce_req_hdr.msg_type.req == e_bedrock_req_rd_miss)
+                   || (lce_req_hdr.msg_type.req == e_bedrock_req_wr_miss))
               )
             ) else
       $error("CCE PMA violation - cacheable requests must target cacheable memory");
@@ -147,7 +147,7 @@ module bp_cce_reg
   wire queue_op      = (decoded_inst_i.op == e_op_queue);
 
   // Flag next values
-  wire lce_req_rqf   = (lce_req_hdr.msg_type.req == e_bedrock_req_wr)
+  wire lce_req_rqf   = (lce_req_hdr.msg_type.req == e_bedrock_req_wr_miss)
                        | (lce_req_hdr.msg_type.req == e_bedrock_req_uc_wr);
   wire lce_req_ucf   = (lce_req_hdr.msg_type.req == e_bedrock_req_uc_rd)
                        | (lce_req_hdr.msg_type.req == e_bedrock_req_uc_wr);

--- a/bp_me/src/v/lce/bp_lce_req.sv
+++ b/bp_me/src/v/lce/bp_lce_req.sv
@@ -252,8 +252,8 @@ module bp_lce_req
         lce_req.header.size = req_block_size_lp;
         lce_req.header.addr = cache_req_r.addr;
         lce_req.header.msg_type = (cache_req_r.msg_type == e_miss_load)
-          ? e_bedrock_req_rd
-          : e_bedrock_req_wr;
+          ? e_bedrock_req_rd_miss
+          : e_bedrock_req_wr_miss;
 
         lce_req_payload.lru_way_id = lg_lce_assoc_lp'(cache_req_metadata_r.hit_or_repl_way);
         lce_req_payload.non_exclusive = (cache_req_r.msg_type == e_miss_load)

--- a/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_req.sv
+++ b/bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_req.sv
@@ -76,8 +76,8 @@ module bp_me_wormhole_packet_encode_lce_req
 
     unique case (header_cast_i.msg_type)
       // read, write, and uncached read requests have no data
-      e_bedrock_req_rd
-      ,e_bedrock_req_wr
+      e_bedrock_req_rd_miss
+      ,e_bedrock_req_wr_miss
       ,e_bedrock_req_uc_rd: header_cast_o.wh_hdr.len = coh_noc_len_width_p'(lce_cce_req_req_len_lp);
       // uncached write (store) has data
       e_bedrock_req_uc_wr:

--- a/bp_me/test/common/bp_me_nonsynth_cce_tracer.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cce_tracer.sv
@@ -107,11 +107,11 @@ module bp_me_nonsynth_cce_tracer
     if (~reset_i) begin
       // inbound messages
       if (lce_req_v_i & lce_req_yumi_i) begin
-        if (lce_req.header.msg_type.req == e_bedrock_req_rd | lce_req.header.msg_type.req == e_bedrock_req_wr) begin
+        if (lce_req.header.msg_type.req == e_bedrock_req_rd_miss | lce_req.header.msg_type.req == e_bedrock_req_wr_miss) begin
         $fdisplay(file, "[%t]: CCE[%0d] REQ LCE[%0d] addr[%H] wg[%0d] wr[%0b] ne[%0b] uc[%0b] lruWay[%0d]"
                  , $time, lce_req_payload.dst_id, lce_req_payload.src_id, lce_req.header.addr
                  , lce_req.header.addr[lg_block_size_in_bytes_lp +: lg_cce_way_groups_lp]
-                 , (lce_req.header.msg_type.req == e_bedrock_req_wr)
+                 , (lce_req.header.msg_type.req == e_bedrock_req_wr_miss)
                  , lce_req_payload.non_exclusive
                  , 1'b0
                  , lce_req_payload.lru_way_id

--- a/bp_top/src/v/bp_clint_slice.sv
+++ b/bp_top/src/v/bp_clint_slice.sv
@@ -168,6 +168,7 @@ bp_bedrock_xce_mem_msg_s mem_resp_lo;
 assign mem_resp_lo =
   '{header : '{
     msg_type       : mem_cmd_lo.header.msg_type
+    ,subop         : e_bedrock_amoswap
     ,addr          : mem_cmd_lo.header.addr
     ,payload       : mem_cmd_lo.header.payload
     ,size          : mem_cmd_lo.header.size

--- a/bp_top/src/v/bp_clint_slice.sv
+++ b/bp_top/src/v/bp_clint_slice.sv
@@ -168,7 +168,7 @@ bp_bedrock_xce_mem_msg_s mem_resp_lo;
 assign mem_resp_lo =
   '{header : '{
     msg_type       : mem_cmd_lo.header.msg_type
-    ,subop         : e_bedrock_amoswap
+    ,subop         : e_bedrock_store
     ,addr          : mem_cmd_lo.header.addr
     ,payload       : mem_cmd_lo.header.payload
     ,size          : mem_cmd_lo.header.size

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -326,7 +326,7 @@ module testbench
            ,.v_o(early_v_o)
            ,.load_data(early_data_o[0+:65])
            ,.cache_miss_o('0)
-           ,.wt_req(wt_req)
+           ,.wt_req('0)
            ,.store_data(st_data_tv_r[0+:dword_width_gp])
 
            ,.data_mem_v_i(data_mem_v_li)

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -326,7 +326,7 @@ module testbench
            ,.v_o(early_v_o)
            ,.load_data(early_data_o[0+:65])
            ,.cache_miss_o('0)
-           ,.wt_req('0)
+           ,.wt_req(wt_req)
            ,.store_data(st_data_tv_r[0+:dword_width_gp])
 
            ,.data_mem_v_i(data_mem_v_li)

--- a/docs/interface_specification.md
+++ b/docs/interface_specification.md
@@ -147,7 +147,7 @@ routed through a FIFO. BlackParrot provides 3 types of Cache Engines:
 More details are provided about the LCE and CCE interface in the following section.
 
 A UCE implementation must support the following operations:
-- Engine loads, stores and optionally amo operations
+- Engine loads, stores and amo operations
 - Handle remote invalidations
 - Handle both uncached and cached requests
 - Support both write-through and write-back protocols
@@ -171,7 +171,7 @@ bp_cache_req_s, which contains the following fields.
 
 Additionally, the Cache Engine may require some metadata in order to service cache misses. This metadata may not be available at the same time as the request, due to the nature of high performance caches. The handshake here is valid-only. If a Cache Engine needs metadata in order to service the miss, it needs to be ready to accept metadata at any cycle later than or equal to the original cache miss. The cache is required to eventually provide this data, although not in any particular cycle. The latency between a cache request and its metadata must be a known constant for all message types, under all backpressure conditions. The current metadata fields are:
 - Dirty
-- Replacement way
+- Hit or Replacement way
 
 The fill interface is implemented as a set of ready-valid connections that provide read/write access
 to memory structures in a typical cache. A single cache request may trigger a set of fill responses. To decouple cache logic from any particular fill strategy, there is an additional signal which is raised when a request is
@@ -217,8 +217,9 @@ A memory command or response packet is composed of:
   - Write request
   - Uncached read request
   - Uncached write request
-  - Writeback
   - Prefetch
+  - Atomic operation
+- Subop type (amoswap, amolr, amosc, amoadd, amoxor, amoand, amoor, amomin, amomax, amominu, amomaxu)
 - Physical address
 - Request Size
 - Payload (A black-box to the command receiver, this is returned as-is along with the memory response)


### PR DESCRIPTION
Minor fixes
- Need to read from tag mem on L2 ops for self-invalidation
- Add flush to dirty signal to prevent speculative dirtying
- Clarified stat mem update using fast_read / fast_write
- Don't write stat mem on fencei ops
- Combining amo_noreturn, wt_req and uncached_store 