### PR TITLE
Fixing replay pending bug

### DIFF
--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -260,11 +260,12 @@ module bp_be_detector
                      | ptw_busy_i
                      | (~mem_ready_i & isd_status_cast_i.mem_v)
                      | (~long_ready_i & isd_status_cast_i.long_v)
+                     | (irq_pending_i & ~replay_pending_i)
                      | cmd_haz_v;
     end
 
   // Generate calculator control signals
-  assign dispatch_v_o  = ~(control_haz_v | data_haz_v | struct_haz_v) & ~irq_pending_i;
+  assign dispatch_v_o  = ~(control_haz_v | data_haz_v | struct_haz_v);
   assign interrupt_v_o = irq_pending_i & ~replay_pending_i & ~ptw_busy_i & ~cfg_bus_cast_i.freeze;
 
   bp_be_dep_status_s dep_status_n;

--- a/bp_me/src/v/cce/bp_uce.sv
+++ b/bp_me/src/v/cce/bp_uce.sv
@@ -600,6 +600,7 @@ module bp_uce
                 mem_cmd_cast_o.header.size           = bp_bedrock_msg_size_e'(cache_req_cast_i.size);
                 mem_cmd_cast_payload.lce_id          = lce_id_i;
                 mem_cmd_cast_o.header.payload        = mem_cmd_cast_payload;
+                mem_cmd_cast_o.header.subop          = mem_wr_subop;
                 mem_cmd_cast_o.data                  = cache_req_cast_i.data;
                 mem_cmd_v_o                          = mem_cmd_ready_i & ~cache_req_credits_full_o;
 


### PR DESCRIPTION
Previously, dispatch would be blocked if there was an interrupt while a cache request was being replayed.

RTL is good to go, but needs a test.  Maybe a bunch of L1 amoadds with an interrupt timer going off (edited) 

