### PR TITLE
Adding bedrock register and stream peripherals

### DIFF
--- a/bp_common/src/include/bp_common_cfg_bus_pkgdef.svh
+++ b/bp_common/src/include/bp_common_cfg_bus_pkgdef.svh
@@ -47,7 +47,7 @@
   localparam cfg_reg_dcache_mode_gp    = 'h0404;
   localparam cfg_reg_cce_id_gp         = 'h0600;
   localparam cfg_reg_cce_mode_gp       = 'h0604;
-  localparam cfg_mem_base_cce_ucode_gp = 'h8000;
+  localparam cfg_mem_cce_ucode_gp      = 'h8???;
 
 `endif
 

--- a/bp_me/src/v/cache/bp_me_bedrock_register.sv
+++ b/bp_me/src/v/cache/bp_me_bedrock_register.sv
@@ -1,0 +1,94 @@
+
+`include "bp_common_defines.svh"
+`include "bp_me_defines.svh"
+
+module bp_me_bedrock_register
+ import bp_common_pkg::*;
+ import bp_me_pkg::*;
+ #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+   `declare_bp_proc_params(bp_params_p)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, dword_width_gp, lce_id_width_p, lce_assoc_p, xce)
+
+   , parameter reg_width_p = dword_width_gp
+   , parameter reg_addr_width_p = paddr_width_p
+   , parameter els_p = 1
+   , parameter integer base_addr_p [els_p-1:0] = '0
+   )
+  (input                                            clk_i
+   , input                                          reset_i
+
+   , input [xce_mem_msg_header_width_lp-1:0]        mem_cmd_header_i
+   , input [dword_width_gp-1:0]                     mem_cmd_data_i
+   , input                                          mem_cmd_v_i
+   , output logic                                   mem_cmd_ready_and_o
+
+   , output logic [xce_mem_msg_header_width_lp-1:0] mem_resp_header_o
+   , output logic [dword_width_gp-1:0]              mem_resp_data_o
+   , output logic                                   mem_resp_v_o
+   , input                                          mem_resp_ready_and_i
+
+
+   // Synchronous read/write interface.
+   // Actually 1rw, but expose both ports to prevent unnecessary and gates
+   , output logic [els_p-1:0]                       r_v_o
+   , output logic [els_p-1:0]                       w_v_o
+   , output logic [reg_addr_width_p-1:0]            addr_o
+   , output logic [reg_width_p-1:0]                 data_o
+   , input [els_p-1:0][reg_width_p-1:0]             data_i
+   );
+
+  `declare_bp_bedrock_mem_if(paddr_width_p, dword_width_gp, lce_id_width_p, lce_assoc_p, xce);
+
+  bp_bedrock_xce_mem_msg_header_s mem_cmd_header_li;
+  logic [dword_width_gp-1:0] mem_cmd_data_li;
+  logic mem_cmd_v_li, mem_cmd_yumi_li;
+  bsg_one_fifo
+   #(.width_p($bits(bp_bedrock_xce_mem_msg_s)))
+   header_fifo
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+  
+     ,.data_i({mem_cmd_data_i, mem_cmd_header_i})
+     ,.v_i(mem_cmd_v_i)
+     ,.ready_o(mem_cmd_ready_and_o)
+  
+     ,.data_o({mem_cmd_data_li, mem_cmd_header_li})
+     ,.v_o(mem_cmd_v_li)
+     ,.yumi_i(mem_cmd_yumi_li)
+     );
+
+  logic [els_p-1:0] r_v_r;
+  bsg_dff
+   #(.width_p(els_p))
+   v_reg
+    (.clk_i(clk_i)
+     ,.data_i(r_v_o)
+     ,.data_o(r_v_r)
+     );
+
+  logic [reg_width_p-1:0] rdata_lo;
+  bsg_mux_one_hot
+   #(.width_p(reg_width_p), .els_p(els_p))
+   rmux_oh
+    (.data_i(data_i)
+     ,.sel_one_hot_i(r_v_r)
+     ,.data_o(rdata_lo)
+     );
+
+      wire wr_not_rd  = (mem_cmd_header_li.msg_type inside {e_bedrock_mem_wr, e_bedrock_mem_uc_wr});
+  for (genvar i = 0; i < els_p; i++)
+    begin : dec
+      wire addr_match = mem_cmd_v_li & (mem_cmd_header_li.addr inside {base_addr_p[i]});
+      assign r_v_o[i] = addr_match & ~wr_not_rd;
+      assign w_v_o[i] = addr_match &  wr_not_rd;
+    end
+      assign addr_o = (mem_cmd_header_li.addr);
+      assign data_o = (mem_cmd_data_li);
+
+  assign mem_resp_header_o = mem_cmd_header_li;
+  assign mem_resp_data_o = rdata_lo;
+  assign mem_resp_v_o = mem_cmd_v_li & (|r_v_r | wr_not_rd);
+  assign mem_cmd_yumi_li = mem_resp_ready_and_i & mem_resp_v_o;
+
+endmodule
+

--- a/bp_me/src/v/cache/bp_me_bedrock_register.sv
+++ b/bp_me/src/v/cache/bp_me_bedrock_register.sv
@@ -12,7 +12,7 @@ module bp_me_bedrock_register
    , parameter reg_width_p = dword_width_gp
    , parameter reg_addr_width_p = paddr_width_p
    , parameter els_p = 1
-   , parameter integer base_addr_p [els_p-1:0] = '0
+   , parameter integer base_addr_p [els_p-1:0] = '{0}
    )
   (input                                            clk_i
    , input                                          reset_i
@@ -78,7 +78,7 @@ module bp_me_bedrock_register
       wire wr_not_rd  = (mem_cmd_header_li.msg_type inside {e_bedrock_mem_wr, e_bedrock_mem_uc_wr});
   for (genvar i = 0; i < els_p; i++)
     begin : dec
-      wire addr_match = mem_cmd_v_li & (mem_cmd_header_li.addr inside {base_addr_p[i]});
+      wire addr_match = mem_cmd_v_li & (mem_cmd_header_li.addr[0+:reg_addr_width_p] inside {base_addr_p[i]});
       assign r_v_o[i] = addr_match & ~wr_not_rd;
       assign w_v_o[i] = addr_match &  wr_not_rd;
     end

--- a/bp_top/src/v/bp_cfg.sv
+++ b/bp_top/src/v/bp_cfg.sv
@@ -105,9 +105,11 @@ module bp_cfg
         hio_mask_r <= hio_mask_w_v_li ? data_lo : hio_mask_r;
       end
 
+  // Access to CCE ucode memory must be aligned
+  localparam cce_pc_offset_width_lp = `BSG_SAFE_CLOG2(cce_pc_width_p>>3);
   assign cce_ucode_v_o    = cce_ucode_r_v_li | cce_ucode_w_v_li;
   assign cce_ucode_w_o    = cce_ucode_w_v_li;
-  assign cce_ucode_addr_o = addr_lo[3+:cce_pc_width_p];
+  assign cce_ucode_addr_o = addr_lo[cce_pc_offset_width_lp+:cce_pc_width_p];
   assign cce_ucode_data_o = data_lo[0+:cce_instr_width_gp];
 
   logic [core_id_width_p-1:0] core_id_li;

--- a/bp_top/src/v/bp_cfg.sv
+++ b/bp_top/src/v/bp_cfg.sv
@@ -13,66 +13,78 @@ module bp_cfg
 
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    )
-  (input                                     clk_i
-   , input                                   reset_i
+  (input                                            clk_i
+   , input                                          reset_i
 
-   , input [xce_mem_msg_width_lp-1:0]        mem_cmd_i
-   , input                                   mem_cmd_v_i
-   , output                                  mem_cmd_ready_and_o
+   , input [xce_mem_msg_header_width_lp-1:0]        mem_cmd_header_i
+   , input [dword_width_gp-1:0]                     mem_cmd_data_i
+   , input                                          mem_cmd_v_i
+   , output logic                                   mem_cmd_ready_and_o
 
-   , output logic [xce_mem_msg_width_lp-1:0] mem_resp_o
-   , output logic                            mem_resp_v_o
-   , input                                   mem_resp_yumi_i
+   , output logic [xce_mem_msg_header_width_lp-1:0] mem_resp_header_o
+   , output logic [dword_width_gp-1:0]              mem_resp_data_o
+   , output logic                                   mem_resp_v_o
+   , input                                          mem_resp_ready_and_i
 
-   , output logic [cfg_bus_width_lp-1:0]     cfg_bus_o
-   , input [io_noc_did_width_p-1:0]          did_i
-   , input [io_noc_did_width_p-1:0]          host_did_i
-   , input [coh_noc_cord_width_p-1:0]        cord_i
+   , output logic [cfg_bus_width_lp-1:0]            cfg_bus_o
+   , input [io_noc_did_width_p-1:0]                 did_i
+   , input [io_noc_did_width_p-1:0]                 host_did_i
+   , input [coh_noc_cord_width_p-1:0]               cord_i
 
    // ucode programming interface, synchronous read, direct connection to RAM
-   , output logic                            cce_ucode_v_o
-   , output logic                            cce_ucode_w_o
-   , output logic [cce_pc_width_p-1:0]       cce_ucode_addr_o
-   , output logic [cce_instr_width_gp-1:0]   cce_ucode_data_o
-   , input [cce_instr_width_gp-1:0]          cce_ucode_data_i
+   , output logic                                   cce_ucode_v_o
+   , output logic                                   cce_ucode_w_o
+   , output logic [cce_pc_width_p-1:0]              cce_ucode_addr_o
+   , output logic [cce_instr_width_gp-1:0]          cce_ucode_data_o
+   , input [cce_instr_width_gp-1:0]                 cce_ucode_data_i
    );
 
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_bedrock_mem_if(paddr_width_p, dword_width_gp, lce_id_width_p, lce_assoc_p, xce);
+  `bp_cast_o(bp_cfg_bus_s, cfg_bus);
 
-  bp_cfg_bus_s cfg_bus_cast_o;
-  bp_bedrock_xce_mem_msg_s mem_cmd_li, mem_cmd_lo;
+  logic cord_r_v_li, did_r_v_li, host_did_r_v_li, hio_mask_r_v_li;
+  logic cord_w_v_li, did_w_v_li, host_did_w_v_li, hio_mask_w_v_li;
+  logic cce_ucode_r_v_li, cce_mode_r_v_li, dcache_mode_r_v_li, icache_mode_r_v_li, freeze_r_v_li;
+  logic cce_ucode_w_v_li, cce_mode_w_v_li, dcache_mode_w_v_li, icache_mode_w_v_li, freeze_w_v_li;
+  logic [cfg_addr_width_gp-1:0] addr_lo;
+  logic [dword_width_gp-1:0] data_lo;
+  logic [8:0][dword_width_gp-1:0] data_li;
 
-  assign cfg_bus_o = cfg_bus_cast_o;
-  assign mem_cmd_li = mem_cmd_i;
-
-  logic mem_cmd_v_lo, mem_cmd_yumi_li;
-  bsg_one_fifo
-   #(.width_p($bits(bp_bedrock_xce_mem_msg_s)))
-   small_fifo
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.data_i(mem_cmd_li)
-     ,.v_i(mem_cmd_v_i)
-     ,.ready_o(mem_cmd_ready_and_o)
-
-     ,.data_o(mem_cmd_lo)
-     ,.v_o(mem_cmd_v_lo)
-     ,.yumi_i(mem_cmd_yumi_li)
+  localparam integer base_addr_lp [8:0] =
+    '{cfg_reg_cord_gp, cfg_reg_did_gp, cfg_reg_host_did_gp, cfg_reg_hio_mask_gp
+      ,cfg_reg_cce_mode_gp, cfg_reg_dcache_mode_gp, cfg_reg_icache_mode_gp
+      ,cfg_mem_cce_ucode_gp
+      ,cfg_reg_freeze_gp
+      };
+  bp_me_bedrock_register
+   #(.bp_params_p(bp_params_p)
+     ,.els_p(9)
+     ,.reg_addr_width_p(cfg_addr_width_gp)
+     ,.base_addr_p(base_addr_lp)
+     )
+   register
+    (.*
+     ,.r_v_o({cord_r_v_li, did_r_v_li, host_did_r_v_li, hio_mask_r_v_li
+              ,cce_mode_r_v_li, dcache_mode_r_v_li, icache_mode_r_v_li
+              ,cce_ucode_r_v_li
+              ,freeze_r_v_li
+              })
+     ,.w_v_o({cord_w_v_li, did_w_v_li, host_did_w_v_li, hio_mask_w_v_li
+              ,cce_mode_w_v_li, dcache_mode_w_v_li, icache_mode_w_v_li
+              ,cce_ucode_w_v_li
+              ,freeze_w_v_li
+              })
+     ,.addr_o(addr_lo)
+     ,.data_o(data_lo)
+     ,.data_i(data_li)
      );
 
   logic         freeze_r;
   bp_lce_mode_e icache_mode_r;
   bp_lce_mode_e dcache_mode_r;
   bp_cce_mode_e cce_mode_r;
-
-  wire                         cfg_v_li    = mem_cmd_v_lo;
-  wire                         cfg_w_v_li  = cfg_v_li & (mem_cmd_lo.header.msg_type == e_bedrock_mem_uc_wr);
-  wire                         cfg_r_v_li  = cfg_v_li & (mem_cmd_lo.header.msg_type == e_bedrock_mem_uc_rd);
-  wire [cfg_addr_width_gp-1:0] cfg_addr_li = mem_cmd_lo.header.addr[0+:cfg_addr_width_gp];
-  wire [cfg_data_width_gp-1:0] cfg_data_li = mem_cmd_lo.data[0+:cfg_data_width_gp];
-
+  logic [hio_width_p-1:0] hio_mask_r;
   always_ff @(posedge clk_i)
     if (reset_i)
       begin
@@ -80,47 +92,21 @@ module bp_cfg
         icache_mode_r       <= e_lce_mode_uncached;
         dcache_mode_r       <= e_lce_mode_uncached;
         cce_mode_r          <= e_cce_mode_uncached;
+        hio_mask_r          <= '0;
       end
-    else if (cfg_w_v_li)
+    else
       begin
-        unique
-        case (cfg_addr_li)
-          cfg_reg_freeze_gp      : freeze_r       <= cfg_data_li;
-          cfg_reg_icache_mode_gp : icache_mode_r  <= bp_lce_mode_e'(cfg_data_li);
-          cfg_reg_dcache_mode_gp : dcache_mode_r  <= bp_lce_mode_e'(cfg_data_li);
-          cfg_reg_cce_mode_gp    : cce_mode_r     <= bp_cce_mode_e'(cfg_data_li);
-          default : begin end
-        endcase
+        freeze_r <= freeze_w_v_li ? data_lo : freeze_r;
+        icache_mode_r <= icache_mode_w_v_li ? bp_lce_mode_e'(data_lo) : icache_mode_r;
+        dcache_mode_r <= dcache_mode_w_v_li ? bp_lce_mode_e'(data_lo) : dcache_mode_r;
+        cce_mode_r <= cce_mode_w_v_li ? bp_cce_mode_e'(data_lo) : cce_mode_r;
+        hio_mask_r <= hio_mask_w_v_li ? data_lo : hio_mask_r;
       end
 
-  wire cord_r_v_li        = cfg_r_v_li & (cfg_addr_li == cfg_reg_cord_gp);
-  wire did_r_v_li         = cfg_r_v_li & (cfg_addr_li == cfg_reg_did_gp);
-  wire host_did_r_v_li    = cfg_r_v_li & (cfg_addr_li == cfg_reg_host_did_gp);
-  wire hio_r_v_li         = cfg_r_v_li & (cfg_addr_li == cfg_reg_hio_mask_gp);
-  wire freeze_r_v_li      = cfg_r_v_li & (cfg_addr_li == cfg_reg_freeze_gp);
-  wire icache_mode_r_v_li = cfg_r_v_li & (cfg_addr_li == cfg_reg_icache_mode_gp);
-  wire dcache_mode_r_v_li = cfg_r_v_li & (cfg_addr_li == cfg_reg_dcache_mode_gp);
-  wire cce_mode_r_v_li    = cfg_r_v_li & (cfg_addr_li == cfg_reg_cce_mode_gp);
-
-  assign cce_ucode_v_o    = (cfg_r_v_li | cfg_w_v_li) & (cfg_addr_li >= cfg_mem_base_cce_ucode_gp);
-  assign cce_ucode_w_o    = cfg_w_v_li & (cfg_addr_li >= cfg_mem_base_cce_ucode_gp);
-  assign cce_ucode_addr_o = cfg_addr_li[3+:cce_pc_width_p];
-  assign cce_ucode_data_o = cfg_data_li[0+:cce_instr_width_gp];
-
-  wire hio_w_v_li = cfg_w_v_li & (cfg_addr_li == cfg_reg_hio_mask_gp);
-  wire [hio_width_p-1:0] hio_li = cfg_data_li[hio_width_p-1:0];
-
-  // Enabled DIDs
-  logic [hio_width_p-1:0] hio_mask_r;
-  bsg_dff_reset_en
-   #(.width_p(hio_width_p))
-   hio_mask_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-     ,.en_i(hio_w_v_li)
-     ,.data_i(hio_li)
-     ,.data_o(hio_mask_r)
-     );
+  assign cce_ucode_v_o    = cce_ucode_r_v_li | cce_ucode_w_v_li;
+  assign cce_ucode_w_o    = cce_ucode_w_v_li;
+  assign cce_ucode_addr_o = addr_lo[3+:cce_pc_width_p];
+  assign cce_ucode_data_o = data_lo[0+:cce_instr_width_gp];
 
   logic [core_id_width_p-1:0] core_id_li;
   logic [cce_id_width_p-1:0]  cce_id_li;
@@ -146,67 +132,15 @@ module bp_cfg
                             ,hio_mask: hio_mask_r
                             };
 
-  logic rdata_v_r;
-  bsg_dff_reset
-   #(.width_p(1))
-   rdata_v_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.data_i(mem_cmd_v_lo)
-     ,.data_o(rdata_v_r)
-     );
-
-  logic [8:0] read_sel_one_hot_r;
-  bsg_dff_reset_en
-   #(.width_p(9))
-   read_reg_one_hot
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-     ,.en_i(mem_cmd_v_lo)
-
-     ,.data_i({freeze_r_v_li, hio_r_v_li, host_did_r_v_li, did_r_v_li, cord_r_v_li, cce_ucode_v_o, icache_mode_r_v_li, dcache_mode_r_v_li, cce_mode_r_v_li})
-     ,.data_o(read_sel_one_hot_r)
-     );
-
-  // This mux is huge...but sparse. Should synthesize out alright
-  logic [dword_width_gp-1:0] read_data;
-  bsg_mux_one_hot
-   #(.width_p(dword_width_gp), .els_p(9))
-   read_mux_one_hot
-    (.data_i({dword_width_gp'(freeze_r)
-              ,dword_width_gp'(hio_mask_r)
-              ,dword_width_gp'(host_did_i)
-              ,dword_width_gp'(did_i)
-              ,dword_width_gp'(cord_i)
-              ,dword_width_gp'(cce_ucode_data_i)
-              ,dword_width_gp'(icache_mode_r)
-              ,dword_width_gp'(dcache_mode_r)
-              ,dword_width_gp'(cce_mode_r)
-              })
-     ,.sel_one_hot_i(read_sel_one_hot_r)
-
-     ,.data_o(read_data)
-     );
-
-  logic [dword_width_gp-1:0] read_data_r;
-  bsg_dff_en_bypass
-   #(.width_p(dword_width_gp))
-   rdata_reg
-    (.clk_i(clk_i)
-     ,.en_i(rdata_v_r)
-
-     ,.data_i(read_data)
-     ,.data_o(read_data_r)
-     );
-
-  bp_bedrock_xce_mem_msg_s mem_resp_lo;
-  assign mem_resp_lo = '{header: mem_cmd_lo.header, data: dword_width_gp'(read_data_r)};
-
-  assign mem_resp_o = mem_resp_lo;
-  assign mem_resp_v_o = mem_cmd_v_lo & rdata_v_r;
-  assign mem_cmd_yumi_li = mem_resp_yumi_i;
-
+  assign data_li[0] = freeze_r;
+  assign data_li[1] = cce_ucode_data_i;
+  assign data_li[2] = icache_mode_r;
+  assign data_li[3] = dcache_mode_r;
+  assign data_li[4] = cce_mode_r;
+  assign data_li[5] = hio_mask_r;
+  assign data_li[6] = host_did_i;
+  assign data_li[7] = did_i;
+  assign data_li[8] = cord_i;
 
 endmodule
 

--- a/bp_top/src/v/bp_cfg.sv
+++ b/bp_top/src/v/bp_cfg.sv
@@ -20,11 +20,13 @@ module bp_cfg
    , input [dword_width_gp-1:0]                     mem_cmd_data_i
    , input                                          mem_cmd_v_i
    , output logic                                   mem_cmd_ready_and_o
+   , input                                          mem_cmd_last_i
 
    , output logic [xce_mem_msg_header_width_lp-1:0] mem_resp_header_o
    , output logic [dword_width_gp-1:0]              mem_resp_data_o
    , output logic                                   mem_resp_v_o
    , input                                          mem_resp_ready_and_i
+   , output logic                                   mem_resp_last_o
 
    , output logic [cfg_bus_width_lp-1:0]            cfg_bus_o
    , input [io_noc_did_width_p-1:0]                 did_i

--- a/bp_top/src/v/bp_clint_slice.sv
+++ b/bp_top/src/v/bp_clint_slice.sv
@@ -19,11 +19,13 @@ module bp_clint_slice
    , input [dword_width_gp-1:0]                         mem_cmd_data_i
    , input                                              mem_cmd_v_i
    , output logic                                       mem_cmd_ready_and_o
+   , input                                              mem_cmd_last_i
 
    , output logic [xce_mem_msg_header_width_lp-1:0]     mem_resp_header_o
    , output logic [dword_width_gp-1:0]                  mem_resp_data_o
    , output logic                                       mem_resp_v_o
    , input                                              mem_resp_ready_and_i
+   , output logic                                       mem_resp_last_o
 
    // Local interrupts
    , output logic                                       software_irq_o

--- a/bp_top/src/v/bp_clint_slice.sv
+++ b/bp_top/src/v/bp_clint_slice.sv
@@ -15,75 +15,46 @@ module bp_clint_slice
   (input                                                clk_i
    , input                                              reset_i
 
-   , input [xce_mem_msg_width_lp-1:0]                   mem_cmd_i
+   , input [xce_mem_msg_header_width_lp-1:0]            mem_cmd_header_i
+   , input [dword_width_gp-1:0]                         mem_cmd_data_i
    , input                                              mem_cmd_v_i
-   , output                                             mem_cmd_ready_and_o
+   , output logic                                       mem_cmd_ready_and_o
 
-   , output [xce_mem_msg_width_lp-1:0]                  mem_resp_o
-   , output                                             mem_resp_v_o
-   , input                                              mem_resp_yumi_i
+   , output logic [xce_mem_msg_header_width_lp-1:0]     mem_resp_header_o
+   , output logic [dword_width_gp-1:0]                  mem_resp_data_o
+   , output logic                                       mem_resp_v_o
+   , input                                              mem_resp_ready_and_i
 
    // Local interrupts
-   , output                                             software_irq_o
-   , output                                             timer_irq_o
-   , output                                             external_irq_o
+   , output logic                                       software_irq_o
+   , output logic                                       timer_irq_o
+   , output logic                                       external_irq_o
    );
 
   `declare_bp_bedrock_mem_if(paddr_width_p, dword_width_gp, lce_id_width_p, lce_assoc_p, xce);
   `declare_bp_memory_map(paddr_width_p, caddr_width_p);
-  
-  bp_bedrock_xce_mem_msg_s mem_cmd_li, mem_cmd_lo;
-  assign mem_cmd_li = mem_cmd_i;
-  
-  logic small_fifo_v_lo, small_fifo_yumi_li;
-  bsg_one_fifo
-   #(.width_p($bits(bp_bedrock_xce_mem_msg_s)))
-   small_fifo
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-  
-     ,.data_i(mem_cmd_li)
-     ,.v_i(mem_cmd_v_i)
-     ,.ready_o(mem_cmd_ready_and_o)
-  
-     ,.data_o(mem_cmd_lo)
-     ,.v_o(small_fifo_v_lo)
-     ,.yumi_i(small_fifo_yumi_li)
-     );
-  
-  logic mipi_cmd_v;
-  logic mtimecmp_cmd_v;
-  logic mtime_cmd_v;
-  logic plic_cmd_v;
+
+  logic [paddr_width_p-1:0] addr_lo;
+  logic [dword_width_gp-1:0] data_lo;
+  logic [3:0][dword_width_gp-1:0] data_li;
+  logic plic_w_v_li, mtime_w_v_li, mtimecmp_w_v_li, mipi_w_v_li;
   logic wr_not_rd;
-  
-  bp_local_addr_s local_addr;
-  assign local_addr = mem_cmd_lo.header.addr;
-  
-  always_comb
-    begin
-      mtime_cmd_v    = 1'b0;
-      mtimecmp_cmd_v = 1'b0;
-      mipi_cmd_v     = 1'b0;
-      plic_cmd_v     = 1'b0;
-  
-      wr_not_rd = mem_cmd_lo.header.msg_type inside {e_bedrock_mem_wr, e_bedrock_mem_uc_wr};
-  
-      unique
-      casez ({local_addr.dev, local_addr.addr})
-        mtime_reg_addr_gp        : mtime_cmd_v    = small_fifo_v_lo;
-        mtimecmp_reg_base_addr_gp: mtimecmp_cmd_v = small_fifo_v_lo;
-        mipi_reg_base_addr_gp    : mipi_cmd_v     = small_fifo_v_lo;
-        plic_reg_base_addr_gp    : plic_cmd_v     = small_fifo_v_lo;
-        default: begin end
-      endcase
-    end
-  
-  logic [dword_width_gp-1:0] mtime_r, mtime_val_li, mtimecmp_n, mtimecmp_r;
-  logic                     mipi_n, mipi_r;
-  logic                     plic_n, plic_r;
-  
-  // TODO: Should be actual RTC
+  bp_me_bedrock_register
+   #(.bp_params_p(bp_params_p)
+     ,.els_p(4)
+     ,.base_addr_p('{plic_reg_base_addr_gp, mtime_reg_addr_gp, mtimecmp_reg_base_addr_gp, mipi_reg_base_addr_gp})
+     )
+   register
+    (.*
+     // We ignore reads because these are all asynchronous registers
+     ,.r_v_o()
+     ,.w_v_o({plic_w_v_li, mtime_w_v_li, mtimecmp_w_v_li, mipi_w_v_li})
+     ,.addr_o(addr_lo)
+     ,.data_o(data_lo)
+     ,.data_i(data_li)
+     );
+
+  // TODO: Should be actual RTC, or at least programmable
   localparam ds_width_lp = 5;
   localparam [ds_width_lp-1:0] ds_ratio_li = 8;
   logic mtime_inc_li;
@@ -95,24 +66,22 @@ module bp_clint_slice
      ,.init_val_r_i(ds_ratio_li)
      ,.strobe_r_o(mtime_inc_li)
      );
-  assign mtime_val_li = mem_cmd_lo.data[0+:dword_width_gp];
-  wire mtime_w_v_li = wr_not_rd & mtime_cmd_v;
+  logic [dword_width_gp-1:0] mtime_r;
+  wire [dword_width_gp-1:0] mtime_n = data_lo;
   bsg_counter_set_en
-   #(.lg_max_val_lp(dword_width_gp)
-     ,.reset_val_p(0)
-     )
+   #(.lg_max_val_lp(dword_width_gp), .reset_val_p(0))
    mtime_counter
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
   
      ,.set_i(mtime_w_v_li)
      ,.en_i(mtime_inc_li)
-     ,.val_i(mtime_val_li)
+     ,.val_i(mtime_n)
      ,.count_o(mtime_r)
      );
   
-  assign mtimecmp_n = mem_cmd_lo.data[0+:dword_width_gp];
-  wire mtimecmp_w_v_li = wr_not_rd & mtimecmp_cmd_v;
+  logic [dword_width_gp-1:0] mtimecmp_r;
+  wire [dword_width_gp-1:0] mtimecmp_n = data_lo;
   bsg_dff_reset_en
    #(.width_p(dword_width_gp))
    mtimecmp_reg
@@ -125,8 +94,8 @@ module bp_clint_slice
      );
   assign timer_irq_o = (mtime_r >= mtimecmp_r);
   
-  assign mipi_n = mem_cmd_lo.data[0];
-  wire mipi_w_v_li = wr_not_rd & mipi_cmd_v;
+  logic mipi_r;
+  wire mipi_n = data_lo[0];
   bsg_dff_reset_en
    #(.width_p(1))
    mipi_reg
@@ -139,8 +108,8 @@ module bp_clint_slice
      );
   assign software_irq_o = mipi_r;
   
-  assign plic_n = mem_cmd_lo.data[0];
-  wire plic_w_v_li = wr_not_rd & plic_cmd_v;
+  logic plic_r;
+  wire plic_n = data_lo[0];
   bsg_dff_reset_en
    #(.width_p(1))
    plic_reg
@@ -152,29 +121,11 @@ module bp_clint_slice
      ,.data_o(plic_r)
      );
   assign external_irq_o = plic_r;
-  
-  wire [dword_width_gp-1:0] rdata_lo = plic_cmd_v
-                                      ? dword_width_gp'(plic_r)
-                                      : mipi_cmd_v
-                                        ? dword_width_gp'(mipi_r)
-                                        : mtimecmp_cmd_v
-                                          ? dword_width_gp'(mtimecmp_r)
-                                          : mtime_r;
-  
-  bp_bedrock_xce_mem_msg_s mem_resp_lo;
-  assign mem_resp_lo =
-    '{header : '{
-      msg_type       : mem_cmd_lo.header.msg_type
-      ,subop         : e_bedrock_store
-      ,addr          : mem_cmd_lo.header.addr
-      ,payload       : mem_cmd_lo.header.payload
-      ,size          : mem_cmd_lo.header.size
-      }
-      ,data          : dword_width_gp'(rdata_lo)
-      };
-  assign mem_resp_o = mem_resp_lo;
-  assign mem_resp_v_o = small_fifo_v_lo;
-  assign small_fifo_yumi_li = mem_resp_yumi_i;
-
+ 
+  assign data_li[0] = mipi_r;
+  assign data_li[1] = mtimecmp_r;
+  assign data_li[2] = mtime_r;
+  assign data_li[3] = plic_r;
+ 
 endmodule
 

--- a/bp_top/src/v/bp_clint_slice.sv
+++ b/bp_top/src/v/bp_clint_slice.sv
@@ -34,15 +34,16 @@ module bp_clint_slice
   `declare_bp_bedrock_mem_if(paddr_width_p, dword_width_gp, lce_id_width_p, lce_assoc_p, xce);
   `declare_bp_memory_map(paddr_width_p, caddr_width_p);
 
-  logic [paddr_width_p-1:0] addr_lo;
+  logic [cfg_addr_width_gp-1:0] addr_lo;
   logic [dword_width_gp-1:0] data_lo;
   logic [3:0][dword_width_gp-1:0] data_li;
   logic plic_w_v_li, mtime_w_v_li, mtimecmp_w_v_li, mipi_w_v_li;
-  logic wr_not_rd;
+  localparam integer base_addr_lp [3:0] = '{plic_reg_base_addr_gp, mtime_reg_addr_gp, mtimecmp_reg_base_addr_gp, mipi_reg_base_addr_gp};
   bp_me_bedrock_register
    #(.bp_params_p(bp_params_p)
      ,.els_p(4)
-     ,.base_addr_p('{plic_reg_base_addr_gp, mtime_reg_addr_gp, mtimecmp_reg_base_addr_gp, mipi_reg_base_addr_gp})
+     ,.reg_addr_width_p(cfg_addr_width_gp)
+     ,.base_addr_p(base_addr_lp)
      )
    register
     (.*

--- a/bp_top/src/v/bp_loopback.sv
+++ b/bp_top/src/v/bp_loopback.sv
@@ -20,25 +20,27 @@ module bp_cce_loopback
     , input [dword_width_gp-1:0]                     mem_cmd_data_i
     , input                                          mem_cmd_v_i
     , output logic                                   mem_cmd_ready_and_o
+    , input logic                                    mem_cmd_last_i
 
     , output logic [cce_mem_msg_header_width_lp-1:0] mem_resp_header_o
     , output logic [dword_width_gp-1:0]              mem_resp_data_o
     , output logic                                   mem_resp_v_o
     , input                                          mem_resp_ready_and_i
+    , output logic                                   mem_resp_last_o
     );
 
   // Used to decouple to help prevent deadlock
   bsg_one_fifo
-   #(.width_p(cce_mem_msg_header_width_lp))
+   #(.width_p(1+cce_mem_msg_header_width_lp))
    loopback_buffer
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.data_i(mem_cmd_header_i)
+     ,.data_i({mem_cmd_last_i, mem_cmd_header_i})
      ,.v_i(mem_cmd_v_i)
      ,.ready_o(mem_cmd_ready_and_o)
 
-     ,.data_o(mem_resp_header_o)
+     ,.data_o({mem_resp_last_o, mem_resp_header_o})
      ,.v_o(mem_resp_v_o)
      ,.yumi_i(mem_resp_ready_and_i & mem_resp_v_o)
      );

--- a/bp_top/src/v/bp_loopback.sv
+++ b/bp_top/src/v/bp_loopback.sv
@@ -13,41 +13,36 @@ module bp_cce_loopback
     `declare_bp_proc_params(bp_params_p)
     `declare_bp_bedrock_mem_if_widths(paddr_width_p, dword_width_gp, lce_id_width_p, lce_assoc_p, cce)
     )
-   (input                                           clk_i
-    , input                                         reset_i
+   (input                                            clk_i
+    , input                                          reset_i
 
-    , input [cce_mem_msg_width_lp-1:0]              mem_cmd_i
-    , input                                         mem_cmd_v_i
-    , output                                        mem_cmd_ready_and_o
+    , input [cce_mem_msg_header_width_lp-1:0]        mem_cmd_header_i
+    , input [dword_width_gp-1:0]                     mem_cmd_data_i
+    , input                                          mem_cmd_v_i
+    , output logic                                   mem_cmd_ready_and_o
 
-    , output [cce_mem_msg_width_lp-1:0]             mem_resp_o
-    , output                                        mem_resp_v_o
-    , input                                         mem_resp_yumi_i
+    , output logic [cce_mem_msg_header_width_lp-1:0] mem_resp_header_o
+    , output logic [dword_width_gp-1:0]              mem_resp_data_o
+    , output logic                                   mem_resp_v_o
+    , input                                          mem_resp_ready_and_i
     );
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, dword_width_gp, lce_id_width_p, lce_assoc_p, cce);
-
-  bp_bedrock_cce_mem_msg_s mem_cmd_cast_i;
-  bp_bedrock_cce_mem_msg_s mem_resp_cast_o;
-
-  assign mem_cmd_cast_i = mem_cmd_i;
-  assign mem_resp_o = mem_resp_cast_o;
-
+  // Used to decouple to help prevent deadlock
   bsg_one_fifo
-   #(.width_p($bits(mem_cmd_cast_i.header)))
+   #(.width_p(cce_mem_msg_header_width_lp))
    loopback_buffer
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.data_i(mem_cmd_cast_i.header)
+     ,.data_i(mem_cmd_header_i)
      ,.v_i(mem_cmd_v_i)
      ,.ready_o(mem_cmd_ready_and_o)
 
-     ,.data_o(mem_resp_cast_o.header)
+     ,.data_o(mem_resp_header_o)
      ,.v_o(mem_resp_v_o)
-     ,.yumi_i(mem_resp_yumi_i)
+     ,.yumi_i(mem_resp_ready_and_i & mem_resp_v_o)
      );
-  assign mem_resp_cast_o.data = '0;
+  assign mem_resp_data_o = '0;
 
 endmodule
 

--- a/bp_top/src/v/bp_tile.sv
+++ b/bp_top/src/v/bp_tile.sv
@@ -172,13 +172,15 @@ module bp_tile
     (.clk_i(clk_i)
      ,.reset_i(reset_r)
 
-     ,.mem_cmd_i(cfg_mem_cmd)
+     ,.mem_cmd_header_i(cfg_mem_cmd.header)
+     ,.mem_cmd_data_i(cfg_mem_cmd.data)
      ,.mem_cmd_v_i(cfg_mem_cmd_v_li)
      ,.mem_cmd_ready_and_o(cfg_mem_cmd_ready_and_lo)
 
-     ,.mem_resp_o(cfg_mem_resp)
+     ,.mem_resp_header_o(cfg_mem_resp.header)
+     ,.mem_resp_data_o(cfg_mem_resp.data)
      ,.mem_resp_v_o(cfg_mem_resp_v_lo)
-     ,.mem_resp_yumi_i(cfg_mem_resp_yumi_li)
+     ,.mem_resp_ready_and_i(cfg_mem_resp_yumi_li)
 
      ,.cfg_bus_o(cfg_bus_lo)
      ,.did_i(my_did_i)
@@ -839,13 +841,15 @@ module bp_tile
     (.clk_i(clk_i)
      ,.reset_i(reset_r)
 
-     ,.mem_cmd_i(loopback_mem_cmd)
+     ,.mem_cmd_header_i(loopback_mem_cmd.header)
+     ,.mem_cmd_data_i(loopback_mem_cmd.data)
      ,.mem_cmd_v_i(loopback_mem_cmd_v_li)
      ,.mem_cmd_ready_and_o(loopback_mem_cmd_ready_and_lo)
 
-     ,.mem_resp_o(loopback_mem_resp)
+     ,.mem_resp_header_o(loopback_mem_resp.header)
+     ,.mem_resp_data_o(loopback_mem_resp.data)
      ,.mem_resp_v_o(loopback_mem_resp_v_lo)
-     ,.mem_resp_yumi_i(loopback_mem_resp_yumi_li)
+     ,.mem_resp_ready_and_i(loopback_mem_resp_yumi_li)
      );
 
 endmodule

--- a/bp_top/src/v/bp_tile.sv
+++ b/bp_top/src/v/bp_tile.sv
@@ -198,13 +198,15 @@ module bp_tile
     (.clk_i(clk_i)
      ,.reset_i(reset_r)
 
-     ,.mem_cmd_i(clint_mem_cmd)
+     ,.mem_cmd_header_i(clint_mem_cmd.header)
+     ,.mem_cmd_data_i(clint_mem_cmd.data)
      ,.mem_cmd_v_i(clint_mem_cmd_v_li)
      ,.mem_cmd_ready_and_o(clint_mem_cmd_ready_and_lo)
 
-     ,.mem_resp_o(clint_mem_resp)
+     ,.mem_resp_header_o(clint_mem_resp.header)
+     ,.mem_resp_data_o(clint_mem_resp.data)
      ,.mem_resp_v_o(clint_mem_resp_v_lo)
-     ,.mem_resp_yumi_i(clint_mem_resp_yumi_li)
+     ,.mem_resp_ready_and_i(clint_mem_resp_yumi_li)
 
      ,.timer_irq_o(timer_irq_li)
      ,.software_irq_o(software_irq_li)

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -426,13 +426,15 @@ module bp_unicore_lite
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.mem_cmd_i(cfg_cmd)
+     ,.mem_cmd_header_i(cfg_cmd.header)
+     ,.mem_cmd_data_i(cfg_cmd.data)
      ,.mem_cmd_v_i(cfg_cmd_v_li)
      ,.mem_cmd_ready_and_o(cfg_cmd_ready_and_lo)
 
-     ,.mem_resp_o(cfg_resp)
+     ,.mem_resp_header_o(cfg_resp.header)
+     ,.mem_resp_data_o(cfg_resp.data)
      ,.mem_resp_v_o(cfg_resp_v_lo)
-     ,.mem_resp_yumi_i(cfg_resp_yumi_li)
+     ,.mem_resp_ready_and_i(cfg_resp_yumi_li)
 
      ,.cfg_bus_o(cfg_bus_lo)
      ,.did_i('0)
@@ -452,13 +454,15 @@ module bp_unicore_lite
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.mem_cmd_i(loopback_cmd)
+     ,.mem_cmd_header_i(loopback_cmd.header)
+     ,.mem_cmd_data_i(loopback_cmd.data)
      ,.mem_cmd_v_i(loopback_cmd_v_li)
      ,.mem_cmd_ready_and_o(loopback_cmd_ready_and_lo)
 
-     ,.mem_resp_o(loopback_resp)
+     ,.mem_resp_header_o(loopback_resp.header)
+     ,.mem_resp_data_o(loopback_resp.data)
      ,.mem_resp_v_o(loopback_resp_v_lo)
-     ,.mem_resp_yumi_i(loopback_resp_yumi_li)
+     ,.mem_resp_ready_and_i(loopback_resp_yumi_li)
      );
 
 endmodule

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -405,13 +405,15 @@ module bp_unicore_lite
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.mem_cmd_i(clint_cmd)
+     ,.mem_cmd_header_i(clint_cmd.header)
+     ,.mem_cmd_data_i(clint_cmd.data)
      ,.mem_cmd_v_i(clint_cmd_v_li)
      ,.mem_cmd_ready_and_o(clint_cmd_ready_and_lo)
 
-     ,.mem_resp_o(clint_resp)
+     ,.mem_resp_header_o(clint_resp.header)
+     ,.mem_resp_data_o(clint_resp.data)
      ,.mem_resp_v_o(clint_resp_v_lo)
-     ,.mem_resp_yumi_i(clint_resp_yumi_li)
+     ,.mem_resp_ready_and_i(clint_resp_yumi_li)
 
      ,.timer_irq_o(timer_irq_li)
      ,.software_irq_o(software_irq_li)

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -231,6 +231,7 @@ $BP_ME_DIR/src/v/lce/bp_lce_req.sv
 $BP_ME_DIR/src/v/lce/bp_lce_cmd.sv
 # Cache
 $BP_ME_DIR/src/v/cache/bp_me_cce_to_cache.sv
+$BP_ME_DIR/src/v/cache/bp_me_bedrock_register.sv
 # CCE
 $BP_ME_DIR/src/v/cce/bp_cce.sv
 $BP_ME_DIR/src/v/cce/bp_cce_alu.sv

--- a/docs/bedrock_guide.md
+++ b/docs/bedrock_guide.md
@@ -60,7 +60,8 @@ The BedRock Stream protocol comprises the following signals:
 * Last
 
 Each message is sent as one or more header plus data beats using a shared ready&valid handshake.
-The last signal is raised with valid when the sender is transmitting the last header plus data beat.
+The last signal is raised along with valid when the sender is transmitting the last header plus data beat.
+Last must not be raised if there is no valid data available.
 The data field is typically 64-bits, but may be any 512/N-bits wide that is at least 64-bits.
 
 When sending multiple beat messages, the sender must increment the address in the header by
@@ -71,7 +72,7 @@ is smaller than the data channel size,
 the requested data is repeated to fill the channel. For example the data response for a 16-bit
 request using a 64-bit channel for some data value A has a 64-bit data response of [A, A, A, A].
 
-## BedRock Lite
+## BedRock Lite (Deprecated)
 
 BedRock Lite is a wide variant of BedRock Stream. BedRock Lite does not use the Last signal as
 every message is a single header plus data beat. The data channel width is equal to the cache or
@@ -81,6 +82,8 @@ so the critical word is placed in the least significant bits.
 
 Requests for data that smaller than the data channel width result in responses where the returned
 data is replicated to fill the data channel width.
+
+BedRock Lite is deprecated and should be replaced by Stream interfaces wherever found.
 
 ## BedRock Burst
 
@@ -99,7 +102,8 @@ zero or more data beats. The BedRock Burst protocol has the following signals:
 In this protocol, the header and data channels have independent ready&valid handshakes. The header
 is accompanied by a has\_data signal that is raised if the message has at least one data beats.
 The data channel is accompanied by a last signal that is raised with data\_valid on the last data
-beat. As with BedRock Stream, the data channel may is typically 64-bits wide, but may be any
+beat. Last must not be raised if there is no valid data available.
+As with BedRock Stream, the data channel may is typically 64-bits wide, but may be any
 512/N-bits wide that is at least 64-bits.
 
 The sender contract is:


### PR DESCRIPTION
- Converts the tile peripherals to single-beat stream in prep for future
- Adds bp_me_bedrock_register which acts as a Bedrock->GPIO converter. This makes things a little bit easier to connect low-performance peripherals to a tile. Can be expanded as needed for bursting requirements

Depends on #888 