### PR TITLE
fix me_cce_to_cache bug - prevent sending responses until clear tag done

### DIFF
--- a/bp_fe/test/tb/bp_fe_icache/testbench.sv
+++ b/bp_fe/test/tb/bp_fe_icache/testbench.sv
@@ -81,7 +81,7 @@ module testbench
   assign cfg_bus_li = cfg_bus_cast_li;
 
   logic mem_cmd_v_lo, mem_resp_v_lo;
-  logic mem_cmd_ready_and_lo, mem_resp_yumi_li;
+  logic mem_cmd_yumi_li, mem_cmd_ready_and_lo, mem_resp_yumi_li;
   bp_bedrock_cce_mem_msg_s mem_cmd_lo, mem_resp_lo;
 
   logic [trace_replay_data_width_lp-1:0] trace_data_lo;
@@ -230,8 +230,9 @@ module testbench
 
      ,.mem_cmd_o(mem_cmd_lo)
      ,.mem_cmd_v_o(mem_cmd_v_lo)
-     ,.mem_cmd_ready_and_i(mem_cmd_ready_and_lo)
+     ,.mem_cmd_yumi_i(mem_cmd_yumi_li)
     );
+  assign mem_cmd_yumi_li = mem_cmd_ready_and_lo & mem_cmd_v_lo;
 
   // Memory
   bp_nonsynth_mem

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -51,7 +51,7 @@ module wrapper
 
    , output logic [cce_mem_msg_width_lp-1:0] mem_cmd_o
    , output                                  mem_cmd_v_o
-   , input                                   mem_cmd_ready_and_i
+   , input                                   mem_cmd_yumi_i
    );
 
   `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
@@ -329,7 +329,7 @@ module wrapper
 
        ,.mem_cmd_o(mem_cmd_o)
        ,.mem_cmd_v_o(mem_cmd_v_o)
-       ,.mem_cmd_yumi_i(mem_cmd_ready_and_i & mem_cmd_v_o)
+       ,.mem_cmd_yumi_i(mem_cmd_yumi_i)
        );
 
       assign mem_resp_yumi_o = mem_resp_ready_and_lo & mem_resp_v_i;
@@ -381,7 +381,7 @@ module wrapper
 
        ,.mem_cmd_o(mem_cmd_o)
        ,.mem_cmd_v_o(mem_cmd_v_o)
-       ,.mem_cmd_yumi_i(mem_cmd_ready_and_i & mem_cmd_v_o)
+       ,.mem_cmd_yumi_i(mem_cmd_yumi_i)
 
        ,.mem_resp_i(fifo_mem_resp_lo)
        ,.mem_resp_v_i(fifo_mem_resp_v_lo)

--- a/bp_me/src/v/cache/bp_me_cce_to_cache.sv
+++ b/bp_me/src/v/cache/bp_me_cce_to_cache.sv
@@ -44,7 +44,7 @@ module bp_me_cce_to_cache
     , output logic                        v_o
     , input                               ready_i
 
-    , input [l2_data_width_p-1:0]          data_i
+    , input [l2_data_width_p-1:0]         data_i
     , input                               v_i
     , output logic                        yumi_o
   );
@@ -320,7 +320,10 @@ module bp_me_cce_to_cache
 
     case (resp_state_r)
       RESP_RESET: begin
-        resp_state_n = RESP_READY;
+        // hold in RESP_RESET until command FSM finishes clearing cache tags
+        resp_state_n = (cmd_state_n == READY) ? RESP_READY : RESP_RESET;
+        // cache "acks" TAGST commands with zero-data responses
+        yumi_o = v_i;
       end
       RESP_READY: begin
         is_resp_ready = 1'b1;


### PR DESCRIPTION
This change fixes a bug in bp_me_cce_to_cache module to disallow sending mem_resp messages until after the CLEAR_TAG routine completes in the command FSM. Prior to this, a valid memory command could arrive and trigger a memory response, regardless of the mem_cmd_ready_o status. So while consumption of the incoming mem_cmd obeyed handshaking rules, a valid command arriving before tag clear was done would trigger the sending of invalid memory response.