### PR TITLE
Fix handshake signal names and identify mismatches

### DIFF
--- a/bp_be/test/tb/bp_be_dcache/testbench.sv
+++ b/bp_be/test/tb/bp_be_dcache/testbench.sv
@@ -92,7 +92,7 @@ module testbench
   assign cfg_bus_li = cfg_bus_cast_li;
 
   logic mem_cmd_v_lo, mem_resp_v_lo;
-  logic mem_cmd_ready_lo, mem_resp_yumi_lo;
+  logic mem_cmd_ready_and_lo, mem_resp_yumi_lo;
   bp_bedrock_cce_mem_msg_s mem_cmd_lo, mem_resp_lo;
 
   logic [num_caches_p-1:0][trace_replay_data_width_lp-1:0] trace_data_lo;
@@ -259,7 +259,7 @@ module testbench
 
      ,.mem_cmd_v_o(mem_cmd_v_lo)
      ,.mem_cmd_o(mem_cmd_lo)
-     ,.mem_cmd_ready_i(mem_cmd_ready_lo)
+     ,.mem_cmd_ready_and_i(mem_cmd_ready_and_lo)
      );
 
   // Memory
@@ -275,7 +275,7 @@ module testbench
 
      ,.mem_cmd_i(mem_cmd_lo)
      ,.mem_cmd_v_i(mem_cmd_v_lo)
-     ,.mem_cmd_ready_o(mem_cmd_ready_lo)
+     ,.mem_cmd_ready_and_o(mem_cmd_ready_and_lo)
 
      ,.mem_resp_o(mem_resp_lo)
      ,.mem_resp_v_o(mem_resp_v_lo)
@@ -351,16 +351,16 @@ module testbench
           ,.lce_id_i(lce_id_i)
           ,.lce_req_i(lce_req_o)
           ,.lce_req_v_i(lce_req_v_o)
-          ,.lce_req_ready_i(lce_req_ready_i)
+          ,.lce_req_ready_then_i(lce_req_ready_then_i)
           ,.lce_resp_i(lce_resp_o)
           ,.lce_resp_v_i(lce_resp_v_o)
-          ,.lce_resp_ready_i(lce_resp_ready_i)
+          ,.lce_resp_ready_then_i(lce_resp_ready_then_i)
           ,.lce_cmd_i(lce_cmd_i)
           ,.lce_cmd_v_i(lce_cmd_v_i)
           ,.lce_cmd_yumi_i(lce_cmd_yumi_o)
           ,.lce_cmd_o_i(lce_cmd_o)
           ,.lce_cmd_o_v_i(lce_cmd_v_o)
-          ,.lce_cmd_o_ready_i(lce_cmd_ready_i)
+          ,.lce_cmd_o_ready_then_i(lce_cmd_ready_then_i)
           );
 
     bind bp_cce_fsm
@@ -407,7 +407,7 @@ module testbench
 
      ,.mem_cmd_i(mem_cmd_lo)
      ,.mem_cmd_v_i(mem_cmd_v_lo)
-     ,.mem_cmd_ready_i(mem_cmd_ready_lo)
+     ,.mem_cmd_ready_and_i(mem_cmd_ready_and_lo)
 
      ,.mem_resp_i(mem_resp_lo)
      ,.mem_resp_v_i(mem_resp_v_lo)

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -100,10 +100,10 @@ module wrapper
 
    logic [num_caches_p-1:0] lce_req_v_lo, lce_resp_v_lo;
    logic cce_lce_req_v_li, cce_lce_req_yumi_lo;
-   logic [num_caches_p-1:0] lce_req_ready_li, lce_resp_ready_li, fifo_lce_cmd_ready_lo;
+   logic [num_caches_p-1:0] lce_req_ready_and_li, lce_resp_ready_and_li, fifo_lce_cmd_ready_lo;
    logic cce_lce_resp_v_li, cce_lce_resp_yumi_lo;
-   logic [num_caches_p-1:0] lce_cmd_v_li, lce_cmd_yumi_lo, lce_cmd_v_lo, lce_cmd_ready_li;
-   logic cce_lce_cmd_v_lo, cce_lce_cmd_ready_li;
+   logic [num_caches_p-1:0] lce_cmd_v_li, lce_cmd_yumi_lo, lce_cmd_v_lo, lce_cmd_ready_and_li;
+   logic cce_lce_cmd_v_lo, cce_lce_cmd_ready_and_li;
 
    `declare_bp_bedrock_lce_if(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
    `declare_bp_bedrock_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce);
@@ -300,13 +300,13 @@ module wrapper
 
               ,.lce_req_o(lce_req_lo[i])
               ,.lce_req_v_o(lce_req_v_lo[i])
-              // TODO: mismatch - connects to ready_and_rev on link
-              ,.lce_req_ready_then_i(lce_req_ready_li[i])
+              // TODO: mismatch, but okay - connects to ready_and_rev on link
+              ,.lce_req_ready_then_i(lce_req_ready_and_li[i])
 
               ,.lce_resp_o(lce_resp_lo[i])
               ,.lce_resp_v_o(lce_resp_v_lo[i])
-              // TODO: mismatch - connects to ready_and_rev on link
-              ,.lce_resp_ready_then_i(lce_resp_ready_li[i])
+              // TODO: mismatch, but okay - connects to ready_and_rev on link
+              ,.lce_resp_ready_then_i(lce_resp_ready_and_li[i])
 
               ,.lce_cmd_i(lce_cmd_li[i])
               ,.lce_cmd_v_i(lce_cmd_v_li[i])
@@ -314,8 +314,8 @@ module wrapper
 
               ,.lce_cmd_o(lce_cmd_lo[i])
               ,.lce_cmd_v_o(lce_cmd_v_lo[i])
-              // TODO: mismatch - connects to ready_and_rev on link
-              ,.lce_cmd_ready_then_i(lce_cmd_ready_li[i])
+              // TODO: mismatch, but okay - connects to ready_and_rev on link
+              ,.lce_cmd_ready_then_i(lce_cmd_ready_and_li[i])
               );
 
            // Request out
@@ -328,7 +328,7 @@ module wrapper
            assign lce_req_link_lo[i].data = lce_req_packet_lo[i];
            assign lce_req_link_lo[i].v = lce_req_v_lo[i];
            assign lce_req_link_lo[i].ready_and_rev = 1'b0;
-           assign lce_req_ready_li[i] = lce_req_link_li[i].ready_and_rev;
+           assign lce_req_ready_and_li[i] = lce_req_link_li[i].ready_and_rev;
 
            // Command out
            assign lce_cmd_packet_lo[i].payload = lce_cmd_lo[i];
@@ -345,7 +345,7 @@ module wrapper
            // Conversion from command packet to link format
            assign lce_cmd_link_lo[i].data = lce_cmd_packet_lo[i];
            assign lce_cmd_link_lo[i].v = lce_cmd_v_lo[i];
-           assign lce_cmd_ready_li[i] = lce_cmd_link_li[i].ready_and_rev;
+           assign lce_cmd_ready_and_li[i] = lce_cmd_link_li[i].ready_and_rev;
 
            // LCE cmd demanding -> demanding conversion
            bsg_two_fifo
@@ -373,7 +373,7 @@ module wrapper
            assign lce_resp_link_lo[i].data = lce_resp_packet_lo[i];
            assign lce_resp_link_lo[i].v = lce_resp_v_lo[i];
            assign lce_resp_link_lo[i].ready_and_rev = 1'b0;
-           assign lce_resp_ready_li[i] = lce_resp_link_li[i].ready_and_rev;
+           assign lce_resp_ready_and_li[i] = lce_resp_link_li[i].ready_and_rev;
 
          end
        else if (uce_p == 1)
@@ -471,7 +471,7 @@ module wrapper
        assign cce_lce_cmd_link_lo.data = cce_lce_cmd_packet_lo;
        assign cce_lce_cmd_link_lo.v = cce_lce_cmd_v_lo;
        assign cce_lce_cmd_link_lo.ready_and_rev = '0;
-       assign cce_lce_cmd_ready_li = cce_lce_cmd_link_li.ready_and_rev;
+       assign cce_lce_cmd_ready_and_li = cce_lce_cmd_link_li.ready_and_rev;
 
        // Response adapter to convert from the link format to the CCE
        // response input  format
@@ -586,7 +586,8 @@ module wrapper
 
           ,.lce_cmd_o(cce_lce_cmd_lo)
           ,.lce_cmd_v_o(cce_lce_cmd_v_lo)
-          ,.lce_cmd_ready_i(cce_lce_cmd_ready_li)
+          // TODO: mismatch, but okay - ready_i used ready->valid by FSM CCE
+          ,.lce_cmd_ready_i(cce_lce_cmd_ready_and_li)
 
           ,.mem_resp_i(mem_resp_to_cce)
           ,.mem_resp_v_i(mem_resp_v_to_cce)
@@ -594,7 +595,7 @@ module wrapper
 
           ,.mem_cmd_o(mem_cmd_o)
           ,.mem_cmd_v_o(mem_cmd_v_o)
-          // TODO: ready_i is used ready->valid by FSM CCE
+          // TODO: mismatch, but okay - ready_i used ready->valid by FSM CCE
           ,.mem_cmd_ready_i(mem_cmd_ready_and_i)
           );
 

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -57,7 +57,7 @@ module wrapper
 
    , output logic                                      mem_cmd_v_o
    , output logic [cce_mem_msg_width_lp-1:0]           mem_cmd_o
-   , input                                             mem_cmd_ready_i
+   , input                                             mem_cmd_ready_and_i
    );
 
    // Cache to Rolly FIFO signals
@@ -300,11 +300,13 @@ module wrapper
 
               ,.lce_req_o(lce_req_lo[i])
               ,.lce_req_v_o(lce_req_v_lo[i])
-              ,.lce_req_ready_i(lce_req_ready_li[i])
+              // TODO: mismatch - connects to ready_and_rev on link
+              ,.lce_req_ready_then_i(lce_req_ready_li[i])
 
               ,.lce_resp_o(lce_resp_lo[i])
               ,.lce_resp_v_o(lce_resp_v_lo[i])
-              ,.lce_resp_ready_i(lce_resp_ready_li[i])
+              // TODO: mismatch - connects to ready_and_rev on link
+              ,.lce_resp_ready_then_i(lce_resp_ready_li[i])
 
               ,.lce_cmd_i(lce_cmd_li[i])
               ,.lce_cmd_v_i(lce_cmd_v_li[i])
@@ -312,7 +314,8 @@ module wrapper
 
               ,.lce_cmd_o(lce_cmd_lo[i])
               ,.lce_cmd_v_o(lce_cmd_v_lo[i])
-              ,.lce_cmd_ready_i(lce_cmd_ready_li[i])
+              // TODO: mismatch - connects to ready_and_rev on link
+              ,.lce_cmd_ready_then_i(lce_cmd_ready_li[i])
               );
 
            // Request out
@@ -419,7 +422,7 @@ module wrapper
 
              ,.mem_cmd_o(mem_cmd_o)
              ,.mem_cmd_v_o(mem_cmd_v_o)
-             ,.mem_cmd_yumi_i(mem_cmd_ready_i & mem_cmd_v_o)
+             ,.mem_cmd_yumi_i(mem_cmd_ready_and_i & mem_cmd_v_o)
 
              ,.mem_resp_i(mem_resp_i)
              ,.mem_resp_v_i(mem_resp_v_i)
@@ -591,7 +594,8 @@ module wrapper
 
           ,.mem_cmd_o(mem_cmd_o)
           ,.mem_cmd_v_o(mem_cmd_v_o)
-          ,.mem_cmd_ready_i(mem_cmd_ready_i)
+          // TODO: ready_i is used ready->valid by FSM CCE
+          ,.mem_cmd_ready_i(mem_cmd_ready_and_i)
           );
 
        // Inbound Mem to CCE

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -300,12 +300,10 @@ module wrapper
 
               ,.lce_req_o(lce_req_lo[i])
               ,.lce_req_v_o(lce_req_v_lo[i])
-              // TODO: mismatch, but okay - connects to ready_and_rev on link
               ,.lce_req_ready_then_i(lce_req_ready_and_li[i])
 
               ,.lce_resp_o(lce_resp_lo[i])
               ,.lce_resp_v_o(lce_resp_v_lo[i])
-              // TODO: mismatch, but okay - connects to ready_and_rev on link
               ,.lce_resp_ready_then_i(lce_resp_ready_and_li[i])
 
               ,.lce_cmd_i(lce_cmd_li[i])
@@ -314,7 +312,6 @@ module wrapper
 
               ,.lce_cmd_o(lce_cmd_lo[i])
               ,.lce_cmd_v_o(lce_cmd_v_lo[i])
-              // TODO: mismatch, but okay - connects to ready_and_rev on link
               ,.lce_cmd_ready_then_i(lce_cmd_ready_and_li[i])
               );
 
@@ -586,7 +583,6 @@ module wrapper
 
           ,.lce_cmd_o(cce_lce_cmd_lo)
           ,.lce_cmd_v_o(cce_lce_cmd_v_lo)
-          // TODO: mismatch, but okay - ready_i used ready->valid by FSM CCE
           ,.lce_cmd_ready_i(cce_lce_cmd_ready_and_li)
 
           ,.mem_resp_i(mem_resp_to_cce)
@@ -595,7 +591,6 @@ module wrapper
 
           ,.mem_cmd_o(mem_cmd_o)
           ,.mem_cmd_v_o(mem_cmd_v_o)
-          // TODO: mismatch, but okay - ready_i used ready->valid by FSM CCE
           ,.mem_cmd_ready_i(mem_cmd_ready_and_i)
           );
 

--- a/bp_fe/test/tb/bp_fe_icache/testbench.sv
+++ b/bp_fe/test/tb/bp_fe_icache/testbench.sv
@@ -81,7 +81,7 @@ module testbench
   assign cfg_bus_li = cfg_bus_cast_li;
 
   logic mem_cmd_v_lo, mem_resp_v_lo;
-  logic mem_cmd_ready_lo, mem_resp_yumi_li;
+  logic mem_cmd_ready_and_lo, mem_resp_yumi_li;
   bp_bedrock_cce_mem_msg_s mem_cmd_lo, mem_resp_lo;
 
   logic [trace_replay_data_width_lp-1:0] trace_data_lo;
@@ -206,7 +206,7 @@ module testbench
    #(.bp_params_p(bp_params_p)
     ,.uce_p(uce_p)
    )
-   dut
+   wrapper
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
@@ -230,7 +230,7 @@ module testbench
 
      ,.mem_cmd_o(mem_cmd_lo)
      ,.mem_cmd_v_o(mem_cmd_v_lo)
-     ,.mem_cmd_ready_i(mem_cmd_ready_lo)
+     ,.mem_cmd_ready_and_i(mem_cmd_ready_and_lo)
     );
 
   // Memory
@@ -245,8 +245,8 @@ module testbench
     ,.reset_i(reset_i)
 
     ,.mem_cmd_i(mem_cmd_lo)
-    ,.mem_cmd_v_i(mem_cmd_ready_lo & mem_cmd_v_lo)
-    ,.mem_cmd_ready_o(mem_cmd_ready_lo)
+    ,.mem_cmd_v_i(mem_cmd_ready_and_lo & mem_cmd_v_lo)
+    ,.mem_cmd_ready_and_o(mem_cmd_ready_and_lo)
 
     ,.mem_resp_o(mem_resp_lo)
     ,.mem_resp_v_o(mem_resp_v_lo)
@@ -324,16 +324,16 @@ module testbench
           ,.lce_id_i(lce_id_i)
           ,.lce_req_i(lce_req_o)
           ,.lce_req_v_i(lce_req_v_o)
-          ,.lce_req_ready_i(lce_req_ready_i)
+          ,.lce_req_ready_then_i(lce_req_ready_then_i)
           ,.lce_resp_i(lce_resp_o)
           ,.lce_resp_v_i(lce_resp_v_o)
-          ,.lce_resp_ready_i(lce_resp_ready_i)
+          ,.lce_resp_ready_then_i(lce_resp_ready_then_i)
           ,.lce_cmd_i(lce_cmd_i)
           ,.lce_cmd_v_i(lce_cmd_v_i)
           ,.lce_cmd_yumi_i(lce_cmd_yumi_o)
           ,.lce_cmd_o_i(lce_cmd_o)
           ,.lce_cmd_o_v_i(lce_cmd_v_o)
-          ,.lce_cmd_o_ready_i(lce_cmd_ready_i)
+          ,.lce_cmd_o_ready_then_i(lce_cmd_ready_then_i)
           );
 
     bind bp_cce_fsm
@@ -376,8 +376,8 @@ module testbench
      ,.reset_i(reset_i)
 
      ,.mem_cmd_i(mem_cmd_lo)
-     ,.mem_cmd_v_i(mem_cmd_ready_lo & mem_cmd_v_lo)
-     ,.mem_cmd_ready_i(mem_cmd_ready_lo)
+     ,.mem_cmd_v_i(mem_cmd_ready_and_lo & mem_cmd_v_lo)
+     ,.mem_cmd_ready_and_i(mem_cmd_ready_and_lo)
 
      ,.mem_resp_i(mem_resp_lo)
      ,.mem_resp_v_i(mem_resp_v_lo)

--- a/bp_fe/test/tb/bp_fe_icache/testbench.sv
+++ b/bp_fe/test/tb/bp_fe_icache/testbench.sv
@@ -245,7 +245,7 @@ module testbench
     ,.reset_i(reset_i)
 
     ,.mem_cmd_i(mem_cmd_lo)
-    ,.mem_cmd_v_i(mem_cmd_ready_and_lo & mem_cmd_v_lo)
+    ,.mem_cmd_v_i(mem_cmd_v_lo)
     ,.mem_cmd_ready_and_o(mem_cmd_ready_and_lo)
 
     ,.mem_resp_o(mem_resp_lo)
@@ -376,7 +376,7 @@ module testbench
      ,.reset_i(reset_i)
 
      ,.mem_cmd_i(mem_cmd_lo)
-     ,.mem_cmd_v_i(mem_cmd_ready_and_lo & mem_cmd_v_lo)
+     ,.mem_cmd_v_i(mem_cmd_v_lo)
      ,.mem_cmd_ready_and_i(mem_cmd_ready_and_lo)
 
      ,.mem_resp_i(mem_resp_lo)

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -217,11 +217,11 @@ module wrapper
 
   if (uce_p == 0) begin : CCE
     logic lce_req_v_lo, lce_resp_v_lo, lce_cmd_v_lo, fifo_lce_cmd_v_lo;
-    logic lce_req_ready_li, lce_resp_ready_li, lce_cmd_ready_li, fifo_lce_cmd_yumi_li;
+    logic lce_req_ready_then_li, lce_resp_ready_then_li, lce_cmd_ready_then_li, fifo_lce_cmd_yumi_li;
     bp_bedrock_lce_req_msg_s lce_req_lo;
     bp_bedrock_lce_resp_msg_s lce_resp_lo;
     bp_bedrock_lce_cmd_msg_s lce_cmd_lo, fifo_lce_cmd_lo;
-    logic mem_resp_ready_lo;
+    logic mem_resp_ready_and_lo;
 
     // I-Cache LCE
     bp_lce
@@ -268,11 +268,11 @@ module wrapper
 
        ,.lce_req_o(lce_req_lo)
        ,.lce_req_v_o(lce_req_v_lo)
-       ,.lce_req_ready_then_i(lce_req_ready_li)
+       ,.lce_req_ready_then_i(lce_req_ready_then_li)
 
        ,.lce_resp_o(lce_resp_lo)
        ,.lce_resp_v_o(lce_resp_v_lo)
-       ,.lce_resp_ready_then_i(lce_resp_ready_li)
+       ,.lce_resp_ready_then_i(lce_resp_ready_then_li)
 
        ,.lce_cmd_i(fifo_lce_cmd_lo)
        ,.lce_cmd_v_i(fifo_lce_cmd_v_lo)
@@ -293,7 +293,9 @@ module wrapper
 
        // from CCE
        ,.v_i(lce_cmd_v_lo)
-       ,.ready_o(lce_cmd_ready_li)
+       // TODO: mismatch, but okay
+       // FIFO provides ready_and but it is used ready_then by CCE
+       ,.ready_o(lce_cmd_ready_then_li)
        ,.data_i(lce_cmd_lo)
 
        // to LCE
@@ -313,29 +315,29 @@ module wrapper
 
        ,.lce_req_i(lce_req_lo)
        ,.lce_req_v_i(lce_req_v_lo)
-       ,.lce_req_ready_o(lce_req_ready_li)
+       ,.lce_req_ready_o(lce_req_ready_then_li)
 
        ,.lce_resp_i(lce_resp_lo)
        ,.lce_resp_v_i(lce_resp_v_lo)
-       ,.lce_resp_ready_o(lce_resp_ready_li)
+       ,.lce_resp_ready_o(lce_resp_ready_then_li)
 
        ,.lce_cmd_o(lce_cmd_lo)
        ,.lce_cmd_v_o(lce_cmd_v_lo)
-       ,.lce_cmd_ready_i(lce_cmd_ready_li)
+       ,.lce_cmd_ready_i(lce_cmd_ready_then_li)
 
        ,.mem_resp_i(mem_resp_i)
        ,.mem_resp_v_i(mem_resp_v_i)
-       ,.mem_resp_ready_o(mem_resp_ready_lo)
+       ,.mem_resp_ready_o(mem_resp_ready_and_lo)
 
        ,.mem_cmd_o(mem_cmd_o)
        ,.mem_cmd_v_o(mem_cmd_v_o)
        ,.mem_cmd_yumi_i(mem_cmd_ready_and_i & mem_cmd_v_o)
        );
 
-      assign mem_resp_yumi_o = mem_resp_ready_lo & mem_resp_v_i;
+      assign mem_resp_yumi_o = mem_resp_ready_and_lo & mem_resp_v_i;
   end
   else begin: UCE
-    logic mem_resp_ready_lo;
+    logic mem_resp_ready_and_lo;
     logic fifo_mem_resp_v_lo, fifo_mem_resp_yumi_li;
     bp_bedrock_cce_mem_msg_s fifo_mem_resp_lo;
 
@@ -398,14 +400,14 @@ module wrapper
 
        ,.v_i(mem_resp_v_i)
        ,.data_i(mem_resp_i)
-       ,.ready_o(mem_resp_ready_lo)
+       ,.ready_o(mem_resp_ready_and_lo)
 
        ,.v_o(fifo_mem_resp_v_lo)
        ,.data_o(fifo_mem_resp_lo)
        ,.yumi_i(fifo_mem_resp_yumi_li)
        );
 
-    assign mem_resp_yumi_o = mem_resp_ready_lo & mem_resp_v_i;
+    assign mem_resp_yumi_o = mem_resp_ready_and_lo & mem_resp_v_i;
   end
 endmodule
 

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -51,7 +51,7 @@ module wrapper
 
    , output logic [cce_mem_msg_width_lp-1:0] mem_cmd_o
    , output                                  mem_cmd_v_o
-   , input                                   mem_cmd_ready_i
+   , input                                   mem_cmd_ready_and_i
    );
 
   `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
@@ -268,11 +268,11 @@ module wrapper
 
        ,.lce_req_o(lce_req_lo)
        ,.lce_req_v_o(lce_req_v_lo)
-       ,.lce_req_ready_i(lce_req_ready_li)
+       ,.lce_req_ready_then_i(lce_req_ready_li)
 
        ,.lce_resp_o(lce_resp_lo)
        ,.lce_resp_v_o(lce_resp_v_lo)
-       ,.lce_resp_ready_i(lce_resp_ready_li)
+       ,.lce_resp_ready_then_i(lce_resp_ready_li)
 
        ,.lce_cmd_i(fifo_lce_cmd_lo)
        ,.lce_cmd_v_i(fifo_lce_cmd_v_lo)
@@ -280,7 +280,7 @@ module wrapper
 
        ,.lce_cmd_o()
        ,.lce_cmd_v_o()
-       ,.lce_cmd_ready_i(1'b1)
+       ,.lce_cmd_ready_then_i(1'b1)
        );
 
 
@@ -329,7 +329,7 @@ module wrapper
 
        ,.mem_cmd_o(mem_cmd_o)
        ,.mem_cmd_v_o(mem_cmd_v_o)
-       ,.mem_cmd_yumi_i(mem_cmd_ready_i & mem_cmd_v_o)
+       ,.mem_cmd_yumi_i(mem_cmd_ready_and_i & mem_cmd_v_o)
        );
 
       assign mem_resp_yumi_o = mem_resp_ready_lo & mem_resp_v_i;
@@ -381,7 +381,7 @@ module wrapper
 
        ,.mem_cmd_o(mem_cmd_o)
        ,.mem_cmd_v_o(mem_cmd_v_o)
-       ,.mem_cmd_yumi_i(mem_cmd_ready_i & mem_cmd_v_o)
+       ,.mem_cmd_yumi_i(mem_cmd_ready_and_i & mem_cmd_v_o)
 
        ,.mem_resp_i(fifo_mem_resp_lo)
        ,.mem_resp_v_i(fifo_mem_resp_v_lo)

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -217,7 +217,7 @@ module wrapper
 
   if (uce_p == 0) begin : CCE
     logic lce_req_v_lo, lce_resp_v_lo, lce_cmd_v_lo, fifo_lce_cmd_v_lo;
-    logic lce_req_ready_then_li, lce_resp_ready_then_li, lce_cmd_ready_then_li, fifo_lce_cmd_yumi_li;
+    logic lce_req_ready_then_li, lce_resp_ready_then_li, lce_cmd_ready_and_li, fifo_lce_cmd_yumi_li;
     bp_bedrock_lce_req_msg_s lce_req_lo;
     bp_bedrock_lce_resp_msg_s lce_resp_lo;
     bp_bedrock_lce_cmd_msg_s lce_cmd_lo, fifo_lce_cmd_lo;
@@ -293,9 +293,7 @@ module wrapper
 
        // from CCE
        ,.v_i(lce_cmd_v_lo)
-       // TODO: mismatch, but okay
-       // FIFO provides ready_and but it is used ready_then by CCE
-       ,.ready_o(lce_cmd_ready_then_li)
+       ,.ready_o(lce_cmd_ready_and_li)
        ,.data_i(lce_cmd_lo)
 
        // to LCE
@@ -323,7 +321,7 @@ module wrapper
 
        ,.lce_cmd_o(lce_cmd_lo)
        ,.lce_cmd_v_o(lce_cmd_v_lo)
-       ,.lce_cmd_ready_i(lce_cmd_ready_then_li)
+       ,.lce_cmd_ready_i(lce_cmd_ready_and_li)
 
        ,.mem_resp_i(mem_resp_i)
        ,.mem_resp_v_i(mem_resp_v_i)

--- a/bp_me/src/v/cache/bp_me_cce_to_cache.sv
+++ b/bp_me/src/v/cache/bp_me_cce_to_cache.sv
@@ -33,7 +33,7 @@ module bp_me_cce_to_cache
     // manycore-side
     , input  [cce_mem_msg_width_lp-1:0]   mem_cmd_i
     , input                               mem_cmd_v_i
-    , output logic                        mem_cmd_ready_o
+    , output logic                        mem_cmd_ready_and_o
 
     , output [cce_mem_msg_width_lp-1:0]   mem_resp_o
     , output logic                        mem_resp_v_o
@@ -79,7 +79,7 @@ module bp_me_cce_to_cache
   assign mem_cmd_cast_i = mem_cmd_i;
   assign mem_resp_o = mem_resp_cast_o;
 
-  logic mem_cmd_ready_lo;
+  logic mem_cmd_ready_and_lo;
   bp_bedrock_cce_mem_msg_s mem_cmd_lo;
   logic mem_cmd_v_lo, mem_cmd_yumi_li;
   bsg_fifo_1r1w_small
@@ -90,7 +90,7 @@ module bp_me_cce_to_cache
 
     ,.data_i(mem_cmd_i)
     ,.v_i(mem_cmd_v_i)
-    ,.ready_o(mem_cmd_ready_lo)
+    ,.ready_o(mem_cmd_ready_and_lo)
 
     ,.data_o(mem_cmd_lo)
     ,.v_o(mem_cmd_v_lo)
@@ -133,7 +133,7 @@ module bp_me_cce_to_cache
     tagst_received_n = tagst_received_r;
     v_o = 1'b0;
 
-    mem_cmd_ready_o = mem_cmd_ready_lo;
+    mem_cmd_ready_and_o = mem_cmd_ready_and_lo;
     mem_cmd_yumi_li = 1'b0;
 
     cmd_state_n = cmd_state_r;
@@ -142,12 +142,12 @@ module bp_me_cce_to_cache
 
     case (cmd_state_r)
       RESET: begin
-        mem_cmd_ready_o = 1'b0;
+        mem_cmd_ready_and_o = 1'b0;
 
         cmd_state_n = CLEAR_TAG;
       end
       CLEAR_TAG: begin
-        mem_cmd_ready_o = 1'b0;
+        mem_cmd_ready_and_o = 1'b0;
 
         v_o = tagst_sent_r != (l2_assoc_p*l2_sets_p);
 

--- a/bp_me/src/v/cce/bp_io_cce.sv
+++ b/bp_me/src/v/cce/bp_io_cce.sv
@@ -21,7 +21,7 @@ module bp_io_cce
 
    , output logic [lce_cmd_msg_width_lp-1:0]  lce_cmd_o
    , output logic                             lce_cmd_v_o
-   , input                                    lce_cmd_ready_i
+   , input                                    lce_cmd_ready_then_i
 
    , input [cce_mem_msg_width_lp-1:0]         io_resp_i
    , input                                    io_resp_v_i
@@ -29,7 +29,7 @@ module bp_io_cce
 
    , output logic [cce_mem_msg_width_lp-1:0]  io_cmd_o
    , output logic                             io_cmd_v_o
-   , input                                    io_cmd_ready_i
+   , input                                    io_cmd_ready_then_i
 
    );
 
@@ -53,7 +53,7 @@ module bp_io_cce
   assign io_resp_cast_i = io_resp_i;
   assign io_cmd_o       = io_cmd_cast_o;
 
-  assign lce_req_yumi_o  = lce_req_v_i & io_cmd_ready_i;
+  assign lce_req_yumi_o  = lce_req_v_i & io_cmd_ready_then_i;
   assign io_cmd_v_o      = lce_req_yumi_o;
   wire lce_req_wr_not_rd = (lce_req_cast_i.header.msg_type.req == e_bedrock_req_uc_wr);
   always_comb begin
@@ -68,7 +68,7 @@ module bp_io_cce
     io_cmd_cast_o.data                    = lce_req_cast_i.data;
   end
 
-  assign io_resp_yumi_o  = io_resp_v_i & lce_cmd_ready_i;
+  assign io_resp_yumi_o  = io_resp_v_i & lce_cmd_ready_then_i;
   assign lce_cmd_v_o     = io_resp_yumi_o;
   wire io_resp_wr_not_rd = (io_resp_cast_i.header.msg_type.mem == e_bedrock_mem_uc_wr);
   always_comb

--- a/bp_me/src/v/lce/bp_lce.sv
+++ b/bp_me/src/v/lce/bp_lce.sv
@@ -88,12 +88,12 @@ module bp_lce
     // Req: ready->valid
     , output logic [lce_req_msg_width_lp-1:0]        lce_req_o
     , output logic                                   lce_req_v_o
-    , input                                          lce_req_ready_i
+    , input                                          lce_req_ready_then_i
 
     // Resp: ready->valid
     , output logic [lce_resp_msg_width_lp-1:0]       lce_resp_o
     , output logic                                   lce_resp_v_o
-    , input                                          lce_resp_ready_i
+    , input                                          lce_resp_ready_then_i
 
     // CCE-LCE interface
     // Cmd_i: valid->yumi
@@ -105,7 +105,7 @@ module bp_lce
     // Cmd_o: ready->valid
     , output logic [lce_cmd_msg_width_lp-1:0]        lce_cmd_o
     , output logic                                   lce_cmd_v_o
-    , input                                          lce_cmd_ready_i
+    , input                                          lce_cmd_ready_then_i
   );
 
   //synopsys translate_off
@@ -161,7 +161,7 @@ module bp_lce
 
       ,.lce_req_o(lce_req_o)
       ,.lce_req_v_o(lce_req_v_o)
-      ,.lce_req_ready_i(lce_req_ready_i)
+      ,.lce_req_ready_then_i(lce_req_ready_then_i)
       );
 
   // LCE Command Module
@@ -210,11 +210,11 @@ module bp_lce
 
       ,.lce_resp_o(lce_resp_o)
       ,.lce_resp_v_o(lce_resp_v_o)
-      ,.lce_resp_ready_i(lce_resp_ready_i)
+      ,.lce_resp_ready_then_i(lce_resp_ready_then_i)
 
       ,.lce_cmd_o(lce_cmd_o)
       ,.lce_cmd_v_o(lce_cmd_v_o)
-      ,.lce_cmd_ready_i(lce_cmd_ready_i)
+      ,.lce_cmd_ready_then_i(lce_cmd_ready_then_i)
       );
 
 

--- a/bp_me/src/v/lce/bp_lce_cmd.sv
+++ b/bp_me/src/v/lce/bp_lce_cmd.sv
@@ -104,7 +104,7 @@ module bp_lce_cmd
     // Resp: ready->valid
     , output logic [lce_resp_msg_width_lp-1:0]       lce_resp_o
     , output logic                                   lce_resp_v_o
-    , input                                          lce_resp_ready_i
+    , input                                          lce_resp_ready_then_i
 
     // CCE-LCE interface
     // Cmd_i: valid->yumi
@@ -116,7 +116,7 @@ module bp_lce_cmd
     // Cmd_o: ready->valid
     , output logic [lce_cmd_msg_width_lp-1:0]        lce_cmd_o
     , output logic                                   lce_cmd_v_o
-    , input                                          lce_cmd_ready_i
+    , input                                          lce_cmd_ready_then_i
   );
 
   `declare_bp_bedrock_lce_if(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
@@ -342,7 +342,7 @@ module bp_lce_cmd
               lce_resp_payload.src_id = lce_id_i;
               lce_resp.header.payload = lce_resp_payload;
               lce_resp.header.msg_type.resp = e_bedrock_resp_sync_ack;
-              lce_resp_v_o = lce_resp_ready_i;
+              lce_resp_v_o = lce_resp_ready_then_i;
               lce_cmd_yumi_o = lce_resp_v_o;
 
               // reset the counter when last sync is received and ack is sent
@@ -377,7 +377,7 @@ module bp_lce_cmd
               tag_mem_pkt.opcode = e_cache_tag_mem_set_state;
               tag_mem_pkt_v_o = lce_cmd_v_i;
 
-              lce_resp_v_o = tag_mem_pkt_yumi_i & lce_resp_ready_i;
+              lce_resp_v_o = tag_mem_pkt_yumi_i & lce_resp_ready_then_i;
               lce_resp.header.addr = lce_cmd.header.addr;
               lce_resp.header.msg_type.resp = e_bedrock_resp_inv_ack;
               lce_resp_payload.src_id = lce_id_i;
@@ -573,7 +573,7 @@ module bp_lce_cmd
         lce_resp_payload.src_id = lce_id_i;
         lce_resp_payload.dst_id = lce_cmd_payload.src_id;
         lce_resp.header.payload = lce_resp_payload;
-        lce_resp_v_o = lce_cmd_v_i & lce_resp_ready_i;
+        lce_resp_v_o = lce_cmd_v_i & lce_resp_ready_then_i;
 
         lce_cmd_yumi_o = lce_resp_v_o;
 
@@ -606,7 +606,7 @@ module bp_lce_cmd
         // handshakes
         // outbound command is ready->valid
         // inbound is valid->yumi, but only dequeue when outbound sends
-        lce_cmd_v_o = lce_cmd_ready_i & lce_cmd_v_i & data_buf_v_r;
+        lce_cmd_v_o = lce_cmd_ready_then_i & lce_cmd_v_i & data_buf_v_r;
 
         // dequeue the command if transfer is last action
         lce_cmd_yumi_o = lce_cmd_v_o & (lce_cmd.header.msg_type.cmd != e_bedrock_cmd_st_tr_wb);
@@ -648,7 +648,7 @@ module bp_lce_cmd
         lce_resp_payload.src_id = lce_id_i;
         lce_resp_payload.dst_id = lce_cmd_payload.src_id;
         lce_resp.header.payload = lce_resp_payload;
-        lce_resp_v_o = lce_resp_ready_i & stat_buf_v_r & ~stat_buf_r.dirty[lce_cmd_way_id];
+        lce_resp_v_o = lce_resp_ready_then_i & stat_buf_v_r & ~stat_buf_r.dirty[lce_cmd_way_id];
         // dequeue command only if sending null writeback
         lce_cmd_yumi_o = lce_resp_v_o;
 
@@ -693,7 +693,7 @@ module bp_lce_cmd
         lce_resp_payload.dst_id = lce_cmd_payload.src_id;
         lce_resp.header.payload = lce_resp_payload;
         lce_resp.header.size = cmd_block_size_lp;
-        lce_resp_v_o = lce_resp_ready_i & data_buf_v_r;
+        lce_resp_v_o = lce_resp_ready_then_i & data_buf_v_r;
 
         lce_cmd_yumi_o = lce_resp_v_o;
 

--- a/bp_me/src/v/lce/bp_lce_req.sv
+++ b/bp_me/src/v/lce/bp_lce_req.sv
@@ -95,7 +95,7 @@ module bp_lce_req
     // Req: ready->valid
     , output logic [lce_req_msg_width_lp-1:0]        lce_req_o
     , output logic                                   lce_req_v_o
-    , input                                          lce_req_ready_i
+    , input                                          lce_req_ready_then_i
   );
 
   `declare_bp_bedrock_lce_if(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
@@ -166,7 +166,7 @@ module bp_lce_req
   // Outstanding request credit counter
   logic [`BSG_WIDTH(credits_p)-1:0] credit_count_lo;
   wire credit_v_li = lce_req_v_o;
-  wire credit_ready_li = lce_req_ready_i;
+  wire credit_ready_li = lce_req_ready_then_i;
   wire credit_returned_li = cache_req_complete_i | uc_store_req_complete_i;
   bsg_flow_counter
     #(.els_p(credits_p))
@@ -212,7 +212,7 @@ module bp_lce_req
 
       // Ready for new request
       e_ready: begin
-        ready_o = ~credits_full_o & lce_req_ready_i & ((lce_mode_i == e_lce_mode_uncached) || sync_done_i);
+        ready_o = ~credits_full_o & lce_req_ready_then_i & ((lce_mode_i == e_lce_mode_uncached) || sync_done_i);
 
         if (ready_o)
           unique case (cache_req.msg_type)
@@ -222,7 +222,7 @@ module bp_lce_req
               state_n = cache_req_yumi_o ? e_send_cached_req : e_ready;
             end
             e_uc_store: begin
-              lce_req_v_o = lce_req_ready_i & cache_req_v_i;
+              lce_req_v_o = lce_req_ready_then_i & cache_req_v_i;
 
               lce_req.data[0+:dword_width_gp] = cache_req.data[0+:dword_width_gp];
               lce_req.header.size = bp_bedrock_msg_size_e'(cache_req.size);
@@ -247,7 +247,7 @@ module bp_lce_req
         // valid cache request arrived last cycle (or earlier) and is held in cache_req_r
 
         // send when port is ready and metadata has arrived
-        lce_req_v_o = lce_req_ready_i & cache_req_metadata_v_r;
+        lce_req_v_o = lce_req_ready_then_i & cache_req_metadata_v_r;
 
         lce_req.header.size = req_block_size_lp;
         lce_req.header.addr = cache_req_r.addr;
@@ -275,7 +275,7 @@ module bp_lce_req
         // valid cache request arrived last cycle (or earlier) and is held in cache_req_r
 
         // send when port is ready and metadata has arrived
-        lce_req_v_o = lce_req_ready_i;
+        lce_req_v_o = lce_req_ready_then_i;
 
         lce_req.header.size = bp_bedrock_msg_size_e'(cache_req_r.size);
         lce_req.header.addr = cache_req_r.addr;

--- a/bp_me/src/v/wormhole/bp_me_cce_to_mem_link_bidir.sv
+++ b/bp_me/src/v/wormhole/bp_me_cce_to_mem_link_bidir.sv
@@ -31,7 +31,7 @@ module bp_me_cce_to_mem_link_bidir
    // Master link
    , input  [cce_mem_msg_width_lp-1:0]            mem_cmd_i
    , input                                        mem_cmd_v_i
-   , output                                       mem_cmd_ready_o
+   , output                                       mem_cmd_ready_and_o
 
    , output [cce_mem_msg_width_lp-1:0]            mem_resp_o
    , output                                       mem_resp_v_o
@@ -44,7 +44,7 @@ module bp_me_cce_to_mem_link_bidir
 
    , input [cce_mem_msg_width_lp-1:0]             mem_resp_i
    , input                                        mem_resp_v_i
-   , output                                       mem_resp_ready_o
+   , output                                       mem_resp_ready_and_o
 
    // NOC interface
    , input [bsg_ready_and_link_sif_width_lp-1:0]  cmd_link_i
@@ -97,7 +97,7 @@ bp_me_cce_to_mem_link_master
 
   ,.mem_cmd_i(mem_cmd_i)
   ,.mem_cmd_v_i(mem_cmd_v_i)
-  ,.mem_cmd_ready_o(mem_cmd_ready_o)
+  ,.mem_cmd_ready_and_o(mem_cmd_ready_and_o)
 
   ,.mem_resp_o(mem_resp_o)
   ,.mem_resp_v_o(mem_resp_v_o)
@@ -130,7 +130,7 @@ bp_me_cce_to_mem_link_client
 
   ,.mem_resp_i(mem_resp_i)
   ,.mem_resp_v_i(mem_resp_v_i)
-  ,.mem_resp_ready_o(mem_resp_ready_o)
+  ,.mem_resp_ready_and_o(mem_resp_ready_and_o)
 
   ,.cmd_link_i(client_cmd_link_li)
   ,.resp_link_o(client_resp_link_lo)

--- a/bp_me/src/v/wormhole/bp_me_cce_to_mem_link_client.sv
+++ b/bp_me/src/v/wormhole/bp_me_cce_to_mem_link_client.sv
@@ -34,7 +34,7 @@ module bp_me_cce_to_mem_link_client
 
   , input [cce_mem_msg_width_lp-1:0]             mem_resp_i
   , input                                        mem_resp_v_i
-  , output                                       mem_resp_ready_o
+  , output                                       mem_resp_ready_and_o
 
   // bsg_noc_wormhole interface
   , input [bsg_ready_and_link_sif_width_lp-1:0]  cmd_link_i
@@ -73,7 +73,7 @@ module bp_me_cce_to_mem_link_client
 
       ,.packet_i(mem_resp_packet_lo)
       ,.v_i(mem_resp_v_i)
-      ,.ready_o(mem_resp_ready_o)
+      ,.ready_o(mem_resp_ready_and_o)
       );
   assign mem_cmd_o = {mem_cmd_packet_lo.data, mem_cmd_packet_lo.header.msg_hdr};
   assign mem_cmd_v_o = mem_cmd_packet_v_lo & fifo_ready_lo;

--- a/bp_me/src/v/wormhole/bp_me_cce_to_mem_link_master.sv
+++ b/bp_me/src/v/wormhole/bp_me_cce_to_mem_link_master.sv
@@ -27,7 +27,7 @@ module bp_me_cce_to_mem_link_master
    // CCE-MEM Interface
    , input  [cce_mem_msg_width_lp-1:0]            mem_cmd_i
    , input                                        mem_cmd_v_i
-   , output                                       mem_cmd_ready_o
+   , output                                       mem_cmd_ready_and_o
 
    , output [cce_mem_msg_width_lp-1:0]            mem_resp_o
    , output                                       mem_resp_v_o
@@ -88,7 +88,7 @@ bsg_wormhole_router_adapter
 
    ,.packet_i(mem_cmd_packet_li)
    ,.v_i(mem_cmd_v_i)
-   ,.ready_o(mem_cmd_ready_o)
+   ,.ready_o(mem_cmd_ready_and_o)
 
    ,.link_o(cmd_link_o)
    ,.link_i(resp_link_i)

--- a/bp_me/test/common/bp_me_nonsynth_lce_tracer.sv
+++ b/bp_me/test/common/bp_me_nonsynth_lce_tracer.sv
@@ -42,11 +42,11 @@ module bp_me_nonsynth_lce_tracer
     // LCE-CCE Interface
     ,input [lce_req_msg_width_lp-1:0]                       lce_req_i
     ,input                                                  lce_req_v_i
-    ,input                                                  lce_req_ready_i
+    ,input                                                  lce_req_ready_then_i
 
     ,input [lce_resp_msg_width_lp-1:0]                      lce_resp_i
     ,input                                                  lce_resp_v_i
-    ,input                                                  lce_resp_ready_i
+    ,input                                                  lce_resp_ready_then_i
 
     ,input [lce_cmd_msg_width_lp-1:0]                       lce_cmd_i
     ,input                                                  lce_cmd_v_i
@@ -54,7 +54,7 @@ module bp_me_nonsynth_lce_tracer
 
     ,input [lce_cmd_msg_width_lp-1:0]                       lce_cmd_o_i
     ,input                                                  lce_cmd_o_v_i
-    ,input                                                  lce_cmd_o_ready_i
+    ,input                                                  lce_cmd_o_ready_then_i
   );
 
   // LCE-CCE interface structs
@@ -91,7 +91,7 @@ module bp_me_nonsynth_lce_tracer
       // LCE-CCE Interface
 
       // request to CCE
-      if (lce_req_v_i & lce_req_ready_i) begin
+      if (lce_req_v_i & lce_req_ready_then_i) begin
         assert(lce_req_payload.src_id == lce_id_i) else $error("Bad LCE Request - source mismatch");
         $fdisplay(file, "[%t]: LCE[%0d] REQ addr[%H] cce[%0d] msg[%b] ne[%b] lru[%0d] size[%b] %H"
                   , $time, lce_req_payload.src_id, lce_req.header.addr, lce_req_payload.dst_id, lce_req.header.msg_type
@@ -101,7 +101,7 @@ module bp_me_nonsynth_lce_tracer
       end
 
       // response to CCE
-      if (lce_resp_v_i & lce_resp_ready_i) begin
+      if (lce_resp_v_i & lce_resp_ready_then_i) begin
         assert(lce_resp_payload.src_id == lce_id_i) else $error("Bad LCE Response - source mismatch");
         $fdisplay(file, "[%t]: LCE[%0d] RESP addr[%H] cce[%0d] msg[%b] len[%b] %H"
                   , $time, lce_resp_payload.src_id, lce_resp.header.addr, lce_resp_payload.dst_id, lce_resp.header.msg_type
@@ -120,7 +120,7 @@ module bp_me_nonsynth_lce_tracer
       end
 
       // command from LCE
-      if (lce_cmd_o_v_i & lce_cmd_o_ready_i) begin
+      if (lce_cmd_o_v_i & lce_cmd_o_ready_then_i) begin
         $fdisplay(file, "[%t]: LCE[%0d] CMD OUT dst[%0d] addr[%H] CCE[%0d] msg[%b] way[%0d] state[%b] tgt[%0d] tgt_way[%0d] len[%b] %H"
                   , $time, lce_id_i, lce_cmd_lo_payload.dst_id, lce_cmd_lo.header.addr, lce_cmd_lo_payload.src_id, lce_cmd_lo.header.msg_type
                   , lce_cmd_lo_payload.way_id, lce_cmd_lo_payload.state, lce_cmd_lo_payload.target, lce_cmd_lo_payload.target_way_id

--- a/bp_me/test/common/bp_mem_nonsynth_tracer.sv
+++ b/bp_me/test/common/bp_mem_nonsynth_tracer.sv
@@ -21,7 +21,7 @@ module bp_mem_nonsynth_tracer
    // BP side
    , input [cce_mem_msg_width_lp-1:0]    mem_cmd_i
    , input                               mem_cmd_v_i
-   , input                               mem_cmd_ready_i
+   , input                               mem_cmd_ready_and_i
 
    , input [cce_mem_msg_width_lp-1:0]    mem_resp_i
    , input                               mem_resp_v_i
@@ -30,7 +30,7 @@ module bp_mem_nonsynth_tracer
 
 `declare_bp_bedrock_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce);
 
-wire unused = &{mem_cmd_ready_i, mem_resp_v_i};
+wire unused = &{mem_resp_v_i};
 
 integer file;
 always_ff @(negedge reset_i) begin
@@ -44,7 +44,7 @@ assign mem_cmd_cast_i = mem_cmd_i;
 assign mem_resp_cast_i = mem_resp_i;
 
 always_ff @(posedge clk_i) begin
-  if (mem_cmd_v_i)
+  if (mem_cmd_v_i & mem_cmd_ready_and_i)
     case (mem_cmd_cast_i.header.msg_type.mem)
       e_bedrock_mem_rd:
         $fwrite(file, "[%t] CMD  RD  : (%x) %b\n", $time, mem_cmd_cast_i.header.addr, mem_cmd_cast_i.header.size);

--- a/bp_me/test/common/bp_nonsynth_mem.sv
+++ b/bp_me/test/common/bp_nonsynth_mem.sv
@@ -22,7 +22,7 @@ module bp_nonsynth_mem
 
    , input [cce_mem_msg_width_lp-1:0]        mem_cmd_i
    , input                                   mem_cmd_v_i
-   , output logic                            mem_cmd_ready_o
+   , output logic                            mem_cmd_ready_and_o
 
    , output logic [cce_mem_msg_width_lp-1:0] mem_resp_o
    , output logic                            mem_resp_v_o
@@ -46,7 +46,7 @@ module bp_nonsynth_mem
 
      ,.mem_cmd_i(mem_cmd_i)
      ,.mem_cmd_v_i(mem_cmd_v_i)
-     ,.mem_cmd_ready_o(mem_cmd_ready_o)
+     ,.mem_cmd_ready_and_o(mem_cmd_ready_and_o)
 
      ,.mem_resp_o(mem_resp_o)
      ,.mem_resp_v_o(mem_resp_v_o)

--- a/bp_me/test/tb/bp_cce/testbench.sv
+++ b/bp_me/test/tb/bp_cce/testbench.sv
@@ -112,7 +112,7 @@ assign cfg_mem_cmd = '{header: cfg_mem_cmd_lo.header
 bp_bedrock_cce_mem_msg_s mem_resp;
 logic                    mem_resp_v, mem_resp_yumi;
 bp_bedrock_cce_mem_msg_s mem_cmd;
-logic                    mem_cmd_v, mem_cmd_ready;
+logic                    mem_cmd_v, mem_cmd_ready_then;
 
 // LCE-CCE IF
 bp_bedrock_lce_req_msg_s  lce_req_lo, lce_req;
@@ -176,11 +176,11 @@ bp_me_nonsynth_mock_lce #(
 
   ,.lce_req_o(lce_req_lo)
   ,.lce_req_v_o(lce_req_v_lo)
-  ,.lce_req_ready_i(lce_req_ready_li)
+  ,.lce_req_ready_then_i(lce_req_ready_li)
 
   ,.lce_resp_o(lce_resp_lo)
   ,.lce_resp_v_o(lce_resp_v_lo)
-  ,.lce_resp_ready_i(lce_resp_ready_li)
+  ,.lce_resp_ready_then_i(lce_resp_ready_li)
 
   ,.lce_cmd_i(lce_cmd)
   ,.lce_cmd_v_i(lce_cmd_v)
@@ -188,7 +188,7 @@ bp_me_nonsynth_mock_lce #(
 
   ,.lce_cmd_o(lce_cmd_out_lo)
   ,.lce_cmd_v_o(lce_cmd_out_v_lo)
-  ,.lce_cmd_ready_i(lce_cmd_out_ready_li)
+  ,.lce_cmd_ready_then_i(lce_cmd_out_ready_li)
 );
 
 bind bp_me_nonsynth_mock_lce
@@ -204,16 +204,16 @@ bind bp_me_nonsynth_mock_lce
       ,.lce_id_i(lce_id_i)
       ,.lce_req_i(lce_req_o)
       ,.lce_req_v_i(lce_req_v_o)
-      ,.lce_req_ready_i(lce_req_ready_i)
+      ,.lce_req_ready_then_i(lce_req_ready_then_i)
       ,.lce_resp_i(lce_resp_o)
       ,.lce_resp_v_i(lce_resp_v_o)
-      ,.lce_resp_ready_i(lce_resp_ready_i)
+      ,.lce_resp_ready_then_i(lce_resp_ready_then_i)
       ,.lce_cmd_i(lce_cmd_i)
       ,.lce_cmd_v_i(lce_cmd_v_i)
       ,.lce_cmd_yumi_i(lce_cmd_yumi_o)
       ,.lce_cmd_o_i(lce_cmd_o)
       ,.lce_cmd_o_v_i(lce_cmd_v_o)
-      ,.lce_cmd_o_ready_i(lce_cmd_ready_i)
+      ,.lce_cmd_o_ready_then_i(lce_cmd_ready_then_i)
       );
 
 bind bp_me_nonsynth_mock_lce
@@ -389,7 +389,7 @@ wrapper
 
   ,.mem_cmd_o(mem_cmd)
   ,.mem_cmd_v_o(mem_cmd_v)
-  ,.mem_cmd_ready_i(mem_cmd_ready)
+  ,.mem_cmd_ready_i(mem_cmd_ready_then)
 );
 
 
@@ -414,7 +414,7 @@ mem_cmd_buffer
   // from CCE
   ,.v_i(mem_cmd_v)
   ,.data_i(mem_cmd)
-  ,.ready_o(mem_cmd_ready)
+  ,.ready_o(mem_cmd_ready_then)
   // to memory
   ,.v_o(mem_cmd_v_lo)
   ,.data_o(mem_cmd_lo)
@@ -453,7 +453,7 @@ mem
 
   ,.mem_cmd_i(mem_cmd_lo)
   ,.mem_cmd_v_i(mem_cmd_v_lo & mem_cmd_ready_lo)
-  ,.mem_cmd_ready_o(mem_cmd_ready_lo)
+  ,.mem_cmd_ready_and_o(mem_cmd_ready_lo)
 
   ,.mem_resp_o(mem_resp_lo)
   ,.mem_resp_v_o(mem_resp_v_lo)
@@ -471,7 +471,7 @@ bp_mem_nonsynth_tracer
 
    ,.mem_cmd_i(mem_cmd)
    ,.mem_cmd_v_i(mem_cmd_v)
-   ,.mem_cmd_ready_i(mem_cmd_ready)
+   ,.mem_cmd_ready_and_i(mem_cmd_ready_then)
 
    ,.mem_resp_i(mem_resp)
    ,.mem_resp_v_i(mem_resp_v)
@@ -488,7 +488,7 @@ bp_cfg
 
    ,.mem_cmd_i(cfg_mem_cmd)
    ,.mem_cmd_v_i(cfg_mem_cmd_v_lo)
-   ,.mem_cmd_ready_o(cfg_mem_cmd_ready_li)
+   ,.mem_cmd_ready_and_o(cfg_mem_cmd_ready_li)
 
    ,.mem_resp_o()
    ,.mem_resp_v_o(cfg_resp_v_lo)

--- a/bp_top/src/v/bp_cacc_tile.sv
+++ b/bp_top/src/v/bp_cacc_tile.sv
@@ -89,11 +89,12 @@ module bp_cacc_tile
 
      ,.lce_cmd_o(cce_lce_cmd_lo)
      ,.lce_cmd_v_o(cce_lce_cmd_v_lo)
-     ,.lce_cmd_ready_i(cce_lce_cmd_ready_li)
+     // TODO: mismatch, but okay. ready_and used as ready_then
+     ,.lce_cmd_ready_then_i(cce_lce_cmd_ready_li)
 
      ,.io_cmd_o(cce_io_cmd_lo)
      ,.io_cmd_v_o(cce_io_cmd_v_lo)
-     ,.io_cmd_ready_i(cce_io_cmd_ready_li)
+     ,.io_cmd_ready_then_i(cce_io_cmd_ready_li)
 
      ,.io_resp_i(cce_io_resp_li)
      ,.io_resp_v_i(cce_io_resp_v_li)

--- a/bp_top/src/v/bp_cacc_tile.sv
+++ b/bp_top/src/v/bp_cacc_tile.sv
@@ -89,7 +89,6 @@ module bp_cacc_tile
 
      ,.lce_cmd_o(cce_lce_cmd_lo)
      ,.lce_cmd_v_o(cce_lce_cmd_v_lo)
-     // TODO: mismatch, but okay. ready_and used as ready_then
      ,.lce_cmd_ready_then_i(cce_lce_cmd_ready_li)
 
      ,.io_cmd_o(cce_io_cmd_lo)

--- a/bp_top/src/v/bp_cacc_tile.sv
+++ b/bp_top/src/v/bp_cacc_tile.sv
@@ -42,10 +42,10 @@ module bp_cacc_tile
   bp_bedrock_lce_req_msg_s  cce_lce_req_li;
   logic cce_lce_req_v_li, cce_lce_req_yumi_lo;
   bp_bedrock_lce_cmd_msg_s cce_lce_cmd_lo;
-  logic cce_lce_cmd_v_lo, cce_lce_cmd_ready_li;
+  logic cce_lce_cmd_v_lo, cce_lce_cmd_ready_and_li;
 
   bp_bedrock_cce_mem_msg_s cce_io_cmd_lo;
-  logic cce_io_cmd_v_lo, cce_io_cmd_ready_li;
+  logic cce_io_cmd_v_lo, cce_io_cmd_ready_and_li;
   bp_bedrock_cce_mem_msg_s cce_io_resp_li;
   logic cce_io_resp_v_li, cce_io_resp_yumi_lo;
 
@@ -89,11 +89,11 @@ module bp_cacc_tile
 
      ,.lce_cmd_o(cce_lce_cmd_lo)
      ,.lce_cmd_v_o(cce_lce_cmd_v_lo)
-     ,.lce_cmd_ready_then_i(cce_lce_cmd_ready_li)
+     ,.lce_cmd_ready_then_i(cce_lce_cmd_ready_and_li)
 
      ,.io_cmd_o(cce_io_cmd_lo)
      ,.io_cmd_v_o(cce_io_cmd_v_lo)
-     ,.io_cmd_ready_then_i(cce_io_cmd_ready_li)
+     ,.io_cmd_ready_then_i(cce_io_cmd_ready_and_li)
 
      ,.io_resp_i(cce_io_resp_li)
      ,.io_resp_v_i(cce_io_resp_v_li)
@@ -229,7 +229,7 @@ module bp_cacc_tile
 
      ,.packet_i(cce_lce_cmd_packet_lo)
      ,.v_i(cce_lce_cmd_v_lo)
-     ,.ready_o(cce_lce_cmd_ready_li)
+     ,.ready_o(cce_lce_cmd_ready_and_li)
 
      ,.link_i(cce_lce_cmd_link_li)
      ,.link_o(cce_lce_cmd_link_lo)
@@ -274,7 +274,7 @@ module bp_cacc_tile
 
          ,.io_cmd_i(cce_io_cmd_lo)
          ,.io_cmd_v_i(cce_io_cmd_v_lo)
-         ,.io_cmd_ready_o(cce_io_cmd_ready_li)
+         ,.io_cmd_ready_o(cce_io_cmd_ready_and_li)
 
          ,.io_resp_o(cce_io_resp_li)
          ,.io_resp_v_o(cce_io_resp_v_li)

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -190,11 +190,11 @@ bp_lce
 
     ,.lce_req_o(lce_req_o)
     ,.lce_req_v_o(lce_req_v_o)
-    ,.lce_req_ready_i(lce_req_ready_i)
+    ,.lce_req_ready_then_i(lce_req_ready_i)
 
     ,.lce_resp_o(lce_resp_o)
     ,.lce_resp_v_o(lce_resp_v_o)
-    ,.lce_resp_ready_i(lce_resp_ready_i)
+    ,.lce_resp_ready_then_i(lce_resp_ready_i)
 
     ,.lce_cmd_i(lce_cmd_i)
     ,.lce_cmd_v_i(lce_cmd_v_i)
@@ -202,7 +202,7 @@ bp_lce
 
     ,.lce_cmd_o(lce_cmd_o)
     ,.lce_cmd_v_o(lce_cmd_v_o)
-    ,.lce_cmd_ready_i(lce_cmd_ready_i)
+    ,.lce_cmd_ready_then_i(lce_cmd_ready_i)
     );
 
 

--- a/bp_top/src/v/bp_cfg.sv
+++ b/bp_top/src/v/bp_cfg.sv
@@ -17,7 +17,7 @@ module bp_cfg
 
    , input [xce_mem_msg_width_lp-1:0]   mem_cmd_i
    , input                              mem_cmd_v_i
-   , output                             mem_cmd_ready_o
+   , output                             mem_cmd_ready_and_o
 
    , output [xce_mem_msg_width_lp-1:0]  mem_resp_o
    , output                             mem_resp_v_o
@@ -32,8 +32,8 @@ module bp_cfg
    , output                             cce_ucode_v_o
    , output                             cce_ucode_w_o
    , output [cce_pc_width_p-1:0]        cce_ucode_addr_o
-   , output [cce_instr_width_gp-1:0]     cce_ucode_data_o
-   , input [cce_instr_width_gp-1:0]      cce_ucode_data_i
+   , output [cce_instr_width_gp-1:0]    cce_ucode_data_o
+   , input [cce_instr_width_gp-1:0]     cce_ucode_data_i
    );
 
   `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
@@ -54,7 +54,7 @@ module bp_cfg
 
      ,.data_i(mem_cmd_li)
      ,.v_i(mem_cmd_v_i)
-     ,.ready_o(mem_cmd_ready_o)
+     ,.ready_o(mem_cmd_ready_and_o)
 
      ,.data_o(mem_cmd_lo)
      ,.v_o(mem_cmd_v_lo)

--- a/bp_top/src/v/bp_clint_slice.sv
+++ b/bp_top/src/v/bp_clint_slice.sv
@@ -17,7 +17,7 @@ module bp_clint_slice
 
    , input [xce_mem_msg_width_lp-1:0]                   mem_cmd_i
    , input                                              mem_cmd_v_i
-   , output                                             mem_cmd_ready_o
+   , output                                             mem_cmd_ready_and_o
 
    , output [xce_mem_msg_width_lp-1:0]                  mem_resp_o
    , output                                             mem_resp_v_o
@@ -44,7 +44,7 @@ module bp_clint_slice
   
      ,.data_i(mem_cmd_li)
      ,.v_i(mem_cmd_v_i)
-     ,.ready_o(mem_cmd_ready_o)
+     ,.ready_o(mem_cmd_ready_and_o)
   
      ,.data_o(mem_cmd_lo)
      ,.v_o(small_fifo_v_lo)

--- a/bp_top/src/v/bp_core.sv
+++ b/bp_top/src/v/bp_core.sv
@@ -24,30 +24,30 @@ module bp_core
  (input                                          clk_i
   , input                                        reset_i
 
-    , input [cfg_bus_width_lp-1:0]                 cfg_bus_i
+  , input [cfg_bus_width_lp-1:0]                 cfg_bus_i
 
-    // LCE-CCE interface
-    , output [1:0][lce_req_msg_width_lp-1:0]       lce_req_o
-    , output [1:0]                                 lce_req_v_o
-    , input [1:0]                                  lce_req_ready_then_i
+  // LCE-CCE interface
+  , output [1:0][lce_req_msg_width_lp-1:0]       lce_req_o
+  , output [1:0]                                 lce_req_v_o
+  , input [1:0]                                  lce_req_ready_then_i
 
-    , output [1:0][lce_resp_msg_width_lp-1:0]      lce_resp_o
-    , output [1:0]                                 lce_resp_v_o
-    , input [1:0]                                  lce_resp_ready_then_i
+  , output [1:0][lce_resp_msg_width_lp-1:0]      lce_resp_o
+  , output [1:0]                                 lce_resp_v_o
+  , input [1:0]                                  lce_resp_ready_then_i
 
-    // CCE-LCE interface
-    , input [1:0][lce_cmd_msg_width_lp-1:0]        lce_cmd_i
-    , input [1:0]                                  lce_cmd_v_i
-    , output [1:0]                                 lce_cmd_yumi_o
+  // CCE-LCE interface
+  , input [1:0][lce_cmd_msg_width_lp-1:0]        lce_cmd_i
+  , input [1:0]                                  lce_cmd_v_i
+  , output [1:0]                                 lce_cmd_yumi_o
 
-    , output [1:0][lce_cmd_msg_width_lp-1:0]       lce_cmd_o
-    , output [1:0]                                 lce_cmd_v_o
-    , input [1:0]                                  lce_cmd_ready_then_i
+  , output [1:0][lce_cmd_msg_width_lp-1:0]       lce_cmd_o
+  , output [1:0]                                 lce_cmd_v_o
+  , input [1:0]                                  lce_cmd_ready_then_i
 
-    , input                                        timer_irq_i
-    , input                                        software_irq_i
-    , input                                        external_irq_i
-    );
+  , input                                        timer_irq_i
+  , input                                        software_irq_i
+  , input                                        external_irq_i
+  );
 
   `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache);

--- a/bp_top/src/v/bp_core.sv
+++ b/bp_top/src/v/bp_core.sv
@@ -24,30 +24,30 @@ module bp_core
  (input                                          clk_i
   , input                                        reset_i
 
-  , input [cfg_bus_width_lp-1:0]                 cfg_bus_i
+    , input [cfg_bus_width_lp-1:0]                 cfg_bus_i
 
-  // LCE-CCE interface
-  , output [1:0][lce_req_msg_width_lp-1:0]       lce_req_o
-  , output [1:0]                                 lce_req_v_o
-  , input [1:0]                                  lce_req_ready_i
+    // LCE-CCE interface
+    , output [1:0][lce_req_msg_width_lp-1:0]       lce_req_o
+    , output [1:0]                                 lce_req_v_o
+    , input [1:0]                                  lce_req_ready_then_i
 
-  , output [1:0][lce_resp_msg_width_lp-1:0]      lce_resp_o
-  , output [1:0]                                 lce_resp_v_o
-  , input [1:0]                                  lce_resp_ready_i
+    , output [1:0][lce_resp_msg_width_lp-1:0]      lce_resp_o
+    , output [1:0]                                 lce_resp_v_o
+    , input [1:0]                                  lce_resp_ready_then_i
 
-  // CCE-LCE interface
-  , input [1:0][lce_cmd_msg_width_lp-1:0]        lce_cmd_i
-  , input [1:0]                                  lce_cmd_v_i
-  , output [1:0]                                 lce_cmd_yumi_o
+    // CCE-LCE interface
+    , input [1:0][lce_cmd_msg_width_lp-1:0]        lce_cmd_i
+    , input [1:0]                                  lce_cmd_v_i
+    , output [1:0]                                 lce_cmd_yumi_o
 
-  , output [1:0][lce_cmd_msg_width_lp-1:0]       lce_cmd_o
-  , output [1:0]                                 lce_cmd_v_o
-  , input [1:0]                                  lce_cmd_ready_i
+    , output [1:0][lce_cmd_msg_width_lp-1:0]       lce_cmd_o
+    , output [1:0]                                 lce_cmd_v_o
+    , input [1:0]                                  lce_cmd_ready_then_i
 
-  , input                                        timer_irq_i
-  , input                                        software_irq_i
-  , input                                        external_irq_i
-  );
+    , input                                        timer_irq_i
+    , input                                        software_irq_i
+    , input                                        external_irq_i
+    );
 
   `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache);
@@ -209,11 +209,11 @@ module bp_core
 
      ,.lce_req_o(lce_req_o[0])
      ,.lce_req_v_o(lce_req_v_o[0])
-     ,.lce_req_ready_i(lce_req_ready_i[0])
+     ,.lce_req_ready_then_i(lce_req_ready_then_i[0])
 
      ,.lce_resp_o(lce_resp_o[0])
      ,.lce_resp_v_o(lce_resp_v_o[0])
-     ,.lce_resp_ready_i(lce_resp_ready_i[0])
+     ,.lce_resp_ready_then_i(lce_resp_ready_then_i[0])
 
      ,.lce_cmd_i(lce_cmd_i[0])
      ,.lce_cmd_v_i(lce_cmd_v_i[0])
@@ -221,7 +221,7 @@ module bp_core
 
      ,.lce_cmd_o(lce_cmd_o[0])
      ,.lce_cmd_v_o(lce_cmd_v_o[0])
-     ,.lce_cmd_ready_i(lce_cmd_ready_i[0])
+     ,.lce_cmd_ready_then_i(lce_cmd_ready_then_i[0])
      );
 
   bp_lce
@@ -271,11 +271,11 @@ module bp_core
 
      ,.lce_req_o(lce_req_o[1])
      ,.lce_req_v_o(lce_req_v_o[1])
-     ,.lce_req_ready_i(lce_req_ready_i[1])
+     ,.lce_req_ready_then_i(lce_req_ready_then_i[1])
 
      ,.lce_resp_o(lce_resp_o[1])
      ,.lce_resp_v_o(lce_resp_v_o[1])
-     ,.lce_resp_ready_i(lce_resp_ready_i[1])
+     ,.lce_resp_ready_then_i(lce_resp_ready_then_i[1])
 
      ,.lce_cmd_i(lce_cmd_i[1])
      ,.lce_cmd_v_i(lce_cmd_v_i[1])
@@ -283,7 +283,7 @@ module bp_core
 
      ,.lce_cmd_o(lce_cmd_o[1])
      ,.lce_cmd_v_o(lce_cmd_v_o[1])
-     ,.lce_cmd_ready_i(lce_cmd_ready_i[1])
+     ,.lce_cmd_ready_then_i(lce_cmd_ready_then_i[1])
      );
 
 endmodule

--- a/bp_top/src/v/bp_io_link_to_lce.sv
+++ b/bp_top/src/v/bp_io_link_to_lce.sv
@@ -26,11 +26,11 @@ module bp_io_link_to_lce
 
    , output [cce_mem_msg_width_lp-1:0]   io_resp_o
    , output                              io_resp_v_o
-   , input                               io_resp_ready_i
+   , input                               io_resp_ready_then_i
 
    , output [lce_req_msg_width_lp-1:0]   lce_req_o
    , output                              lce_req_v_o
-   , input                               lce_req_ready_i
+   , input                               lce_req_ready_then_i
 
    , input [lce_cmd_msg_width_lp-1:0]    lce_cmd_i
    , input                               lce_cmd_v_i
@@ -53,10 +53,10 @@ module bp_io_link_to_lce
   assign lce_req_o  = lce_req_lo;
   assign lce_cmd_li = lce_cmd_i;
 
-  assign lce_req_v_o    = lce_req_ready_i & io_cmd_v_i;
+  assign lce_req_v_o    = lce_req_ready_then_i & io_cmd_v_i;
   assign io_cmd_yumi_o  = lce_req_v_o;
 
-  assign io_resp_v_o    = io_resp_ready_i & lce_cmd_v_i;
+  assign io_resp_v_o    = io_resp_ready_then_i & lce_cmd_v_i;
   assign lce_cmd_yumi_o = io_resp_v_o;
 
   logic [cce_id_width_p-1:0] cce_id_lo;

--- a/bp_top/src/v/bp_io_tile.sv
+++ b/bp_top/src/v/bp_io_tile.sv
@@ -39,14 +39,14 @@ module bp_io_tile
   `declare_bp_memory_map(paddr_width_p, caddr_width_p);
 
   bp_bedrock_lce_req_msg_s  cce_lce_req_li, lce_lce_req_lo;
-  logic cce_lce_req_v_li, cce_lce_req_yumi_lo, lce_lce_req_v_lo, lce_lce_req_ready_li;
+  logic cce_lce_req_v_li, cce_lce_req_yumi_lo, lce_lce_req_v_lo, lce_lce_req_ready_and_li;
   bp_bedrock_lce_cmd_msg_s cce_lce_cmd_lo, lce_lce_cmd_li;
   logic cce_lce_cmd_v_lo, cce_lce_cmd_ready_li, lce_lce_cmd_v_li, lce_lce_cmd_yumi_lo;
 
   bp_bedrock_cce_mem_msg_s cce_io_cmd_lo, lce_io_cmd_li;
   logic cce_io_cmd_v_lo, cce_io_cmd_ready_li, lce_io_cmd_v_li, lce_io_cmd_yumi_lo;
   bp_bedrock_cce_mem_msg_s cce_io_resp_li, lce_io_resp_lo;
-  logic cce_io_resp_v_li, cce_io_resp_yumi_lo, lce_io_resp_v_lo, lce_io_resp_ready_li;
+  logic cce_io_resp_v_li, cce_io_resp_yumi_lo, lce_io_resp_v_lo, lce_io_resp_ready_and_li;
 
   logic reset_r;
   always_ff @(posedge clk_i)
@@ -79,11 +79,11 @@ module bp_io_tile
 
      ,.io_resp_o(lce_io_resp_lo)
      ,.io_resp_v_o(lce_io_resp_v_lo)
-     ,.io_resp_ready_then_i(lce_io_resp_ready_li)
+     ,.io_resp_ready_then_i(lce_io_resp_ready_and_li)
 
      ,.lce_req_o(lce_lce_req_lo)
      ,.lce_req_v_o(lce_lce_req_v_lo)
-     ,.lce_req_ready_then_i(lce_lce_req_ready_li)
+     ,.lce_req_ready_then_i(lce_lce_req_ready_and_li)
 
      ,.lce_cmd_i(lce_lce_cmd_li)
      ,.lce_cmd_v_i(lce_lce_cmd_v_li)
@@ -140,7 +140,7 @@ module bp_io_tile
 
      ,.packet_i(lce_req_packet_lo)
      ,.v_i(lce_lce_req_v_lo)
-     ,.ready_o(lce_lce_req_ready_li)
+     ,.ready_o(lce_lce_req_ready_and_li)
 
      ,.link_i(lce_req_link_i)
      ,.link_o(lce_req_link_o)
@@ -225,7 +225,7 @@ module bp_io_tile
 
      ,.mem_resp_i(lce_io_resp_lo)
      ,.mem_resp_v_i(lce_io_resp_v_lo)
-     ,.mem_resp_ready_and_o(lce_io_resp_ready_li)
+     ,.mem_resp_ready_and_o(lce_io_resp_ready_and_li)
 
      ,.my_cord_i(io_noc_cord_width_p'(my_did_i))
      ,.my_cid_i('0)

--- a/bp_top/src/v/bp_io_tile.sv
+++ b/bp_top/src/v/bp_io_tile.sv
@@ -79,12 +79,10 @@ module bp_io_tile
 
      ,.io_resp_o(lce_io_resp_lo)
      ,.io_resp_v_o(lce_io_resp_v_lo)
-     // TODO: mismatch, but okay. ready_and used as ready_then
      ,.io_resp_ready_then_i(lce_io_resp_ready_li)
 
      ,.lce_req_o(lce_lce_req_lo)
      ,.lce_req_v_o(lce_lce_req_v_lo)
-     // TODO: mismatch, but okay. ready_and used as ready_then
      ,.lce_req_ready_then_i(lce_lce_req_ready_li)
 
      ,.lce_cmd_i(lce_lce_cmd_li)
@@ -106,12 +104,10 @@ module bp_io_tile
 
      ,.lce_cmd_o(cce_lce_cmd_lo)
      ,.lce_cmd_v_o(cce_lce_cmd_v_lo)
-     // TODO: mismatch, but okay. ready_and used as ready_then
      ,.lce_cmd_ready_then_i(cce_lce_cmd_ready_li)
 
      ,.io_cmd_o(cce_io_cmd_lo)
      ,.io_cmd_v_o(cce_io_cmd_v_lo)
-     // TODO: mismatch, but okay. ready_and used as ready_then
      ,.io_cmd_ready_then_i(cce_io_cmd_ready_li)
 
      ,.io_resp_i(cce_io_resp_li)

--- a/bp_top/src/v/bp_io_tile.sv
+++ b/bp_top/src/v/bp_io_tile.sv
@@ -79,11 +79,13 @@ module bp_io_tile
 
      ,.io_resp_o(lce_io_resp_lo)
      ,.io_resp_v_o(lce_io_resp_v_lo)
-     ,.io_resp_ready_i(lce_io_resp_ready_li)
+     // TODO: mismatch, but okay. ready_and used as ready_then
+     ,.io_resp_ready_then_i(lce_io_resp_ready_li)
 
      ,.lce_req_o(lce_lce_req_lo)
      ,.lce_req_v_o(lce_lce_req_v_lo)
-     ,.lce_req_ready_i(lce_lce_req_ready_li)
+     // TODO: mismatch, but okay. ready_and used as ready_then
+     ,.lce_req_ready_then_i(lce_lce_req_ready_li)
 
      ,.lce_cmd_i(lce_lce_cmd_li)
      ,.lce_cmd_v_i(lce_lce_cmd_v_li)
@@ -104,11 +106,13 @@ module bp_io_tile
 
      ,.lce_cmd_o(cce_lce_cmd_lo)
      ,.lce_cmd_v_o(cce_lce_cmd_v_lo)
-     ,.lce_cmd_ready_i(cce_lce_cmd_ready_li)
+     // TODO: mismatch, but okay. ready_and used as ready_then
+     ,.lce_cmd_ready_then_i(cce_lce_cmd_ready_li)
 
      ,.io_cmd_o(cce_io_cmd_lo)
      ,.io_cmd_v_o(cce_io_cmd_v_lo)
-     ,.io_cmd_ready_i(cce_io_cmd_ready_li)
+     // TODO: mismatch, but okay. ready_and used as ready_then
+     ,.io_cmd_ready_then_i(cce_io_cmd_ready_li)
 
      ,.io_resp_i(cce_io_resp_li)
      ,.io_resp_v_i(cce_io_resp_v_li)
@@ -213,7 +217,7 @@ module bp_io_tile
 
      ,.mem_cmd_i(cce_io_cmd_lo)
      ,.mem_cmd_v_i(cce_io_cmd_v_lo)
-     ,.mem_cmd_ready_o(cce_io_cmd_ready_li)
+     ,.mem_cmd_ready_and_o(cce_io_cmd_ready_li)
 
      ,.mem_resp_o(cce_io_resp_li)
      ,.mem_resp_v_o(cce_io_resp_v_li)
@@ -225,7 +229,7 @@ module bp_io_tile
 
      ,.mem_resp_i(lce_io_resp_lo)
      ,.mem_resp_v_i(lce_io_resp_v_lo)
-     ,.mem_resp_ready_o(lce_io_resp_ready_li)
+     ,.mem_resp_ready_and_o(lce_io_resp_ready_li)
 
      ,.my_cord_i(io_noc_cord_width_p'(my_did_i))
      ,.my_cid_i('0)

--- a/bp_top/src/v/bp_l2e_tile.sv
+++ b/bp_top/src/v/bp_l2e_tile.sv
@@ -129,7 +129,7 @@ module bp_l2e_tile
 
      ,.mem_cmd_i(cfg_mem_cmd)
      ,.mem_cmd_v_i(cfg_mem_cmd_v_li)
-     ,.mem_cmd_ready_o(cfg_mem_cmd_ready_lo)
+     ,.mem_cmd_ready_and_o(cfg_mem_cmd_ready_lo)
 
      ,.mem_resp_o(cfg_mem_resp)
      ,.mem_resp_v_o(cfg_mem_resp_v_lo)
@@ -316,7 +316,7 @@ module bp_l2e_tile
 
      ,.mem_cmd_i(cache_mem_cmd_li)
      ,.mem_cmd_v_i(cache_mem_cmd_v_li)
-     ,.mem_cmd_ready_o(cache_mem_cmd_ready_lo)
+     ,.mem_cmd_ready_and_o(cache_mem_cmd_ready_lo)
 
      ,.mem_resp_o(cache_mem_resp_lo)
      ,.mem_resp_v_o(cache_mem_resp_v_lo)
@@ -425,7 +425,7 @@ module bp_l2e_tile
 
      ,.mem_cmd_i(loopback_mem_cmd)
      ,.mem_cmd_v_i(loopback_mem_cmd_v_li)
-     ,.mem_cmd_ready_o(loopback_mem_cmd_ready_lo)
+     ,.mem_cmd_ready_and_o(loopback_mem_cmd_ready_lo)
 
      ,.mem_resp_o(loopback_mem_resp)
      ,.mem_resp_v_o(loopback_mem_resp_v_lo)

--- a/bp_top/src/v/bp_loopback.sv
+++ b/bp_top/src/v/bp_loopback.sv
@@ -33,10 +33,6 @@ module bp_cce_loopback
   assign mem_cmd_cast_i = mem_cmd_i;
   assign mem_resp_o = mem_resp_cast_o;
 
-  // NOTE: one fifo comments imply that input is ready->valid, but implementation
-  // is actually ready&valid. Ready comes directly from current state of full_r
-  // register. Valid_i is ignored if fifo is full. Data captured on v_i & ready_o.
-  // Interface can be used ready->valid though, but penalty is cycle time limit
   bsg_one_fifo
    #(.width_p($bits(mem_cmd_cast_i.header)))
    loopback_buffer

--- a/bp_top/src/v/bp_loopback.sv
+++ b/bp_top/src/v/bp_loopback.sv
@@ -18,7 +18,7 @@ module bp_cce_loopback
 
     , input [cce_mem_msg_width_lp-1:0]              mem_cmd_i
     , input                                         mem_cmd_v_i
-    , output                                        mem_cmd_ready_o
+    , output                                        mem_cmd_ready_and_o
 
     , output [cce_mem_msg_width_lp-1:0]             mem_resp_o
     , output                                        mem_resp_v_o
@@ -33,6 +33,10 @@ module bp_cce_loopback
   assign mem_cmd_cast_i = mem_cmd_i;
   assign mem_resp_o = mem_resp_cast_o;
 
+  // NOTE: one fifo comments imply that input is ready->valid, but implementation
+  // is actually ready&valid. Ready comes directly from current state of full_r
+  // register. Valid_i is ignored if fifo is full. Data captured on v_i & ready_o.
+  // Interface can be used ready->valid though, but penalty is cycle time limit
   bsg_one_fifo
    #(.width_p($bits(mem_cmd_cast_i.header)))
    loopback_buffer
@@ -41,7 +45,7 @@ module bp_cce_loopback
 
      ,.data_i(mem_cmd_cast_i.header)
      ,.v_i(mem_cmd_v_i)
-     ,.ready_o(mem_cmd_ready_o)
+     ,.ready_o(mem_cmd_ready_and_o)
 
      ,.data_o(mem_resp_cast_o.header)
      ,.v_o(mem_resp_v_o)

--- a/bp_top/src/v/bp_sacc_tile.sv
+++ b/bp_top/src/v/bp_sacc_tile.sv
@@ -39,11 +39,11 @@ module bp_sacc_tile
   bp_bedrock_lce_req_msg_s  cce_lce_req_li, lce_lce_req_lo;
   logic cce_lce_req_v_li, cce_lce_req_yumi_lo, lce_lce_req_v_lo, lce_req_ready_li;
   bp_bedrock_lce_cmd_msg_s cce_lce_cmd_lo, lce_lce_cmd_li;
-  logic cce_lce_cmd_v_lo, cce_lce_cmd_ready_li, lce_lce_cmd_v_li, lce_lce_cmd_yumi_lo;
+  logic cce_lce_cmd_v_lo, cce_lce_cmd_ready_and_li, lce_lce_cmd_v_li, lce_lce_cmd_yumi_lo;
   bp_bedrock_cce_mem_msg_s cce_io_cmd_lo, lce_io_cmd_li;
-  logic cce_io_cmd_v_lo, cce_io_cmd_ready_li, lce_io_cmd_v_li, lce_io_cmd_yumi_lo;
+  logic cce_io_cmd_v_lo, cce_io_cmd_ready_and_li, lce_io_cmd_v_li, lce_io_cmd_yumi_lo;
   bp_bedrock_cce_mem_msg_s cce_io_resp_li, lce_io_resp_lo;
-  logic cce_io_resp_v_li, cce_io_resp_yumi_lo, lce_io_resp_v_lo, lce_io_resp_ready_li;
+  logic cce_io_resp_v_li, cce_io_resp_yumi_lo, lce_io_resp_v_lo, lce_io_resp_ready_and_li;
 
   logic reset_r;
   always_ff @(posedge clk_i)
@@ -75,7 +75,7 @@ module bp_sacc_tile
 
      ,.io_resp_o(lce_io_resp_lo)
      ,.io_resp_v_o(lce_io_resp_v_lo)
-     ,.io_resp_ready_then_i(lce_io_resp_ready_li)
+     ,.io_resp_ready_then_i(lce_io_resp_ready_and_li)
 
      ,.lce_req_o(lce_lce_req_lo)
      ,.lce_req_v_o(lce_lce_req_v_lo)
@@ -100,11 +100,11 @@ module bp_sacc_tile
 
      ,.lce_cmd_o(cce_lce_cmd_lo)
      ,.lce_cmd_v_o(cce_lce_cmd_v_lo)
-     ,.lce_cmd_ready_then_i(cce_lce_cmd_ready_li)
+     ,.lce_cmd_ready_then_i(cce_lce_cmd_ready_and_li)
 
      ,.io_cmd_o(cce_io_cmd_lo)
      ,.io_cmd_v_o(cce_io_cmd_v_lo)
-     ,.io_cmd_ready_then_i(cce_io_cmd_ready_li)
+     ,.io_cmd_ready_then_i(cce_io_cmd_ready_and_li)
 
      ,.io_resp_i(cce_io_resp_li)
      ,.io_resp_v_i(cce_io_resp_v_li)
@@ -172,7 +172,7 @@ module bp_sacc_tile
 
      ,.packet_i(cce_lce_cmd_packet_lo)
      ,.v_i(cce_lce_cmd_v_lo)
-     ,.ready_o(cce_lce_cmd_ready_li)
+     ,.ready_o(cce_lce_cmd_ready_and_li)
 
      ,.link_i(lce_cmd_link_i)
      ,.link_o(lce_cmd_link_o)
@@ -195,7 +195,7 @@ module bp_sacc_tile
 
          ,.io_cmd_i(cce_io_cmd_lo)
          ,.io_cmd_v_i(cce_io_cmd_v_lo)
-         ,.io_cmd_ready_o(cce_io_cmd_ready_li)
+         ,.io_cmd_ready_o(cce_io_cmd_ready_and_li)
 
          ,.io_resp_o(cce_io_resp_li)
          ,.io_resp_v_o(cce_io_resp_v_li)
@@ -207,7 +207,7 @@ module bp_sacc_tile
 
          ,.io_resp_i(lce_io_resp_lo)
          ,.io_resp_v_i(lce_io_resp_v_lo)
-         ,.io_resp_ready_o(lce_io_resp_ready_li)
+         ,.io_resp_ready_o(lce_io_resp_ready_and_li)
          );
     end
 

--- a/bp_top/src/v/bp_sacc_tile.sv
+++ b/bp_top/src/v/bp_sacc_tile.sv
@@ -100,12 +100,10 @@ module bp_sacc_tile
 
      ,.lce_cmd_o(cce_lce_cmd_lo)
      ,.lce_cmd_v_o(cce_lce_cmd_v_lo)
-     // TODO: mismatch, but okay. ready_and used as ready_then
      ,.lce_cmd_ready_then_i(cce_lce_cmd_ready_li)
 
      ,.io_cmd_o(cce_io_cmd_lo)
      ,.io_cmd_v_o(cce_io_cmd_v_lo)
-     // TODO: mismatch, but okay. ready_and used as ready_then
      ,.io_cmd_ready_then_i(cce_io_cmd_ready_li)
 
      ,.io_resp_i(cce_io_resp_li)

--- a/bp_top/src/v/bp_sacc_tile.sv
+++ b/bp_top/src/v/bp_sacc_tile.sv
@@ -75,11 +75,11 @@ module bp_sacc_tile
 
      ,.io_resp_o(lce_io_resp_lo)
      ,.io_resp_v_o(lce_io_resp_v_lo)
-     ,.io_resp_ready_i(lce_io_resp_ready_li)
+     ,.io_resp_ready_then_i(lce_io_resp_ready_li)
 
      ,.lce_req_o(lce_lce_req_lo)
      ,.lce_req_v_o(lce_lce_req_v_lo)
-     ,.lce_req_ready_i(lce_req_ready_li)
+     ,.lce_req_ready_then_i(lce_req_ready_li)
 
      ,.lce_cmd_i(lce_lce_cmd_li)
      ,.lce_cmd_v_i(lce_lce_cmd_v_li)
@@ -100,11 +100,13 @@ module bp_sacc_tile
 
      ,.lce_cmd_o(cce_lce_cmd_lo)
      ,.lce_cmd_v_o(cce_lce_cmd_v_lo)
-     ,.lce_cmd_ready_i(cce_lce_cmd_ready_li)
+     // TODO: mismatch, but okay. ready_and used as ready_then
+     ,.lce_cmd_ready_then_i(cce_lce_cmd_ready_li)
 
      ,.io_cmd_o(cce_io_cmd_lo)
      ,.io_cmd_v_o(cce_io_cmd_v_lo)
-     ,.io_cmd_ready_i(cce_io_cmd_ready_li)
+     // TODO: mismatch, but okay. ready_and used as ready_then
+     ,.io_cmd_ready_then_i(cce_io_cmd_ready_li)
 
      ,.io_resp_i(cce_io_resp_li)
      ,.io_resp_v_i(cce_io_resp_v_li)

--- a/bp_top/src/v/bp_tile.sv
+++ b/bp_top/src/v/bp_tile.sv
@@ -154,7 +154,7 @@ module bp_tile
 
      ,.mem_cmd_i(cfg_mem_cmd)
      ,.mem_cmd_v_i(cfg_mem_cmd_v_li)
-     ,.mem_cmd_ready_o(cfg_mem_cmd_ready_lo)
+     ,.mem_cmd_ready_and_o(cfg_mem_cmd_ready_lo)
 
      ,.mem_resp_o(cfg_mem_resp)
      ,.mem_resp_v_o(cfg_mem_resp_v_lo)
@@ -180,7 +180,7 @@ module bp_tile
 
      ,.mem_cmd_i(clint_mem_cmd)
      ,.mem_cmd_v_i(clint_mem_cmd_v_li)
-     ,.mem_cmd_ready_o(clint_mem_cmd_ready_lo)
+     ,.mem_cmd_ready_and_o(clint_mem_cmd_ready_lo)
 
      ,.mem_resp_o(clint_mem_resp)
      ,.mem_resp_v_o(clint_mem_resp_v_lo)
@@ -202,7 +202,7 @@ module bp_tile
 
      ,.lce_req_o(lce_req_lo)
      ,.lce_req_v_o(lce_req_v_lo)
-     ,.lce_req_ready_i(lce_req_ready_li)
+     ,.lce_req_ready_then_i(lce_req_ready_li)
 
      ,.lce_cmd_i(lce_cmd_li)
      ,.lce_cmd_v_i(lce_cmd_v_li)
@@ -210,11 +210,11 @@ module bp_tile
 
      ,.lce_cmd_o(lce_cmd_lo)
      ,.lce_cmd_v_o(lce_cmd_v_lo)
-     ,.lce_cmd_ready_i(lce_cmd_ready_li)
+     ,.lce_cmd_ready_then_i(lce_cmd_ready_li)
 
      ,.lce_resp_o(lce_resp_lo)
      ,.lce_resp_v_o(lce_resp_v_lo)
-     ,.lce_resp_ready_i(lce_resp_ready_li)
+     ,.lce_resp_ready_then_i(lce_resp_ready_li)
 
      ,.timer_irq_i(timer_irq_li)
      ,.software_irq_i(software_irq_li)
@@ -559,7 +559,7 @@ module bp_tile
 
      ,.mem_cmd_i(cache_mem_cmd_li)
      ,.mem_cmd_v_i(cache_mem_cmd_v_li)
-     ,.mem_cmd_ready_o(cache_mem_cmd_ready_lo)
+     ,.mem_cmd_ready_and_o(cache_mem_cmd_ready_lo)
 
      ,.mem_resp_o(cache_mem_resp_lo)
      ,.mem_resp_v_o(cache_mem_resp_v_lo)
@@ -668,7 +668,7 @@ module bp_tile
 
      ,.mem_cmd_i(loopback_mem_cmd)
      ,.mem_cmd_v_i(loopback_mem_cmd_v_li)
-     ,.mem_cmd_ready_o(loopback_mem_cmd_ready_lo)
+     ,.mem_cmd_ready_and_o(loopback_mem_cmd_ready_lo)
 
      ,.mem_resp_o(loopback_mem_resp)
      ,.mem_resp_v_o(loopback_mem_resp_v_lo)

--- a/bp_top/src/v/bp_unicore.sv
+++ b/bp_top/src/v/bp_unicore.sv
@@ -23,7 +23,7 @@ module bp_unicore
    // Outgoing I/O
    , output logic [uce_mem_msg_width_lp-1:0]           io_cmd_o
    , output logic                                      io_cmd_v_o
-   , input                                             io_cmd_ready_i
+   , input                                             io_cmd_ready_then_i
 
    , input [uce_mem_msg_width_lp-1:0]                  io_resp_i
    , input                                             io_resp_v_i
@@ -36,7 +36,7 @@ module bp_unicore
 
    , output logic [uce_mem_msg_width_lp-1:0]           io_resp_o
    , output logic                                      io_resp_v_o
-   , input                                             io_resp_ready_i
+   , input                                             io_resp_ready_and_i
 
    // DRAM interface
    , output logic [dma_pkt_width_lp-1:0]               dma_pkt_o
@@ -58,7 +58,7 @@ module bp_unicore
   `declare_bp_bedrock_mem_if(paddr_width_p, uce_mem_data_width_lp, lce_id_width_p, lce_assoc_p, uce);
 
   bp_bedrock_uce_mem_msg_s mem_cmd_lo;
-  logic mem_cmd_v_lo, mem_cmd_ready_li;
+  logic mem_cmd_v_lo, mem_cmd_ready_and_li;
   bp_bedrock_uce_mem_msg_s mem_resp_li;
   logic mem_resp_v_li, mem_resp_yumi_lo;
 
@@ -70,7 +70,7 @@ module bp_unicore
 
      ,.io_cmd_o(io_cmd_o)
      ,.io_cmd_v_o(io_cmd_v_o)
-     ,.io_cmd_ready_i(io_cmd_ready_i)
+     ,.io_cmd_ready_then_i(io_cmd_ready_then_i)
 
      ,.io_resp_i(io_resp_i)
      ,.io_resp_v_i(io_resp_v_i)
@@ -82,11 +82,13 @@ module bp_unicore
 
      ,.io_resp_o(io_resp_o)
      ,.io_resp_v_o(io_resp_v_o)
-     ,.io_resp_ready_i(io_resp_ready_i)
+     ,.io_resp_ready_and_i(io_resp_ready_and_i)
 
      ,.mem_cmd_o(mem_cmd_lo)
      ,.mem_cmd_v_o(mem_cmd_v_lo)
-     ,.mem_cmd_ready_i(mem_cmd_ready_li)
+     // TODO: handshake mismatch!!
+     // Unicore lite uses as ready->valid, but me_cce_to_cache uses ready&valid
+     ,.mem_cmd_ready_then_i(mem_cmd_ready_and_li)
 
      ,.mem_resp_i(mem_resp_li)
      ,.mem_resp_v_i(mem_resp_v_li)
@@ -107,7 +109,7 @@ module bp_unicore
   
      ,.mem_cmd_i(mem_cmd_lo)
      ,.mem_cmd_v_i(mem_cmd_v_lo)
-     ,.mem_cmd_ready_o(mem_cmd_ready_li)
+     ,.mem_cmd_ready_and_o(mem_cmd_ready_and_li)
 
      ,.mem_resp_o(mem_resp_li)
      ,.mem_resp_v_o(mem_resp_v_li)

--- a/bp_top/src/v/bp_unicore.sv
+++ b/bp_top/src/v/bp_unicore.sv
@@ -23,7 +23,7 @@ module bp_unicore
    // Outgoing I/O
    , output logic [uce_mem_msg_width_lp-1:0]           io_cmd_o
    , output logic                                      io_cmd_v_o
-   , input                                             io_cmd_ready_then_i
+   , input                                             io_cmd_ready_and_i
 
    , input [uce_mem_msg_width_lp-1:0]                  io_resp_i
    , input                                             io_resp_v_i
@@ -70,7 +70,7 @@ module bp_unicore
 
      ,.io_cmd_o(io_cmd_o)
      ,.io_cmd_v_o(io_cmd_v_o)
-     ,.io_cmd_ready_then_i(io_cmd_ready_then_i)
+     ,.io_cmd_ready_and_i(io_cmd_ready_and_i)
 
      ,.io_resp_i(io_resp_i)
      ,.io_resp_v_i(io_resp_v_i)
@@ -86,9 +86,7 @@ module bp_unicore
 
      ,.mem_cmd_o(mem_cmd_lo)
      ,.mem_cmd_v_o(mem_cmd_v_lo)
-     // TODO: handshake mismatch!!
-     // Unicore lite uses as ready->valid, but me_cce_to_cache uses ready&valid
-     ,.mem_cmd_ready_then_i(mem_cmd_ready_and_li)
+     ,.mem_cmd_ready_and_i(mem_cmd_ready_and_li)
 
      ,.mem_resp_i(mem_resp_li)
      ,.mem_resp_v_i(mem_resp_v_li)

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -22,7 +22,7 @@ module bp_unicore_lite
    // Outgoing I/O
    , output logic [uce_mem_msg_width_lp-1:0]           io_cmd_o
    , output logic                                      io_cmd_v_o
-   , input                                             io_cmd_ready_then_i
+   , input                                             io_cmd_ready_and_i
 
    , input [uce_mem_msg_width_lp-1:0]                  io_resp_i
    , input                                             io_resp_v_i
@@ -40,7 +40,7 @@ module bp_unicore_lite
    // Outgoing DRAM
    , output logic [uce_mem_msg_width_lp-1:0]           mem_cmd_o
    , output logic                                      mem_cmd_v_o
-   , input                                             mem_cmd_ready_then_i
+   , input                                             mem_cmd_ready_and_i
 
    , input [uce_mem_msg_width_lp-1:0]                  mem_resp_i
    , input                                             mem_resp_v_i
@@ -389,8 +389,10 @@ module bp_unicore_lite
   assign cfg_cmd_v_li      = |proc_cmd_grant_lo & cfg_cmd_ready_and_lo & is_cfg_cmd;
   // TODO: handshake violation! clint slice is R&V
   assign clint_cmd_v_li    = |proc_cmd_grant_lo & clint_cmd_ready_and_lo & is_clint_cmd;
-  assign io_cmd_v_o        = |proc_cmd_grant_lo & io_cmd_ready_then_i & is_io_cmd;
-  assign mem_cmd_v_o       = |proc_cmd_grant_lo & mem_cmd_ready_then_i & is_mem_cmd;
+  // TODO: handshake violation! input ports are R&V
+  assign io_cmd_v_o        = |proc_cmd_grant_lo & io_cmd_ready_and_i & is_io_cmd;
+  // TODO: handshake violation! input ports are R&V
+  assign mem_cmd_v_o       = |proc_cmd_grant_lo & mem_cmd_ready_and_i & is_mem_cmd;
   // TODO: handshake violation! loopback is R&V
   assign loopback_cmd_v_li = |proc_cmd_grant_lo & loopback_cmd_ready_and_lo & is_loopback_cmd;
 

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -22,7 +22,7 @@ module bp_unicore_lite
    // Outgoing I/O
    , output logic [uce_mem_msg_width_lp-1:0]           io_cmd_o
    , output logic                                      io_cmd_v_o
-   , input                                             io_cmd_ready_i
+   , input                                             io_cmd_ready_then_i
 
    , input [uce_mem_msg_width_lp-1:0]                  io_resp_i
    , input                                             io_resp_v_i
@@ -35,12 +35,12 @@ module bp_unicore_lite
 
    , output logic [uce_mem_msg_width_lp-1:0]           io_resp_o
    , output logic                                      io_resp_v_o
-   , input                                             io_resp_ready_i
+   , input                                             io_resp_ready_and_i
 
    // Outgoing DRAM
    , output logic [uce_mem_msg_width_lp-1:0]           mem_cmd_o
    , output logic                                      mem_cmd_v_o
-   , input                                             mem_cmd_ready_i
+   , input                                             mem_cmd_ready_then_i
 
    , input [uce_mem_msg_width_lp-1:0]                  mem_resp_i
    , input                                             mem_resp_v_i
@@ -101,7 +101,7 @@ module bp_unicore_lite
 
   bp_bedrock_uce_mem_msg_s cfg_cmd_li;
   bp_bedrock_xce_mem_msg_s cfg_cmd;
-  logic cfg_cmd_v_li, cfg_cmd_ready_lo;
+  logic cfg_cmd_v_li, cfg_cmd_ready_and_lo;
   bp_bedrock_uce_mem_msg_s cfg_resp_lo;
   bp_bedrock_xce_mem_msg_s cfg_resp;
   logic cfg_resp_v_lo, cfg_resp_yumi_li;
@@ -114,7 +114,7 @@ module bp_unicore_lite
 
   bp_bedrock_uce_mem_msg_s clint_cmd_li;
   bp_bedrock_xce_mem_msg_s clint_cmd;
-  logic clint_cmd_v_li, clint_cmd_ready_lo;
+  logic clint_cmd_v_li, clint_cmd_ready_and_lo;
   bp_bedrock_uce_mem_msg_s clint_resp_lo;
   bp_bedrock_xce_mem_msg_s clint_resp;
   logic clint_resp_v_lo, clint_resp_yumi_li;
@@ -127,7 +127,7 @@ module bp_unicore_lite
 
   bp_bedrock_uce_mem_msg_s loopback_cmd_li;
   bp_bedrock_xce_mem_msg_s loopback_cmd;
-  logic loopback_cmd_v_li, loopback_cmd_ready_lo;
+  logic loopback_cmd_v_li, loopback_cmd_ready_and_lo;
   bp_bedrock_uce_mem_msg_s loopback_resp_lo;
   bp_bedrock_xce_mem_msg_s loopback_resp;
   logic loopback_resp_v_lo, loopback_resp_yumi_li;
@@ -313,7 +313,7 @@ module bp_unicore_lite
 
   assign io_resp_o = uce_mem_msg_width_lp'(proc_resp_li[2]);
   assign io_resp_v_o = proc_resp_v_li[2];
-  assign proc_resp_yumi_lo[2] = io_resp_ready_i & io_resp_v_o;
+  assign proc_resp_yumi_lo[2] = io_resp_ready_and_i & io_resp_v_o;
 
   // Command arbitration logic
   // This is suboptimal. We could have an arbiter for each of I$ D$ and I/O, to get higher
@@ -385,11 +385,14 @@ module bp_unicore_lite
   wire is_mem_cmd          = (~local_cmd_li & ~is_other_domain) || (local_cmd_li & (device_cmd_li == cache_dev_gp));
   wire is_loopback_cmd     = local_cmd_li & ~is_cfg_cmd & ~is_clint_cmd & ~is_io_cmd & ~is_mem_cmd;
 
-  assign cfg_cmd_v_li      = |proc_cmd_grant_lo & cfg_cmd_ready_lo & is_cfg_cmd;
-  assign clint_cmd_v_li    = |proc_cmd_grant_lo & clint_cmd_ready_lo & is_clint_cmd;
-  assign io_cmd_v_o        = |proc_cmd_grant_lo & io_cmd_ready_i & is_io_cmd;
-  assign mem_cmd_v_o       = |proc_cmd_grant_lo & mem_cmd_ready_i & is_mem_cmd;
-  assign loopback_cmd_v_li = |proc_cmd_grant_lo & loopback_cmd_ready_lo & is_loopback_cmd;
+  // TODO: handshake violation! CFG is R&V
+  assign cfg_cmd_v_li      = |proc_cmd_grant_lo & cfg_cmd_ready_and_lo & is_cfg_cmd;
+  // TODO: handshake violation! clint slice is R&V
+  assign clint_cmd_v_li    = |proc_cmd_grant_lo & clint_cmd_ready_and_lo & is_clint_cmd;
+  assign io_cmd_v_o        = |proc_cmd_grant_lo & io_cmd_ready_then_i & is_io_cmd;
+  assign mem_cmd_v_o       = |proc_cmd_grant_lo & mem_cmd_ready_then_i & is_mem_cmd;
+  // TODO: handshake violation! loopback is R&V
+  assign loopback_cmd_v_li = |proc_cmd_grant_lo & loopback_cmd_ready_and_lo & is_loopback_cmd;
 
   wire any_cmd_li = |{mem_cmd_v_o, io_cmd_v_o, loopback_cmd_v_li, clint_cmd_v_li, cfg_cmd_v_li};
 
@@ -403,7 +406,7 @@ module bp_unicore_lite
 
      ,.mem_cmd_i(clint_cmd)
      ,.mem_cmd_v_i(clint_cmd_v_li)
-     ,.mem_cmd_ready_o(clint_cmd_ready_lo)
+     ,.mem_cmd_ready_and_o(clint_cmd_ready_and_lo)
 
      ,.mem_resp_o(clint_resp)
      ,.mem_resp_v_o(clint_resp_v_lo)
@@ -422,7 +425,7 @@ module bp_unicore_lite
 
      ,.mem_cmd_i(cfg_cmd)
      ,.mem_cmd_v_i(cfg_cmd_v_li)
-     ,.mem_cmd_ready_o(cfg_cmd_ready_lo)
+     ,.mem_cmd_ready_and_o(cfg_cmd_ready_and_lo)
 
      ,.mem_resp_o(cfg_resp)
      ,.mem_resp_v_o(cfg_resp_v_lo)
@@ -448,7 +451,7 @@ module bp_unicore_lite
 
      ,.mem_cmd_i(loopback_cmd)
      ,.mem_cmd_v_i(loopback_cmd_v_li)
-     ,.mem_cmd_ready_o(loopback_cmd_ready_lo)
+     ,.mem_cmd_ready_and_o(loopback_cmd_ready_and_lo)
 
      ,.mem_resp_o(loopback_resp)
      ,.mem_resp_v_o(loopback_resp_v_lo)

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -385,15 +385,10 @@ module bp_unicore_lite
   wire is_mem_cmd          = (~local_cmd_li & ~is_other_domain) || (local_cmd_li & (device_cmd_li == cache_dev_gp));
   wire is_loopback_cmd     = local_cmd_li & ~is_cfg_cmd & ~is_clint_cmd & ~is_io_cmd & ~is_mem_cmd;
 
-  // TODO: handshake violation! CFG is R&V
   assign cfg_cmd_v_li      = |proc_cmd_grant_lo & cfg_cmd_ready_and_lo & is_cfg_cmd;
-  // TODO: handshake violation! clint slice is R&V
   assign clint_cmd_v_li    = |proc_cmd_grant_lo & clint_cmd_ready_and_lo & is_clint_cmd;
-  // TODO: handshake violation! input ports are R&V
   assign io_cmd_v_o        = |proc_cmd_grant_lo & io_cmd_ready_and_i & is_io_cmd;
-  // TODO: handshake violation! input ports are R&V
   assign mem_cmd_v_o       = |proc_cmd_grant_lo & mem_cmd_ready_and_i & is_mem_cmd;
-  // TODO: handshake violation! loopback is R&V
   assign loopback_cmd_v_li = |proc_cmd_grant_lo & loopback_cmd_ready_and_lo & is_loopback_cmd;
 
   wire any_cmd_li = |{mem_cmd_v_o, io_cmd_v_o, loopback_cmd_v_li, clint_cmd_v_li, cfg_cmd_v_li};

--- a/bp_top/test/common/bp_nonsynth_host.sv
+++ b/bp_top/test/common/bp_nonsynth_host.sv
@@ -30,7 +30,7 @@ module bp_nonsynth_host
 
    , input [cce_mem_msg_width_lp-1:0]        io_cmd_i
    , input                                   io_cmd_v_i
-   , output logic                            io_cmd_ready_o
+   , output logic                            io_cmd_ready_and_o
 
    , output logic [cce_mem_msg_width_lp-1:0] io_resp_o
    , output logic                            io_resp_v_o
@@ -104,7 +104,7 @@ module bp_nonsynth_host
 
      ,.data_i(io_cmd_li)
      ,.v_i(io_cmd_v_i)
-     ,.ready_o(io_cmd_ready_o)
+     ,.ready_o(io_cmd_ready_and_o)
 
      ,.data_o(io_cmd_lo)
      ,.v_o(io_cmd_v_lo)

--- a/bp_top/test/common/bp_nonsynth_nbf_loader.sv
+++ b/bp_top/test/common/bp_nonsynth_nbf_loader.sv
@@ -37,7 +37,7 @@ module bp_nonsynth_nbf_loader
 
   ,input  [cce_mem_msg_width_lp-1:0]       io_resp_i
   ,input                                   io_resp_v_i
-  ,output                                  io_resp_ready_o
+  ,output                                  io_resp_ready_and_o
 
   ,output                                  done_o
   );
@@ -53,7 +53,7 @@ module bp_nonsynth_nbf_loader
 
   // response network not used
   wire unused_resp = &{io_resp_i, io_resp_v_i};
-  assign io_resp_ready_o = 1'b1;
+  assign io_resp_ready_and_o = 1'b1;
 
   logic [`BSG_WIDTH(io_noc_max_credits_p)-1:0] credit_count_lo;
   bsg_flow_counter

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -137,7 +137,7 @@ module testbench
      ,.io_cmd_o(proc_io_cmd_lo)
      ,.io_cmd_v_o(proc_io_cmd_v_lo)
      // TODO: verify handshake
-     // wrapper (unicore) uses this signal as ready->valid 
+     // wrapper (unicore) uses this signal as ready->valid
      ,.io_cmd_ready_then_i(proc_io_cmd_ready_li)
 
      ,.io_resp_i(proc_io_resp_li)
@@ -596,16 +596,16 @@ module testbench
               ,.lce_id_i(lce_id_i)
               ,.lce_req_i(lce_req_o)
               ,.lce_req_v_i(lce_req_v_o)
-              ,.lce_req_ready_i(lce_req_ready_i)
+              ,.lce_req_ready_i(lce_req_ready_then_i)
               ,.lce_resp_i(lce_resp_o)
               ,.lce_resp_v_i(lce_resp_v_o)
-              ,.lce_resp_ready_i(lce_resp_ready_i)
+              ,.lce_resp_ready_i(lce_resp_ready_then_i)
               ,.lce_cmd_i(lce_cmd_i)
               ,.lce_cmd_v_i(lce_cmd_v_i)
               ,.lce_cmd_yumi_i(lce_cmd_yumi_o)
               ,.lce_cmd_o_i(lce_cmd_o)
               ,.lce_cmd_o_v_i(lce_cmd_v_o)
-              ,.lce_cmd_o_ready_i(lce_cmd_ready_i)
+              ,.lce_cmd_o_ready_i(lce_cmd_ready_then_i)
               );
         end
     end

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -107,7 +107,7 @@ module testbench
      );
 
   bp_bedrock_cce_mem_msg_s proc_io_cmd_lo;
-  logic proc_io_cmd_v_lo, proc_io_cmd_ready_li;
+  logic proc_io_cmd_v_lo, proc_io_cmd_ready_and_li;
   bp_bedrock_cce_mem_msg_s proc_io_resp_li;
   logic proc_io_resp_v_li, proc_io_resp_yumi_lo;
 
@@ -136,9 +136,7 @@ module testbench
 
      ,.io_cmd_o(proc_io_cmd_lo)
      ,.io_cmd_v_o(proc_io_cmd_v_lo)
-     // TODO: verify handshake
-     // wrapper (unicore) uses this signal as ready->valid
-     ,.io_cmd_ready_then_i(proc_io_cmd_ready_li)
+     ,.io_cmd_ready_and_i(proc_io_cmd_ready_and_li)
 
      ,.io_resp_i(proc_io_resp_li)
      ,.io_resp_v_i(proc_io_resp_v_li)
@@ -242,8 +240,10 @@ module testbench
      ,.reset_i(reset_i)
 
      ,.io_cmd_i(proc_io_cmd_lo)
-     ,.io_cmd_v_i(proc_io_cmd_v_lo & proc_io_cmd_ready_li)
-     ,.io_cmd_ready_o(proc_io_cmd_ready_li)
+     // TODO: verify works
+     ,.io_cmd_v_i(proc_io_cmd_v_lo)
+     //,.io_cmd_v_i(proc_io_cmd_v_lo & proc_io_cmd_ready_and_li)
+     ,.io_cmd_ready_and_o(proc_io_cmd_ready_and_li)
 
      ,.io_resp_o(proc_io_resp_li)
      ,.io_resp_v_o(proc_io_resp_v_li)

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -596,16 +596,16 @@ module testbench
               ,.lce_id_i(lce_id_i)
               ,.lce_req_i(lce_req_o)
               ,.lce_req_v_i(lce_req_v_o)
-              ,.lce_req_ready_i(lce_req_ready_then_i)
+              ,.lce_req_ready_then_i(lce_req_ready_then_i)
               ,.lce_resp_i(lce_resp_o)
               ,.lce_resp_v_i(lce_resp_v_o)
-              ,.lce_resp_ready_i(lce_resp_ready_then_i)
+              ,.lce_resp_ready_then_i(lce_resp_ready_then_i)
               ,.lce_cmd_i(lce_cmd_i)
               ,.lce_cmd_v_i(lce_cmd_v_i)
               ,.lce_cmd_yumi_i(lce_cmd_yumi_o)
               ,.lce_cmd_o_i(lce_cmd_o)
               ,.lce_cmd_o_v_i(lce_cmd_v_o)
-              ,.lce_cmd_o_ready_i(lce_cmd_ready_then_i)
+              ,.lce_cmd_o_ready_then_i(lce_cmd_ready_then_i)
               );
         end
     end

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -240,9 +240,7 @@ module testbench
      ,.reset_i(reset_i)
 
      ,.io_cmd_i(proc_io_cmd_lo)
-     // TODO: verify works
      ,.io_cmd_v_i(proc_io_cmd_v_lo)
-     //,.io_cmd_v_i(proc_io_cmd_v_lo & proc_io_cmd_ready_and_li)
      ,.io_cmd_ready_and_o(proc_io_cmd_ready_and_li)
 
      ,.io_resp_o(proc_io_resp_li)

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -119,7 +119,7 @@ module testbench
   bp_bedrock_cce_mem_msg_s load_cmd_lo;
   logic load_cmd_v_lo, load_cmd_yumi_li;
   bp_bedrock_cce_mem_msg_s load_resp_li;
-  logic load_resp_v_li, load_resp_ready_lo;
+  logic load_resp_v_li, load_resp_ready_and_lo;
 
   `declare_bsg_cache_dma_pkt_s(caddr_width_p);
   bsg_cache_dma_pkt_s [num_cce_p-1:0] dma_pkt_lo;
@@ -136,7 +136,9 @@ module testbench
 
      ,.io_cmd_o(proc_io_cmd_lo)
      ,.io_cmd_v_o(proc_io_cmd_v_lo)
-     ,.io_cmd_ready_i(proc_io_cmd_ready_li)
+     // TODO: verify handshake
+     // wrapper (unicore) uses this signal as ready->valid 
+     ,.io_cmd_ready_then_i(proc_io_cmd_ready_li)
 
      ,.io_resp_i(proc_io_resp_li)
      ,.io_resp_v_i(proc_io_resp_v_li)
@@ -148,7 +150,7 @@ module testbench
 
      ,.io_resp_o(load_resp_li)
      ,.io_resp_v_o(load_resp_v_li)
-     ,.io_resp_ready_i(load_resp_ready_lo)
+     ,.io_resp_ready_and_i(load_resp_ready_and_lo)
 
      ,.dma_pkt_o(dma_pkt_lo)
      ,.dma_pkt_v_o(dma_pkt_v_lo)
@@ -202,9 +204,10 @@ module testbench
      ,.io_cmd_v_o(load_cmd_v_lo)
      ,.io_cmd_yumi_i(load_cmd_yumi_li)
 
+     // NOTE: IO response ready_o is always high - acts as sink
      ,.io_resp_i(load_resp_li)
      ,.io_resp_v_i(load_resp_v_li)
-     ,.io_resp_ready_o(load_resp_ready_lo)
+     ,.io_resp_ready_and_o(load_resp_ready_and_lo)
 
      ,.done_o()
      );

--- a/bp_top/test/tb/bp_tethered/wrapper.sv
+++ b/bp_top/test/tb/bp_tethered/wrapper.sv
@@ -27,7 +27,7 @@ module wrapper
    // Outgoing I/O
    , output [cce_mem_msg_width_lp-1:0]                      io_cmd_o
    , output                                                 io_cmd_v_o
-   , input                                                  io_cmd_ready_then_i
+   , input                                                  io_cmd_ready_and_i
 
    , input [cce_mem_msg_width_lp-1:0]                       io_resp_i
    , input                                                  io_resp_v_i
@@ -101,9 +101,9 @@ module wrapper
          ,.dram_resp_link_i(dram_resp_link_li)
          );
 
-      logic io_cmd_ready_lo, io_resp_ready_lo;
-      assign io_cmd_yumi_o = io_cmd_ready_lo & io_cmd_v_i;
-      assign io_resp_yumi_o = io_resp_ready_lo & io_resp_v_i;
+      logic io_cmd_ready_and_lo, io_resp_ready_and_lo;
+      assign io_cmd_yumi_o = io_cmd_ready_and_lo & io_cmd_v_i;
+      assign io_resp_yumi_o = io_resp_ready_and_lo & io_resp_v_i;
       wire [io_noc_cord_width_p-1:0] dst_cord_lo = 1;
       bp_me_cce_to_mem_link_bidir
        #(.bp_params_p(bp_params_p)
@@ -119,7 +119,7 @@ module wrapper
 
          ,.mem_cmd_i(io_cmd_i)
          ,.mem_cmd_v_i(io_cmd_v_i)
-         ,.mem_cmd_ready_o(io_cmd_ready_lo)
+         ,.mem_cmd_ready_and_o(io_cmd_ready_and_lo)
 
          ,.mem_resp_o(io_resp_o)
          ,.mem_resp_v_o(io_resp_v_o)
@@ -132,13 +132,11 @@ module wrapper
 
          ,.mem_cmd_o(io_cmd_o)
          ,.mem_cmd_v_o(io_cmd_v_o)
-         // TODO: handshake mismatch. Should work because ready_then is early
-         // and it is being & with v_o to create yumi_i
-         ,.mem_cmd_yumi_i(io_cmd_ready_then_i & io_cmd_v_o)
+         ,.mem_cmd_yumi_i(io_cmd_ready_and_i & io_cmd_v_o)
 
          ,.mem_resp_i(io_resp_i)
          ,.mem_resp_v_i(io_resp_v_i)
-         ,.mem_resp_ready_o(io_resp_ready_lo)
+         ,.mem_resp_ready_and_o(io_resp_ready_and_lo)
 
          ,.cmd_link_i(proc_cmd_link_lo)
          ,.cmd_link_o(proc_cmd_link_li)

--- a/bp_top/test/tb/bp_tethered/wrapper.sv
+++ b/bp_top/test/tb/bp_tethered/wrapper.sv
@@ -27,7 +27,7 @@ module wrapper
    // Outgoing I/O
    , output [cce_mem_msg_width_lp-1:0]                      io_cmd_o
    , output                                                 io_cmd_v_o
-   , input                                                  io_cmd_ready_i
+   , input                                                  io_cmd_ready_then_i
 
    , input [cce_mem_msg_width_lp-1:0]                       io_resp_i
    , input                                                  io_resp_v_i
@@ -40,7 +40,7 @@ module wrapper
 
    , output [cce_mem_msg_width_lp-1:0]                      io_resp_o
    , output                                                 io_resp_v_o
-   , input                                                  io_resp_ready_i
+   , input                                                  io_resp_ready_and_i
 
    // DRAM interface
    , output logic [num_cce_p-1:0][dma_pkt_width_lp-1:0]     dma_pkt_o
@@ -123,7 +123,7 @@ module wrapper
 
          ,.mem_resp_o(io_resp_o)
          ,.mem_resp_v_o(io_resp_v_o)
-         ,.mem_resp_yumi_i(io_resp_ready_i & io_resp_v_o)
+         ,.mem_resp_yumi_i(io_resp_ready_and_i & io_resp_v_o)
 
          ,.my_cord_i(io_noc_cord_width_p'(dram_did_li))
          ,.my_cid_i('0)
@@ -132,7 +132,9 @@ module wrapper
 
          ,.mem_cmd_o(io_cmd_o)
          ,.mem_cmd_v_o(io_cmd_v_o)
-         ,.mem_cmd_yumi_i(io_cmd_ready_i & io_cmd_v_o)
+         // TODO: handshake mismatch. Should work because ready_then is early
+         // and it is being & with v_o to create yumi_i
+         ,.mem_cmd_yumi_i(io_cmd_ready_then_i & io_cmd_v_o)
 
          ,.mem_resp_i(io_resp_i)
          ,.mem_resp_v_i(io_resp_v_i)

--- a/ci/dcache_regress.sh
+++ b/ci/dcache_regress.sh
@@ -40,5 +40,5 @@ parallel --jobs ${JOBS} --results regress_logs --progress "$cmd_base UCE_P=1 WT_
 parallel --jobs ${JOBS} --results regress_logs --progress "$cmd_base UCE_P=1 WT_P=1 CFG={}" ::: "${cfgs[@]}"
 
 # Check for failures in the report directory
-grep -cr "FAIL" */syn/reports/ && echo "[CI CHECK] $0: FAILED" && exit 1
+grep -cr "FAIL" bp_be/syn/reports/ && echo "[CI CHECK] $0: FAILED" && exit 1
 echo "[CI CHECK] $0: PASSED" && exit 0

--- a/ci/icache_regress.sh
+++ b/ci/icache_regress.sh
@@ -39,5 +39,5 @@ parallel --jobs ${JOBS} --results regress_logs --progress "$cmd_base UCE_P=0 CFG
 parallel --jobs ${JOBS} --results regress_logs --progress "$cmd_base UCE_P=1 CFG={}" ::: "${cfgs[@]}"
 
 # Check for failures in the report directory
-grep -cr "FAIL" */syn/reports/ && echo "[CI CHECK] $0: FAILED" && exit 1
+grep -cr "FAIL" bp_fe/syn/reports/ && echo "[CI CHECK] $0: FAILED" && exit 1
 echo "[CI CHECK] $0: PASSED" && exit 0

--- a/ci/me_regress.sh
+++ b/ci/me_regress.sh
@@ -42,5 +42,5 @@ parallel --jobs ${JOBS} --results regress_logs --progress "$cmd_base COH_PROTO={
 parallel --jobs ${JOBS} --results regress_logs --progress "$cmd_base COH_PROTO=mesi CFG={}" ::: e_bp_multicore_half_cfg
 
 # Check for failures in the report directory
-grep -cr "FAIL" */syn/reports/ && echo "[CI CHECK] $0: FAILED" && exit 1
+grep -cr "FAIL" bp_me/syn/reports/ && echo "[CI CHECK] $0: FAILED" && exit 1
 echo "[CI CHECK] $0: PASSED" && exit 0

--- a/ci/single_core_testlist.sh
+++ b/ci/single_core_testlist.sh
@@ -41,5 +41,5 @@ echo "Running ${JOBS} jobs with ${CORES_PER_JOB} cores per job"
 parallel --jobs ${JOBS} --results regress_logs --progress "$cmd_base CFG={}" ::: "${cfgs[@]}"
 
 # Check for failures in the report directory
-grep -cr "FAIL" */syn/reports/ && echo "[CI CHECK] $0: FAILED" && exit 1
+grep -cr "FAIL" bp_top/syn/reports/ && echo "[CI CHECK] $0: FAILED" && exit 1
 echo "[CI CHECK] $0: PASSED" && exit 0


### PR DESCRIPTION
The BP repo is littered with ambiguous signal names (i.e., ready_i, is it ready_and or ready_then?). This change aims to clarify and fix a subset of these signal naming issues as they keep cropping up when implementing new features.

There is a small CI fix, too, that has the scripts check for failures in only the proper directory.