### PR TITLE
Bump SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TOP ?= $(shell git rev-parse --show-toplevel)
 
-.PHONY: bleach_all libs tools sdk hdk prep prep_bsg sdk_checkout hdk_checkout
+.PHONY: bleach_all libs tools sdk hdk prep prep_bsg sdk_checkout hdk_checkout checkout
 
 include $(TOP)/Makefile.common
 
@@ -8,22 +8,29 @@ libs:
 	cd $(TOP); git submodule update --init --recursive --checkout $(SHALLOW_SUB) $(BASEJUMP_STL_DIR)
 	cd $(TOP); git submodule update --init --recursive --checkout $(SHALLOW_SUB) $(HARDFLOAT_DIR)
 
+sdk_checkout:
+	cd $(TOP); git submodule update --init --checkout $(SHALLOW_SUB) $(BP_SDK_DIR)
+
+hdk_checkout:
+	cd $(TOP); git submodule update --init --checkout $(SHALLOW_SUB) $(BP_HDK_DIR)
+
+checkout:
+	$(MAKE) libs
+	$(MAKE) sdk_checkout
+	$(MAKE) hdk_checkout
+
 tools_lite: libs
 	$(MAKE) -C $(BP_TOOLS_DIR) tools_lite
 
 tools: libs
 	$(MAKE) -C $(BP_TOOLS_DIR) tools
 
-sdk_checkout:
-	cd $(TOP); git submodule update --init --checkout $(SHALLOW_SUB) $(BP_SDK_DIR)
-
-sdk: tools sdk_checkout
+sdk: tools
+	$(MAKE) sdk_checkout
 	$(MAKE) -C $(BP_SDK_DIR) sdk
 
-hdk_checkout:
-	cd $(TOP); git submodule update --init --checkout $(SHALLOW_SUB) $(BP_HDK_DIR)
-
-hdk: sdk hdk_checkout
+hdk: sdk
+	$(MAKE) hdk_checkout
 	$(MAKE) -C $(BP_HDK_DIR) hdk
 
 prep: hdk
@@ -34,7 +41,9 @@ prep_bsg: prep
 	$(MAKE) -C $(BP_SDK_DIR) bsg_cadenv
 	$(MAKE) -C $(BP_HDK_DIR) bsg_cadenv
 
-prep_lite: tools_lite sdk_checkout hdk_checkout
+prep_lite: tools_lite
+	$(MAKE) sdk_checkout
+	$(MAKE) hdk_checkout
 	$(MAKE) -C $(BP_SDK_DIR) sdk_lite
 
 bsg_cadenv:

--- a/Makefile.common
+++ b/Makefile.common
@@ -28,5 +28,6 @@ BSG_CADENV_DIR ?= $(TOP)/external/bsg_cadenv
 -include $(BP_HDK_DIR)/Makefile.common
 -include $(BP_SDK_DIR)/Makefile.common
 
-# Makes clones much faster. Comment out if you see "fatal: reference is not a tree"
-SHALLOW_SUB ?= --depth=1
+# Makes clones much faster. Try setting to --depth=1, otherwise leave
+# unset if you see "fatal: reference is not a tree"
+export SHALLOW_SUB ?=

--- a/tools/Makefile.common
+++ b/tools/Makefile.common
@@ -31,5 +31,6 @@ export LM_LICENSE_FILE ?=
 
 export PATH := $(BP_TOOLS_INSTALL_DIR)/bin:$(PATH)
 
-# Makes clones much faster. Comment out if you see "fatal: reference is not a tree"
-SHALLOW_SUB ?= --depth=1
+# Makes clones much faster. Try setting to --depth=1, otherwise leave
+# unset if you see "fatal: reference is not a tree"
+export SHALLOW_SUB ?=


### PR DESCRIPTION
This PR fixes the broken QEMU link. We don't use QEMU so there's no testing needed to see if versions are compatible.

I was able to reproduce the breakage with a fresh clone & make of sdk. Fix was updating the qemu pointer to 5.0.1-stable, which should hopefully be...stable.

@muwyse can you try a fresh clone of black-parrot and do make sdk, just to test this end to end.