### PR TITLE
Fix typo in bp_mem

### DIFF
--- a/bp_me/test/common/bp_mem.sv
+++ b/bp_me/test/common/bp_mem.sv
@@ -5,7 +5,7 @@
 
 // Set default DRAM package
 `ifndef dram_pkg
-`define dram_pkg bsg_dramsim2_hmb2_4gb_x128_pkg
+`define dram_pkg bsg_dramsim3_hbm2_4gb_x128_pkg
 `endif
 
 `include "bp_common_defines.svh"


### PR DESCRIPTION
Default dram_pkg is non-existent, at least until they invent high-memory-bandwidth DRAM