### PR TITLE
Fix usage of IF1 state in IF2 branch prediction fallback logic

### DIFF
--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -227,10 +227,10 @@ module bp_fe_pc_gen
      );
   assign return_addr_n = pc_if2_r + vaddr_width_p'(4);
 
-  wire btb_miss_ras = ~pred_if1_r.btb | (pc_if1_r != ras_tgt_lo);
-  wire btb_miss_br  = ~pred_if1_r.btb | (pc_if1_r != br_tgt_lo);
+  wire btb_miss_ras = pc_if1_r != ras_tgt_lo;
+  wire btb_miss_br  = pc_if1_r != br_tgt_lo;
   assign ovr_ret    = btb_miss_ras & is_ret;
-  assign ovr_taken  = btb_miss_br & ((is_br & pred_if1_r.bht[1]) | is_jal);
+  assign ovr_taken  = btb_miss_br & ((is_br & pred_if2_r.bht[1]) | is_jal);
   assign ovr_o      = ovr_taken | ovr_ret;
   assign br_tgt_lo  = pc_if2_r + scan_instr.imm;
   assign fetch_pc_o = pc_if2_r;


### PR DESCRIPTION
 `pred_if1_r.btb`  and `pred_if1_r.bht` are always zero in this context, as the register which it takes input from contains only this:

https://github.com/black-parrot/black-parrot/blob/f5cbac361c8099b18b9b665c00bc02f691b654d4/bp_fe/src/v/bp_fe_pc_gen.sv#L88-L94

Based on suggestions from Dan and some trial-and-error, this PR introduces are what I believe to be the _correct_ values to use in the modified expressions. My reasoning for the changes is as follows.
- `btb_miss_ras` and `btb_miss_br` are checking on the RHS of the `|` for a mismatch in the selected pc of the first stage, which is why they use the `if1` value. However, on the LHS of that expression, it is presumably attempting to check whether the prediction of the preceding instruction came from the BTB, which would be the PC currently in IF2. So I believe lines 230 and 231 were intended to reference `pred_if2_r`. Swapping this out had a slight positive impact on overall performance.
- Dan suggested based on a glance at the logic here that the `~pred_if1_r.btb` seems unnecessary. In my own words, it probably shouldn't matter in the first place whether the original prediction was a hit in the BTB -- if the relevant predictor's output matches where we actually went, that should be sufficient to allow the fetched instruction to continue through the pipeline. Removing the `~pred_if1_r.btb`s entirely showed a larger improvement than just the above.
- The `ovr_taken` logic seems to be checking whether we expect the current branch to be taken, but it was doing so using the BHT result of the instruction currently in the IF1 stage. It seems to me like this should instead be referencing IF2. This change gave a further improvement to overall performance.

Overall, this reduces the number of cycles taken to run 5 iterations of CoreMark by 1.2%. Full benchmarks are below.

Dan suggested I look more closely at the branch prediction behaviors and attempt to further validate correctness; I have not yet done so, but figured I'd open this PR now and I can circle back with some more analysis as desired, perhaps with separate PRs if this seems reasonable on its own.

This PR targets `fe_dev`, which I _think_ is the right thing to do. Let me know if not.

The below are my notes on benchmarking the included changes.

---

For reference, the unmodified baseline: 5 iters of CoreMark takes 1895523 total cycles. Self-reported MPKI is 24 and BHT hit % is 86 -- note that both of these are reported as integers and thus very coarse. Aggregate mIPC is 807. I am using the "total cycles" value as a stand-in for CoreMark score.

The `if1` -> `if2` change on just those two lines decreases the total cycles taken to 1892389 (0.16% decrease). The branch profile numbers are coarse, but slightly improved: MPKI 23 and BHT hit percentage 87. Aggregate mIPC is 808.

Independently from the above change, removing those two checks before the `|` altogether decreases total cycles to 1882969 (0.66% decrease) but does not affect the overall MPKI or BHT as reported in the branch stats. mIPC is 813.

The above plus replacing `pred_if1_r` with `pred_if2_r` in the assignment for `ovr_taken` a few lines below decreases total cycles to 1871940 (1.2% decrease, cumulatively). MPKI is 21 and BHT hit% is 88. mIPC is 817.

I wouldn't trust the self-reported BHT hit percentage as I'm actively changing the values it uses to detect hits.
