### PR TITLE
Update CFG addresses

### DIFF
--- a/bp_common/software/py/nbf.py
+++ b/bp_common/software/py/nbf.py
@@ -26,14 +26,47 @@ import math
 import os
 import subprocess
 
+#  // The overall memory map of the config link is:
+#  //   16'h0000 - 16'h01ff: chip level config
+#  //   16'h0200 - 16'h03ff: fe config
+#  //   16'h0400 - 16'h05ff: be config
+#  //   16'h0600 - 16'h06ff: me config
+#  //   16'h0800 - 16'h7fff: reserved
+#  //   16'h8000 - 16'h8fff: cce ucode
+#
+#  localparam cfg_addr_width_gp = 20;
+#  localparam cfg_data_width_gp = 64;
+#
+#  localparam cfg_base_addr_gp          = 'h0200_0000;
+#  localparam cfg_reg_unused_gp         = 'h0004;
+#  localparam cfg_reg_freeze_gp         = 'h0008;
+#  localparam cfg_reg_core_id_gp        = 'h000c;
+#  localparam cfg_reg_did_gp            = 'h0010;
+#  localparam cfg_reg_cord_gp           = 'h0014;
+#  localparam cfg_reg_host_did_gp       = 'h0018;
+#  localparam cfg_reg_hio_mask_gp       = 'h001c;
+#  localparam cfg_reg_icache_id_gp      = 'h0200;
+#  localparam cfg_reg_icache_mode_gp    = 'h0204;
+#  localparam cfg_reg_dcache_id_gp      = 'h0400;
+#  localparam cfg_reg_dcache_mode_gp    = 'h0404;
+#  localparam cfg_reg_cce_id_gp         = 'h0600;
+#  localparam cfg_reg_cce_mode_gp       = 'h0604;
+#  localparam cfg_mem_base_cce_ucode_gp = 'h8000;
+
 cfg_base_addr          = 0x200000
-cfg_reg_reset          = 0x01
-cfg_reg_freeze         = 0x02
-cfg_hio_mask           = 0x09
-cfg_reg_icache_mode    = 0x22
-cfg_reg_npc            = 0x40
-cfg_reg_dcache_mode    = 0x43
-cfg_reg_cce_mode       = 0x81
+cfg_reg_unused         = 0x0004
+cfg_reg_freeze         = 0x0008
+cfg_reg_core_id        = 0x000c
+cfg_reg_did            = 0x0010
+cfg_reg_cord           = 0x0014
+cfg_reg_host_did       = 0x0018
+cfg_reg_hio_mask       = 0x001c
+cfg_reg_icache_id      = 0x0200
+cfg_reg_icache_mode    = 0x0204
+cfg_reg_dcache_id      = 0x0400
+cfg_reg_dcache_mode    = 0x0404
+cfg_reg_cce_id         = 0x0600
+cfg_reg_cce_mode       = 0x0604
 cfg_mem_base_cce_ucode = 0x8000
 
 cfg_core_offset = 24
@@ -184,12 +217,8 @@ class NBF:
   # users only have to call this function.
   def dump(self):
 
-    # Reset set
-    self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_reset, 1)
     # Freeze set
     self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_freeze, 1)
-    # Reset clear
-    self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_reset, 0)
     
     self.print_fence()
 
@@ -199,7 +228,7 @@ class NBF:
       if self.ucode_file:
         for core in range(self.ncpus):
           for i in range(len(self.ucode)):
-            full_addr = cfg_base_addr + cfg_mem_base_cce_ucode + (core << cfg_core_offset) + i
+            full_addr = cfg_base_addr + cfg_mem_base_cce_ucode + (core << cfg_core_offset) + i*8
             self.print_nbf(3, full_addr, self.ucode[i])
        
       # Write I$, D$, and CCE modes

--- a/bp_common/src/include/bp_common_cfg_bus_pkgdef.svh
+++ b/bp_common/src/include/bp_common_cfg_bus_pkgdef.svh
@@ -23,30 +23,30 @@
   } bp_cce_mode_e;
 
   // The overall memory map of the config link is:
-  //   16'h0000 - 16'h001f: chip level config
-  //   16'h0020 - 16'h003f: fe config
-  //   16'h0040 - 16'h005f: be config
-  //   16'h0060 - 16'h007f: me config
-  //   16'h0080 - 16'h00ff: reserved
+  //   16'h0000 - 16'h01ff: chip level config
+  //   16'h0200 - 16'h03ff: fe config
+  //   16'h0400 - 16'h05ff: be config
+  //   16'h0600 - 16'h07ff: me config
+  //   16'h0800 - 16'h7fff: reserved
   //   16'h8000 - 16'h8fff: cce ucode
 
   localparam cfg_addr_width_gp = 20;
   localparam cfg_data_width_gp = 64;
 
   localparam cfg_base_addr_gp          = 'h0200_0000;
-  localparam cfg_reg_reset_gp          = 'h0001; // Unused
-  localparam cfg_reg_freeze_gp         = 'h0002;
-  localparam cfg_reg_core_id_gp        = 'h0005;
-  localparam cfg_reg_did_gp            = 'h0006;
-  localparam cfg_reg_cord_gp           = 'h0007;
-  localparam cfg_reg_host_did_gp       = 'h0008;
-  localparam cfg_reg_hio_mask_gp       = 'h0009;
-  localparam cfg_reg_icache_id_gp      = 'h0021;
-  localparam cfg_reg_icache_mode_gp    = 'h0022;
-  localparam cfg_reg_dcache_id_gp      = 'h0042;
-  localparam cfg_reg_dcache_mode_gp    = 'h0043;
-  localparam cfg_reg_cce_id_gp         = 'h0080;
-  localparam cfg_reg_cce_mode_gp       = 'h0081;
+  localparam cfg_reg_unused_gp         = 'h0004;
+  localparam cfg_reg_freeze_gp         = 'h0008;
+  localparam cfg_reg_core_id_gp        = 'h000c;
+  localparam cfg_reg_did_gp            = 'h0010;
+  localparam cfg_reg_cord_gp           = 'h0014;
+  localparam cfg_reg_host_did_gp       = 'h0018;
+  localparam cfg_reg_hio_mask_gp       = 'h001c;
+  localparam cfg_reg_icache_id_gp      = 'h0200;
+  localparam cfg_reg_icache_mode_gp    = 'h0204;
+  localparam cfg_reg_dcache_id_gp      = 'h0400;
+  localparam cfg_reg_dcache_mode_gp    = 'h0404;
+  localparam cfg_reg_cce_id_gp         = 'h0600;
+  localparam cfg_reg_cce_mode_gp       = 'h0604;
   localparam cfg_mem_base_cce_ucode_gp = 'h8000;
 
 `endif

--- a/bp_top/src/v/bp_cfg.sv
+++ b/bp_top/src/v/bp_cfg.sv
@@ -104,7 +104,7 @@ module bp_cfg
 
   assign cce_ucode_v_o    = (cfg_r_v_li | cfg_w_v_li) & (cfg_addr_li >= cfg_mem_base_cce_ucode_gp);
   assign cce_ucode_w_o    = cfg_w_v_li & (cfg_addr_li >= cfg_mem_base_cce_ucode_gp);
-  assign cce_ucode_addr_o = cfg_addr_li[0+:cce_pc_width_p];
+  assign cce_ucode_addr_o = cfg_addr_li[3+:cce_pc_width_p];
   assign cce_ucode_data_o = cfg_data_li[0+:cce_instr_width_gp];
 
   wire hio_w_v_li = cfg_w_v_li & (cfg_addr_li == cfg_reg_hio_mask_gp);

--- a/docs/platform_guide.md
+++ b/docs/platform_guide.md
@@ -31,25 +31,10 @@ BlackParrot supports the following CSRs:
 ## Memory-mapped Devices
 BlackParrot supports having a number of devices in each tile. In a standard BlackParrot tile there is:
 * CLINT (Core Local Interrupt Controller)
-  * Contains memory-mapped registers used to control interrupts in a tile
-  * mtime: 0x30_bff8
-  * mtimecmp: 0x30_4000
-  * mipi: 0x30_0000
-  * mtime increments at a frequency much lower than the clock speed
-  * When mtimecmp >= mtime, a timer irq is raised
-  * When mipi is set, a software irq is raised
-TODO: update config map
 * CFG (Tile Configuration Controller)
-  * Contains memory-mapped registers which provide system-level configuration options and debug access
-  * Freeze - prevents the processor from executing instructions
-  * Core id (read-only) - identifies the core among all cores
-  * Icache id (read-only) - the LCE id of the icache
-  * Icache mode - Uncached only, fully coherent, or nonspeculative mode
-  * Dcache id (read-only) - the LCE id of the dcache
-  * Dcache mode - Uncached only, or fully coherent
-  * CCE id (read-only) - the CCE id of the tile
-  * CCE mode - Uncached only, or fully coherent
-  * Domain mask - Enable bits for addresses higher than cacheable address space
+* L2S (L2 cache slice)
+
+The map for configuration registers within these devices is shown below.
 
 ## Fencing
 There are two types of fence instructions defined by RISC-V: FENCE.I (instruction fence) and FENCE
@@ -139,18 +124,18 @@ These addresses are per-tile. To access them on a tile N, prepend N to the addre
 |          | putchar     | 10_1000         | Puts a character onto the terminal of a tethered host                                                                             |
 |          | finish      | 10_2000-10_2fff | Terminates a multicore BlackParrot simulation, when finish[x] is received for each core x in the system                           |
 |          | putch       | 10_3000-10_3fff | putch[x] puts a character into a private terminal for core x. This is useful for debugging multicore simulations                  |
-| CFG      | freeze      | 20_0001         | Freezes the core, preventing all fetch operations. Will drain the pipeline if set during runtime.                                 |
-|          | core_id     | 20_0005         | Read-only. This tile's core id. This is a local id within the chip                                                                |
-|          | did         | 20_0006         | Read-only. This tile's domain id. This is an chip-wide identifier                                                                 |
-|          | cord        | 20_0007         | Read-only. This tile's coordinate. In {y,x} format                                                                                |
-|          | host_did    | 20_0008         | Host domain id. This identifies which direction to send host packets, relative to our own domain id                               |
-|          | domain_mask | 20_0009         | A mask of the upper uncached bits of an address. If an address width an unset domain bit is loaded, it will cause an access fault |
-|          | icache_id   | 20_0021         | Read-only. The I$ Engine ID.                                                                                                      |
-|          | icache_mode | 20_0022         | The I$ mode. Either uncached, cached, or nonspec (will not send a speculative miss)                                               |
-|          | dcache_id   | 20_0042         | Read-only. The D$ Engine ID.                                                                                                      |
-|          | dcache_mode | 20_0043         | The D$ mode. Either uncached or cached. (D$ will never send speculative misses)                                                   |
-|          | cce_id      | 20_0080         | Read-only. The CCE Engine ID.                                                                                                     |
-|          | cce_mode    | 20_0081         | The CCE mode. Either uncached or cached. Undefined behavior results when sending cached requests to a CCE in uncached mode        |
+| CFG      | freeze      | 20_0008         | Freezes the core, preventing all fetch operations. Will drain the pipeline if set during runtime.                                 |
+|          | core_id     | 20_000c         | Read-only. This tile's core id. This is a local id within the chip                                                                |
+|          | did         | 20_0010         | Read-only. This tile's domain id. This is an chip-wide identifier                                                                 |
+|          | cord        | 20_0014         | Read-only. This tile's coordinate. In {y,x} format                                                                                |
+|          | host_did    | 20_0018         | Host domain id. This identifies which direction to send host packets, relative to our own domain id                               |
+|          | hio_mask    | 20_001c         | A mask of the upper uncached bits of an address. If an address width an unset domain bit is loaded, it will cause an access fault |
+|          | icache_id   | 20_0200         | Read-only. The I$ Engine ID.                                                                                                      |
+|          | icache_mode | 20_0204         | The I$ mode. Either uncached, cached, or nonspec (will not send a speculative miss)                                               |
+|          | dcache_id   | 20_0400         | Read-only. The D$ Engine ID.                                                                                                      |
+|          | dcache_mode | 20_0404         | The D$ mode. Either uncached or cached. (D$ will never send speculative misses)                                                   |
+|          | cce_id      | 20_0600         | Read-only. The CCE Engine ID.                                                                                                     |
+|          | cce_mode    | 20_0604         | The CCE mode. Either uncached or cached. Undefined behavior results when sending cached requests to a CCE in uncached mode        |
 |          | cce_ucode   | 20_8000-20_8fff | The CCE instruction RAM. Must be written before enabling cached mode in a microcoded CCE                                          |
 | CLINT    | mipi        | 30_0000         | mip (software interrupt) bit                                                                                                      |
 |          | mtimecmp    | 30_4000         | Timer compare register. When mtime > mtimecmp, a timer irq is raised in the core                                                  |


### PR DESCRIPTION
Non 64-bit alignment causes issues with external buses which don't support wrapping behavior. This patch increases the space allocated to registers within the CFG bus. It'll break external software, but the internal nbf loader has been updated to support this. Docs have been updated to reflect the changes

A future patch should create a header which unifies the NBF loader along with the RTL so that they stay in sync automatically. Further changes to these addresses before that QoL enhancement are discouraged.