### PR TITLE
Adding aviary ROM

### DIFF
--- a/bp_common/src/include/bp_common_aviary_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_pkgdef.svh
@@ -269,23 +269,23 @@
       ,fe_cmd_fifo_els   : 4
 
       ,async_coh_clk       : 0
-      ,coh_noc_max_credits : 8
       ,coh_noc_flit_width  : 128
       ,coh_noc_cid_width   : 2
       ,coh_noc_len_width   : 3
+      ,coh_noc_max_credits : 8
 
       ,async_mem_clk         : 0
-      ,mem_noc_max_credits   : 8
       ,mem_noc_flit_width    : 64
       ,mem_noc_cid_width     : 2
       ,mem_noc_len_width     : 4
+      ,mem_noc_max_credits   : 8
 
       ,async_io_clk         : 0
-      ,io_noc_did_width     : 3
-      ,io_noc_max_credits   : 16
       ,io_noc_flit_width    : 64
       ,io_noc_cid_width     : 2
+      ,io_noc_did_width     : 3
       ,io_noc_len_width     : 4
+      ,io_noc_max_credits   : 16
       };
 
   // Default configuration is unicore

--- a/bp_common/src/v/bsg_rom_param.v
+++ b/bp_common/src/v/bsg_rom_param.v
@@ -1,0 +1,18 @@
+
+module bsg_rom_param
+ #(parameter data_width_p = "inv"
+   //, parameter logic [data_width_p-1:0] data_p = "inv"
+   , parameter data_p = "inv"
+   , parameter width_p = "inv"
+   , parameter els_p = "inv"
+
+   , localparam lg_els_lp = `BSG_SAFE_CLOG2(els_p)
+   )
+  (input [lg_els_lp-1:0] addr_i
+   , output logic [width_p-1:0] data_o
+   );
+
+  assign data_o = data_p[addr_i*width_p+:width_p];
+
+endmodule
+

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -299,3 +299,4 @@ $BP_COMMON_DIR/src/v/bsg_async_noc_link.sv
 $BP_COMMON_DIR/src/v/bsg_dff_reset_half.v
 $BP_COMMON_DIR/src/v/bsg_cache_dma_to_wormhole.v
 $BP_COMMON_DIR/src/v/bsg_wormhole_to_cache_dma_fanout.v
+$BP_COMMON_DIR/src/v/bsg_rom_param.v


### PR DESCRIPTION
This PR adds a Verilog "ROM" containing the aviary information, allowing BP to query it with no hardware overhead. In silicon, this would either be a once-programmable ROM, flash, some configuration bits in HW, etc. This should let us write more portable tests which use libperch more flexibly

- [x] Hardware aviary ROM
- [x] Perch enhancements (https://github.com/black-parrot-sdk/perch/pull/3)
- [x] bp-tests smoke test (https://github.com/black-parrot-sdk/bp-tests/pull/13)