### PR TITLE
[WIP] Making LCE modules helpful

### DIFF
--- a/bp_me/src/v/lce/bp_lce.sv
+++ b/bp_me/src/v/lce/bp_lce.sv
@@ -89,12 +89,12 @@ module bp_lce
     // Req: ready->valid
     , output logic [lce_req_msg_width_lp-1:0]        lce_req_o
     , output logic                                   lce_req_v_o
-    , input                                          lce_req_ready_then_i
+    , input                                          lce_req_ready_and_i
 
     // Resp: ready->valid
     , output logic [lce_resp_msg_width_lp-1:0]       lce_resp_o
     , output logic                                   lce_resp_v_o
-    , input                                          lce_resp_ready_then_i
+    , input                                          lce_resp_ready_and_i
 
     // CCE-LCE interface
     // Cmd_i: valid->yumi
@@ -106,8 +106,8 @@ module bp_lce
     // Cmd_o: ready->valid
     , output logic [lce_cmd_msg_width_lp-1:0]        lce_cmd_o
     , output logic                                   lce_cmd_v_o
-    , input                                          lce_cmd_ready_then_i
-  );
+    , input                                          lce_cmd_ready_and_i
+    );
 
   //synopsys translate_off
   initial begin
@@ -162,7 +162,7 @@ module bp_lce
 
       ,.lce_req_o(lce_req_o)
       ,.lce_req_v_o(lce_req_v_o)
-      ,.lce_req_ready_then_i(lce_req_ready_then_i)
+      ,.lce_req_ready_and_i(lce_req_ready_and_i)
       );
 
   // LCE Command Module
@@ -212,11 +212,11 @@ module bp_lce
 
       ,.lce_resp_o(lce_resp_o)
       ,.lce_resp_v_o(lce_resp_v_o)
-      ,.lce_resp_ready_then_i(lce_resp_ready_then_i)
+      ,.lce_resp_ready_and_i(lce_resp_ready_and_i)
 
       ,.lce_cmd_o(lce_cmd_o)
       ,.lce_cmd_v_o(lce_cmd_v_o)
-      ,.lce_cmd_ready_then_i(lce_cmd_ready_then_i)
+      ,.lce_cmd_ready_and_i(lce_cmd_ready_and_i)
       );
 
 

--- a/bp_top/src/v/bp_core.sv
+++ b/bp_top/src/v/bp_core.sv
@@ -29,11 +29,11 @@ module bp_core
   // LCE-CCE interface
   , output [1:0][lce_req_msg_width_lp-1:0]       lce_req_o
   , output [1:0]                                 lce_req_v_o
-  , input [1:0]                                  lce_req_ready_then_i
+  , input [1:0]                                  lce_req_ready_and_i
 
   , output [1:0][lce_resp_msg_width_lp-1:0]      lce_resp_o
   , output [1:0]                                 lce_resp_v_o
-  , input [1:0]                                  lce_resp_ready_then_i
+  , input [1:0]                                  lce_resp_ready_and_i
 
   // CCE-LCE interface
   , input [1:0][lce_cmd_msg_width_lp-1:0]        lce_cmd_i
@@ -42,7 +42,7 @@ module bp_core
 
   , output [1:0][lce_cmd_msg_width_lp-1:0]       lce_cmd_o
   , output [1:0]                                 lce_cmd_v_o
-  , input [1:0]                                  lce_cmd_ready_then_i
+  , input [1:0]                                  lce_cmd_ready_and_i
 
   , input                                        timer_irq_i
   , input                                        software_irq_i
@@ -212,11 +212,11 @@ module bp_core
 
      ,.lce_req_o(lce_req_o[0])
      ,.lce_req_v_o(lce_req_v_o[0])
-     ,.lce_req_ready_then_i(lce_req_ready_then_i[0])
+     ,.lce_req_ready_and_i(lce_req_ready_and_i[0])
 
      ,.lce_resp_o(lce_resp_o[0])
      ,.lce_resp_v_o(lce_resp_v_o[0])
-     ,.lce_resp_ready_then_i(lce_resp_ready_then_i[0])
+     ,.lce_resp_ready_and_i(lce_resp_ready_and_i[0])
 
      ,.lce_cmd_i(lce_cmd_i[0])
      ,.lce_cmd_v_i(lce_cmd_v_i[0])
@@ -224,7 +224,7 @@ module bp_core
 
      ,.lce_cmd_o(lce_cmd_o[0])
      ,.lce_cmd_v_o(lce_cmd_v_o[0])
-     ,.lce_cmd_ready_then_i(lce_cmd_ready_then_i[0])
+     ,.lce_cmd_ready_and_i(lce_cmd_ready_and_i[0])
      );
 
   bp_lce
@@ -275,11 +275,11 @@ module bp_core
 
      ,.lce_req_o(lce_req_o[1])
      ,.lce_req_v_o(lce_req_v_o[1])
-     ,.lce_req_ready_then_i(lce_req_ready_then_i[1])
+     ,.lce_req_ready_and_i(lce_req_ready_and_i[1])
 
      ,.lce_resp_o(lce_resp_o[1])
      ,.lce_resp_v_o(lce_resp_v_o[1])
-     ,.lce_resp_ready_then_i(lce_resp_ready_then_i[1])
+     ,.lce_resp_ready_and_i(lce_resp_ready_and_i[1])
 
      ,.lce_cmd_i(lce_cmd_i[1])
      ,.lce_cmd_v_i(lce_cmd_v_i[1])
@@ -287,7 +287,7 @@ module bp_core
 
      ,.lce_cmd_o(lce_cmd_o[1])
      ,.lce_cmd_v_o(lce_cmd_v_o[1])
-     ,.lce_cmd_ready_then_i(lce_cmd_ready_then_i[1])
+     ,.lce_cmd_ready_and_i(lce_cmd_ready_and_i[1])
      );
 
 endmodule

--- a/bp_top/src/v/bp_tile.sv
+++ b/bp_top/src/v/bp_tile.sv
@@ -71,7 +71,7 @@ module bp_tile
 
   // Proc-side connections network connections
   bp_bedrock_lce_req_msg_s [1:0] lce_req_lo;
-  logic [1:0] lce_req_v_lo, lce_req_ready_li;
+  logic [1:0] lce_req_v_lo, lce_req_ready_and_li;
   bp_bedrock_lce_resp_msg_s [1:0] lce_resp_lo;
   logic [1:0] lce_resp_v_lo, lce_resp_ready_li;
   bp_bedrock_lce_cmd_msg_s [1:0] lce_cmd_li;
@@ -202,7 +202,7 @@ module bp_tile
 
      ,.lce_req_o(lce_req_lo)
      ,.lce_req_v_o(lce_req_v_lo)
-     ,.lce_req_ready_then_i(lce_req_ready_li)
+     ,.lce_req_ready_and_i(lce_req_ready_and_li)
 
      ,.lce_cmd_i(lce_cmd_li)
      ,.lce_cmd_v_i(lce_cmd_v_li)
@@ -210,11 +210,11 @@ module bp_tile
 
      ,.lce_cmd_o(lce_cmd_lo)
      ,.lce_cmd_v_o(lce_cmd_v_lo)
-     ,.lce_cmd_ready_then_i(lce_cmd_ready_li)
+     ,.lce_cmd_ready_and_i(lce_cmd_ready_li)
 
      ,.lce_resp_o(lce_resp_lo)
      ,.lce_resp_v_o(lce_resp_v_lo)
-     ,.lce_resp_ready_then_i(lce_resp_ready_li)
+     ,.lce_resp_ready_and_i(lce_resp_ready_li)
 
      ,.timer_irq_i(timer_irq_li)
      ,.software_irq_i(software_irq_li)
@@ -302,7 +302,7 @@ module bp_tile
 
          ,.packet_i(lce_req_packet_lo[i])
          ,.v_i(lce_req_v_lo[i])
-         ,.ready_o(lce_req_ready_li[i])
+         ,.ready_o(lce_req_ready_and_li[i])
 
          ,.link_i(lce_req_link_li[i])
          ,.link_o(lce_req_link_lo[i])

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -547,64 +547,64 @@ module testbench
 
       if (multicore_p)
         begin
-          bind bp_cce_wrapper
-            bp_me_nonsynth_cce_tracer
-             #(.bp_params_p(bp_params_p))
-             cce_tracer
-              (.clk_i(clk_i & testbench.cce_trace_en_lo)
-              ,.reset_i(reset_i)
-              ,.freeze_i(cfg_bus_cast_i.freeze)
+          //bind bp_cce_wrapper
+          //  bp_me_nonsynth_cce_tracer
+          //   #(.bp_params_p(bp_params_p))
+          //   cce_tracer
+          //    (.clk_i(clk_i & testbench.cce_trace_en_lo)
+          //    ,.reset_i(reset_i)
+          //    ,.freeze_i(cfg_bus_cast_i.freeze)
 
-              ,.cce_id_i(cfg_bus_cast_i.cce_id)
+          //    ,.cce_id_i(cfg_bus_cast_i.cce_id)
 
-              // To CCE
-              ,.lce_req_i(lce_req_i)
-              ,.lce_req_v_i(lce_req_v_i)
-              ,.lce_req_yumi_i(lce_req_yumi_o)
-              ,.lce_resp_i(lce_resp_i)
-              ,.lce_resp_v_i(lce_resp_v_i)
-              ,.lce_resp_yumi_i(lce_resp_yumi_o)
+          //    // To CCE
+          //    ,.lce_req_i(lce_req_i)
+          //    ,.lce_req_v_i(lce_req_v_i)
+          //    ,.lce_req_yumi_i(lce_req_yumi_o)
+          //    ,.lce_resp_i(lce_resp_i)
+          //    ,.lce_resp_v_i(lce_resp_v_i)
+          //    ,.lce_resp_yumi_i(lce_resp_yumi_o)
 
-              // From CCE
-              ,.lce_cmd_i(lce_cmd_o)
-              ,.lce_cmd_v_i(lce_cmd_v_o)
-              ,.lce_cmd_ready_i(lce_cmd_ready_i)
+          //    // From CCE
+          //    ,.lce_cmd_i(lce_cmd_o)
+          //    ,.lce_cmd_v_i(lce_cmd_v_o)
+          //    ,.lce_cmd_ready_i(lce_cmd_ready_i)
 
-              // To CCE
-              ,.mem_resp_i(mem_resp_i)
-              ,.mem_resp_v_i(mem_resp_v_i)
-              ,.mem_resp_yumi_i(mem_resp_yumi_o)
+          //    // To CCE
+          //    ,.mem_resp_i(mem_resp_i)
+          //    ,.mem_resp_v_i(mem_resp_v_i)
+          //    ,.mem_resp_yumi_i(mem_resp_yumi_o)
 
-              // From CCE
-              ,.mem_cmd_i(mem_cmd_o)
-              ,.mem_cmd_v_i(mem_cmd_v_o)
-              ,.mem_cmd_ready_i(mem_cmd_ready_i)
-              );
+          //    // From CCE
+          //    ,.mem_cmd_i(mem_cmd_o)
+          //    ,.mem_cmd_v_i(mem_cmd_v_o)
+          //    ,.mem_cmd_ready_i(mem_cmd_ready_i)
+          //    );
 
-          bind bp_lce
-            bp_me_nonsynth_lce_tracer
-              #(.bp_params_p(bp_params_p)
-                ,.sets_p(sets_p)
-                ,.assoc_p(assoc_p)
-                ,.block_width_p(block_width_p)
-                )
-              lce_tracer
-              (.clk_i(clk_i & testbench.lce_trace_en_lo)
-              ,.reset_i(reset_i)
-              ,.lce_id_i(lce_id_i)
-              ,.lce_req_i(lce_req_o)
-              ,.lce_req_v_i(lce_req_v_o)
-              ,.lce_req_ready_then_i(lce_req_ready_then_i)
-              ,.lce_resp_i(lce_resp_o)
-              ,.lce_resp_v_i(lce_resp_v_o)
-              ,.lce_resp_ready_then_i(lce_resp_ready_then_i)
-              ,.lce_cmd_i(lce_cmd_i)
-              ,.lce_cmd_v_i(lce_cmd_v_i)
-              ,.lce_cmd_yumi_i(lce_cmd_yumi_o)
-              ,.lce_cmd_o_i(lce_cmd_o)
-              ,.lce_cmd_o_v_i(lce_cmd_v_o)
-              ,.lce_cmd_o_ready_then_i(lce_cmd_ready_then_i)
-              );
+          //bind bp_lce
+          //  bp_me_nonsynth_lce_tracer
+          //    #(.bp_params_p(bp_params_p)
+          //      ,.sets_p(sets_p)
+          //      ,.assoc_p(assoc_p)
+          //      ,.block_width_p(block_width_p)
+          //      )
+          //    lce_tracer
+          //    (.clk_i(clk_i & testbench.lce_trace_en_lo)
+          //    ,.reset_i(reset_i)
+          //    ,.lce_id_i(lce_id_i)
+          //    ,.lce_req_i(lce_req_o)
+          //    ,.lce_req_v_i(lce_req_v_o)
+          //    ,.lce_req_ready_i(lce_req_yumi_i)
+          //    ,.lce_resp_i(lce_resp_o)
+          //    ,.lce_resp_v_i(lce_resp_v_o)
+          //    ,.lce_resp_ready_i(lce_resp_yumi_i)
+          //    ,.lce_cmd_i(lce_cmd_i)
+          //    ,.lce_cmd_v_i(lce_cmd_v_i)
+          //    ,.lce_cmd_yumi_i(lce_cmd_yumi_o)
+          //    ,.lce_cmd_o_i(lce_cmd_o)
+          //    ,.lce_cmd_o_v_i(lce_cmd_v_o)
+          //    ,.lce_cmd_o_ready_i(lce_cmd_yumi_i)
+          //    );
         end
     end
 


### PR DESCRIPTION
This PR makes the LCEs as helpful as possible. There's still 1 demanding interface: the incoming lce_cmd interface. This must be demanding since the cache engine interface *_mem_pkts are demanding. I suppose those could also be made to be helpful, but that would require a rework of the cache pipeline as well, and this PR is already decently sized