### PR TITLE
bp_common_defines.svh: remove no-op self-include

### DIFF
--- a/bp_common/src/include/bp_common_defines.svh
+++ b/bp_common/src/include/bp_common_defines.svh
@@ -2,7 +2,6 @@
 `define BP_COMMON_DEFINES_SVH
 
   `include "bsg_defines.v"
-  `include "bp_common_defines.svh"
   `include "bp_common_core_if.svh"
   `include "bp_common_bedrock_if.svh"
   `include "bp_common_cache_engine_if.svh"


### PR DESCRIPTION
Noticed this as I was messing with includes elsewhere. `bp_common_defines.svh` includes itself, which doesn't have an effect anyway due to the header-guard. Just a minor cleanup.