### PR TITLE
add config variable for ucode loading in nbf

### DIFF
--- a/bp_me/test/tb/bp_cce/Makefile.params
+++ b/bp_me/test/tb/bp_cce/Makefile.params
@@ -19,7 +19,6 @@ export LCE_MODE_P ?= 0
 export ME_TEST_P ?= 0
 
 COH_PROTO   ?= mesi
-CCE_MEM_PATH = $(BP_ME_DIR)/src/asm/roms
 CCE_MEM      = $(COH_PROTO).mem
 
 NUMS = $(shell seq 0 `expr $(NUM_LCE_P) - 1`)

--- a/bp_top/test/tb/bp_tethered/Makefile.cfgs
+++ b/bp_top/test/tb/bp_tethered/Makefile.cfgs
@@ -51,3 +51,9 @@ else
 	export PADDR_WIDTH ?= $(_PADDR_WIDTH)
 endif
 
+_UCODE_CFG :=$(findstring cce_ucode,$(CFG))
+ifeq ($(_UCODE_CFG),)
+	export UCODE_CFG ?= 0
+else
+	export UCODE_CFG ?= 1
+endif

--- a/bp_top/test/tb/bp_tethered/Makefile.params
+++ b/bp_top/test/tb/bp_tethered/Makefile.params
@@ -1,5 +1,4 @@
 export COH_PROTO   ?= mesi
-export CCE_MEM_PATH = $(BP_ME_DIR)/src/asm/roms
 export CCE_MEM      = $(COH_PROTO).mem
 
 export CCE_TRACE_P    ?= 0

--- a/bp_top/test/tb/bp_tethered/Makefile.vcs
+++ b/bp_top/test/tb/bp_tethered/Makefile.vcs
@@ -61,7 +61,13 @@ $(SIM_DIR)/prog.riscv: $(BP_SDK_PROG_DIR)/$(SUITE)/$(PROG).riscv
 $(SIM_DIR)/prog.elf: $(SIM_DIR)/prog.riscv
 	cp $^ $@
 
-$(SIM_DIR)/cce_ucode.mem: $(BP_SDK_UCODE_DIR)/$(CCE_MEM)
+ifeq ($(UCODE_CFG), 1)
+CCE_UCODE_FILE ?= $(BP_SDK_UCODE_DIR)/$(CCE_MEM)
+else
+CCE_UCODE_FILE ?=
+endif
+
+$(SIM_DIR)/cce_ucode.mem: $(CCE_UCODE_FILE)
 ifeq ($(UCODE_CFG), 1)
 	cp $< $@
 endif

--- a/bp_top/test/tb/bp_tethered/Makefile.vcs
+++ b/bp_top/test/tb/bp_tethered/Makefile.vcs
@@ -62,9 +62,14 @@ $(SIM_DIR)/prog.elf: $(SIM_DIR)/prog.riscv
 	cp $^ $@
 
 $(SIM_DIR)/cce_ucode.mem: $(BP_SDK_UCODE_DIR)/$(CCE_MEM)
+ifeq ($(UCODE_CFG), 1)
 	cp $< $@
+endif
 
-NBF_INPUTS ?= --ncpus=$(NCPUS) --ucode=cce_ucode.mem
+NBF_INPUTS ?= --ncpus=$(NCPUS)
+ifeq ($(UCODE_CFG), 1)
+NBF_INPUTS += --ucode=cce_ucode.mem
+endif
 ifeq ($(PRELOAD_MEM_P), 0)
 NBF_INPUTS += --mem=prog.mem --skip_zeros
 endif

--- a/bp_top/test/tb/bp_tethered/Makefile.verilator
+++ b/bp_top/test/tb/bp_tethered/Makefile.verilator
@@ -40,9 +40,14 @@ $(SIM_DIR)/prog.elf: $(SIM_DIR)/prog.riscv
 	cp $^ $@
 
 $(SIM_DIR)/cce_ucode.mem: $(BP_SDK_UCODE_DIR)/$(CCE_MEM)
+ifeq ($(UCODE_CFG), 1)
 	cp $< $@
+endif
 
-NBF_INPUTS ?= --ncpus=$(NCPUS) --ucode=cce_ucode.mem
+NBF_INPUTS ?= --ncpus=$(NCPUS)
+ifeq ($(UCODE_CFG), 1)
+NBF_INPUTS += --ucode=cce_ucode.mem
+endif
 NBF_INPUTS += --mem=prog.mem --skip_zeros
 ifeq ($(NBF_CONFIG_P), 1)
 NBF_INPUTS += --config

--- a/bp_top/test/tb/bp_tethered/Makefile.verilator
+++ b/bp_top/test/tb/bp_tethered/Makefile.verilator
@@ -39,7 +39,13 @@ $(SIM_DIR)/prog.riscv: $(BP_SDK_PROG_DIR)/$(SUITE)/$(PROG).riscv
 $(SIM_DIR)/prog.elf: $(SIM_DIR)/prog.riscv
 	cp $^ $@
 
-$(SIM_DIR)/cce_ucode.mem: $(BP_SDK_UCODE_DIR)/$(CCE_MEM)
+ifeq ($(UCODE_CFG), 1)
+CCE_UCODE_FILE ?= $(BP_SDK_UCODE_DIR)/$(CCE_MEM)
+else
+CCE_UCODE_FILE ?=
+endif
+
+$(SIM_DIR)/cce_ucode.mem: $(CCE_UCODE_FILE)
 ifeq ($(UCODE_CFG), 1)
 	cp $< $@
 endif


### PR DESCRIPTION
This PR adds a config variable in the bp_tethered testbench to detect whether the nbf file should load CCE ucode. The CCE ucode is only included in the nbf (and copied to the sim folder) if the config name contains the string "cce_ucode", as all standard configs with the ucode CCE do.

Note: a custom config that uses the ucode CCE by setting the cce_ucode field (https://github.com/black-parrot/black-parrot/blob/master/bp_common/src/include/bp_common_aviary_pkgdef.svh#L132) of the params struct to 1 will fail to load the ucode with this approach unless the config name can be set to include the string "cce_ucode".

Closes #840  

Also removes a deprecated variable in the makefiles related to CCE ucode file.