### PR TITLE
Add tag and data critical hints

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -68,7 +68,8 @@ module bp_be_calculator_top
   , input                                           cache_req_busy_i
   , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
   , output logic                                    cache_req_metadata_v_o
-  , input                                           cache_req_critical_i
+  , input                                           cache_req_critical_tag_i
+  , input                                           cache_req_critical_data_i
   , input                                           cache_req_complete_i
   , input                                           cache_req_credits_full_i
   , input                                           cache_req_credits_empty_i
@@ -291,7 +292,8 @@ module bp_be_calculator_top
      ,.cache_req_busy_i(cache_req_busy_i)
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
-     ,.cache_req_critical_i(cache_req_critical_i)
+     ,.cache_req_critical_tag_i(cache_req_critical_tag_i)
+     ,.cache_req_critical_data_i(cache_req_critical_data_i)
      ,.cache_req_complete_i(cache_req_complete_i)
      ,.cache_req_credits_full_i(cache_req_credits_full_i)
      ,.cache_req_credits_empty_i(cache_req_credits_empty_i)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -69,7 +69,8 @@ module bp_be_pipe_mem
    , input                                           cache_req_busy_i
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
-   , input                                           cache_req_critical_i
+   , input                                           cache_req_critical_tag_i
+   , input                                           cache_req_critical_data_i
    , input                                           cache_req_complete_i
    , input                                           cache_req_credits_full_i
    , input                                           cache_req_credits_empty_i
@@ -268,7 +269,8 @@ module bp_be_pipe_mem
       ,.cache_req_busy_i(cache_req_busy_i)
       ,.cache_req_metadata_o(cache_req_metadata_o)
       ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
-      ,.cache_req_critical_i(cache_req_critical_i)
+      ,.cache_req_critical_tag_i(cache_req_critical_tag_i)
+      ,.cache_req_critical_data_i(cache_req_critical_data_i)
       ,.cache_req_complete_i(cache_req_complete_i)
       ,.cache_req_credits_full_i(cache_req_credits_full_i)
       ,.cache_req_credits_empty_i(cache_req_credits_empty_i)

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -142,7 +142,8 @@ module bp_be_dcache
    , input                                           cache_req_busy_i
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
-   , input                                           cache_req_critical_i
+   , input                                           cache_req_critical_tag_i
+   , input                                           cache_req_critical_data_i
    , input                                           cache_req_complete_i
    // Unused
    , input                                           cache_req_credits_full_i

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -43,7 +43,8 @@ module bp_be_top
    , input                                           cache_req_busy_i
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
-   , input                                           cache_req_critical_i
+   , input                                           cache_req_critical_tag_i
+   , input                                           cache_req_critical_data_i
    , input                                           cache_req_complete_i
    , input                                           cache_req_credits_full_i
    , input                                           cache_req_credits_empty_i
@@ -201,7 +202,8 @@ module bp_be_top
      ,.cache_req_yumi_i(cache_req_yumi_i)
      ,.cache_req_busy_i(cache_req_busy_i)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
-     ,.cache_req_critical_i(cache_req_critical_i)
+     ,.cache_req_critical_tag_i(cache_req_critical_tag_i)
+     ,.cache_req_critical_data_i(cache_req_critical_data_i)
      ,.cache_req_complete_i(cache_req_complete_i)
      ,.cache_req_credits_full_i(cache_req_credits_full_i)
      ,.cache_req_credits_empty_i(cache_req_credits_empty_i)

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -72,7 +72,7 @@ module wrapper
    // Miss, Management Interfaces
    logic [num_caches_p-1:0] cache_req_v_lo, cache_req_metadata_v_lo;
    logic [num_caches_p-1:0] cache_req_yumi_lo, cache_req_busy_lo;
-   logic [num_caches_p-1:0] cache_req_complete_lo, cache_req_critical_lo;
+   logic [num_caches_p-1:0] cache_req_complete_lo, cache_req_critical_tag_lo, cache_req_critical_data_lo;
    logic [num_caches_p-1:0][dcache_req_width_lp-1:0] cache_req_lo;
    logic [num_caches_p-1:0][dcache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
 
@@ -229,7 +229,8 @@ module wrapper
        ,.cache_req_yumi_i(cache_req_yumi_lo[i])
        ,.cache_req_busy_i(cache_req_busy_lo[i])
        ,.cache_req_complete_i(cache_req_complete_lo[i])
-       ,.cache_req_critical_i(cache_req_critical_lo[i])
+       ,.cache_req_critical_tag_i(cache_req_critical_tag_lo[i])
+       ,.cache_req_critical_data_i(cache_req_critical_data_lo[i])
        ,.cache_req_credits_full_i(cache_req_credits_full_lo[i])
        ,.cache_req_credits_empty_i(cache_req_credits_empty_lo[i])
 
@@ -278,7 +279,8 @@ module wrapper
               ,.cache_req_busy_o(cache_req_busy_lo[i])
               ,.cache_req_metadata_i(cache_req_metadata_lo[i])
               ,.cache_req_metadata_v_i(cache_req_metadata_v_lo[i])
-              ,.cache_req_critical_o(cache_req_critical_lo[i])
+              ,.cache_req_critical_tag_o(cache_req_critical_tag_lo[i])
+              ,.cache_req_critical_data_o(cache_req_critical_data_lo[i])
               ,.cache_req_complete_o(cache_req_complete_lo[i])
               ,.cache_req_credits_full_o(cache_req_credits_full_lo[i])
               ,.cache_req_credits_empty_o(cache_req_credits_empty_lo[i])

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -83,7 +83,8 @@ module bp_fe_icache
    , input                                            cache_req_busy_i
    , output logic [icache_req_metadata_width_lp-1:0]  cache_req_metadata_o
    , output logic                                     cache_req_metadata_v_o
-   , input                                            cache_req_critical_i
+   , input                                            cache_req_critical_tag_i
+   , input                                            cache_req_critical_data_i
    , input                                            cache_req_complete_i
    , input                                            cache_req_credits_full_i
    , input                                            cache_req_credits_empty_i

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -35,7 +35,8 @@ module bp_fe_top
    , input                                            cache_req_busy_i
    , output logic [icache_req_metadata_width_lp-1:0]  cache_req_metadata_o
    , output logic                                     cache_req_metadata_v_o
-   , input                                            cache_req_critical_i
+   , input                                            cache_req_critical_tag_i
+   , input                                            cache_req_critical_data_i
    , input                                            cache_req_complete_i
    , input                                            cache_req_credits_full_i
    , input                                            cache_req_credits_empty_i
@@ -298,7 +299,8 @@ module bp_fe_top
      ,.cache_req_busy_i(cache_req_busy_i)
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
-     ,.cache_req_critical_i(cache_req_critical_i)
+     ,.cache_req_critical_tag_i(cache_req_critical_tag_i)
+     ,.cache_req_critical_data_i(cache_req_critical_data_i)
      ,.cache_req_complete_i(cache_req_complete_i)
      ,.cache_req_credits_full_i(cache_req_credits_full_i)
      ,.cache_req_credits_empty_i(cache_req_credits_empty_i)

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -68,7 +68,7 @@ module wrapper
   logic cache_req_v_lo;
   logic [icache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
   logic cache_req_metadata_v_lo;
-  logic cache_req_critical_li, cache_req_complete_li;
+  logic cache_req_critical_tag_li, cache_req_critical_data_li, cache_req_complete_li;
   logic cache_req_credits_full_li, cache_req_credits_empty_li;
 
   // Fill Interfaces
@@ -194,7 +194,8 @@ module wrapper
      ,.cache_req_busy_i(cache_req_busy_li)
      ,.cache_req_metadata_o(cache_req_metadata_lo)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_lo)
-     ,.cache_req_critical_i(cache_req_critical_li)
+     ,.cache_req_critical_tag_i(cache_req_critical_tag_li)
+     ,.cache_req_critical_data_i(cache_req_critical_data_li)
      ,.cache_req_complete_i(cache_req_complete_li)
      ,.cache_req_credits_full_i(cache_req_credits_full_li)
      ,.cache_req_credits_empty_i(cache_req_credits_empty_li)
@@ -246,7 +247,8 @@ module wrapper
        ,.cache_req_busy_o(cache_req_busy_li)
        ,.cache_req_metadata_i(cache_req_metadata_lo)
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
-       ,.cache_req_critical_o(cache_req_critical_li)
+       ,.cache_req_critical_tag_o(cache_req_critical_tag_li)
+       ,.cache_req_critical_data_o(cache_req_critical_data_li)
        ,.cache_req_complete_o(cache_req_complete_li)
        ,.cache_req_credits_full_o(cache_req_credits_full_li)
        ,.cache_req_credits_empty_o(cache_req_credits_empty_li)
@@ -359,7 +361,8 @@ module wrapper
        ,.cache_req_busy_o(cache_req_busy_li)
        ,.cache_req_metadata_i(cache_req_metadata_lo)
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
-       ,.cache_req_critical_o(cache_req_critical_li)
+       ,.cache_req_critical_tag_o(cache_req_critical_tag_li)
+       ,.cache_req_critical_data_o(cache_req_critical_data_li)
        ,.cache_req_complete_o(cache_req_complete_li)
        ,.cache_req_credits_full_o(cache_req_credits_full_li)
        ,.cache_req_credits_empty_o(cache_req_credits_empty_li)

--- a/bp_me/src/v/cce/bp_uce.sv
+++ b/bp_me/src/v/cce/bp_uce.sv
@@ -57,7 +57,8 @@ module bp_uce
     , output logic                                   cache_req_busy_o
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
-    , output logic                                   cache_req_critical_o
+    , output logic                                   cache_req_critical_tag_o
+    , output logic                                   cache_req_critical_data_o
     , output logic                                   cache_req_complete_o
     , output logic                                   cache_req_credits_full_o
     , output logic                                   cache_req_credits_empty_o
@@ -445,7 +446,9 @@ module bp_uce
      ,.clear_i(critical_recv)
      ,.data_o(critical_pending)
      );
-  assign cache_req_critical_o = critical_pending & critical_recv;
+  // This is sufficient for UCE because we only set tags on requests, not invalidation
+  assign cache_req_critical_tag_o = tag_mem_pkt_yumi_i & (tag_mem_pkt_cast_o.opcode == e_cache_tag_mem_set_tag);
+  assign cache_req_critical_data_o = critical_pending & critical_recv;
 
   bp_cache_req_wr_subop_e cache_wr_subop;
   bp_bedrock_wr_subop_e mem_wr_subop;

--- a/bp_me/src/v/lce/bp_lce.sv
+++ b/bp_me/src/v/lce/bp_lce.sv
@@ -60,7 +60,8 @@ module bp_lce
     , output logic                                   cache_req_busy_o
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
-    , output logic                                   cache_req_critical_o
+    , output logic                                   cache_req_critical_tag_o
+    , output logic                                   cache_req_critical_data_o
     , output logic                                   cache_req_complete_o
     , output logic                                   cache_req_credits_full_o
     , output logic                                   cache_req_credits_empty_o
@@ -186,7 +187,8 @@ module bp_lce
       ,.ready_o(cmd_ready_lo)
       ,.sync_done_o(sync_done_lo)
       ,.cache_req_complete_o(cache_req_complete_o)
-      ,.cache_req_critical_o(cache_req_critical_o)
+      ,.cache_req_critical_tag_o(cache_req_critical_tag_o)
+      ,.cache_req_critical_data_o(cache_req_critical_data_o)
       ,.uc_store_req_complete_o(uc_store_req_complete_lo)
 
       ,.data_mem_pkt_o(data_mem_pkt_o)

--- a/bp_me/src/v/lce/bp_lce_cmd.sv
+++ b/bp_me/src/v/lce/bp_lce_cmd.sv
@@ -93,8 +93,9 @@ module bp_lce_cmd
     // request complete signals
     // cached requests and uncached loads block in the caches, but uncached stores do not
     // cache_req_complete_o is routed to the cache to indicate a blocking request is complete
+    , output logic                                   cache_req_critical_tag_o
+    , output logic                                   cache_req_critical_data_o
     , output logic                                   cache_req_complete_o
-    , output logic                                   cache_req_critical_o
     // uncached store request complete is used by the LCE to decrement the request credit counter
     // when an uncached store complete, but is not routed to the cache because the caches do not
     // block (miss) on uncached stores
@@ -272,7 +273,8 @@ module bp_lce_cmd
 
     cache_req_complete_o = 1'b0;
     //TODO: support partial fill, currently not supported
-    cache_req_critical_o = 1'b0;
+    cache_req_critical_tag_o = 1'b0;
+    cache_req_critical_data_o = 1'b0;
 
     // LCE-CCE Interface signals
     lce_cmd_yumi_o = 1'b0;
@@ -421,7 +423,8 @@ module bp_lce_cmd
 
               // TODO: This is sufficient for the critical signal when only
               //   line width fills
-              cache_req_critical_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+              cache_req_critical_tag_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+              cache_req_critical_data_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
 
               // send coherence ack after updating tag and data memories
               state_n = (tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i)
@@ -553,7 +556,7 @@ module bp_lce_cmd
 
               lce_cmd_yumi_o = data_mem_pkt_yumi_i;
 
-              cache_req_critical_o = lce_cmd_yumi_o;
+              cache_req_critical_data_o = lce_cmd_yumi_o;
               cache_req_complete_o = lce_cmd_yumi_o;
             end
 

--- a/bp_top/src/v/bp_core.sv
+++ b/bp_top/src/v/bp_core.sv
@@ -59,14 +59,14 @@ module bp_core
   logic icache_req_v_lo, icache_req_yumi_li, icache_req_busy_li;
   bp_icache_req_metadata_s icache_req_metadata_lo;
   logic icache_req_metadata_v_lo;
-  logic icache_req_critical_li, icache_req_complete_li;
+  logic icache_req_critical_tag_li, icache_req_critical_data_li, icache_req_complete_li;
   logic icache_req_credits_full_li, icache_req_credits_empty_li;
 
   bp_dcache_req_s dcache_req_lo;
   logic dcache_req_v_lo, dcache_req_yumi_li, dcache_req_busy_li;
   bp_dcache_req_metadata_s dcache_req_metadata_lo;
   logic dcache_req_metadata_v_lo;
-  logic dcache_req_critical_li, dcache_req_complete_li;
+  logic dcache_req_critical_tag_li, dcache_req_critical_data_li, dcache_req_complete_li;
   logic dcache_req_credits_full_li, dcache_req_credits_empty_li;
 
   bp_icache_tag_mem_pkt_s icache_tag_mem_pkt_li;
@@ -113,7 +113,8 @@ module bp_core
      ,.icache_req_metadata_o(icache_req_metadata_lo)
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
      ,.icache_req_complete_i(icache_req_complete_li)
-     ,.icache_req_critical_i(icache_req_critical_li)
+     ,.icache_req_critical_tag_i(icache_req_critical_tag_li)
+     ,.icache_req_critical_data_i(icache_req_critical_data_li)
      ,.icache_req_credits_full_i(icache_req_credits_full_li)
      ,.icache_req_credits_empty_i(icache_req_credits_empty_li)
 
@@ -139,7 +140,8 @@ module bp_core
      ,.dcache_req_metadata_o(dcache_req_metadata_lo)
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
      ,.dcache_req_complete_i(dcache_req_complete_li)
-     ,.dcache_req_critical_i(dcache_req_critical_li)
+     ,.dcache_req_critical_tag_i(dcache_req_critical_tag_li)
+     ,.dcache_req_critical_data_i(dcache_req_critical_data_li)
      ,.dcache_req_credits_full_i(dcache_req_credits_full_li)
      ,.dcache_req_credits_empty_i(dcache_req_credits_empty_li)
 
@@ -187,7 +189,8 @@ module bp_core
      ,.cache_req_busy_o(icache_req_busy_li)
      ,.cache_req_metadata_i(icache_req_metadata_lo)
      ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
-     ,.cache_req_critical_o(icache_req_critical_li)
+     ,.cache_req_critical_tag_o(icache_req_critical_tag_li)
+     ,.cache_req_critical_data_o(icache_req_critical_data_li)
      ,.cache_req_complete_o(icache_req_complete_li)
      ,.cache_req_credits_full_o(icache_req_credits_full_li)
      ,.cache_req_credits_empty_o(icache_req_credits_empty_li)
@@ -249,7 +252,8 @@ module bp_core
      ,.cache_req_busy_o(dcache_req_busy_li)
      ,.cache_req_metadata_i(dcache_req_metadata_lo)
      ,.cache_req_metadata_v_i(dcache_req_metadata_v_lo)
-     ,.cache_req_critical_o(dcache_req_critical_li)
+     ,.cache_req_critical_tag_o(dcache_req_critical_tag_li)
+     ,.cache_req_critical_data_o(dcache_req_critical_data_li)
      ,.cache_req_complete_o(dcache_req_complete_li)
      ,.cache_req_credits_full_o(dcache_req_credits_full_li)
      ,.cache_req_credits_empty_o(dcache_req_credits_empty_li)

--- a/bp_top/src/v/bp_core_minimal.sv
+++ b/bp_top/src/v/bp_core_minimal.sv
@@ -27,7 +27,8 @@ module bp_core_minimal
    , input                                           icache_req_busy_i
    , output logic [icache_req_metadata_width_lp-1:0] icache_req_metadata_o
    , output logic                                    icache_req_metadata_v_o
-   , input                                           icache_req_critical_i
+   , input                                           icache_req_critical_tag_i
+   , input                                           icache_req_critical_data_i
    , input                                           icache_req_complete_i
    , input                                           icache_req_credits_full_i
    , input                                           icache_req_credits_empty_i
@@ -53,7 +54,8 @@ module bp_core_minimal
    , input                                           dcache_req_busy_i
    , output logic [dcache_req_metadata_width_lp-1:0] dcache_req_metadata_o
    , output logic                                    dcache_req_metadata_v_o
-   , input                                           dcache_req_critical_i
+   , input                                           dcache_req_critical_tag_i
+   , input                                           dcache_req_critical_data_i
    , input                                           dcache_req_complete_i
    , input                                           dcache_req_credits_full_i
    , input                                           dcache_req_credits_empty_i
@@ -110,7 +112,8 @@ module bp_core_minimal
      ,.cache_req_busy_i(icache_req_busy_i)
      ,.cache_req_metadata_o(icache_req_metadata_o)
      ,.cache_req_metadata_v_o(icache_req_metadata_v_o)
-     ,.cache_req_critical_i(icache_req_critical_i)
+     ,.cache_req_critical_tag_i(icache_req_critical_tag_i)
+     ,.cache_req_critical_data_i(icache_req_critical_data_i)
      ,.cache_req_complete_i(icache_req_complete_i)
      ,.cache_req_credits_full_i(icache_req_credits_full_i)
      ,.cache_req_credits_empty_i(icache_req_credits_empty_i)
@@ -153,7 +156,8 @@ module bp_core_minimal
      ,.cache_req_busy_i(dcache_req_busy_i)
      ,.cache_req_metadata_o(dcache_req_metadata_o)
      ,.cache_req_metadata_v_o(dcache_req_metadata_v_o)
-     ,.cache_req_critical_i(dcache_req_critical_i)
+     ,.cache_req_critical_tag_i(dcache_req_critical_tag_i)
+     ,.cache_req_critical_data_i(dcache_req_critical_data_i)
      ,.cache_req_complete_i(dcache_req_complete_i)
      ,.cache_req_credits_full_i(dcache_req_credits_full_i)
      ,.cache_req_credits_empty_i(dcache_req_credits_empty_i)

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -58,7 +58,7 @@ module bp_unicore_lite
   logic icache_req_v_lo, icache_req_yumi_li, icache_req_busy_li;
   bp_icache_req_metadata_s icache_req_metadata_lo;
   logic icache_req_metadata_v_lo;
-  logic icache_req_critical_li, icache_req_complete_li;
+  logic icache_req_critical_tag_li, icache_req_critical_data_li, icache_req_complete_li;
   logic icache_req_credits_full_li, icache_req_credits_empty_li;
 
   bp_icache_tag_mem_pkt_s icache_tag_mem_pkt_li;
@@ -77,7 +77,7 @@ module bp_unicore_lite
   logic dcache_req_v_lo, dcache_req_yumi_li, dcache_req_busy_li;
   bp_dcache_req_metadata_s dcache_req_metadata_lo;
   logic dcache_req_metadata_v_lo;
-  logic dcache_req_critical_li, dcache_req_complete_li;
+  logic dcache_req_critical_tag_li, dcache_req_critical_data_li, dcache_req_complete_li;
   logic dcache_req_credits_full_li, dcache_req_credits_empty_li;
 
   bp_dcache_tag_mem_pkt_s dcache_tag_mem_pkt_li;
@@ -152,8 +152,9 @@ module bp_unicore_lite
      ,.icache_req_busy_i(icache_req_busy_li)
      ,.icache_req_metadata_o(icache_req_metadata_lo)
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
+     ,.icache_req_critical_tag_i(icache_req_critical_tag_li)
+     ,.icache_req_critical_data_i(icache_req_critical_data_li)
      ,.icache_req_complete_i(icache_req_complete_li)
-     ,.icache_req_critical_i(icache_req_critical_li)
      ,.icache_req_credits_full_i(icache_req_credits_full_li)
      ,.icache_req_credits_empty_i(icache_req_credits_empty_li)
 
@@ -178,8 +179,9 @@ module bp_unicore_lite
      ,.dcache_req_busy_i(dcache_req_busy_li)
      ,.dcache_req_metadata_o(dcache_req_metadata_lo)
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
+     ,.dcache_req_critical_tag_i(dcache_req_critical_tag_li)
+     ,.dcache_req_critical_data_i(dcache_req_critical_data_li)
      ,.dcache_req_complete_i(dcache_req_complete_li)
-     ,.dcache_req_critical_i(dcache_req_critical_li)
      ,.dcache_req_credits_full_i(dcache_req_credits_full_li)
      ,.dcache_req_credits_empty_i(dcache_req_credits_empty_li)
 
@@ -227,7 +229,8 @@ module bp_unicore_lite
     ,.cache_req_busy_o(dcache_req_busy_li)
     ,.cache_req_metadata_i(dcache_req_metadata_lo)
     ,.cache_req_metadata_v_i(dcache_req_metadata_v_lo)
-    ,.cache_req_critical_o(dcache_req_critical_li)
+    ,.cache_req_critical_tag_o(dcache_req_critical_tag_li)
+    ,.cache_req_critical_data_o(dcache_req_critical_data_li)
     ,.cache_req_complete_o(dcache_req_complete_li)
     ,.cache_req_credits_full_o(dcache_req_credits_full_li)
     ,.cache_req_credits_empty_o(dcache_req_credits_empty_li)
@@ -277,7 +280,8 @@ module bp_unicore_lite
      ,.cache_req_busy_o(icache_req_busy_li)
      ,.cache_req_metadata_i(icache_req_metadata_lo)
      ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
-     ,.cache_req_critical_o(icache_req_critical_li)
+     ,.cache_req_critical_tag_o(icache_req_critical_tag_li)
+     ,.cache_req_critical_data_o(icache_req_critical_data_li)
      ,.cache_req_complete_o(icache_req_complete_li)
      ,.cache_req_credits_full_o(icache_req_credits_full_li)
      ,.cache_req_credits_empty_o(icache_req_credits_empty_li)

--- a/docs/interface_specification.md
+++ b/docs/interface_specification.md
@@ -144,6 +144,9 @@ routed through a FIFO. BlackParrot provides 3 types of Cache Engines:
   memory. In this way, a UCE is a combination of an LCE and a CCE, optimized for size and complexity
   in order to service a single cache.
 
+Additionally, the BlackParrot HDK provides additional cache engines for connecting to external
+memory systems.
+
 More details are provided about the LCE and CCE interface in the following section.
 
 A UCE implementation must support the following operations:
@@ -205,7 +208,13 @@ The stat memory contains LRU and dirty data for a block, and the packet format i
 - Replacement way
 - Replacement index
 
+When the critical data of a transaction is being sent, cache_req_critical_data_o will go high.
+When the critical tag of a transaction is being sent, cache_req_critical_tag_o will go high.
 When a transaction is completed, cache_req_complete_o will go high for one cycle.
+
+There are additional signals for available credits in the engine, used for fencing. Empty credits
+signify all downstream transactions have completed, whereas full credits signify no more
+transactions may be sent to the network.
 
 ## Memory Interface
 


### PR DESCRIPTION
This PR adds distinct tag and data critical signals in the cache engine interface (the critical signal was previous implicitly data only). These signals can be used for snooping or early restart of the cache pipeline. Should be no functional change, just the new signals and the doc update