### PR TITLE
remove use of hardcoded cce_ucode address in cfg

### DIFF
--- a/bp_top/src/v/bp_cfg.sv
+++ b/bp_top/src/v/bp_cfg.sv
@@ -97,8 +97,8 @@ module bp_cfg
   wire cord_r_v_li      = cfg_r_v_li & (cfg_addr_li == cfg_reg_cord_gp);
   wire domain_r_v_li    = cfg_r_v_li & (cfg_addr_li == cfg_reg_domain_mask_gp);
 
-  assign cce_ucode_v_o    = (cfg_r_v_li | cfg_w_v_li) & (cfg_addr_li >= 16'h8000);
-  assign cce_ucode_w_o    = cfg_w_v_li & (cfg_addr_li >= 16'h8000);
+  assign cce_ucode_v_o    = (cfg_r_v_li | cfg_w_v_li) & (cfg_addr_li >= cfg_mem_base_cce_ucode_gp);
+  assign cce_ucode_w_o    = cfg_w_v_li & (cfg_addr_li >= cfg_mem_base_cce_ucode_gp);
   assign cce_ucode_addr_o = cfg_addr_li[0+:cce_pc_width_p];
   assign cce_ucode_data_o = cfg_data_li[0+:cce_instr_width_gp];
 


### PR DESCRIPTION
Change use of hardcoded address to use globally defined param in bp_cfg for ucode loading.

Closes #751 