### PR TITLE
Minimizing arbitration near cache engines

### DIFF
--- a/bp_be/syn/flist.vcs
+++ b/bp_be/syn/flist.vcs
@@ -254,6 +254,7 @@ $BP_ME_DIR/src/v/wormhole/bp_me_wormhole_packet_encode_lce_resp.sv
 $BP_ME_DIR/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.sv
 $BP_ME_DIR/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.sv
 ## TOP
+$BP_TOP_DIR/src/v/bp_loopback.sv
 $BP_TOP_DIR/src/v/bp_nd_socket.sv
 $BP_TOP_DIR/src/v/bp_cacc_vdp.sv
 $BP_TOP_DIR/src/v/bp_cacc_tile.sv

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -419,7 +419,7 @@ module wrapper
 
              ,.mem_cmd_o(mem_cmd_o)
              ,.mem_cmd_v_o(mem_cmd_v_o)
-             ,.mem_cmd_ready_i(mem_cmd_ready_i)
+             ,.mem_cmd_yumi_i(mem_cmd_ready_i & mem_cmd_v_o)
 
              ,.mem_resp_i(mem_resp_i)
              ,.mem_resp_v_i(mem_resp_v_i)

--- a/bp_fe/syn/flist.vcs
+++ b/bp_fe/syn/flist.vcs
@@ -228,6 +228,7 @@ $BP_ME_DIR/src/v/wormhole/bp_me_wormhole_packet_encode_lce_resp.sv
 $BP_ME_DIR/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.sv
 $BP_ME_DIR/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.sv
 ## TOP
+$BP_TOP_DIR/src/v/bp_loopback.sv
 $BP_TOP_DIR/src/v/bp_nd_socket.sv
 $BP_TOP_DIR/src/v/bp_cacc_vdp.sv
 $BP_TOP_DIR/src/v/bp_cacc_tile.sv

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -381,7 +381,7 @@ module wrapper
 
        ,.mem_cmd_o(mem_cmd_o)
        ,.mem_cmd_v_o(mem_cmd_v_o)
-       ,.mem_cmd_ready_i(mem_cmd_ready_i)
+       ,.mem_cmd_yumi_i(mem_cmd_ready_i & mem_cmd_v_o)
 
        ,.mem_resp_i(fifo_mem_resp_lo)
        ,.mem_resp_v_i(fifo_mem_resp_v_lo)

--- a/bp_me/src/v/cce/bp_uce.sv
+++ b/bp_me/src/v/cce/bp_uce.sv
@@ -79,7 +79,7 @@ module bp_uce
 
     , output [uce_mem_msg_width_lp-1:0]              mem_cmd_o
     , output logic                                   mem_cmd_v_o
-    , input                                          mem_cmd_ready_i
+    , input                                          mem_cmd_yumi_i
 
     , input [uce_mem_msg_width_lp-1:0]               mem_resp_i
     , input                                          mem_resp_v_i
@@ -392,7 +392,7 @@ module bp_uce
    mem_cmd_done_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
-     ,.set_i(mem_cmd_done & mem_cmd_v_o)
+     ,.set_i(mem_cmd_done & mem_cmd_yumi_i)
      ,.clear_i(cache_req_complete_o | way_up | writeback_complete)
      ,.data_o(mem_cmd_done_r)
      );
@@ -401,7 +401,7 @@ module bp_uce
   //
   logic [`BSG_WIDTH(coh_noc_max_credits_p)-1:0] credit_count_lo;
   wire credit_v_li = mem_cmd_v_o;
-  wire credit_ready_li = mem_cmd_ready_i;
+  wire credit_ready_li = mem_cmd_yumi_i;
   // credit is returned when request completes
   // UC store done for UC Store, UC Data for UC Load, Set Tag Wakeup for
   // a miss that is actually an upgrade, and data and tag for normal requests.
@@ -434,7 +434,7 @@ module bp_uce
   //   start waiting when we enter the sending state, and then we'll
   //   know the next non-write response will be critical
   logic critical_pending;
-  wire critical_sent = is_send_critical & mem_cmd_v_o;
+  wire critical_sent = is_send_critical & mem_cmd_yumi_i;
   wire critical_recv = mem_resp_yumi_o & load_resp_v_li;
   bsg_dff_reset_set_clear
    #(.width_p(1))
@@ -573,13 +573,13 @@ module bp_uce
             mem_cmd_cast_payload.lce_id    = lce_id_i;
             mem_cmd_cast_o.header.payload = mem_cmd_cast_payload;
             mem_cmd_cast_o.data                  = writeback_data;
-            mem_cmd_v_o = mem_cmd_ready_i & dirty_data_v_r & dirty_tag_v_r;
-            mem_cmd_up = mem_cmd_v_o;
+            mem_cmd_v_o = dirty_data_v_r & dirty_tag_v_r;
+            mem_cmd_up = mem_cmd_yumi_i;
 
-            way_up = mem_cmd_done & mem_cmd_v_o;
-            index_up = way_done & mem_cmd_done & mem_cmd_v_o;
+            way_up = mem_cmd_done & mem_cmd_up;
+            index_up = way_done & way_up;
 
-            state_n = (mem_cmd_done & mem_cmd_v_o & index_done & way_done)
+            state_n = (mem_cmd_done & index_done & way_done & mem_cmd_yumi_i)
                       ? e_flush_fence
                       : index_up
                         ? e_flush_read
@@ -604,9 +604,9 @@ module bp_uce
                 mem_cmd_cast_o.header.payload        = mem_cmd_cast_payload;
                 mem_cmd_cast_o.header.subop          = mem_wr_subop;
                 mem_cmd_cast_o.data                  = cache_req_cast_i.data;
-                mem_cmd_v_o                          = mem_cmd_ready_i & ~cache_req_credits_full_o;
+                mem_cmd_v_o                          = ~cache_req_credits_full_o;
 
-                cache_req_complete_o = mem_cmd_v_o;
+                cache_req_complete_o = mem_cmd_yumi_i;
                 cache_req_yumi_o = cache_req_complete_o;
               end
             else
@@ -653,10 +653,10 @@ module bp_uce
             mem_cmd_cast_payload.lce_id    = lce_id_i;
             mem_cmd_cast_o.header.payload  = mem_cmd_cast_payload;
             mem_cmd_cast_o.data            = writeback_data;
-            mem_cmd_v_o = mem_cmd_ready_i;
-            mem_cmd_up = mem_cmd_v_o;
+            mem_cmd_v_o = ~cache_req_credits_full_o;
+            mem_cmd_up = mem_cmd_yumi_i;
 
-            writeback_complete = mem_cmd_done & mem_cmd_v_o;
+            writeback_complete = mem_cmd_done & mem_cmd_yumi_i;
             state_n = writeback_complete ? e_send_critical : e_uc_writeback_write_req;
           end
 
@@ -669,9 +669,9 @@ module bp_uce
               mem_cmd_cast_payload.way_id          = lce_assoc_p'(cache_req_metadata_r.hit_or_repl_way);
               mem_cmd_cast_payload.lce_id          = lce_id_i;
               mem_cmd_cast_o.header.payload = mem_cmd_cast_payload;
-              mem_cmd_v_o = mem_cmd_ready_i & cache_req_metadata_v_r;
-              mem_cmd_up = mem_cmd_v_o;
-              state_n = mem_cmd_v_o
+              mem_cmd_v_o = cache_req_metadata_v_r;
+              mem_cmd_up = mem_cmd_yumi_i;
+              state_n = mem_cmd_up
                         ? cache_req_metadata_r.dirty
                           ? e_writeback_evict
                           : e_read_req
@@ -686,9 +686,9 @@ module bp_uce
               mem_cmd_cast_o.header.payload        = mem_cmd_cast_payload;
               mem_cmd_cast_o.header.subop          = mem_wr_subop;
               mem_cmd_cast_o.data                  = cache_req_r.data;
-              mem_cmd_v_o                          = mem_cmd_ready_i;
+              mem_cmd_v_o                          = ~cache_req_credits_full_o;
 
-              state_n = mem_cmd_v_o ? uc_store_v_r ? e_ready: e_uc_read_wait : e_send_critical;
+              state_n = mem_cmd_yumi_i ? uc_store_v_r ? e_ready: e_uc_read_wait : e_send_critical;
             end
 
         e_writeback_evict:
@@ -738,8 +738,8 @@ module bp_uce
             mem_cmd_cast_payload.way_id          = lce_assoc_p'(cache_req_metadata_r.hit_or_repl_way);
             mem_cmd_cast_payload.lce_id          = lce_id_i;
             mem_cmd_cast_o.header.payload = mem_cmd_cast_payload;
-            mem_cmd_v_o = mem_cmd_ready_i & ~mem_cmd_done_r & ~cache_req_credits_full_o;
-            mem_cmd_up = mem_cmd_v_o;
+            mem_cmd_v_o = ~mem_cmd_done_r & ~cache_req_credits_full_o;
+            mem_cmd_up = mem_cmd_yumi_i;
 
             cache_req_complete_o = fill_done & mem_cmd_done_r & tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
             state_n = cache_req_complete_o ? e_writeback_write_req : e_writeback_read_req;
@@ -752,10 +752,10 @@ module bp_uce
             mem_cmd_cast_payload.lce_id    = lce_id_i;
             mem_cmd_cast_o.header.payload = mem_cmd_cast_payload;
             mem_cmd_cast_o.data                  = writeback_data;
-            mem_cmd_v_o = mem_cmd_ready_i & dirty_data_v_r & dirty_tag_v_r;
-            mem_cmd_up = mem_cmd_v_o;
+            mem_cmd_v_o = dirty_data_v_r & dirty_tag_v_r;
+            mem_cmd_up = mem_cmd_yumi_i;
 
-            writeback_complete = mem_cmd_done & mem_cmd_v_o;
+            writeback_complete = mem_cmd_done & mem_cmd_up;
             state_n = writeback_complete ? e_ready : e_writeback_write_req;
           end
         e_read_req:
@@ -785,8 +785,8 @@ module bp_uce
             mem_cmd_cast_payload.way_id          = lce_assoc_p'(cache_req_metadata_r.hit_or_repl_way);
             mem_cmd_cast_payload.lce_id          = lce_id_i;
             mem_cmd_cast_o.header.payload = mem_cmd_cast_payload;
-            mem_cmd_v_o = mem_cmd_ready_i & ~mem_cmd_done_r & ~cache_req_credits_full_o;
-            mem_cmd_up = mem_cmd_v_o;
+            mem_cmd_v_o = ~mem_cmd_done_r & ~cache_req_credits_full_o;
+            mem_cmd_up = mem_cmd_yumi_i;
 
             cache_req_complete_o = fill_done & mem_cmd_done_r & tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
             state_n = cache_req_complete_o ? e_ready : e_read_req;

--- a/bp_me/syn/flist.vcs
+++ b/bp_me/syn/flist.vcs
@@ -171,6 +171,7 @@ $BP_ME_DIR/src/v/cce/bp_io_cce.sv
 # NETWORK
 $BP_ME_DIR/src/v/wormhole/bp_me_cord_to_id.sv
 ## TOP Files
+$BP_TOP_DIR/src/v/bp_loopback.sv
 $BP_TOP_DIR/src/v/bp_cfg.sv
 
 # BSG Staging area

--- a/bp_top/src/v/bp_cfg.sv
+++ b/bp_top/src/v/bp_cfg.sv
@@ -10,8 +10,6 @@ module bp_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, dword_width_gp, lce_id_width_p, lce_assoc_p, xce)
 
-   // TODO: Should I be a global param
-   , localparam cfg_max_outstanding_p = 1
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    )
   (input                                clk_i
@@ -48,8 +46,8 @@ module bp_cfg
   assign mem_cmd_li = mem_cmd_i;
 
   logic mem_cmd_v_lo, mem_cmd_yumi_li;
-  bsg_fifo_1r1w_small
-   #(.width_p($bits(bp_bedrock_xce_mem_msg_s)), .els_p(cfg_max_outstanding_p))
+  bsg_one_fifo
+   #(.width_p($bits(bp_bedrock_xce_mem_msg_s)))
    small_fifo
     (.clk_i(clk_i)
      ,.reset_i(reset_i)

--- a/bp_top/src/v/bp_clint_slice.sv
+++ b/bp_top/src/v/bp_clint_slice.sv
@@ -11,9 +11,6 @@ module bp_clint_slice
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, dword_width_gp, lce_id_width_p, lce_assoc_p, xce)
-
-   // TODO: Should I be a global param?
-   , localparam clint_max_outstanding_p = 2
    )
   (input                                                clk_i
    , input                                              reset_i
@@ -32,152 +29,152 @@ module bp_clint_slice
    , output                                             external_irq_o
    );
 
-`declare_bp_bedrock_mem_if(paddr_width_p, dword_width_gp, lce_id_width_p, lce_assoc_p, xce);
-`declare_bp_memory_map(paddr_width_p, caddr_width_p);
-
-bp_bedrock_xce_mem_msg_s mem_cmd_li, mem_cmd_lo;
-assign mem_cmd_li = mem_cmd_i;
-
-logic small_fifo_v_lo, small_fifo_yumi_li;
-bsg_fifo_1r1w_small
- #(.width_p($bits(bp_bedrock_xce_mem_msg_s)), .els_p(clint_max_outstanding_p))
- small_fifo
-  (.clk_i(clk_i)
-   ,.reset_i(reset_i)
-
-   ,.data_i(mem_cmd_li)
-   ,.v_i(mem_cmd_v_i)
-   ,.ready_o(mem_cmd_ready_o)
-
-   ,.data_o(mem_cmd_lo)
-   ,.v_o(small_fifo_v_lo)
-   ,.yumi_i(small_fifo_yumi_li)
-   );
-
-logic mipi_cmd_v;
-logic mtimecmp_cmd_v;
-logic mtime_cmd_v;
-logic plic_cmd_v;
-logic wr_not_rd;
-
-bp_local_addr_s local_addr;
-assign local_addr = mem_cmd_lo.header.addr;
-
-always_comb
-  begin
-    mtime_cmd_v    = 1'b0;
-    mtimecmp_cmd_v = 1'b0;
-    mipi_cmd_v     = 1'b0;
-    plic_cmd_v     = 1'b0;
-
-    wr_not_rd = mem_cmd_lo.header.msg_type inside {e_bedrock_mem_wr, e_bedrock_mem_uc_wr};
-
-    unique
-    casez ({local_addr.dev, local_addr.addr})
-      mtime_reg_addr_gp        : mtime_cmd_v    = small_fifo_v_lo;
-      mtimecmp_reg_base_addr_gp: mtimecmp_cmd_v = small_fifo_v_lo;
-      mipi_reg_base_addr_gp    : mipi_cmd_v     = small_fifo_v_lo;
-      plic_reg_base_addr_gp    : plic_cmd_v     = small_fifo_v_lo;
-      default: begin end
-    endcase
-  end
-
-logic [dword_width_gp-1:0] mtime_r, mtime_val_li, mtimecmp_n, mtimecmp_r;
-logic                     mipi_n, mipi_r;
-logic                     plic_n, plic_r;
-
-// TODO: Should be actual RTC
-localparam ds_width_lp = 5;
-localparam [ds_width_lp-1:0] ds_ratio_li = 8;
-logic mtime_inc_li;
-bsg_strobe
- #(.width_p(ds_width_lp))
- bsg_rtc_strobe
-  (.clk_i(clk_i)
-   ,.reset_r_i(reset_i)
-   ,.init_val_r_i(ds_ratio_li)
-   ,.strobe_r_o(mtime_inc_li)
-   );
-assign mtime_val_li = mem_cmd_lo.data[0+:dword_width_gp];
-wire mtime_w_v_li = wr_not_rd & mtime_cmd_v;
-bsg_counter_set_en
- #(.lg_max_val_lp(dword_width_gp)
-   ,.reset_val_p(0)
-   )
- mtime_counter
-  (.clk_i(clk_i)
-   ,.reset_i(reset_i)
-
-   ,.set_i(mtime_w_v_li)
-   ,.en_i(mtime_inc_li)
-   ,.val_i(mtime_val_li)
-   ,.count_o(mtime_r)
-   );
-
-assign mtimecmp_n = mem_cmd_lo.data[0+:dword_width_gp];
-wire mtimecmp_w_v_li = wr_not_rd & mtimecmp_cmd_v;
-bsg_dff_reset_en
- #(.width_p(dword_width_gp))
- mtimecmp_reg
-  (.clk_i(clk_i)
-   ,.reset_i(reset_i)
-
-   ,.en_i(mtimecmp_w_v_li)
-   ,.data_i(mtimecmp_n)
-   ,.data_o(mtimecmp_r)
-   );
-assign timer_irq_o = (mtime_r >= mtimecmp_r);
-
-assign mipi_n = mem_cmd_lo.data[0];
-wire mipi_w_v_li = wr_not_rd & mipi_cmd_v;
-bsg_dff_reset_en
- #(.width_p(1))
- mipi_reg
-  (.clk_i(clk_i)
-   ,.reset_i(reset_i)
-   ,.en_i(mipi_w_v_li)
-
-   ,.data_i(mipi_n)
-   ,.data_o(mipi_r)
-   );
-assign software_irq_o = mipi_r;
-
-assign plic_n = mem_cmd_lo.data[0];
-wire plic_w_v_li = wr_not_rd & plic_cmd_v;
-bsg_dff_reset_en
- #(.width_p(1))
- plic_reg
-  (.clk_i(clk_i)
-   ,.reset_i(reset_i)
-   ,.en_i(plic_w_v_li)
-
-   ,.data_i(plic_n)
-   ,.data_o(plic_r)
-   );
-assign external_irq_o = plic_r;
-
-wire [dword_width_gp-1:0] rdata_lo = plic_cmd_v
-                                    ? dword_width_gp'(plic_r)
-                                    : mipi_cmd_v
-                                      ? dword_width_gp'(mipi_r)
-                                      : mtimecmp_cmd_v
-                                        ? dword_width_gp'(mtimecmp_r)
-                                        : mtime_r;
-
-bp_bedrock_xce_mem_msg_s mem_resp_lo;
-assign mem_resp_lo =
-  '{header : '{
-    msg_type       : mem_cmd_lo.header.msg_type
-    ,subop         : e_bedrock_store
-    ,addr          : mem_cmd_lo.header.addr
-    ,payload       : mem_cmd_lo.header.payload
-    ,size          : mem_cmd_lo.header.size
-    }
-    ,data          : dword_width_gp'(rdata_lo)
-    };
-assign mem_resp_o = mem_resp_lo;
-assign mem_resp_v_o = small_fifo_v_lo;
-assign small_fifo_yumi_li = mem_resp_yumi_i;
+  `declare_bp_bedrock_mem_if(paddr_width_p, dword_width_gp, lce_id_width_p, lce_assoc_p, xce);
+  `declare_bp_memory_map(paddr_width_p, caddr_width_p);
+  
+  bp_bedrock_xce_mem_msg_s mem_cmd_li, mem_cmd_lo;
+  assign mem_cmd_li = mem_cmd_i;
+  
+  logic small_fifo_v_lo, small_fifo_yumi_li;
+  bsg_one_fifo
+   #(.width_p($bits(bp_bedrock_xce_mem_msg_s)))
+   small_fifo
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+  
+     ,.data_i(mem_cmd_li)
+     ,.v_i(mem_cmd_v_i)
+     ,.ready_o(mem_cmd_ready_o)
+  
+     ,.data_o(mem_cmd_lo)
+     ,.v_o(small_fifo_v_lo)
+     ,.yumi_i(small_fifo_yumi_li)
+     );
+  
+  logic mipi_cmd_v;
+  logic mtimecmp_cmd_v;
+  logic mtime_cmd_v;
+  logic plic_cmd_v;
+  logic wr_not_rd;
+  
+  bp_local_addr_s local_addr;
+  assign local_addr = mem_cmd_lo.header.addr;
+  
+  always_comb
+    begin
+      mtime_cmd_v    = 1'b0;
+      mtimecmp_cmd_v = 1'b0;
+      mipi_cmd_v     = 1'b0;
+      plic_cmd_v     = 1'b0;
+  
+      wr_not_rd = mem_cmd_lo.header.msg_type inside {e_bedrock_mem_wr, e_bedrock_mem_uc_wr};
+  
+      unique
+      casez ({local_addr.dev, local_addr.addr})
+        mtime_reg_addr_gp        : mtime_cmd_v    = small_fifo_v_lo;
+        mtimecmp_reg_base_addr_gp: mtimecmp_cmd_v = small_fifo_v_lo;
+        mipi_reg_base_addr_gp    : mipi_cmd_v     = small_fifo_v_lo;
+        plic_reg_base_addr_gp    : plic_cmd_v     = small_fifo_v_lo;
+        default: begin end
+      endcase
+    end
+  
+  logic [dword_width_gp-1:0] mtime_r, mtime_val_li, mtimecmp_n, mtimecmp_r;
+  logic                     mipi_n, mipi_r;
+  logic                     plic_n, plic_r;
+  
+  // TODO: Should be actual RTC
+  localparam ds_width_lp = 5;
+  localparam [ds_width_lp-1:0] ds_ratio_li = 8;
+  logic mtime_inc_li;
+  bsg_strobe
+   #(.width_p(ds_width_lp))
+   bsg_rtc_strobe
+    (.clk_i(clk_i)
+     ,.reset_r_i(reset_i)
+     ,.init_val_r_i(ds_ratio_li)
+     ,.strobe_r_o(mtime_inc_li)
+     );
+  assign mtime_val_li = mem_cmd_lo.data[0+:dword_width_gp];
+  wire mtime_w_v_li = wr_not_rd & mtime_cmd_v;
+  bsg_counter_set_en
+   #(.lg_max_val_lp(dword_width_gp)
+     ,.reset_val_p(0)
+     )
+   mtime_counter
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+  
+     ,.set_i(mtime_w_v_li)
+     ,.en_i(mtime_inc_li)
+     ,.val_i(mtime_val_li)
+     ,.count_o(mtime_r)
+     );
+  
+  assign mtimecmp_n = mem_cmd_lo.data[0+:dword_width_gp];
+  wire mtimecmp_w_v_li = wr_not_rd & mtimecmp_cmd_v;
+  bsg_dff_reset_en
+   #(.width_p(dword_width_gp))
+   mtimecmp_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+  
+     ,.en_i(mtimecmp_w_v_li)
+     ,.data_i(mtimecmp_n)
+     ,.data_o(mtimecmp_r)
+     );
+  assign timer_irq_o = (mtime_r >= mtimecmp_r);
+  
+  assign mipi_n = mem_cmd_lo.data[0];
+  wire mipi_w_v_li = wr_not_rd & mipi_cmd_v;
+  bsg_dff_reset_en
+   #(.width_p(1))
+   mipi_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.en_i(mipi_w_v_li)
+  
+     ,.data_i(mipi_n)
+     ,.data_o(mipi_r)
+     );
+  assign software_irq_o = mipi_r;
+  
+  assign plic_n = mem_cmd_lo.data[0];
+  wire plic_w_v_li = wr_not_rd & plic_cmd_v;
+  bsg_dff_reset_en
+   #(.width_p(1))
+   plic_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.en_i(plic_w_v_li)
+  
+     ,.data_i(plic_n)
+     ,.data_o(plic_r)
+     );
+  assign external_irq_o = plic_r;
+  
+  wire [dword_width_gp-1:0] rdata_lo = plic_cmd_v
+                                      ? dword_width_gp'(plic_r)
+                                      : mipi_cmd_v
+                                        ? dword_width_gp'(mipi_r)
+                                        : mtimecmp_cmd_v
+                                          ? dword_width_gp'(mtimecmp_r)
+                                          : mtime_r;
+  
+  bp_bedrock_xce_mem_msg_s mem_resp_lo;
+  assign mem_resp_lo =
+    '{header : '{
+      msg_type       : mem_cmd_lo.header.msg_type
+      ,subop         : e_bedrock_store
+      ,addr          : mem_cmd_lo.header.addr
+      ,payload       : mem_cmd_lo.header.payload
+      ,size          : mem_cmd_lo.header.size
+      }
+      ,data          : dword_width_gp'(rdata_lo)
+      };
+  assign mem_resp_o = mem_resp_lo;
+  assign mem_resp_v_o = small_fifo_v_lo;
+  assign small_fifo_yumi_li = mem_resp_yumi_i;
 
 endmodule
 

--- a/bp_top/src/v/bp_loopback.sv
+++ b/bp_top/src/v/bp_loopback.sv
@@ -33,7 +33,7 @@ module bp_cce_loopback
   assign mem_cmd_cast_i = mem_cmd_i;
   assign mem_resp_o = mem_resp_cast_o;
 
-  bsg_two_fifo
+  bsg_one_fifo
    #(.width_p($bits(mem_cmd_cast_i.header)))
    loopback_buffer
     (.clk_i(clk_i)

--- a/bp_top/src/v/bp_tile.sv
+++ b/bp_top/src/v/bp_tile.sv
@@ -523,41 +523,27 @@ module bp_tile
 
   assign {loopback_mem_cmd_li, cache_mem_cmd_li, clint_mem_cmd_li, cfg_mem_cmd_li} = {4{cce_mem_cmd_lo}};
 
-  bp_bedrock_cce_mem_msg_s mem_resp_selected_li;
-  logic mem_resp_selected_v_li, mem_resp_selected_ready_lo;
+  logic loopback_mem_resp_grant_li, clint_mem_resp_grant_li, cfg_mem_resp_grant_li, cache_mem_resp_grant_li;
   bsg_arb_fixed
-   #(.inputs_p(4)
-     ,.lo_to_hi_p(1)
-     )
+   #(.inputs_p(4), .lo_to_hi_p(1))
    resp_arb
-    (.ready_i(mem_resp_selected_ready_lo)
+    (.ready_i(1'b1)
      ,.reqs_i({loopback_mem_resp_v_lo, clint_mem_resp_v_lo, cfg_mem_resp_v_lo, cache_mem_resp_v_lo})
-     ,.grants_o({loopback_mem_resp_yumi_li, clint_mem_resp_yumi_li, cfg_mem_resp_yumi_li, cache_mem_resp_yumi_li})
+     ,.grants_o({loopback_mem_resp_grant_li, clint_mem_resp_grant_li, cfg_mem_resp_grant_li, cache_mem_resp_grant_li})
      );
 
   bsg_mux_one_hot
    #(.width_p($bits(bp_bedrock_cce_mem_msg_s)), .els_p(4))
    resp_select
     (.data_i({loopback_mem_resp_lo, clint_mem_resp_lo, cfg_mem_resp_lo, cache_mem_resp_lo})
-     ,.sel_one_hot_i({loopback_mem_resp_yumi_li, clint_mem_resp_yumi_li, cfg_mem_resp_yumi_li, cache_mem_resp_yumi_li})
-     ,.data_o(mem_resp_selected_li)
-     );
-
-  assign mem_resp_selected_v_li = loopback_mem_resp_yumi_li | clint_mem_resp_yumi_li | cfg_mem_resp_yumi_li | cache_mem_resp_yumi_li;
-  bsg_two_fifo
-   #(.width_p($bits(bp_bedrock_cce_mem_msg_s)))
-   resp_fifo
-    (.clk_i(clk_i)
-     ,.reset_i(reset_r)
-
-     ,.data_i(mem_resp_selected_li)
-     ,.v_i(mem_resp_selected_v_li)
-     ,.ready_o(mem_resp_selected_ready_lo)
-
+     ,.sel_one_hot_i({loopback_mem_resp_grant_li, clint_mem_resp_grant_li, cfg_mem_resp_grant_li, cache_mem_resp_grant_li})
      ,.data_o(cce_mem_resp_li)
-     ,.v_o(cce_mem_resp_v_li)
-     ,.yumi_i(cce_mem_resp_yumi_lo)
      );
+  assign cce_mem_resp_v_li = |{loopback_mem_resp_v_lo, clint_mem_resp_v_lo, cfg_mem_resp_v_lo, cache_mem_resp_v_lo};
+  assign cache_mem_resp_yumi_li    = cce_mem_resp_yumi_lo & cache_mem_resp_grant_li;
+  assign cfg_mem_resp_yumi_li      = cce_mem_resp_yumi_lo & cfg_mem_resp_grant_li;
+  assign clint_mem_resp_yumi_li    = cce_mem_resp_yumi_lo & clint_mem_resp_grant_li;
+  assign loopback_mem_resp_yumi_li = cce_mem_resp_yumi_lo & loopback_mem_resp_grant_li;
 
   import bsg_cache_pkg::*;
   `declare_bsg_cache_pkt_s(caddr_width_p, l2_data_width_p);
@@ -569,7 +555,7 @@ module bp_tile
    #(.bp_params_p(bp_params_p))
    cce_to_cache
     (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+     ,.reset_i(reset_r)
 
      ,.mem_cmd_i(cache_mem_cmd_li)
      ,.mem_cmd_v_i(cache_mem_cmd_v_li)
@@ -615,7 +601,7 @@ module bp_tile
     )
    cache
     (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+     ,.reset_i(reset_r)
 
      ,.cache_pkt_i(cache_pkt_li)
      ,.v_i(cache_pkt_v_li)
@@ -651,7 +637,7 @@ module bp_tile
      )
    bsg_cache_dma_to_wormhole
     (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+     ,.reset_i(reset_r)
 
      ,.dma_pkt_i(dma_pkt_lo)
      ,.dma_pkt_v_i(dma_pkt_v_lo)

--- a/bp_top/src/v/bp_unicore.sv
+++ b/bp_top/src/v/bp_unicore.sv
@@ -387,9 +387,6 @@ module bp_unicore
   bp_bedrock_uce_mem_msg_s [2:0] cmd_fifo_lo;
   logic [2:0] cmd_fifo_v_lo, cmd_fifo_yumi_li;
 
-  bp_bedrock_uce_mem_msg_s [2:0] resp_fifo_li;
-  logic [2:0] resp_fifo_v_li, resp_fifo_ready_lo;
-
   for (genvar i = 0; i < 3; i++)
     begin : fifo
       bsg_two_fifo
@@ -405,21 +402,6 @@ module bp_unicore
          ,.data_o(cmd_fifo_lo[i])
          ,.v_o(cmd_fifo_v_lo[i])
          ,.yumi_i(cmd_fifo_yumi_li[i])
-         );
-
-      bsg_two_fifo
-       #(.width_p($bits(bp_bedrock_uce_mem_msg_s)))
-       resp_fifo
-        (.clk_i(clk_i)
-         ,.reset_i(reset_i)
-
-         ,.data_i(resp_fifo_li[i])
-         ,.v_i(resp_fifo_v_li[i])
-         ,.ready_o(resp_fifo_ready_lo[i])
-
-         ,.data_o(proc_resp_li[i])
-         ,.v_o(proc_resp_v_li[i])
-         ,.yumi_i(proc_resp_yumi_lo[i])
          );
     end
 
@@ -450,32 +432,36 @@ module bp_unicore
   //   arbitrary orders, especially when considering CLINT or I/O responses
   // This is also suboptimal. Theoretically, we could dequeue into each fifo at once, but this
   //   would require more complex arbitration logic
-  wire resp_arb_ready_li = &resp_fifo_ready_lo;
+  logic loopback_resp_grant_li, cache_resp_grant_li, io_resp_grant_lo, clint_resp_grant_li, cfg_resp_grant_li;
   bsg_arb_fixed
    #(.inputs_p(5), .lo_to_hi_p(0))
    resp_arbiter
-    (.ready_i(resp_arb_ready_li)
+    (.ready_i(1'b1)
      ,.reqs_i({loopback_resp_v_lo, cache_resp_v_lo, io_resp_v_i, clint_resp_v_lo, cfg_resp_v_lo})
-     ,.grants_o({loopback_resp_yumi_li, cache_resp_yumi_li, io_resp_yumi_o, clint_resp_yumi_li, cfg_resp_yumi_li})
+     ,.grants_o({loopback_resp_grant_li, cache_resp_grant_li, io_resp_grant_lo, clint_resp_grant_li, cfg_resp_grant_li})
      );
 
   for (genvar i = 0; i < 3; i++)
     begin : resp_match
       bp_bedrock_uce_mem_msg_s resp_fifo_selected_li;
-      bp_bedrock_uce_mem_payload_s resp_fifo_selected_payload_li;
-      assign resp_fifo_selected_payload_li = resp_fifo_selected_li.header.payload;
+      bp_bedrock_uce_mem_payload_s resp_selected_payload_li;
+      assign resp_selected_payload_li = proc_resp_li[i].header.payload;
       bsg_mux_one_hot
        #(.width_p($bits(bp_bedrock_uce_mem_msg_s)), .els_p(5))
        resp_select
         (.data_i({loopback_resp_lo, cache_resp_lo, io_resp_i, clint_resp_lo, cfg_resp_lo})
-         ,.sel_one_hot_i({loopback_resp_yumi_li, cache_resp_yumi_li, io_resp_yumi_o, clint_resp_yumi_li, cfg_resp_yumi_li})
-         ,.data_o(resp_fifo_selected_li)
+         ,.sel_one_hot_i({loopback_resp_grant_li, cache_resp_grant_li, io_resp_grant_lo, clint_resp_grant_li, cfg_resp_grant_li})
+         ,.data_o(proc_resp_li[i])
          );
-      wire resp_selected_v_li = |{loopback_resp_yumi_li, cache_resp_yumi_li, io_resp_yumi_o, clint_resp_yumi_li, cfg_resp_yumi_li};
+      wire any_resp_v_li = |{loopback_resp_v_lo, cache_resp_v_lo, io_resp_v_i, clint_resp_v_lo, cfg_resp_v_lo};
 
-      assign resp_fifo_v_li[i] = resp_selected_v_li & (resp_fifo_selected_payload_li.lce_id == i);
-      assign resp_fifo_li[i] = resp_fifo_selected_li;
+      assign proc_resp_v_li[i] = any_resp_v_li & (resp_selected_payload_li.lce_id == i);
     end
+  assign cfg_resp_yumi_li      = |proc_resp_yumi_lo & cfg_resp_grant_li;
+  assign clint_resp_yumi_li    = |proc_resp_yumi_lo & clint_resp_grant_li;
+  assign io_resp_yumi_o        = |proc_resp_yumi_lo & io_resp_grant_lo;
+  assign cache_resp_yumi_li    = |proc_resp_yumi_lo & cache_resp_grant_li;
+  assign loopback_resp_yumi_li = |proc_resp_yumi_lo & loopback_resp_grant_li;
 
   bp_local_addr_s local_addr_cast;
   assign local_addr_cast = cmd_fifo_selected_lo.header.addr;

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -248,7 +248,6 @@ $BP_ME_DIR/src/v/cce/bp_io_cce.sv
 $BP_ME_DIR/src/v/cce/bp_cce_fsm.sv
 $BP_ME_DIR/src/v/cce/bp_cce_wrapper.sv
 # Network
-$BP_ME_DIR/src/v/cce/bp_cce_loopback.sv
 $BP_ME_DIR/src/v/cce/bp_uce.sv
 $BP_ME_DIR/src/v/wormhole/bp_me_addr_to_cce_id.sv
 $BP_ME_DIR/src/v/wormhole/bp_me_cce_id_to_cord.sv
@@ -267,6 +266,7 @@ $BP_ME_DIR/src/v/wormhole/bp_stream_to_lite.sv
 $BP_ME_DIR/src/v/wormhole/bp_lite_to_burst.sv
 $BP_ME_DIR/src/v/wormhole/bp_burst_to_lite.sv
 ## TOP
+$BP_TOP_DIR/src/v/bp_loopback.sv
 $BP_TOP_DIR/src/v/bp_nd_socket.sv
 $BP_TOP_DIR/src/v/bp_cacc_vdp.sv
 $BP_TOP_DIR/src/v/bp_cacc_tile.sv


### PR DESCRIPTION
The response fifos here are unnecessary. This PR removes them with a slight modification to how the arbiter is used