### PR TITLE
Improve "lite" make flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,10 @@ prep_bsg: prep
 	$(MAKE) -C $(BP_SDK_DIR) bsg_cadenv
 	$(MAKE) -C $(BP_HDK_DIR) bsg_cadenv
 
-prep_lite: tools
+prep_lite: tools_lite
 	cd $(TOP); git submodule update --init --checkout $(SHALLOW_SUB) $(BP_SDK_DIR)
 	cd $(TOP); git submodule update --init --checkout $(SHALLOW_SUB) $(BP_HDK_DIR)
-	$(MAKE) -C tools tools_lite
-	$(MAKE) -C sdk sdk_lite
+	$(MAKE) -C $(BP_SDK_DIR) sdk_lite
 
 bsg_cadenv:
 	-cd $(TOP); git clone git@github.com:bespoke-silicon-group/bsg_cadenv.git external/bsg_cadenv

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ libs:
 	cd $(TOP); git submodule update --init --recursive --checkout $(SHALLOW_SUB) $(BASEJUMP_STL_DIR)
 	cd $(TOP); git submodule update --init --recursive --checkout $(SHALLOW_SUB) $(HARDFLOAT_DIR)
 
+tools_lite: libs
+	$(MAKE) -C $(BP_TOOLS_DIR) tools_lite
+
 tools: libs
 	$(MAKE) -C $(BP_TOOLS_DIR) tools
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -28,3 +28,5 @@ BSG_CADENV_DIR ?= $(TOP)/external/bsg_cadenv
 -include $(BP_HDK_DIR)/Makefile.common
 -include $(BP_SDK_DIR)/Makefile.common
 
+# Makes clones much faster. Comment out if you see "fatal: reference is not a tree"
+SHALLOW_SUB ?= --depth=1


### PR DESCRIPTION
This change does the following:

1. adds the missing SHALLOW_SUB variable to Makefile.common
2. improves the "lite" make flow, e.g., `make prep_lite`, for the repo by creating a tools_lite target at the top and fixing the dependencies of prep_lite