### PR TITLE
Breaking critical uncached path in cache engines

### DIFF
--- a/bp_be/syn/flist.vcs
+++ b/bp_be/syn/flist.vcs
@@ -287,6 +287,8 @@ $BP_TOP_DIR/src/v/bp_tile_node.sv
 
 # BSG Staging area
 $BP_COMMON_DIR/src/v/bsg_async_noc_link.sv
-$BP_COMMON_DIR/src/v/bsg_dff_reset_half.v
 $BP_COMMON_DIR/src/v/bsg_cache_dma_to_wormhole.v
+$BP_COMMON_DIR/src/v/bsg_dff_reset_half.v
+$BP_COMMON_DIR/src/v/bsg_dff_sync_read.v
 $BP_COMMON_DIR/src/v/bsg_wormhole_to_cache_dma_fanout.v
+

--- a/bp_common/src/v/bsg_dff_sync_read.v
+++ b/bp_common/src/v/bsg_dff_sync_read.v
@@ -1,0 +1,72 @@
+
+// This module buffers data on a synchronous read, useful for buffering
+//   things like an synchronous SRAM read
+module bsg_dff_sync_read
+ #(parameter width_p = "inv"
+
+   // Whether to bypass the read data so that it doesn't create a bubble 
+   , parameter bypass_p = 0
+   )
+  (input clk_i
+   , input reset_i
+
+   // v_n_i is high the cycle before the data comes in
+   // The stored data will always be overwritten and valid always set, regardless
+   //   of the current valid state or incoming yumi
+   , input                      v_n_i
+   , input [width_p-1:0]        data_i
+
+   , output logic [width_p-1:0] data_o
+   , output logic               v_o
+   // yumi_i clears the valid signal
+   , input                      yumi_i
+   );
+
+  logic v_r;
+  bsg_dff
+   #(.width_p(1))
+   v_reg
+    (.clk_i(clk_i)
+
+     ,.data_i(v_n_i)
+     ,.data_o(v_r)
+     );
+
+  bsg_dff_reset_set_clear
+   #(.width_p(1))
+   v_o_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.set_i(v_r)
+     ,.clear_i(yumi_i)
+     ,.data_o(v_o)
+     );
+
+  if (bypass_p)
+    begin : bypass
+      bsg_dff_en_bypass
+       #(.width_p(width_p))
+       data_reg
+        (.clk_i(clk_i)
+
+        ,.en_i(v_r)
+        ,.data_i(data_i)
+        ,.data_o(data_o)
+        );
+    end
+  else
+    begin : no_bypass
+      bsg_dff_en
+       #(.width_p(width_p))
+       data_reg
+        (.clk_i(clk_i)
+
+        ,.en_i(v_r)
+        ,.data_i(data_i)
+        ,.data_o(data_o)
+        );
+    end
+
+endmodule
+

--- a/bp_fe/syn/flist.vcs
+++ b/bp_fe/syn/flist.vcs
@@ -262,4 +262,6 @@ $BP_TOP_DIR/src/v/bp_tile_node.sv
 # BSG Staging area
 $BP_COMMON_DIR/src/v/bsg_async_noc_link.sv
 $BP_COMMON_DIR/src/v/bsg_cache_dma_to_wormhole.v
+$BP_COMMON_DIR/src/v/bsg_dff_sync_read.v
 $BP_COMMON_DIR/src/v/bsg_wormhole_to_cache_dma_fanout.v
+

--- a/bp_me/src/v/lce/bp_lce_req.sv
+++ b/bp_me/src/v/lce/bp_lce_req.sv
@@ -212,34 +212,34 @@ module bp_lce_req
 
       // Ready for new request
       e_ready: begin
-        ready_o = ~credits_full_o & lce_req_ready_then_i & ((lce_mode_i == e_lce_mode_uncached) || sync_done_i);
+        ready_o = lce_req_ready_then_i & ((lce_mode_i == e_lce_mode_uncached) || sync_done_i);
 
-        if (ready_o & cache_req_v_i)
-          unique case (cache_req.msg_type)
-            e_miss_store
-            ,e_miss_load: begin
-              cache_req_yumi_o = cache_req_v_i & (lce_mode_i inside {e_lce_mode_normal, e_lce_mode_nonspec}) & sync_done_i;
-              state_n = cache_req_yumi_o ? e_send_cached_req : e_ready;
-            end
-            e_uc_store: begin
-              lce_req_v_o = lce_req_ready_then_i & cache_req_v_i;
+        // Send off a non-blocking request if we have one
+        if (cache_req_v_r & (cache_req_r.msg_type == e_uc_store))
+          begin
+            lce_req_v_o = lce_req_ready_then_i & cache_req_v_r;
 
-              lce_req.data[0+:dword_width_gp] = cache_req.data[0+:dword_width_gp];
-              lce_req.header.size = bp_bedrock_msg_size_e'(cache_req.size);
-              lce_req.header.addr = cache_req.addr;
-              lce_req.header.msg_type.req = e_bedrock_req_uc_wr;
-              lce_req.header.payload = lce_req_payload;
+            lce_req.data[0+:dword_width_gp] = cache_req_r.data[0+:dword_width_gp];
+            lce_req.header.size = bp_bedrock_msg_size_e'(cache_req_r.size);
+            lce_req.header.addr = cache_req_r.addr;
+            lce_req.header.msg_type.req = e_bedrock_req_uc_wr;
+            lce_req.header.payload = lce_req_payload;
+          end
 
-              cache_req_yumi_o = lce_req_v_o;
-              state_n = e_ready;
-            end
-            e_uc_load: begin
-              cache_req_yumi_o = cache_req_v_i;
-              state_n = e_send_uncached_req;
-            end
-            default: begin
-            end
-          endcase
+        cache_req_yumi_o = cache_req_v_i
+          && ((~cache_req_v_r | lce_req_v_o)
+              || (ready_o & cache_req_v_i & cache_req.msg_type inside {e_uc_load})
+              || (ready_o & cache_req_v_i & cache_req.msg_type inside {e_miss_store, e_miss_load}
+                  & (lce_mode_i inside {e_lce_mode_normal, e_lce_mode_nonspec})
+                  & sync_done_i
+                  )
+              );
+
+        state_n = (cache_req_yumi_o & cache_req.msg_type inside {e_miss_store, e_miss_load})
+          ? e_send_cached_req
+          : (cache_req_yumi_o & cache_req.msg_type inside {e_uc_load})
+            ? e_send_uncached_req
+            : e_ready;
       end
 
       // Cached Request

--- a/bp_me/syn/flist.vcs
+++ b/bp_me/syn/flist.vcs
@@ -185,4 +185,6 @@ $BP_TOP_DIR/src/v/bp_cfg.sv
 # BSG Staging area
 $BP_COMMON_DIR/src/v/bsg_async_noc_link.sv
 $BP_COMMON_DIR/src/v/bsg_cache_dma_to_wormhole.v
+$BP_COMMON_DIR/src/v/bsg_dff_sync_read.v
 $BP_COMMON_DIR/src/v/bsg_wormhole_to_cache_dma_fanout.v
+

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -107,12 +107,12 @@ $BASEJUMP_STL_DIR/bsg_misc/bsg_cycle_counter.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_decode.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_decode_with_v.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff.v
-$BASEJUMP_STL_DIR/bsg_misc/bsg_dff_en_bypass.v
-$BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_en_bypass.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_chain.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_en.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_dff_en_bypass.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_en.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_en_bypass.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_set_clear.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_edge_detect.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_encode_one_hot.v
@@ -307,6 +307,8 @@ $BP_TOP_DIR/src/v/bp_tile_node.sv
 
 # BSG Staging area
 $BP_COMMON_DIR/src/v/bsg_async_noc_link.sv
-$BP_COMMON_DIR/src/v/bsg_dff_reset_half.v
 $BP_COMMON_DIR/src/v/bsg_cache_dma_to_wormhole.v
+$BP_COMMON_DIR/src/v/bsg_dff_reset_half.v
+$BP_COMMON_DIR/src/v/bsg_dff_sync_read.v
 $BP_COMMON_DIR/src/v/bsg_wormhole_to_cache_dma_fanout.v
+


### PR DESCRIPTION
This PR does a few things.

- The most important is the critical path fix in the UCE and LCE.  Currently, we stream out non-blocking requests (uc, wt, l2 amo) in a single cycle. This leads to a path from the cache AMO unit through the cache engine to routers, accelerators, etc.  Instead, this PR delays the output of the request by a single cycle and accepts a new request if the non-blocking request is sent out in the same cycle. In this way, we maintain 100% throughput for non-blocking requests, so there are no cycle-level performance implications.
- The second is adding a tag mem read register in the LCE. This is currently unused because the shadow tags are not needed by the CCE which maintains the true tags. However, I tested it and synthesis rips this unused register out anyway, so I think it's good to have just for future proofing.
- The third is a helper module bsg_dff_sync_read, which maintains a synchronous read buffer. This is purely aesthetic, but there are a bunch of other places in the code where this pattern is used, so we can replace at our leisure.

@muwyse I'm going to pull this into the tapeout branch, so I'd appreciate a quick review. Fine with merging to me_dev after the burst changes if you foresee any conflicts.
