### PR TITLE
Update dev to top_dev

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -24,7 +24,7 @@ module bp_be_calculator_top
     `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
 
    // Generated parameters
-   , localparam cfg_bus_width_lp        = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp        = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam dispatch_pkt_width_lp   = `bp_be_dispatch_pkt_width(vaddr_width_p)
    , localparam branch_pkt_width_lp     = `bp_be_branch_pkt_width(vaddr_width_p)
    , localparam commit_pkt_width_lp     = `bp_be_commit_pkt_width(vaddr_width_p, paddr_width_p)
@@ -91,7 +91,7 @@ module bp_be_calculator_top
   );
 
   // Declare parameterizable structs
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 
   `bp_cast_i(bp_be_dispatch_pkt_s, dispatch_pkt);

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -10,7 +10,7 @@ module bp_be_csr
 
    , localparam csr_cmd_width_lp = $bits(bp_be_csr_cmd_s)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
 
    , localparam commit_pkt_width_lp = `bp_be_commit_pkt_width(vaddr_width_p, paddr_width_p)
    , localparam decode_info_width_lp = `bp_be_decode_info_width
@@ -51,7 +51,7 @@ module bp_be_csr
    );
 
   // Declare parameterizable structs
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 
   `declare_csr_structs(vaddr_width_p, paddr_width_p);

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -20,7 +20,7 @@ module bp_be_pipe_mem
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
    // Generated parameters
-   , localparam cfg_bus_width_lp       = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp       = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam dispatch_pkt_width_lp  = `bp_be_dispatch_pkt_width(vaddr_width_p)
    , localparam ptw_fill_pkt_width_lp  = `bp_be_ptw_fill_pkt_width(vaddr_width_p, paddr_width_p)
    , localparam trans_info_width_lp    = `bp_be_trans_info_width(ptag_width_p)
@@ -94,7 +94,7 @@ module bp_be_pipe_mem
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_cache_engine_if(paddr_width_p, ptag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache);
 
   // Cast input and output ports
@@ -181,7 +181,7 @@ module bp_be_pipe_mem
      ,.trans_en_i(trans_info.translation_en)
      ,.uncached_mode_i((cfg_bus.dcache_mode == e_lce_mode_uncached))
      ,.nonspec_mode_i((cfg_bus.dcache_mode == e_lce_mode_nonspec))
-     ,.domain_mask_i(cfg_bus.domain_mask)
+     ,.hio_mask_i(cfg_bus.hio_mask)
 
      ,.w_v_i(dtlb_w_v)
      ,.w_vtag_i(dtlb_w_vtag)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
@@ -17,7 +17,7 @@ module bp_be_pipe_sys
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
 
-   , localparam cfg_bus_width_lp       = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp       = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam csr_cmd_width_lp       = $bits(bp_be_csr_cmd_s)
    // Generated parameters
    , localparam dispatch_pkt_width_lp = `bp_be_dispatch_pkt_width(vaddr_width_p)

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -21,7 +21,7 @@ module bp_be_detector
    `declare_bp_proc_params(bp_params_p)
 
    // Generated parameters
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam isd_status_width_lp = `bp_be_isd_status_width(vaddr_width_p, branch_metadata_fwd_width_p)
    , localparam dispatch_pkt_width_lp = `bp_be_dispatch_pkt_width(vaddr_width_p)
    , localparam commit_pkt_width_lp = `bp_be_commit_pkt_width(vaddr_width_p, paddr_width_p)
@@ -52,7 +52,7 @@ module bp_be_detector
    , input [wb_pkt_width_lp-1:0]       fwb_pkt_i
    );
 
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);

--- a/bp_be/src/v/bp_be_checker/bp_be_director.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.sv
@@ -22,7 +22,7 @@ module bp_be_director
    `declare_bp_core_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
 
    // Generated parameters
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam isd_status_width_lp = `bp_be_isd_status_width(vaddr_width_p, branch_metadata_fwd_width_p)
    , localparam branch_pkt_width_lp = `bp_be_branch_pkt_width(vaddr_width_p)
    , localparam commit_pkt_width_lp = `bp_be_commit_pkt_width(vaddr_width_p, paddr_width_p)
@@ -52,7 +52,7 @@ module bp_be_director
    );
 
   // Declare parameterized structures
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -21,7 +21,7 @@ module bp_be_scheduler
    `declare_bp_proc_params(bp_params_p)
 
    // Generated parameters
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam fe_queue_width_lp = `bp_fe_queue_width(vaddr_width_p, branch_metadata_fwd_width_p)
    , localparam issue_pkt_width_lp = `bp_be_issue_pkt_width(vaddr_width_p, branch_metadata_fwd_width_p)
    , localparam dispatch_pkt_width_lp = `bp_be_dispatch_pkt_width(vaddr_width_p)
@@ -57,7 +57,7 @@ module bp_be_scheduler
   );
 
   // Declare parameterizable structures
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -109,7 +109,7 @@ module bp_be_dcache
    , parameter fill_width_p   = dcache_fill_width_p
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, dcache)
 
-   , localparam cfg_bus_width_lp    = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp    = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam dcache_pkt_width_lp = $bits(bp_be_dcache_pkt_s)
    )
   (input                              clk_i
@@ -1298,7 +1298,7 @@ module bp_be_dcache
      );
 
   // synopsys translate_off
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
   always_ff @(negedge clk_i)

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -17,7 +17,7 @@ module bp_be_top
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
 
    // Default parameters
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
   )
   (input                                             clk_i
    , input                                           reset_i

--- a/bp_be/test/tb/bp_be_dcache/Makefile.params
+++ b/bp_be/test/tb/bp_be_dcache/Makefile.params
@@ -22,7 +22,7 @@ export TB_PARAMS  = -pvalue+uce_p=$(UCE_P) \
                     -pvalue+dcache_trace_p=$(DCACHE_TRACE_P) \
                     -pvalue+random_yumi_p=$(RANDOM_YUMI_P) \
 
-export DUT_DEFINES =
+export DUT_DEFINES = $(foreach def,$(DEFINES),+define+$(def))
 export TB_DEFINES  = +define+BP_SIM_CLK_PERIOD=$(BP_SIM_CLK_PERIOD) \
                      +define+BP_NUM_LCE=$(BP_NUM_LCE) \
                      +define+BP_COH_NOC_CID_WIDTH=$(BP_COH_NOC_CID_WIDTH) \

--- a/bp_be/test/tb/bp_be_dcache/testbench.sv
+++ b/bp_be/test/tb/bp_be_dcache/testbench.sv
@@ -32,7 +32,7 @@ module testbench
    , parameter dram_type_p                 = BP_DRAM_FLOWVAR // Replaced by the flow with a specific dram_type
 
    // Derived parameters
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam dcache_pkt_width_lp = $bits(bp_be_dcache_pkt_s)
    , localparam trace_replay_data_width_lp = ptag_width_p + dcache_pkt_width_lp + 1 // The 1 extra bit is for uncached accesses
    , localparam trace_rom_addr_width_lp = 8
@@ -43,7 +43,7 @@ module testbench
   (output bit reset_i);
 
   `declare_bp_bedrock_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce)
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
 
   // Bit to deal with initial X->0 transition detection
   bit clk_i;

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -25,7 +25,7 @@ module wrapper
    , parameter debug_p=0
    , parameter lock_max_limit_p=8
 
-   , localparam cfg_bus_width_lp= `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp= `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam block_size_in_words_lp=assoc_p
    , localparam way_id_width_lp=`BSG_SAFE_CLOG2(assoc_p)
 
@@ -117,7 +117,7 @@ module wrapper
    bp_bedrock_lce_resp_msg_s [num_caches_p-1:0] lce_resp_lo;
    bp_bedrock_lce_resp_msg_s cce_lce_resp_li;
 
-   `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
    bp_cfg_bus_s cfg_bus_cast_i;
    assign cfg_bus_cast_i = cfg_bus_i;
 

--- a/bp_common/software/py/nbf.py
+++ b/bp_common/software/py/nbf.py
@@ -14,7 +14,7 @@ import subprocess
 cfg_base_addr          = 0x200000
 cfg_reg_reset          = 0x01
 cfg_reg_freeze         = 0x02
-cfg_domain_mask        = 0x09
+cfg_hio_mask           = 0x09
 cfg_reg_icache_mode    = 0x22
 cfg_reg_npc            = 0x40
 cfg_reg_dcache_mode    = 0x43

--- a/bp_common/src/include/bp_common_addr_defines.svh
+++ b/bp_common/src/include/bp_common_addr_defines.svh
@@ -4,7 +4,7 @@
   `define declare_bp_memory_map(paddr_width_mp, caddr_width_mp) \
     typedef struct packed                                           \
     {                                                               \
-      logic [paddr_width_mp-caddr_width_mp-1:0] domain;             \
+      logic [paddr_width_mp-caddr_width_mp-1:0] hio;                \
       logic [caddr_width_mp-1:0]                caddr;              \
     }  bp_global_addr_s;                                            \
                                                                     \

--- a/bp_common/src/include/bp_common_aviary_defines.svh
+++ b/bp_common/src/include/bp_common_aviary_defines.svh
@@ -41,10 +41,9 @@
                                                                                                    \
     , localparam vaddr_width_p   = proc_param_lp.vaddr_width                                       \
     , localparam paddr_width_p   = proc_param_lp.paddr_width                                       \
-    , localparam dram_max_size_p = proc_param_lp.dram_max_size                                     \
+    , localparam caddr_width_p   = proc_param_lp.caddr_width                                       \
     , localparam asid_width_p    = proc_param_lp.asid_width                                        \
-    , localparam caddr_width_p   = `BSG_SAFE_CLOG2(dram_base_addr_gp+dram_max_size_p)              \
-    , localparam domain_width_p  = paddr_width_p - caddr_width_p                                   \
+    , localparam hio_width_p     = paddr_width_p - caddr_width_p                                   \
                                                                                                    \
     , localparam boot_pc_p       = proc_param_lp.boot_pc                                           \
     , localparam boot_in_debug_p = proc_param_lp.boot_in_debug                                     \
@@ -190,7 +189,7 @@
                                                                                                    \
           ,`bp_aviary_parameter_override(vaddr_width, override_cfg_mp, default_cfg_mp)             \
           ,`bp_aviary_parameter_override(paddr_width, override_cfg_mp, default_cfg_mp)             \
-          ,`bp_aviary_parameter_override(dram_max_size, override_cfg_mp, default_cfg_mp)           \
+          ,`bp_aviary_parameter_override(caddr_width, override_cfg_mp, default_cfg_mp)             \
           ,`bp_aviary_parameter_override(asid_width, override_cfg_mp, default_cfg_mp)              \
                                                                                                    \
           ,`bp_aviary_parameter_override(boot_pc, override_cfg_mp, default_cfg_mp)                 \

--- a/bp_common/src/include/bp_common_aviary_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_pkgdef.svh
@@ -69,7 +69,8 @@
     //   Only tested for 40-bit physical address
     integer unsigned paddr_width;
     // The max size of the connected DRAM i.e. cached address space
-    integer unsigned dram_max_size;
+    //   Only tested for 32-bit cacheable address (4 GB space, with 2 GB local I/O)
+    integer unsigned caddr_width;
     // Address space ID width
     //   Currently unused, so set to 1 bit
     integer unsigned asid_width;
@@ -206,8 +207,7 @@
 
       ,vaddr_width: 39
       ,paddr_width: 40
-      // 4 GB
-      ,dram_max_size : (1 << 31)
+      ,caddr_width: 32
       ,asid_width : 1
 
       ,boot_pc       : dram_base_addr_gp
@@ -766,7 +766,7 @@
 
       ,`bp_aviary_define_override(vaddr_width, BP_VADDR_WIDTH, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(paddr_width, BP_PADDR_WIDTH, `BP_CUSTOM_BASE_CFG)
-      ,`bp_aviary_define_override(dram_max_size, BP_DRAM_MAX_SIZE, `BP_CUSTOM_BASE_CFG)
+      ,`bp_aviary_define_override(caddr_width, BP_CADDR_WIDTH, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(asid_width, BP_ASID_WIDTH, `BP_CUSTOM_BASE_CFG)
 
       ,`bp_aviary_define_override(boot_pc, BP_BOOT_PC, `BP_CUSTOM_BASE_CFG)

--- a/bp_common/src/include/bp_common_cfg_bus_defines.svh
+++ b/bp_common/src/include/bp_common_cfg_bus_defines.svh
@@ -1,7 +1,7 @@
 `ifndef BP_COMMON_CFG_BUS_DEFINES_SVH
 `define BP_COMMON_CFG_BUS_DEFINES_SVH
 
-  `define declare_bp_cfg_bus_s(domain_width_mp, core_id_width_mp, cce_id_width_mp, lce_id_width_mp) \
+  `define declare_bp_cfg_bus_s(hio_width_mp, core_id_width_mp, cce_id_width_mp, lce_id_width_mp) \
     typedef struct packed                             \
     {                                                 \
       logic                        freeze;            \
@@ -12,10 +12,10 @@
       bp_lce_mode_e                dcache_mode;       \
       logic [cce_id_width_mp-1:0]  cce_id;            \
       bp_cce_mode_e                cce_mode;          \
-      logic [domain_width_mp-1:0]  domain_mask;       \
+      logic [hio_width_mp-1:0]     hio_mask;          \
     }  bp_cfg_bus_s
 
-  `define bp_cfg_bus_width(domain_width_mp, core_id_width_mp, cce_id_width_mp, lce_id_width_mp) \
+  `define bp_cfg_bus_width(hio_width_mp, core_id_width_mp, cce_id_width_mp, lce_id_width_mp) \
     (1                                \
      + core_id_width_mp               \
      + lce_id_width_mp                \
@@ -24,7 +24,7 @@
      + $bits(bp_lce_mode_e)           \
      + cce_id_width_mp                \
      + $bits(bp_cce_mode_e)           \
-     + domain_width_mp                \
+     + hio_width_mp                   \
      )
 
 `endif

--- a/bp_common/src/include/bp_common_cfg_bus_pkgdef.svh
+++ b/bp_common/src/include/bp_common_cfg_bus_pkgdef.svh
@@ -40,7 +40,7 @@
   localparam cfg_reg_did_gp            = 'h0006;
   localparam cfg_reg_cord_gp           = 'h0007;
   localparam cfg_reg_host_did_gp       = 'h0008;
-  localparam cfg_reg_domain_mask_gp    = 'h0009;
+  localparam cfg_reg_hio_mask_gp       = 'h0009;
   localparam cfg_reg_icache_id_gp      = 'h0021;
   localparam cfg_reg_icache_mode_gp    = 'h0022;
   localparam cfg_reg_dcache_id_gp      = 'h0042;

--- a/bp_common/src/v/bp_mmu.sv
+++ b/bp_common/src/v/bp_mmu.sv
@@ -22,7 +22,7 @@ module bp_mmu
    , input                                            sum_i
    , input                                            uncached_mode_i
    , input                                            nonspec_mode_i
-   , input [domain_width_p-1:0]                       domain_mask_i
+   , input [hio_width_p-1:0]                       hio_mask_i
 
    , input                                            w_v_i
    , input [vtag_width_p-1:0]                         w_vtag_i
@@ -138,14 +138,14 @@ module bp_mmu
 
   // Fault if higher bits of eaddr do not match vaddr MSB
   wire eaddr_fault_v = ~&r_etag_r[etag_width_p-1:vtag_width_p-1] & |r_etag_r[etag_width_p-1:vtag_width_p-1];
-  // Fault if domain bit is not enabled and we're accessing that domain
-  wire domain_fault_v = (r_instr_r & ptag_lo[ptag_width_p-1-:domain_width_p] != '0)
-    || (ptag_lo[ptag_width_p-1-:domain_width_p] & ~domain_mask_i);
+  // Fault if hio bit is not enabled and we're accessing that hio
+  wire hio_fault_v = (r_instr_r & ptag_lo[ptag_width_p-1-:hio_width_p] != '0)
+    || (ptag_lo[ptag_width_p-1-:hio_width_p] & ~hio_mask_i);
 
   // Access faults
-  wire instr_access_fault_v = r_instr_r & domain_fault_v;
-  wire load_access_fault_v  = r_load_r  & domain_fault_v;
-  wire store_access_fault_v = r_store_r & domain_fault_v;
+  wire instr_access_fault_v = r_instr_r & hio_fault_v;
+  wire load_access_fault_v  = r_load_r  & hio_fault_v;
+  wire store_access_fault_v = r_store_r & hio_fault_v;
   wire any_access_fault_v   = |{instr_access_fault_v, load_access_fault_v, store_access_fault_v};
 
   // Page faults

--- a/bp_common/src/v/bp_pma.sv
+++ b/bp_common/src/v/bp_pma.sv
@@ -19,7 +19,7 @@ module bp_pma
    );
 
   wire is_local_addr = (ptag_i < (dram_base_addr_gp >> page_offset_width_gp));
-  wire is_io_addr    = (ptag_i[ptag_width_p-1-:domain_width_p] != '0);
+  wire is_io_addr    = (ptag_i[ptag_width_p-1-:hio_width_p] != '0);
 
   assign uncached_o = ptag_v_i & (is_local_addr | is_io_addr | uncached_mode_i);
   // For now, uncached mode also means non-idempotency. Will reevaluate if we need

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -43,7 +43,7 @@ module bp_fe_icache
    , parameter fill_width_p  = icache_fill_width_p
 
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, icache)
-   , localparam cfg_bus_width_lp    = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp    = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam icache_pkt_width_lp = `bp_fe_icache_pkt_width(vaddr_width_p)
    )
   (input                                              clk_i
@@ -106,7 +106,7 @@ module bp_fe_icache
    );
 
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, icache);
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
   // Various localparameters

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -14,7 +14,7 @@ module bp_fe_top
    `declare_bp_core_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    )
   (input                                              clk_i
    , input                                            reset_i
@@ -58,7 +58,7 @@ module bp_fe_top
    );
 
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_fe_branch_metadata_fwd_s(btb_tag_width_p, btb_idx_width_p, bht_idx_width_p, ghist_width_p);
   bp_fe_cmd_s fe_cmd_cast_i;
   assign fe_cmd_cast_i = fe_cmd_i;
@@ -235,7 +235,7 @@ module bp_fe_top
      ,.sum_i('0)
      ,.uncached_mode_i((cfg_bus_cast_i.icache_mode == e_lce_mode_uncached))
      ,.nonspec_mode_i((cfg_bus_cast_i.icache_mode == e_lce_mode_nonspec))
-     ,.domain_mask_i(cfg_bus_cast_i.domain_mask)
+     ,.hio_mask_i(cfg_bus_cast_i.hio_mask)
 
      ,.w_v_i(itlb_fill_v)
      ,.w_vtag_i(w_vtag_li)

--- a/bp_fe/test/tb/bp_fe_icache/Makefile.params
+++ b/bp_fe/test/tb/bp_fe_icache/Makefile.params
@@ -14,7 +14,7 @@ export TB_PARAMS  = -pvalue+uce_p=$(UCE_P) \
                     -pvalue+icache_trace_p=$(ICACHE_TRACE_P) \
                     -pvalue+dram_fixed_latency_p=$(DRAM_FIXED_LATENCY)
 
-export DUT_DEFINES =
+export DUT_DEFINES = $(foreach def,$(DEFINES),+define+$(def))
 export TB_DEFINES  = +define+BP_SIM_CLK_PERIOD=$(BP_SIM_CLK_PERIOD) \
                      +define+den2048Mb+sg5+x16+FULL_MEM
 

--- a/bp_fe/test/tb/bp_fe_icache/testbench.sv
+++ b/bp_fe/test/tb/bp_fe_icache/testbench.sv
@@ -22,7 +22,7 @@ module testbench
    // DRAM parameters
    , parameter dram_type_p                 = BP_DRAM_FLOWVAR // Replaced by the flow with a specific dram_type
 
-  , localparam cfg_bus_width_lp = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+  , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
   , localparam trace_replay_data_width_lp = ptag_width_p + vaddr_width_p + 1
   , localparam trace_rom_addr_width_lp = 7
 
@@ -32,7 +32,7 @@ module testbench
   (output bit reset_i);
 
   `declare_bp_bedrock_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce)
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
 
   // Bit to deal with initial X->0 transition detection
   bit clk_i;

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -14,7 +14,7 @@ module wrapper
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam wg_per_cce_lp = (lce_sets_p / num_cce_p)
    , localparam lg_icache_assoc_lp = `BSG_SAFE_CLOG2(icache_assoc_p)
    , localparam way_id_width_lp=`BSG_SAFE_CLOG2(icache_assoc_p)
@@ -54,7 +54,7 @@ module wrapper
    , input                                   mem_cmd_yumi_i
    );
 
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   bp_cfg_bus_s cfg_bus_cast_i;
   assign cfg_bus_cast_i = cfg_bus_i;
 

--- a/bp_me/src/v/cce/bp_cce.sv
+++ b/bp_me/src/v/cce/bp_cce.sv
@@ -33,7 +33,7 @@ module bp_cce
     , localparam counter_width_lp          = `BSG_SAFE_CLOG2(max_counter_val_lp)
 
     // Interface Widths
-    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
     `declare_bp_bedrock_lce_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
     `declare_bp_bedrock_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce)
   )
@@ -101,7 +101,7 @@ module bp_cce
   `declare_bp_bedrock_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce);
 
   // Config Interface
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
 
   // MSHR
   `declare_bp_cce_mshr_s(lce_id_width_p, lce_assoc_p, paddr_width_p);

--- a/bp_me/src/v/cce/bp_cce_fsm.sv
+++ b/bp_me/src/v/cce/bp_cce_fsm.sv
@@ -35,7 +35,7 @@ module bp_cce_fsm
     , localparam num_way_groups_lp         = `BSG_CDIV(cce_way_groups_p, num_cce_p)
     , localparam lg_num_way_groups_lp      = `BSG_SAFE_CLOG2(num_way_groups_lp)
     , localparam inst_ram_addr_width_lp    = `BSG_SAFE_CLOG2(num_cce_instr_ram_els_p)
-    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
 
     // maximal number of tag sets stored in the directory for all LCE types
     , localparam max_tag_sets_lp           = `BSG_CDIV(lce_sets_p, num_cce_p)
@@ -118,7 +118,7 @@ module bp_cce_fsm
   assign lce_req_payload = lce_req.header.payload;
 
   // Config bus
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   bp_cfg_bus_s cfg_bus_cast_i;
   assign cfg_bus_cast_i = cfg_bus_i;
   wire cce_normal_mode_li = (cfg_bus_cast_i.cce_mode == e_cce_mode_normal);

--- a/bp_me/src/v/cce/bp_cce_fsm_top.sv
+++ b/bp_me/src/v/cce/bp_cce_fsm_top.sv
@@ -32,7 +32,7 @@ module bp_cce_fsm_top
     `declare_bp_proc_params(bp_params_p)
 
     // Derived parameters
-    , localparam cfg_bus_width_lp      = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp      = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
     , localparam block_size_in_bytes_lp = (cce_block_width_p/8)
     , localparam lg_num_cce_lp          = `BSG_SAFE_CLOG2(num_cce_p)
     , localparam wg_per_cce_lp          = (lce_sets_p / num_cce_p)

--- a/bp_me/src/v/cce/bp_cce_inst_ram.sv
+++ b/bp_me/src/v/cce/bp_cce_inst_ram.sv
@@ -24,7 +24,7 @@ module bp_cce_inst_ram
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
     // Derived parameters
-    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
   )
   (input                                         clk_i
    , input                                       reset_i
@@ -59,7 +59,7 @@ module bp_cce_inst_ram
   end
   //synopsys translate_on
 
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   bp_cfg_bus_s cfg_bus_cast_i;
   assign cfg_bus_cast_i = cfg_bus_i;
 

--- a/bp_me/src/v/cce/bp_cce_msg.sv
+++ b/bp_me/src/v/cce/bp_cce_msg.sv
@@ -34,7 +34,7 @@ module bp_cce_msg
 
     // Interface Widths
     , localparam mshr_width_lp             = `bp_cce_mshr_width(lce_id_width_p, lce_assoc_p, paddr_width_p)
-    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
     `declare_bp_bedrock_lce_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
     `declare_bp_bedrock_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce)
 
@@ -119,7 +119,7 @@ module bp_cce_msg
   `declare_bp_bedrock_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce);
 
   // Config Interface
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
 
   // MSHR
   `declare_bp_cce_mshr_s(lce_id_width_p, lce_assoc_p, paddr_width_p);

--- a/bp_me/src/v/cce/bp_cce_src_sel.sv
+++ b/bp_me/src/v/cce/bp_cce_src_sel.sv
@@ -28,7 +28,7 @@ module bp_cce_src_sel
     , localparam num_way_groups_lp         = `BSG_CDIV(cce_way_groups_p, num_cce_p)
     , localparam lg_num_way_groups_lp      = `BSG_SAFE_CLOG2(num_way_groups_lp)
 
-    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
 
     `declare_bp_bedrock_lce_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
     `declare_bp_bedrock_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce)
@@ -84,7 +84,7 @@ module bp_cce_src_sel
   end
   //synopsys translate_on
 
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   bp_cfg_bus_s cfg_bus_cast;
   assign cfg_bus_cast = cfg_bus_i;
 

--- a/bp_me/src/v/cce/bp_cce_wrapper.sv
+++ b/bp_me/src/v/cce/bp_cce_wrapper.sv
@@ -20,7 +20,7 @@ module bp_cce_wrapper
     `declare_bp_proc_params(bp_params_p)
 
     // Interface Widths
-    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
     `declare_bp_bedrock_lce_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
     `declare_bp_bedrock_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce)
   )
@@ -64,7 +64,7 @@ module bp_cce_wrapper
   );
 
   // Config Interface
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
 
   // Config bus casting
   bp_cfg_bus_s cfg_bus_cast_i;

--- a/bp_me/src/v/wormhole/bp_me_addr_to_cce_id.sv
+++ b/bp_me/src/v/wormhole/bp_me_addr_to_cce_id.sv
@@ -28,7 +28,7 @@ module bp_me_addr_to_cce_id
   localparam max_sac_cce_lp = max_cac_cce_lp + num_sacc_p;
   localparam max_ioc_cce_lp = max_sac_cce_lp + num_io_p;
 
-  wire external_io_v_li = (global_addr_li.domain > 1'b1);
+  wire external_io_v_li = (global_addr_li.hio > 1'b1);
   wire local_addr_v_li = (paddr_i < dram_base_addr_gp);
   wire dram_addr_v_li = (paddr_i >= dram_base_addr_gp) && (paddr_i < coproc_base_addr_gp);
   wire core_local_addr_v_li = local_addr_v_li && (local_addr_li.tile < num_core_p);
@@ -69,7 +69,7 @@ module bp_me_addr_to_cce_id
         cce_id_o[0+:lg_num_cce_lp] = cce_dst_id_lo;
       else
         cce_id_o = (num_sacc_p > 1)
-                   ? max_cac_cce_lp + paddr_i[paddr_width_p-domain_width_p-1-: (num_sacc_p > 1 ? `BSG_SAFE_CLOG2(num_sacc_p) : 1)]
+                   ? max_cac_cce_lp + paddr_i[paddr_width_p-hio_width_p-1-: (num_sacc_p > 1 ? `BSG_SAFE_CLOG2(num_sacc_p) : 1)]
                    : max_cac_cce_lp;
     end
 

--- a/bp_me/test/common/bp_cce_mmio_cfg_loader.sv
+++ b/bp_me/test/common/bp_cce_mmio_cfg_loader.sv
@@ -24,9 +24,9 @@ module bp_cce_mmio_cfg_loader
     , parameter cce_ucode_filename_p  = "cce_ucode.mem"
     , parameter skip_ram_init_p       = 0
     , parameter clear_freeze_p        = 0
-    // Change the last 8 bits of the data below to indicate the domains
+    // Change the last 8 bits of the data below to indicate the hios
     // to be enabled.
-    , parameter domain_mask_p         = 64'h0000_0000_0000_0001
+    , parameter hio_mask_p         = 64'h0000_0000_0000_0001
 
     , localparam bp_pc_entry_point_gp=39'h10_3000
     )
@@ -308,8 +308,8 @@ module bp_cce_mmio_cfg_loader
           core_cnt_clr = core_prog_done & credits_empty_lo;
 
           cfg_w_v_lo = 1'b1;
-          cfg_addr_lo = cfg_reg_domain_mask_gp;
-          cfg_data_lo = domain_mask_p;
+          cfg_addr_lo = cfg_reg_hio_mask_gp;
+          cfg_data_lo = hio_mask_p;
         end
         BP_FREEZE_CLR: begin
           state_n = core_prog_done ? WAIT_FOR_CREDITS : BP_FREEZE_CLR;

--- a/bp_me/test/common/bp_nonsynth_dram.sv
+++ b/bp_me/test/common/bp_nonsynth_dram.sv
@@ -82,8 +82,8 @@ module bp_nonsynth_dram
            $error("bsg_cache_to_test_dram doesn't support NPOT number of caches. Use AXI mem instead");
          end
 
-        // TODO: May need to use actual hash function 
-       localparam cache_bank_addr_width_lp = `BSG_SAFE_CLOG2(`BSG_CDIV(dram_max_size_p, num_dma_p));
+       // TODO: May need to use actual hash function 
+       localparam cache_bank_addr_width_lp = `dram_pkg::channel_addr_width_p - `BSG_SAFE_CLOG2(num_dma_p);
        bsg_cache_to_test_dram
         #(.num_cache_p(num_dma_p)
           ,.addr_width_p(caddr_width_p)

--- a/bp_me/test/tb/bp_cce/Makefile.params
+++ b/bp_me/test/tb/bp_cce/Makefile.params
@@ -45,7 +45,7 @@ export TB_PARAMS  = \
     -pvalue+lce_tr_trace_p=$(LCE_TR_TRACE_P) \
     -pvalue+dram_trace_p=$(DRAM_TRACE_P) \
 
-export DUT_DEFINES =
+export DUT_DEFINES = $(foreach def,$(DEFINES),+define+$(def))
 export TB_DEFINES  = +define+BP_SIM_CLK_PERIOD=$(BP_SIM_CLK_PERIOD) \
 					 +define+den2048Mb+sg5+x16+FULL_MEM
 

--- a/bp_me/test/tb/bp_cce/testbench.sv
+++ b/bp_me/test/tb/bp_cce/testbench.sv
@@ -51,7 +51,7 @@ function int get_sim_period();
   return (`BP_SIM_CLK_PERIOD);
 endfunction
 
-`declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+`declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
 `declare_bp_bedrock_lce_if(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
 `declare_bp_bedrock_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce);
 `declare_bp_bedrock_mem_if(paddr_width_p, dword_width_gp, lce_id_width_p, lce_assoc_p, xce);

--- a/bp_me/test/tb/bp_cce/wrapper.sv
+++ b/bp_me/test/tb/bp_cce/wrapper.sv
@@ -16,7 +16,7 @@ module wrapper
    // interface widths
    `declare_bp_bedrock_lce_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce)
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
 
    , parameter cce_trace_p = 0
    )

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -11,7 +11,7 @@ module bp_cacc_vdp
     `declare_bp_bedrock_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce)
     `declare_bp_cache_engine_if_widths(paddr_width_p, ptag_width_p, acache_sets_p, acache_assoc_p, dword_width_gp, acache_block_width_p, acache_fill_width_p, cache)
 
-    , localparam cfg_bus_width_lp= `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp= `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
     )
    (
     input                                     clk_i
@@ -53,7 +53,7 @@ module bp_cacc_vdp
   logic                     dcache_miss_v;
   logic                     dcache_pkt_v;
 
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   bp_cfg_bus_s cfg_bus_cast_i;
   assign cfg_bus_cast_i.dcache_id = lce_id_i;
 

--- a/bp_top/src/v/bp_core.sv
+++ b/bp_top/src/v/bp_core.sv
@@ -19,7 +19,7 @@ module bp_core
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
   )
  (input                                          clk_i
   , input                                        reset_i
@@ -49,7 +49,7 @@ module bp_core
   , input                                        external_irq_i
   );
 
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache);
 

--- a/bp_top/src/v/bp_core_complex.sv
+++ b/bp_top/src/v/bp_core_complex.sv
@@ -58,7 +58,7 @@ module bp_core_complex
    , output [N:N][cc_x_dim_p-1:0][mem_noc_ral_link_width_lp-1:0] mem_resp_ver_link_o
    );
 
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, coh_noc_ral_link_s);
   `declare_bsg_ready_and_link_sif_s(mem_noc_flit_width_p, mem_noc_ral_link_s);
 

--- a/bp_top/src/v/bp_core_minimal.sv
+++ b/bp_top/src/v/bp_core_minimal.sv
@@ -14,7 +14,7 @@ module bp_core_minimal
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    )
   (input                                             clk_i
    , input                                           reset_i
@@ -81,7 +81,7 @@ module bp_core_minimal
    );
 
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
 
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 

--- a/bp_top/src/v/bp_io_tile.sv
+++ b/bp_top/src/v/bp_io_tile.sv
@@ -196,7 +196,7 @@ module bp_io_tile
   assign local_addr_lo  = cce_io_cmd_lo.header.addr;
 
   wire is_host_addr  = (~local_addr_lo.nonlocal && (local_addr_lo.dev inside {boot_dev_gp, host_dev_gp}));
-  assign dst_did_lo  = is_host_addr ? host_did_i : global_addr_lo.domain;
+  assign dst_did_lo  = is_host_addr ? host_did_i : global_addr_lo.hio;
   assign dst_cord_lo = dst_did_lo;
 
   bp_me_cce_to_mem_link_bidir

--- a/bp_top/src/v/bp_l2e_tile.sv
+++ b/bp_top/src/v/bp_l2e_tile.sv
@@ -20,7 +20,7 @@ module bp_l2e_tile
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce)
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, dword_width_gp, lce_id_width_p, lce_assoc_p, xce)
 
-    , localparam cfg_bus_width_lp        = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp        = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    // Wormhole parameters
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
@@ -45,7 +45,7 @@ module bp_l2e_tile
    , input [mem_noc_ral_link_width_lp-1:0]                    mem_resp_link_i
    );
 
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_bedrock_lce_if(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
   `declare_bp_bedrock_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce);
   `declare_bp_bedrock_mem_if(paddr_width_p, dword_width_gp, lce_id_width_p, lce_assoc_p, xce);

--- a/bp_top/src/v/bp_multicore.sv
+++ b/bp_top/src/v/bp_multicore.sv
@@ -47,7 +47,7 @@ module bp_multicore
    , input [mc_x_dim_p-1:0][mem_noc_ral_link_width_lp-1:0]  dram_resp_link_i
    );
 
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, bp_coh_ready_and_link_s);
   `declare_bsg_ready_and_link_sif_s(io_noc_flit_width_p, bp_io_ready_and_link_s);
   `declare_bsg_ready_and_link_sif_s(mem_noc_flit_width_p, bp_mem_ready_and_link_s);

--- a/bp_top/src/v/bp_sacc_vdp.sv
+++ b/bp_top/src/v/bp_sacc_vdp.sv
@@ -8,7 +8,7 @@ module bp_sacc_vdp
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
     `declare_bp_bedrock_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce)
-    , localparam cfg_bus_width_lp= `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp= `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
     )
    (
     input                                     clk_i

--- a/bp_top/src/v/bp_tile.sv
+++ b/bp_top/src/v/bp_tile.sv
@@ -19,7 +19,7 @@ module bp_tile
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce)
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, dword_width_gp, lce_id_width_p, lce_assoc_p, xce)
 
-    , localparam cfg_bus_width_lp        = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp        = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    // Wormhole parameters
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
@@ -45,7 +45,7 @@ module bp_tile
    , input [mem_noc_ral_link_width_lp-1:0]                    mem_resp_link_i
    );
 
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_bedrock_lce_if(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
   `declare_bp_bedrock_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce);
   `declare_bp_bedrock_mem_if(paddr_width_p, dword_width_gp, lce_id_width_p, lce_assoc_p, xce);

--- a/bp_top/src/v/bp_unicore.sv
+++ b/bp_top/src/v/bp_unicore.sv
@@ -52,7 +52,7 @@ module bp_unicore
    , input                                             dma_data_yumi_i
    );
 
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache);
   `declare_bp_bedrock_mem_if(paddr_width_p, uce_mem_data_width_lp, lce_id_width_p, lce_assoc_p, uce);

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -47,7 +47,7 @@ module bp_unicore_lite
    , output logic                                      mem_resp_yumi_o
    );
 
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache);
   `declare_bp_bedrock_mem_if(paddr_width_p, uce_mem_data_width_lp, lce_id_width_p, lce_assoc_p, uce);
@@ -382,11 +382,11 @@ module bp_unicore_lite
   wire [dev_id_width_gp-1:0] device_cmd_li = local_addr_cast.dev;
 
   wire local_cmd_li        = (proc_cmd_selected_lo.header.addr < dram_base_addr_gp);
-  wire is_other_domain     = (proc_cmd_selected_lo.header.addr[paddr_width_p-1-:domain_width_p] != 0);
+  wire is_other_hio     = (proc_cmd_selected_lo.header.addr[paddr_width_p-1-:hio_width_p] != 0);
   wire is_cfg_cmd          = local_cmd_li & (device_cmd_li == cfg_dev_gp);
   wire is_clint_cmd        = local_cmd_li & (device_cmd_li == clint_dev_gp);
-  wire is_io_cmd           = (local_cmd_li & (device_cmd_li inside {boot_dev_gp, host_dev_gp})) | is_other_domain;
-  wire is_mem_cmd          = (~local_cmd_li & ~is_other_domain) || (local_cmd_li & (device_cmd_li == cache_dev_gp));
+  wire is_io_cmd           = (local_cmd_li & (device_cmd_li inside {boot_dev_gp, host_dev_gp})) | is_other_hio;
+  wire is_mem_cmd          = (~local_cmd_li & ~is_other_hio) || (local_cmd_li & (device_cmd_li == cache_dev_gp));
   wire is_loopback_cmd     = local_cmd_li & ~is_cfg_cmd & ~is_clint_cmd & ~is_io_cmd & ~is_mem_cmd;
 
   assign cfg_cmd_v_li      = |proc_cmd_grant_lo & cfg_cmd_ready_and_lo & is_cfg_cmd;

--- a/bp_top/test/common/bp_nonsynth_host.sv
+++ b/bp_top/test/common/bp_nonsynth_host.sv
@@ -112,14 +112,14 @@ module bp_nonsynth_host
      );
   assign io_resp_v_o = io_cmd_v_lo;
   assign io_cmd_yumi_li = io_resp_yumi_i;
-  wire [2:0] domain_id = io_cmd_lo.header.addr[paddr_width_p-1-:3];
+  wire [2:0] hio_id = io_cmd_lo.header.addr[paddr_width_p-1-:3];
 
 
   logic putchar_data_cmd_v;
   logic getchar_data_cmd_v;
   logic finish_data_cmd_v;
   logic bootrom_data_cmd_v;
-  logic domain_data_cmd_v;
+  logic hio_data_cmd_v;
   logic putch_core_data_cmd_v;
 
   always_comb
@@ -128,7 +128,7 @@ module bp_nonsynth_host
       getchar_data_cmd_v = 1'b0;
       finish_data_cmd_v = 1'b0;
       bootrom_data_cmd_v = 1'b0;
-      domain_data_cmd_v = io_cmd_yumi_li & (domain_id != '0);
+      hio_data_cmd_v = io_cmd_yumi_li & (hio_id != '0);
       putch_core_data_cmd_v = 1'b0;
 
       unique
@@ -200,8 +200,8 @@ module bp_nonsynth_host
       if (getchar_data_cmd_v)
         pop();
 
-      if (io_cmd_v_i & (domain_id != '0))
-        $display("Warning: Accesing illegal domain %0h. Sending loopback message!", domain_id);
+      if (io_cmd_v_i & (hio_id != '0))
+        $display("Warning: Accesing illegal hio %0h. Sending loopback message!", hio_id);
       for (integer i = 0; i < num_core_p; i++)
         begin
           // PASS when returned value in finish packet is zero
@@ -249,16 +249,16 @@ module bp_nonsynth_host
      ,.data_o(bootrom_final_lo)
      );
 
-  bp_bedrock_cce_mem_msg_s host_io_resp_lo, domain_io_resp_lo, bootrom_io_resp_lo;
+  bp_bedrock_cce_mem_msg_s host_io_resp_lo, hio_io_resp_lo, bootrom_io_resp_lo;
 
   assign host_io_resp_lo = '{header: io_cmd_lo.header, data: ch};
-  assign domain_io_resp_lo = '{header: io_cmd_lo.header, data: '0};
+  assign hio_io_resp_lo = '{header: io_cmd_lo.header, data: '0};
   assign bootrom_io_resp_lo = '{header: io_cmd_lo.header, data: bootrom_final_lo};
 
   assign io_resp_cast_o = bootrom_data_cmd_v
                           ? bootrom_io_resp_lo
-                          : domain_data_cmd_v
-                            ? domain_io_resp_lo
+                          : hio_data_cmd_v
+                            ? hio_io_resp_lo
                             : host_io_resp_lo;
 
   // TODO: Add dynamic enable

--- a/bp_top/test/common/bp_nonsynth_if_verif.sv
+++ b/bp_top/test/common/bp_nonsynth_if_verif.sv
@@ -13,14 +13,14 @@ module bp_nonsynth_if_verif
    `declare_bp_bedrock_lce_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    )
   ();
 
   bp_proc_param_s proc_param;
   assign proc_param = all_cfgs_gp[bp_params_p];
 
-  `declare_bp_cfg_bus_s(domain_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
   `declare_bp_bedrock_lce_if(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
   `declare_bp_bedrock_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce);
@@ -84,8 +84,8 @@ module bp_nonsynth_if_verif
     $warning("Warning: VM will not work without 39 bit vaddr");
   if (paddr_width_p < 40)
     $warning("Warning: paddr < 40 has not been tested");
-  if (dram_max_size_p != (1 << 31))
-    $warning("Warning: dram size != 4GB");
+  if (caddr_width_p != 32)
+    $warning("Warning: caddr != 32 has not been tested");
 
   if ((multicore_p == 1) && ((amo_swap_p != e_none) || (amo_fetch_logic_p != e_none) || (amo_fetch_arithmetic_p != e_none)))
     $fatal("Error: L2 atomics are not currently supported in bp_multicore");

--- a/bp_top/test/tb/bp_tethered/Makefile.cfgs
+++ b/bp_top/test/tb/bp_tethered/Makefile.cfgs
@@ -51,7 +51,10 @@ else
 	export PADDR_WIDTH ?= $(_PADDR_WIDTH)
 endif
 
-_UCODE_CFG :=$(findstring cce_ucode,$(CFG))
+e_bp_custom_cfg_ucode := 1
+$(CFG)_ucode ?= $(findstring cce_ucode,$(CFG))
+
+_UCODE_CFG ?= $($(CFG)_ucode)
 ifeq ($(_UCODE_CFG),)
 	export UCODE_CFG ?= 0
 else

--- a/bp_top/test/tb/bp_tethered/Makefile.params
+++ b/bp_top/test/tb/bp_tethered/Makefile.params
@@ -47,7 +47,7 @@ export TB_PARAMS  = \
 					-pvalue+preload_mem_p=$(PRELOAD_MEM_P) \
                     -pvalue+no_bind_p=$(NO_BIND_P)
 
-export DUT_DEFINES = 
+export DUT_DEFINES = $(foreach def,$(DEFINES),+define+$(def))
 export TB_DEFINES  = +define+BP_SIM_CLK_PERIOD=$(BP_SIM_CLK_PERIOD) \
                      +define+den2048Mb+sg5+x16+FULL_MEM
 


### PR DESCRIPTION
- Renames domain bits to HIO bits for clarity
- Allows direct set of caddr_width rather than dram_max_width parameter
- Enables > 32bit dram address for AXI mem
- Adds assertion to prevent illegal dramsim3 configs
- Adding makefile hook into DUT defines