### PR TITLE
Fix cache tracer associativity

### DIFF
--- a/bp_be/test/tb/bp_be_dcache/testbench.sv
+++ b/bp_be/test/tb/bp_be_dcache/testbench.sv
@@ -289,10 +289,10 @@ module testbench
   bind bp_be_dcache
     bp_nonsynth_cache_tracer
      #(.bp_params_p(bp_params_p)
-      ,.sets_p(dcache_sets_p)
-      ,.assoc_p(dcache_assoc_p)
-      ,.block_width_p(dcache_block_width_p)
-      ,.fill_width_p(dcache_fill_width_p)
+      ,.sets_p(sets_p)
+      ,.assoc_p(assoc_p)
+      ,.block_width_p(block_width_p)
+      ,.fill_width_p(fill_width_p)
       ,.trace_file_p("dcache"))
      dcache_tracer
       (.clk_i(clk_i & (testbench.dcache_trace_p == 1))
@@ -340,9 +340,9 @@ module testbench
     bind bp_lce
       bp_me_nonsynth_lce_tracer
        #(.bp_params_p(bp_params_p)
-         ,.sets_p(dcache_sets_p)
-         ,.assoc_p(dcache_assoc_p)
-         ,.block_width_p(dcache_block_width_p)
+         ,.sets_p(sets_p)
+         ,.assoc_p(assoc_p)
+         ,.block_width_p(block_width_p)
          )
        bp_lce_tracer
          (.clk_i(clk_i & (testbench.lce_trace_p == 1))

--- a/bp_fe/test/tb/bp_fe_icache/testbench.sv
+++ b/bp_fe/test/tb/bp_fe_icache/testbench.sv
@@ -261,10 +261,10 @@ module testbench
   bind bp_fe_icache
     bp_nonsynth_cache_tracer
     #(.bp_params_p(bp_params_p)
-     ,.assoc_p(icache_assoc_p)
-     ,.sets_p(icache_sets_p)
-     ,.block_width_p(icache_block_width_p)
-     ,.fill_width_p(icache_fill_width_p)
+     ,.assoc_p(assoc_p)
+     ,.sets_p(sets_p)
+     ,.block_width_p(block_width_p)
+     ,.fill_width_p(fill_width_p)
      ,.trace_file_p("icache"))
     icache_tracer
       (.clk_i(clk_i & (testbench.icache_trace_p == 1))
@@ -314,9 +314,9 @@ module testbench
     bind bp_lce
       bp_me_nonsynth_lce_tracer
        #(.bp_params_p(bp_params_p)
-         ,.sets_p(icache_sets_p)
-         ,.assoc_p(icache_assoc_p)
-         ,.block_width_p(icache_block_width_p)
+         ,.sets_p(sets_p)
+         ,.assoc_p(assoc_p)
+         ,.block_width_p(block_width_p)
          )
        bp_lce_tracer
          (.clk_i(clk_i & (testbench.lce_trace_p == 1))

--- a/bp_top/test/common/bp_nonsynth_cache_tracer.sv
+++ b/bp_top/test/common/bp_nonsynth_cache_tracer.sv
@@ -112,7 +112,7 @@ module bp_nonsynth_cache_tracer
   integer dmem_bank;
   integer i;
   logic [63:0] tag_mem_v_count_r;
-  logic [icache_assoc_p-1:0][63:0] data_mem_v_count_r;
+  logic [assoc_p-1:0][63:0] data_mem_v_count_r;
 
   always_ff @(posedge clk_i)
     begin
@@ -124,7 +124,7 @@ module bp_nonsynth_cache_tracer
       else
         begin
           tag_mem_v_count_r <= tag_mem_v_count_r + tag_mem_v_i;
-          for (dmem_bank = 0; dmem_bank < icache_assoc_p; dmem_bank++)
+          for (dmem_bank = 0; dmem_bank < assoc_p; dmem_bank++)
             begin
               data_mem_v_count_r[dmem_bank] <= data_mem_v_count_r[dmem_bank] + data_mem_v_i[dmem_bank];
             end

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -338,10 +338,10 @@ module testbench
       bind bp_be_dcache
         bp_nonsynth_cache_tracer
          #(.bp_params_p(bp_params_p)
-          ,.assoc_p(dcache_assoc_p)
-          ,.sets_p(dcache_sets_p)
-          ,.block_width_p(dcache_block_width_p)
-          ,.fill_width_p(dcache_fill_width_p)
+          ,.assoc_p(assoc_p)
+          ,.sets_p(sets_p)
+          ,.block_width_p(block_width_p)
+          ,.fill_width_p(fill_width_p)
           ,.trace_file_p("dcache"))
          dcache_tracer
           (.clk_i(clk_i & testbench.dcache_trace_en_lo)
@@ -390,10 +390,10 @@ module testbench
       bind bp_fe_icache
         bp_nonsynth_cache_tracer
          #(.bp_params_p(bp_params_p)
-          ,.assoc_p(icache_assoc_p)
-          ,.sets_p(icache_sets_p)
-          ,.block_width_p(icache_block_width_p)
-          ,.fill_width_p(icache_fill_width_p)
+          ,.assoc_p(assoc_p)
+          ,.sets_p(sets_p)
+          ,.block_width_p(block_width_p)
+          ,.fill_width_p(fill_width_p)
           ,.trace_file_p("icache"))
          icache_tracer
           (.clk_i(clk_i & testbench.icache_trace_en_lo)


### PR DESCRIPTION
The tracers should use the overridable "assoc_p" variables instead of "icache_assoc_p", etc. Otherwise there is a mismatch between the bound parameters and the instantiated module parameters in the case of targeted testbenches