### PR TITLE
update FSM CCE to use BedRock Stream on memory ports

### DIFF
--- a/bp_common/src/include/bp_common_bedrock_if.svh
+++ b/bp_common/src/include/bp_common_bedrock_if.svh
@@ -83,14 +83,12 @@
    * speculative is set if the request was issued speculatively by the CCE
    */
 
-
   `define declare_bp_bedrock_lce_payload_s(lce_id_width_mp, cce_id_width_mp, lce_assoc_mp, name_mp) \
                                                                                        \
     typedef struct packed                                                              \
     {                                                                                  \
       logic [`BSG_SAFE_CLOG2(lce_assoc_mp)-1:0]    lru_way_id;                         \
       bp_bedrock_req_non_excl_e                    non_exclusive;                      \
-      bp_bedrock_wr_subop_e                        subop;                              \
       logic [lce_id_width_mp-1:0]                  src_id;                             \
       logic [cce_id_width_mp-1:0]                  dst_id;                             \
     } bp_bedrock_``name_mp``_req_payload_s;                                            \
@@ -132,7 +130,7 @@
    */
 
   `define bp_bedrock_req_payload_width(lce_id_width_mp, cce_id_width_mp, lce_assoc_mp) \
-    (cce_id_width_mp+lce_id_width_mp+$bits(bp_bedrock_req_non_excl_e)+$bits(bp_bedrock_wr_subop_e)+`BSG_SAFE_CLOG2(lce_assoc_mp))
+    (cce_id_width_mp+lce_id_width_mp+$bits(bp_bedrock_req_non_excl_e)+`BSG_SAFE_CLOG2(lce_assoc_mp))
 
   `define bp_bedrock_cmd_payload_width(lce_id_width_mp, cce_id_width_mp, lce_assoc_mp) \
     ((2*lce_id_width_mp)+cce_id_width_mp+(2*`BSG_SAFE_CLOG2(lce_assoc_mp))+(2*$bits(bp_coh_states_e)))

--- a/bp_me/src/v/cce/bp_cce_inst_stall.sv
+++ b/bp_me/src/v/cce/bp_cce_inst_stall.sv
@@ -23,12 +23,12 @@ module bp_cce_inst_stall
    // input queue valid signals
    , input                                       lce_req_header_v_i
    , input                                       lce_resp_header_v_i
-   , input                                       mem_resp_header_v_i
+   , input                                       mem_resp_v_i
    , input                                       pending_v_i
 
    // output queue ready signals
+   , input                                       lce_cmd_header_v_i
    , input                                       lce_cmd_header_ready_and_i
-   , input                                       mem_cmd_header_ready_and_i
    , input                                       mem_credits_empty_i
 
    // Messague Unit resource busy signals
@@ -42,6 +42,8 @@ module bp_cce_inst_stall
    , input                                       msg_mem_resp_busy_i
    , input                                       msg_spec_r_busy_i
    , input                                       msg_dir_w_busy_i
+   // memory command send stall
+   , input                                       msg_mem_cmd_stall_i
 
    // Directory busy (e.g., processing read)
    , input                                       dir_busy_i
@@ -50,7 +52,7 @@ module bp_cce_inst_stall
    , output logic                                stall_o
   );
 
-  wire [$bits(bp_cce_inst_src_q_e)-1:0] wfq_v_vec = {lce_req_header_v_i, lce_resp_header_v_i, mem_resp_header_v_i, pending_v_i};
+  wire [$bits(bp_cce_inst_src_q_e)-1:0] wfq_v_vec = {lce_req_header_v_i, lce_resp_header_v_i, mem_resp_v_i, pending_v_i};
   wire [$bits(bp_cce_inst_src_q_e)-1:0] wfq_mask = decoded_inst_i.imm[0+:$bits(bp_cce_inst_src_q_e)];
 
   always_comb begin
@@ -62,23 +64,28 @@ module bp_cce_inst_stall
     // Handshake is v->yumi for headers from fifo
     stall_o |= (decoded_inst_i.lce_req_yumi & ~lce_req_header_v_i);
     stall_o |= (decoded_inst_i.lce_resp_yumi & ~lce_resp_header_v_i);
-    stall_o |= (decoded_inst_i.mem_resp_yumi & ~mem_resp_header_v_i);
+    stall_o |= (decoded_inst_i.lce_cmd_v & ~lce_cmd_header_ready_and_i);
+    stall_o |= (decoded_inst_i.mem_resp_yumi & ~mem_resp_v_i);
     stall_o |= (decoded_inst_i.pending_yumi & ~pending_v_i);
 
     // Pop Header
     stall_o |= (decoded_inst_i.poph & (~lce_req_header_v_i & (decoded_inst_i.popq_qsel == e_src_q_sel_lce_req)));
     stall_o |= (decoded_inst_i.poph & (~lce_resp_header_v_i & (decoded_inst_i.popq_qsel == e_src_q_sel_lce_resp)));
-    stall_o |= (decoded_inst_i.poph & (~mem_resp_header_v_i & (decoded_inst_i.popq_qsel == e_src_q_sel_mem_resp)));
+    stall_o |= (decoded_inst_i.lce_cmd_v & ~lce_cmd_header_ready_and_i);
+    stall_o |= (decoded_inst_i.poph & (~mem_resp_v_i & (decoded_inst_i.popq_qsel == e_src_q_sel_mem_resp)));
 
     // Pop Data
     stall_o |= (decoded_inst_i.popd & (~lce_req_header_v_i & (decoded_inst_i.popq_qsel == e_src_q_sel_lce_req)));
     stall_o |= (decoded_inst_i.popd & (~lce_resp_header_v_i & (decoded_inst_i.popq_qsel == e_src_q_sel_lce_resp)));
-    stall_o |= (decoded_inst_i.popd & (~mem_resp_header_v_i & (decoded_inst_i.popq_qsel == e_src_q_sel_mem_resp)));
+    stall_o |= (decoded_inst_i.lce_cmd_v & ~lce_cmd_header_ready_and_i);
+    stall_o |= (decoded_inst_i.popd & (~mem_resp_v_i & (decoded_inst_i.popq_qsel == e_src_q_sel_mem_resp)));
 
     // Message send
     // Handshake is r&v
-    stall_o |= (decoded_inst_i.lce_cmd_v & ~lce_cmd_header_ready_and_i);
-    stall_o |= (decoded_inst_i.mem_cmd_v & ~mem_cmd_header_ready_and_i);
+    stall_o |= (decoded_inst_i.lce_cmd_v & ~(lce_cmd_header_v_i & lce_cmd_header_ready_and_i));
+    // memory command stall is indicated directly by a signal from message unit
+    stall_o |= msg_mem_cmd_stall_i;
+    // sending a memory command requires a memory credit
     stall_o |= (decoded_inst_i.mem_cmd_v & mem_credits_empty_i);
 
     // Wait for queue operation

--- a/bp_me/src/v/cce/bp_cce_reg.sv
+++ b/bp_me/src/v/cce/bp_cce_reg.sv
@@ -85,16 +85,12 @@ module bp_cce_reg
   `declare_bp_bedrock_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce);
 
   bp_bedrock_lce_req_msg_header_s  lce_req_hdr;
-  bp_bedrock_lce_req_payload_s     lce_req_payload;
   bp_bedrock_lce_resp_msg_header_s lce_resp_hdr;
   bp_bedrock_cce_mem_msg_header_s  mem_resp_hdr;
-  bp_bedrock_cce_mem_payload_s     mem_resp_payload;
 
   assign lce_req_hdr  = lce_req_header_i;
-  assign lce_req_payload = lce_req_hdr.payload;
   assign lce_resp_hdr = lce_resp_header_i;
   assign mem_resp_hdr = mem_resp_header_i;
-  assign mem_resp_payload = mem_resp_hdr.payload;
 
   // Registers
   `declare_bp_cce_mshr_s(lce_id_width_p, lce_assoc_p, paddr_width_p);
@@ -152,7 +148,7 @@ module bp_cce_reg
   wire lce_req_ucf   = (lce_req_hdr.msg_type.req == e_bedrock_req_uc_rd)
                        | (lce_req_hdr.msg_type.req == e_bedrock_req_uc_wr);
   wire lce_resp_nwbf = (lce_resp_hdr.msg_type.resp == e_bedrock_resp_null_wb);
-  wire lce_req_nerf  = (lce_req_payload.non_exclusive == e_bedrock_req_non_excl);
+  wire lce_req_nerf  = (lce_req_hdr.payload.non_exclusive == e_bedrock_req_non_excl);
 
   // operation writes all flags in bulk
   // branch flag ops only use e_opd_flags as source
@@ -233,9 +229,9 @@ module bp_cce_reg
       if (decoded_inst_i.poph) begin
         unique case (decoded_inst_i.popq_qsel)
           e_src_q_sel_lce_req: begin
-            mshr_n.lce_id = lce_req_payload.src_id;
+            mshr_n.lce_id = lce_req_hdr.payload.src_id;
             mshr_n.paddr = lce_req_hdr.addr;
-            mshr_n.lru_way_id = lce_req_payload.lru_way_id;
+            mshr_n.lru_way_id = lce_req_hdr.payload.lru_way_id;
             mshr_n.msg_size = lce_req_hdr.size;
             // flags written here must have their flag_w_v bit set by the decoder
             mshr_n.flags[e_opd_rqf] = lce_req_rqf;
@@ -255,7 +251,7 @@ module bp_cce_reg
             //mshr_n.paddr = mem_resp_hdr.addr;
             //mshr_n.next_coh_state = mem_resp_hdr.payload.state;
             //mshr_n.msg_size = mem_resp_hdr.size;
-            mshr_n.flags[e_opd_sf] = mem_resp_payload.speculative;
+            mshr_n.flags[e_opd_sf] = mem_resp_hdr.payload.speculative;
           end
           default: begin
           end

--- a/bp_me/src/v/cce/bp_cce_src_sel.sv
+++ b/bp_me/src/v/cce/bp_cce_src_sel.sv
@@ -57,12 +57,12 @@ module bp_cce_src_sel
    , input [num_lce_p-1:0]                                          sharers_hits_i
    , input [num_lce_p-1:0][lce_assoc_width_p-1:0]                   sharers_ways_i
    , input bp_coh_states_e [num_lce_p-1:0]                          sharers_coh_states_i
-   , input                                                          mem_resp_header_v_i
+   , input                                                          mem_resp_v_i
    , input                                                          lce_resp_header_v_i
    , input                                                          lce_req_header_v_i
-   , input [lce_req_msg_header_width_lp-1:0]                        lce_req_i
-   , input [lce_resp_msg_header_width_lp-1:0]                       lce_resp_i
-   , input [cce_mem_msg_header_width_lp-1:0]                        mem_resp_i
+   , input [lce_req_msg_header_width_lp-1:0]                        lce_req_header_i
+   , input [lce_resp_msg_header_width_lp-1:0]                       lce_resp_header_i
+   , input [cce_mem_msg_header_width_lp-1:0]                        mem_resp_header_i
    // TODO: data inputs are not guarded by valid
    , input [dword_width_gp-1:0]                                     lce_req_data_i
    , input [dword_width_gp-1:0]                                     lce_resp_data_i
@@ -101,19 +101,13 @@ module bp_cce_src_sel
   `declare_bp_bedrock_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce);
 
   // Message casting
-  bp_bedrock_lce_req_msg_header_s  lce_req;
-  bp_bedrock_lce_resp_msg_header_s lce_resp;
-  bp_bedrock_cce_mem_msg_header_s  mem_resp;
-  bp_bedrock_lce_req_payload_s  lce_req_payload;
-  bp_bedrock_lce_resp_payload_s lce_resp_payload;
-  bp_bedrock_cce_mem_payload_s  mem_resp_payload;
+  bp_bedrock_lce_req_msg_header_s  lce_req_header_li;
+  bp_bedrock_lce_resp_msg_header_s lce_resp_header_li;
+  bp_bedrock_cce_mem_msg_header_s  mem_resp_header_li;
 
-  assign lce_req   = lce_req_i;
-  assign lce_resp  = lce_resp_i;
-  assign mem_resp  = mem_resp_i;
-  assign lce_req_payload = lce_req.payload;
-  assign lce_resp_payload = lce_resp.payload;
-  assign mem_resp_payload = mem_resp.payload;
+  assign lce_req_header_li   = lce_req_header_i;
+  assign lce_resp_header_li  = lce_resp_header_i;
+  assign mem_resp_header_li  = mem_resp_header_i;
 
   always_comb begin
     src_a_o = '0;
@@ -182,12 +176,12 @@ module bp_cce_src_sel
       end
       e_src_sel_queue: begin
         unique case (src_a_i.q)
-          e_opd_mem_resp_v:    src_a_o[0] = mem_resp_header_v_i;
+          e_opd_mem_resp_v:    src_a_o[0] = mem_resp_v_i;
           e_opd_lce_resp_v:    src_a_o[0] = lce_resp_header_v_i;
           e_opd_pending_v:     src_a_o = '0;
           e_opd_lce_req_v:     src_a_o[0] = lce_req_header_v_i;
-          e_opd_lce_resp_type: src_a_o[0+:$bits(bp_bedrock_resp_type_e)] = lce_resp.msg_type.resp;
-          e_opd_mem_resp_type: src_a_o[0+:$bits(bp_bedrock_mem_type_e)] = mem_resp.msg_type.mem;
+          e_opd_lce_resp_type: src_a_o[0+:$bits(bp_bedrock_resp_type_e)] = lce_resp_header_li.msg_type.resp;
+          e_opd_mem_resp_type: src_a_o[0+:$bits(bp_bedrock_mem_type_e)] = mem_resp_header_li.msg_type.mem;
           e_opd_lce_resp_data: src_a_o = lce_resp_data_i[0+:`bp_cce_inst_gpr_width];
           e_opd_mem_resp_data: src_a_o = mem_resp_data_i[0+:`bp_cce_inst_gpr_width];
           e_opd_lce_req_data:  src_a_o = lce_req_data_i[0+:`bp_cce_inst_gpr_width];
@@ -272,12 +266,12 @@ module bp_cce_src_sel
       end
       e_src_sel_queue: begin
         unique case (src_b_i.q)
-          e_opd_mem_resp_v:    src_b_o[0] = mem_resp_header_v_i;
+          e_opd_mem_resp_v:    src_b_o[0] = mem_resp_v_i;
           e_opd_lce_resp_v:    src_b_o[0] = lce_resp_header_v_i;
           e_opd_pending_v:     src_b_o = '0;
           e_opd_lce_req_v:     src_b_o[0] = lce_req_header_v_i;
-          e_opd_lce_resp_type: src_b_o[0+:$bits(bp_bedrock_resp_type_e)] = lce_resp.msg_type.resp;
-          e_opd_mem_resp_type: src_b_o[0+:$bits(bp_bedrock_mem_type_e)] = mem_resp.msg_type.mem;
+          e_opd_lce_resp_type: src_b_o[0+:$bits(bp_bedrock_resp_type_e)] = lce_resp_header_li.msg_type.resp;
+          e_opd_mem_resp_type: src_b_o[0+:$bits(bp_bedrock_mem_type_e)] = mem_resp_header_li.msg_type.mem;
           e_opd_lce_resp_data: src_b_o = lce_resp_data_i[0+:`bp_cce_inst_gpr_width];
           e_opd_mem_resp_data: src_b_o = mem_resp_data_i[0+:`bp_cce_inst_gpr_width];
           e_opd_lce_req_data:  src_b_o = lce_req_data_i[0+:`bp_cce_inst_gpr_width];
@@ -305,9 +299,9 @@ module bp_cce_src_sel
       e_mux_sel_addr_r7:       addr_o = gpr_i[e_opd_r7][0+:paddr_width_p];
       e_mux_sel_addr_mshr_req: addr_o = mshr.paddr;
       e_mux_sel_addr_mshr_lru: addr_o = mshr.lru_paddr;
-      e_mux_sel_addr_lce_req:  addr_o = lce_req.addr;
-      e_mux_sel_addr_lce_resp: addr_o = lce_resp.addr;
-      e_mux_sel_addr_mem_resp: addr_o = mem_resp.addr;
+      e_mux_sel_addr_lce_req:  addr_o = lce_req_header_li.addr;
+      e_mux_sel_addr_lce_resp: addr_o = lce_resp_header_li.addr;
+      e_mux_sel_addr_mem_resp: addr_o = mem_resp_header_li.addr;
       e_mux_sel_addr_pending:  addr_o = '0;
       e_mux_sel_addr_0:        addr_o = '0;
       default:                 addr_o = '0;
@@ -333,9 +327,9 @@ module bp_cce_src_sel
       e_mux_sel_lce_r7:         lce_o = gpr_i[e_opd_r7][0+:lce_id_width_p];
       e_mux_sel_lce_mshr_req:   lce_o = mshr.lce_id;
       e_mux_sel_lce_mshr_owner: lce_o = mshr.owner_lce_id;
-      e_mux_sel_lce_lce_req:    lce_o = lce_req_payload.src_id;
-      e_mux_sel_lce_lce_resp:   lce_o = lce_resp_payload.src_id;
-      e_mux_sel_lce_mem_resp:   lce_o = mem_resp_payload.lce_id;
+      e_mux_sel_lce_lce_req:    lce_o = lce_req_header_li.payload.src_id;
+      e_mux_sel_lce_lce_resp:   lce_o = lce_resp_header_li.payload.src_id;
+      e_mux_sel_lce_mem_resp:   lce_o = mem_resp_header_li.payload.lce_id;
       e_mux_sel_lce_pending:    lce_o = '0;
       e_mux_sel_lce_0:          lce_o = '0;
       default:                  lce_o = '0;

--- a/bp_me/src/v/cce/bp_cce_wrapper.sv
+++ b/bp_me/src/v/cce/bp_cce_wrapper.sv
@@ -6,7 +6,8 @@
  * Description:
  *   This is the top level module for the CCE.
  *
- *   The LCE-CCE and CCE-MEM Interfaces use the BedRock Burst protocol
+ *   The LCE-CCE Interfaces use the BedRock Burst protocol.
+ *   The CCE-MEM Intercaces use the BedRock Stream protocol
  *
  *   It instantiates either the microcode or FSM CCE, based on the param in bp_params_p.
  *
@@ -69,23 +70,17 @@ module bp_cce_wrapper
    , output logic                                   lce_cmd_last_o
 
    // CCE-MEM Interface
-   // BedRock Burst protocol: ready&valid
+   // BedRock Stream protocol: ready&valid
    , input [cce_mem_msg_header_width_lp-1:0]        mem_resp_header_i
-   , input                                          mem_resp_header_v_i
-   , output logic                                   mem_resp_header_ready_and_o
-   , input                                          mem_resp_has_data_i
    , input [dword_width_gp-1:0]                     mem_resp_data_i
-   , input                                          mem_resp_data_v_i
-   , output logic                                   mem_resp_data_ready_and_o
+   , input                                          mem_resp_v_i
+   , output logic                                   mem_resp_ready_and_o
    , input                                          mem_resp_last_i
 
    , output logic [cce_mem_msg_header_width_lp-1:0] mem_cmd_header_o
-   , output logic                                   mem_cmd_header_v_o
-   , input                                          mem_cmd_header_ready_and_i
-   , output logic                                   mem_cmd_has_data_o
    , output logic [dword_width_gp-1:0]              mem_cmd_data_o
-   , output logic                                   mem_cmd_data_v_o
-   , input                                          mem_cmd_data_ready_and_i
+   , output logic                                   mem_cmd_v_o
+   , input                                          mem_cmd_ready_and_i
    , output logic                                   mem_cmd_last_o
   );
 
@@ -107,6 +102,5 @@ module bp_cce_wrapper
     cce
      (.*);
   end
-
 
 endmodule

--- a/bp_me/src/v/cce/bp_uce.sv
+++ b/bp_me/src/v/cce/bp_uce.sv
@@ -298,6 +298,7 @@ module bp_uce
      ,.fsm_yumi_i(fsm_resp_yumi_lo)
      ,.fsm_new_o(fsm_resp_new)
      ,.fsm_done_o(fsm_resp_done)
+     ,.fsm_last_o(/* unused */)
      );
 
   // We check for uncached stores ealier than other requests, because they get sent out in ready
@@ -364,19 +365,21 @@ module bp_uce
   //
   logic [`BSG_WIDTH(coh_noc_max_credits_p)-1:0] credit_count_lo;
   wire credit_v_li = fsm_cmd_done;
-  wire credit_ready_li = fsm_cmd_ready_and_li;
   // credit is returned when request completes
   // UC store done for UC Store, UC Data for UC Load, Set Tag Wakeup for
   // a miss that is actually an upgrade, and data and tag for normal requests.
   wire credit_returned_li = fsm_resp_done;
   bsg_flow_counter
-   #(.els_p(coh_noc_max_credits_p))
+   #(.els_p(coh_noc_max_credits_p)
+      // memory command increments on done singal from stream pump
+      ,.ready_THEN_valid_p(1)
+      )
    credit_counter
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
      ,.v_i(credit_v_li)
-     ,.ready_i(credit_ready_li)
+     ,.ready_i(1'b0) // unused due to ready_then_valid param
 
      ,.yumi_i(credit_returned_li)
      ,.count_o(credit_count_lo)

--- a/bp_me/src/v/dev/bp_me_cce_to_cache.sv
+++ b/bp_me/src/v/dev/bp_me_cce_to_cache.sv
@@ -6,7 +6,7 @@
                     -----------------------------------------
       mem_cmd_i -->| --> pump_in --->  cache_pkt_sel --->    |--> cache_pkt_p
                    |                       |                 |
-  (mem_data_width) |   (mem_data_width)    | (l2_data_width) |  (l2_data_width)
+   (l2_data_width) |   (l2_data_width)     | (l2_data_width) |  (l2_data_width)
                    |                       |                 |
      mem_resp_o <--| <-- pump_out <--  bsg_bus_pack <----    |<-- data_i
                     -----------------------------------------
@@ -40,7 +40,7 @@ module bp_me_cce_to_cache
     input clk_i
     , input reset_i
 
-    // Stream interface
+    // BedRock Stream interface
     , input  [cce_mem_msg_header_width_lp-1:0] mem_cmd_header_i
     , input  [l2_data_width_p-1:0]             mem_cmd_data_i
     , input                                    mem_cmd_v_i
@@ -123,6 +123,7 @@ module bp_me_cce_to_cache
      ,.fsm_yumi_i(mem_cmd_yumi_li)
      ,.fsm_new_o(mem_cmd_new_lo)
      ,.fsm_done_o(mem_cmd_done_lo)
+     ,.fsm_last_o(/* unused */)
      );
 
   bp_local_addr_s local_addr_cast;

--- a/bp_me/src/v/network/bp_me_stream_pump_out.sv
+++ b/bp_me/src/v/network/bp_me_stream_pump_out.sv
@@ -65,11 +65,11 @@ module bp_me_stream_pump_out
    , output logic                                   fsm_ready_and_o
 
    // FSM control signals
-   // stream_cnt is the current stream word being sent
+   // fsm_cnt is the current stream word being sent
    , output logic [data_len_width_lp-1:0]           fsm_cnt_o
-   // stream_new is raised on first beat of every message
+   // fsm_new is raised when first beat of every message is acked
    , output logic                                   fsm_new_o
-   // stream_done is raised when last beat sends
+   // fsm_done is raised when last beat of every message sends
    , output logic                                   fsm_done_o
    );
 
@@ -188,9 +188,10 @@ module bp_me_stream_pump_out
       else if (is_fsm_stream & ~is_msg_stream)
         begin
           // N:1
-          // consume all but last FSM beat silently, then msg consumes last beat
+          // only send msg on last FSM beat
           msg_v_o = is_last_cnt & fsm_v_i;
-          fsm_ready_and_o = ~is_last_cnt;
+          // ack all but last FSM beat silently, then ack last FSM beat when msg beat sends
+          fsm_ready_and_o = ~is_last_cnt | (is_last_cnt & msg_ready_and_i);
           cnt_up = fsm_v_i & ~is_last_cnt;
           // hold address constant at critical address
           msg_header_cast_o.addr[0+:block_offset_width_lp] = critical_addr_r;

--- a/bp_me/src/v/network/bp_me_xbar_burst.sv
+++ b/bp_me/src/v/network/bp_me_xbar_burst.sv
@@ -1,0 +1,136 @@
+/**
+ *
+ * Name:
+ *   bp_me_xbar_burst.sv
+ *
+ * Description:
+ *   This xbar arbitrates BedRock Burst messages between N sources and M sinks.
+ *
+ */
+
+`include "bp_common_defines.svh"
+`include "bp_me_defines.svh"
+
+module bp_me_xbar_burst
+ import bp_common_pkg::*;
+ import bp_me_pkg::*;
+ #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+   `declare_bp_proc_params(bp_params_p)
+
+   , parameter data_width_p    = "inv"
+   , parameter payload_width_p = "inv"
+   , parameter num_source_p    = "inv"
+   , parameter num_sink_p      = "inv"
+   `declare_bp_bedrock_if_widths(paddr_width_p, payload_width_p, data_width_p, lce_id_width_p, lce_assoc_p, xbar)
+
+   , localparam lg_num_source_lp = `BSG_SAFE_CLOG2(num_source_p)
+   , localparam lg_num_sink_lp   = `BSG_SAFE_CLOG2(num_sink_p)
+   )
+  (input                                                              clk_i
+   , input                                                            reset_i
+
+   , input [num_source_p-1:0][xbar_msg_header_width_lp-1:0]           msg_header_i
+   , input [num_source_p-1:0]                                         msg_header_v_i
+   , output logic [num_source_p-1:0]                                  msg_header_yumi_o
+   , input [num_source_p-1:0]                                         msg_has_data_i
+   , input [num_source_p-1:0][data_width_p-1:0]                       msg_data_i
+   , input [num_source_p-1:0]                                         msg_data_v_i
+   , output logic [num_source_p-1:0]                                  msg_data_yumi_o
+   , input [num_source_p-1:0]                                         msg_last_i
+   , input [num_source_p-1:0][lg_num_sink_lp-1:0]                     msg_dst_i
+
+   , output logic [num_sink_p-1:0][xbar_msg_header_width_lp-1:0]      msg_header_o
+   , output logic [num_sink_p-1:0]                                    msg_header_v_o
+   , input [num_sink_p-1:0]                                           msg_header_ready_and_i
+   , output logic [num_sink_p-1:0]                                    msg_has_data_o
+   , output logic [num_sink_p-1:0][data_width_p-1:0]                  msg_data_o
+   , output logic [num_sink_p-1:0]                                    msg_data_v_o
+   , input [num_sink_p-1:0]                                           msg_data_ready_and_i
+   , output logic [num_sink_p-1:0]                                    msg_last_o
+   );
+
+  `declare_bp_bedrock_if(paddr_width_p, payload_width_p, data_width_p, lce_id_width_p, lce_assoc_p, xbar);
+
+  // register to indicate ready to send data
+  logic send_data_r;
+
+  // msg arbitration logic
+  // request arbitration lock on header valid (regardless of whether message has data)
+  // unlock on header ack (no data) or last data ack
+  logic [num_source_p-1:0] msg_grants_lo;
+  wire msg_arb_unlock_li = |{msg_header_yumi_o & ~msg_has_data_i} | |{msg_data_yumi_o & msg_last_i} | reset_i;
+  bsg_locking_arb_fixed
+   #(.inputs_p(num_source_p), .lo_to_hi_p(0))
+   msg_arbiter
+    (.clk_i(clk_i)
+     ,.ready_i(1'b1)
+
+     ,.unlock_i(msg_arb_unlock_li)
+     ,.reqs_i(msg_header_v_i | ({num_source_p{send_data_r}} & msg_data_v_i))
+     ,.grants_o(msg_grants_lo)
+     );
+
+  logic [lg_num_source_lp-1:0] msg_grants_sel_li;
+  logic msg_grants_v_li;
+  bsg_encode_one_hot
+   #(.width_p(num_source_p), .lo_to_hi_p(1))
+   msg_sel
+    (.i(msg_grants_lo)
+     ,.addr_o(msg_grants_sel_li)
+     ,.v_o(msg_grants_v_li)
+     );
+
+  bsg_dff_reset_set_clear
+   #(.width_p(1)
+     ,.clear_over_set_p(1)
+     )
+   send_data_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.set_i(|{msg_header_v_i & msg_header_yumi_o})
+     ,.clear_i(msg_arb_unlock_li)
+     ,.data_o(send_data_r)
+     );
+
+  logic [lg_num_sink_lp-1:0] msg_dst_r;
+  bsg_dff_reset_en
+   #(.width_p(lg_num_sink_lp)
+     ,.reset_val_p(0)
+     )
+   msg_dst_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.en_i(|{msg_header_v_i & msg_header_yumi_o})
+     ,.data_i(msg_dst_i[msg_grants_sel_li])
+     ,.data_o(msg_dst_r)
+     );
+
+  bp_bedrock_xbar_msg_header_s msg_header_selected_lo;
+  bsg_mux_one_hot
+   #(.width_p($bits(bp_bedrock_xbar_msg_header_s)), .els_p(num_source_p))
+   msg_header_select
+    (.data_i(msg_header_i)
+     ,.sel_one_hot_i(msg_grants_lo)
+     ,.data_o(msg_header_selected_lo)
+     );
+  logic [data_width_p-1:0] msg_data_selected_lo;
+  bsg_mux_one_hot
+   #(.width_p(data_width_p), .els_p(num_source_p))
+   msg_data_select
+    (.data_i(msg_data_i)
+     ,.sel_one_hot_i(msg_grants_lo)
+     ,.data_o(msg_data_selected_lo)
+     );
+  assign msg_header_o = {num_sink_p{msg_header_selected_lo}};
+  assign msg_data_o   = {num_sink_p{msg_data_selected_lo}};
+  // output valid header when not sending data (i.e., ready for new header)
+  assign msg_header_v_o      = msg_grants_v_li ? {num_sink_p{~send_data_r}} & (1'b1 << msg_dst_i[msg_grants_sel_li]) : '0;
+  assign msg_header_yumi_o   = msg_grants_lo & {num_source_p{|{msg_header_v_o & msg_header_ready_and_i}}};
+  assign msg_has_data_o      = msg_header_v_o & {num_sink_p{msg_has_data_i[msg_grants_sel_li]}};
+  // output valid data after header sends
+  assign msg_data_v_o        = msg_grants_v_li ? {num_sink_p{send_data_r}} & (1'b1 << msg_dst_r) : '0;
+  assign msg_data_yumi_o     = msg_grants_lo & {num_source_p{|{msg_data_v_o & msg_data_ready_and_i}}};
+  assign msg_last_o          = msg_data_v_o & {num_sink_p{msg_last_i[msg_grants_sel_li]}};
+
+endmodule
+

--- a/bp_me/src/v/network/bp_me_xbar_burst_bidir.sv
+++ b/bp_me/src/v/network/bp_me_xbar_burst_bidir.sv
@@ -1,0 +1,136 @@
+/**
+ *
+ * Name:
+ *   bp_me_xbar_burst_bidir.sv
+ *
+ * Description:
+ *   This xbar arbitrates paired BedRock Burst command/response channels between
+ *   N sources and M sinks.
+ *
+ */
+
+`include "bp_common_defines.svh"
+`include "bp_me_defines.svh"
+
+module bp_me_xbar_burst_bidir
+ import bp_common_pkg::*;
+ import bp_me_pkg::*;
+ #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+   `declare_bp_proc_params(bp_params_p)
+
+   , parameter data_width_p    = "inv"
+   , parameter payload_width_p = "inv"
+   , parameter num_source_p    = "inv"
+   , parameter num_sink_p      = "inv"
+   `declare_bp_bedrock_if_widths(paddr_width_p, payload_width_p, data_width_p, lce_id_width_p, lce_assoc_p, xbar)
+
+   , localparam lg_num_source_lp = `BSG_SAFE_CLOG2(num_source_p)
+   , localparam lg_num_sink_lp   = `BSG_SAFE_CLOG2(num_sink_p)
+   )
+  (input                                                              clk_i
+   , input                                                            reset_i
+
+   , input [num_source_p-1:0][xbar_msg_header_width_lp-1:0]           cmd_header_i
+   , input [num_source_p-1:0]                                         cmd_header_v_i
+   , output logic [num_source_p-1:0]                                  cmd_header_yumi_o
+   , input [num_source_p-1:0]                                         cmd_has_data_i
+   , input [num_source_p-1:0][data_width_p-1:0]                       cmd_data_i
+   , input [num_source_p-1:0]                                         cmd_data_v_i
+   , output logic [num_source_p-1:0]                                  cmd_data_yumi_o
+   , input [num_source_p-1:0]                                         cmd_last_i
+   , input [num_source_p-1:0][lg_num_sink_lp-1:0]                     cmd_dst_i
+
+   , output logic [num_source_p-1:0][xbar_msg_header_width_lp-1:0]    resp_header_o
+   , output logic [num_source_p-1:0]                                  resp_header_v_o
+   , input [num_source_p-1:0]                                         resp_header_ready_and_i
+   , output logic [num_source_p-1:0]                                  resp_has_data_o
+   , output logic [num_source_p-1:0][data_width_p-1:0]                resp_data_o
+   , output logic [num_source_p-1:0]                                  resp_data_v_o
+   , input [num_source_p-1:0]                                         resp_data_ready_and_i
+   , output logic [num_source_p-1:0]                                  resp_last_o
+
+   , output logic [num_sink_p-1:0][xbar_msg_header_width_lp-1:0]      cmd_header_o
+   , output logic [num_sink_p-1:0]                                    cmd_header_v_o
+   , input [num_sink_p-1:0]                                           cmd_header_ready_and_i
+   , output logic [num_sink_p-1:0]                                    cmd_has_data_o
+   , output logic [num_sink_p-1:0][data_width_p-1:0]                  cmd_data_o
+   , output logic [num_sink_p-1:0]                                    cmd_data_v_o
+   , input [num_sink_p-1:0]                                           cmd_data_ready_and_i
+   , output logic [num_sink_p-1:0]                                    cmd_last_o
+
+   , input [num_sink_p-1:0][xbar_msg_header_width_lp-1:0]             resp_header_i
+   , input [num_sink_p-1:0]                                           resp_header_v_i
+   , output logic [num_sink_p-1:0]                                    resp_header_yumi_o
+   , input [num_sink_p-1:0]                                           resp_has_data_i
+   , input [num_sink_p-1:0][data_width_p-1:0]                         resp_data_i
+   , input [num_sink_p-1:0]                                           resp_data_v_i
+   , output logic [num_sink_p-1:0]                                    resp_data_yumi_o
+   , input [num_sink_p-1:0]                                           resp_last_i
+   , input [num_sink_p-1:0][lg_num_source_lp-1:0]                     resp_dst_i
+   );
+
+  // command channel - N:M
+  bp_me_xbar_burst
+   #(.data_width_p(data_width_p)
+     ,.payload_width_p(payload_width_p)
+     ,.num_source_p(num_source_p)
+     ,.num_sink_p(num_sink_p)
+     )
+   cmd_xbar
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.msg_header_i(cmd_header_i)
+     ,.msg_header_v_i(cmd_header_v_i)
+     ,.msg_header_yumi_o(cmd_header_yumi_o)
+     ,.msg_has_data_i(cmd_has_data_i)
+     ,.msg_data_i(cmd_data_i)
+     ,.msg_data_v_i(cmd_data_v_i)
+     ,.msg_data_yumi_o(cmd_data_yumi_o)
+     ,.msg_last_i(cmd_last_i)
+     ,.msg_dst_i(cmd_dst_i)
+
+     ,.msg_header_o(cmd_header_o)
+     ,.msg_header_v_o(cmd_header_v_o)
+     ,.msg_header_ready_and_i(cmd_header_ready_and_i)
+     ,.msg_has_data_o(cmd_has_data_o)
+     ,.msg_data_o(cmd_data_o)
+     ,.msg_data_v_o(cmd_data_v_o)
+     ,.msg_data_ready_and_i(cmd_data_ready_and_i)
+     ,.msg_last_o(cmd_last_o)
+     );
+
+  // response channel - M:N
+  // source and sink params are inverted for response xbar to do sink to source arbitration
+  bp_me_xbar_burst
+   #(.data_width_p(data_width_p)
+     ,.payload_width_p(payload_width_p)
+     ,.num_source_p(num_sink_p)
+     ,.num_sink_p(num_source_p)
+     )
+   resp_xbar
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.msg_header_i(resp_header_i)
+     ,.msg_header_v_i(resp_header_v_i)
+     ,.msg_header_yumi_o(resp_header_yumi_o)
+     ,.msg_has_data_i(resp_has_data_i)
+     ,.msg_data_i(resp_data_i)
+     ,.msg_data_v_i(resp_data_v_i)
+     ,.msg_data_yumi_o(resp_data_yumi_o)
+     ,.msg_last_i(resp_last_i)
+     ,.msg_dst_i(resp_dst_i)
+
+     ,.msg_header_o(resp_header_o)
+     ,.msg_header_v_o(resp_header_v_o)
+     ,.msg_header_ready_and_i(resp_header_ready_and_i)
+     ,.msg_has_data_o(resp_has_data_o)
+     ,.msg_data_o(resp_data_o)
+     ,.msg_data_v_o(resp_data_v_o)
+     ,.msg_data_ready_and_i(resp_data_ready_and_i)
+     ,.msg_last_o(resp_last_o)
+     );
+
+endmodule
+

--- a/bp_me/src/v/network/bp_me_xbar_stream.sv
+++ b/bp_me/src/v/network/bp_me_xbar_stream.sv
@@ -1,20 +1,27 @@
+/**
+ *
+ * Name:
+ *   bp_me_xbar_stream.sv
+ *
+ * Description:
+ *   This xbar arbitrates BedRock Stream messages between N sources and M sinks.
+ *
+ */
 
 `include "bp_common_defines.svh"
 `include "bp_me_defines.svh"
 
-// Command arbitration logic
-// This is suboptimal. We could have an arbiter for each source, to get higher
-//   throughput. So far this isn't a bottle neck, and this approach is less hardware.
 module bp_me_xbar_stream
  import bp_common_pkg::*;
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
 
-   , parameter data_width_p  = "inv"
-   , parameter num_source_p = "inv"
-   , parameter num_sink_p   = "inv"
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, data_width_p, lce_id_width_p, lce_assoc_p, uce)
+   , parameter data_width_p    = "inv"
+   , parameter payload_width_p = "inv"
+   , parameter num_source_p    = "inv"
+   , parameter num_sink_p      = "inv"
+   `declare_bp_bedrock_if_widths(paddr_width_p, payload_width_p, data_width_p, lce_id_width_p, lce_assoc_p, xbar)
 
    , localparam lg_num_source_lp = `BSG_SAFE_CLOG2(num_source_p)
    , localparam lg_num_sink_lp   = `BSG_SAFE_CLOG2(num_sink_p)
@@ -22,124 +29,66 @@ module bp_me_xbar_stream
   (input                                                              clk_i
    , input                                                            reset_i
 
-   , input [num_source_p-1:0][uce_mem_msg_header_width_lp-1:0]        cmd_header_i
-   , input [num_source_p-1:0][data_width_p-1:0]                       cmd_data_i
-   , input [num_source_p-1:0]                                         cmd_v_i
-   , output logic [num_source_p-1:0]                                  cmd_yumi_o
-   , input [num_source_p-1:0]                                         cmd_last_i
-   , input [num_source_p-1:0][lg_num_sink_lp-1:0]                     cmd_dst_i
+   , input [num_source_p-1:0][xbar_msg_header_width_lp-1:0]           msg_header_i
+   , input [num_source_p-1:0][data_width_p-1:0]                       msg_data_i
+   , input [num_source_p-1:0]                                         msg_v_i
+   , output logic [num_source_p-1:0]                                  msg_yumi_o
+   , input [num_source_p-1:0]                                         msg_last_i
+   , input [num_source_p-1:0][lg_num_sink_lp-1:0]                     msg_dst_i
 
-   , output logic [num_source_p-1:0][uce_mem_msg_header_width_lp-1:0] resp_header_o
-   , output logic [num_source_p-1:0][data_width_p-1:0]                resp_data_o
-   , output logic [num_source_p-1:0]                                  resp_v_o
-   , input [num_source_p-1:0]                                         resp_ready_and_i
-   , output logic [num_source_p-1:0]                                  resp_last_o
-
-   , output logic [num_sink_p-1:0][uce_mem_msg_header_width_lp-1:0]   cmd_header_o
-   , output logic [num_sink_p-1:0][data_width_p-1:0]                  cmd_data_o
-   , output logic [num_sink_p-1:0]                                    cmd_v_o
-   , input [num_sink_p-1:0]                                           cmd_ready_and_i
-   , output logic [num_sink_p-1:0]                                    cmd_last_o
-
-   , input [num_sink_p-1:0][uce_mem_msg_header_width_lp-1:0]          resp_header_i
-   , input [num_sink_p-1:0][data_width_p-1:0]                         resp_data_i
-   , input [num_sink_p-1:0]                                           resp_v_i
-   , output logic [num_sink_p-1:0]                                    resp_yumi_o
-   , input [num_sink_p-1:0]                                           resp_last_i
-   , input [num_sink_p-1:0][lg_num_source_lp-1:0]                     resp_dst_i
+   , output logic [num_sink_p-1:0][xbar_msg_header_width_lp-1:0]      msg_header_o
+   , output logic [num_sink_p-1:0][data_width_p-1:0]                  msg_data_o
+   , output logic [num_sink_p-1:0]                                    msg_v_o
+   , input [num_sink_p-1:0]                                           msg_ready_and_i
+   , output logic [num_sink_p-1:0]                                    msg_last_o
    );
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, data_width_p, lce_id_width_p, lce_assoc_p, uce);
+  `declare_bp_bedrock_if(paddr_width_p, payload_width_p, data_width_p, lce_id_width_p, lce_assoc_p, xbar);
 
-  // cmd arbitration logic
-  logic [num_source_p-1:0] cmd_grants_lo;
-  wire cmd_arb_unlock_li = |{cmd_yumi_o & cmd_last_i} | reset_i;
+  // msg arbitration logic
+  logic [num_source_p-1:0] msg_grants_lo;
+  wire msg_arb_unlock_li = |{msg_yumi_o & msg_last_i} | reset_i;
   bsg_locking_arb_fixed
    #(.inputs_p(num_source_p), .lo_to_hi_p(0))
-   cmd_arbiter
+   msg_arbiter
     (.clk_i(clk_i)
      ,.ready_i(1'b1)
 
-     ,.unlock_i(cmd_arb_unlock_li)
-     ,.reqs_i(cmd_v_i)
-     ,.grants_o(cmd_grants_lo)
+     ,.unlock_i(msg_arb_unlock_li)
+     ,.reqs_i(msg_v_i)
+     ,.grants_o(msg_grants_lo)
      );
-  logic [lg_num_source_lp-1:0] cmd_grants_sel_li;
-  logic cmd_grants_v_li;
+  logic [lg_num_source_lp-1:0] msg_grants_sel_li;
+  logic msg_grants_v_li;
   bsg_encode_one_hot
    #(.width_p(num_source_p), .lo_to_hi_p(1))
-   cmd_sel
-    (.i(cmd_grants_lo)
-     ,.addr_o(cmd_grants_sel_li)
-     ,.v_o(cmd_grants_v_li)
+   msg_sel
+    (.i(msg_grants_lo)
+     ,.addr_o(msg_grants_sel_li)
+     ,.v_o(msg_grants_v_li)
      );
 
-  bp_bedrock_uce_mem_msg_header_s cmd_header_selected_lo;
+  bp_bedrock_xbar_msg_header_s msg_header_selected_lo;
   bsg_mux_one_hot
-   #(.width_p($bits(bp_bedrock_uce_mem_msg_header_s)), .els_p(num_source_p))
-   cmd_header_select
-    (.data_i(cmd_header_i)
-     ,.sel_one_hot_i(cmd_grants_lo)
-     ,.data_o(cmd_header_selected_lo)
+   #(.width_p($bits(bp_bedrock_xbar_msg_header_s)), .els_p(num_source_p))
+   msg_header_select
+    (.data_i(msg_header_i)
+     ,.sel_one_hot_i(msg_grants_lo)
+     ,.data_o(msg_header_selected_lo)
      );
-  logic [data_width_p-1:0] cmd_data_selected_lo;
+  logic [data_width_p-1:0] msg_data_selected_lo;
   bsg_mux_one_hot
    #(.width_p(data_width_p), .els_p(num_source_p))
-   cmd_data_select
-    (.data_i(cmd_data_i)
-     ,.sel_one_hot_i(cmd_grants_lo)
-     ,.data_o(cmd_data_selected_lo)
+   msg_data_select
+    (.data_i(msg_data_i)
+     ,.sel_one_hot_i(msg_grants_lo)
+     ,.data_o(msg_data_selected_lo)
      );
-  assign cmd_header_o = {num_sink_p{cmd_header_selected_lo}};
-  assign cmd_data_o   = {num_sink_p{cmd_data_selected_lo}};
-  assign cmd_v_o      = cmd_grants_v_li ? (1'b1 << cmd_dst_i[cmd_grants_sel_li]) : '0;
-  assign cmd_yumi_o   = cmd_grants_lo & {num_source_p{|{cmd_v_o & cmd_ready_and_i}}};
-  assign cmd_last_o   = cmd_v_o & {num_sink_p{cmd_last_i[cmd_grants_sel_li]}};
-
-  // Response arbitration logic
-  logic [num_sink_p-1:0] resp_grant_li;
-  wire resp_arb_unlock_li = reset_i | |{resp_yumi_o & resp_last_i};
-  bsg_locking_arb_fixed
-   #(.inputs_p(num_sink_p), .lo_to_hi_p(1))
-   resp_arbiter
-    (.clk_i(clk_i)
-     ,.ready_i(1'b1)
-
-     ,.unlock_i(resp_arb_unlock_li)
-     ,.reqs_i(resp_v_i)
-     ,.grants_o(resp_grant_li)
-     );
-  logic [lg_num_sink_lp-1:0] resp_grant_sel_li;
-  logic resp_grant_v_li;
-  bsg_encode_one_hot
-   #(.width_p(num_sink_p), .lo_to_hi_p(1))
-   resp_sel
-    (.i(resp_grant_li)
-     ,.addr_o(resp_grant_sel_li)
-     ,.v_o(resp_grant_v_li)
-     );
-
-  bp_bedrock_uce_mem_msg_header_s resp_header_lo;
-  logic [data_width_p-1:0] resp_data_lo;
-  bsg_mux_one_hot
-   #(.width_p($bits(bp_bedrock_uce_mem_msg_header_s)), .els_p(num_sink_p))
-   resp_header_select
-    (.data_i(resp_header_i)
-     ,.sel_one_hot_i(resp_grant_li)
-     ,.data_o(resp_header_lo)
-     );
-  bsg_mux_one_hot
-  #(.width_p(data_width_p), .els_p(num_sink_p))
-  resp_data_select
-   (.data_i(resp_data_i)
-    ,.sel_one_hot_i(resp_grant_li)
-    ,.data_o(resp_data_lo)
-    );
-  assign resp_header_o = {num_source_p{resp_header_lo}};
-  assign resp_data_o   = {num_source_p{resp_data_lo}};
-  assign resp_v_o      = resp_grant_v_li ? (1'b1 << resp_dst_i[resp_grant_sel_li]) : '0;
-  assign resp_yumi_o   = resp_grant_li & {num_sink_p{|{resp_v_o & resp_ready_and_i}}};
-  assign resp_last_o   = resp_v_o & {num_source_p{resp_last_i[resp_grant_sel_li]}};
+  assign msg_header_o = {num_sink_p{msg_header_selected_lo}};
+  assign msg_data_o   = {num_sink_p{msg_data_selected_lo}};
+  assign msg_v_o      = msg_grants_v_li ? (1'b1 << msg_dst_i[msg_grants_sel_li]) : '0;
+  assign msg_yumi_o   = msg_grants_lo & {num_source_p{|{msg_v_o & msg_ready_and_i}}};
+  assign msg_last_o   = msg_v_o & {num_sink_p{msg_last_i[msg_grants_sel_li]}};
 
 endmodule
 

--- a/bp_me/src/v/network/bp_me_xbar_stream_bidir.sv
+++ b/bp_me/src/v/network/bp_me_xbar_stream_bidir.sv
@@ -1,0 +1,112 @@
+/**
+ *
+ * Name:
+ *   bp_me_xbar_stream_bidir.sv
+ *
+ * Description:
+ *   This xbar arbitrates paired BedRock Stream command/response channels between
+ *   N sources and M sinks.
+ *
+ */
+
+`include "bp_common_defines.svh"
+`include "bp_me_defines.svh"
+
+module bp_me_xbar_stream_bidir
+ import bp_common_pkg::*;
+ import bp_me_pkg::*;
+ #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+   `declare_bp_proc_params(bp_params_p)
+
+   , parameter data_width_p    = "inv"
+   , parameter payload_width_p = "inv"
+   , parameter num_source_p    = "inv"
+   , parameter num_sink_p      = "inv"
+   `declare_bp_bedrock_if_widths(paddr_width_p, payload_width_p, data_width_p, lce_id_width_p, lce_assoc_p, xbar)
+
+   , localparam lg_num_source_lp = `BSG_SAFE_CLOG2(num_source_p)
+   , localparam lg_num_sink_lp   = `BSG_SAFE_CLOG2(num_sink_p)
+   )
+  (input                                                              clk_i
+   , input                                                            reset_i
+
+   , input [num_source_p-1:0][xbar_msg_header_width_lp-1:0]           cmd_header_i
+   , input [num_source_p-1:0][data_width_p-1:0]                       cmd_data_i
+   , input [num_source_p-1:0]                                         cmd_v_i
+   , output logic [num_source_p-1:0]                                  cmd_yumi_o
+   , input [num_source_p-1:0]                                         cmd_last_i
+   , input [num_source_p-1:0][lg_num_sink_lp-1:0]                     cmd_dst_i
+
+   , output logic [num_source_p-1:0][xbar_msg_header_width_lp-1:0]    resp_header_o
+   , output logic [num_source_p-1:0][data_width_p-1:0]                resp_data_o
+   , output logic [num_source_p-1:0]                                  resp_v_o
+   , input [num_source_p-1:0]                                         resp_ready_and_i
+   , output logic [num_source_p-1:0]                                  resp_last_o
+
+   , output logic [num_sink_p-1:0][xbar_msg_header_width_lp-1:0]      cmd_header_o
+   , output logic [num_sink_p-1:0][data_width_p-1:0]                  cmd_data_o
+   , output logic [num_sink_p-1:0]                                    cmd_v_o
+   , input [num_sink_p-1:0]                                           cmd_ready_and_i
+   , output logic [num_sink_p-1:0]                                    cmd_last_o
+
+   , input [num_sink_p-1:0][xbar_msg_header_width_lp-1:0]             resp_header_i
+   , input [num_sink_p-1:0][data_width_p-1:0]                         resp_data_i
+   , input [num_sink_p-1:0]                                           resp_v_i
+   , output logic [num_sink_p-1:0]                                    resp_yumi_o
+   , input [num_sink_p-1:0]                                           resp_last_i
+   , input [num_sink_p-1:0][lg_num_source_lp-1:0]                     resp_dst_i
+   );
+
+  // command channel - N:M
+  bp_me_xbar_stream
+   #(.data_width_p(data_width_p)
+     ,.payload_width_p(payload_width_p)
+     ,.num_source_p(num_source_p)
+     ,.num_sink_p(num_sink_p)
+     )
+   cmd_xbar
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.msg_header_i(cmd_header_i)
+     ,.msg_data_i(cmd_data_i)
+     ,.msg_v_i(cmd_v_i)
+     ,.msg_yumi_o(cmd_yumi_o)
+     ,.msg_last_i(cmd_last_i)
+     ,.msg_dst_i(cmd_dst_i)
+
+     ,.msg_header_o(cmd_header_o)
+     ,.msg_data_o(cmd_data_o)
+     ,.msg_v_o(cmd_v_o)
+     ,.msg_ready_and_i(cmd_ready_and_i)
+     ,.msg_last_o(cmd_last_o)
+     );
+
+  // response channel - M:N
+  // source and sink params are inverted for response xbar to do sink to source arbitration
+  bp_me_xbar_stream
+   #(.data_width_p(data_width_p)
+     ,.payload_width_p(payload_width_p)
+     ,.num_source_p(num_sink_p)
+     ,.num_sink_p(num_source_p)
+     )
+   resp_xbar
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.msg_header_i(resp_header_i)
+     ,.msg_data_i(resp_data_i)
+     ,.msg_v_i(resp_v_i)
+     ,.msg_yumi_o(resp_yumi_o)
+     ,.msg_last_i(resp_last_i)
+     ,.msg_dst_i(resp_dst_i)
+
+     ,.msg_header_o(resp_header_o)
+     ,.msg_data_o(resp_data_o)
+     ,.msg_v_o(resp_v_o)
+     ,.msg_ready_and_i(resp_ready_and_i)
+     ,.msg_last_o(resp_last_o)
+     );
+
+endmodule
+

--- a/bp_me/syn/flist.vcs
+++ b/bp_me/syn/flist.vcs
@@ -117,6 +117,7 @@ $BASEJUMP_STL_DIR/bsg_misc/bsg_lfsr.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_lru_pseudo_tree_backup.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_lru_pseudo_tree_decode.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_lru_pseudo_tree_encode.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_locking_arb_fixed.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_mux.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_mux_bitwise.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_mux_butterfly.v
@@ -153,25 +154,25 @@ $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_input_control.v
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.v
 ## ME files
 # CCE
-$BP_ME_DIR/src/v/cce/bp_cce_alu.sv
-$BP_ME_DIR/src/v/cce/bp_cce_arbitrate.sv
-$BP_ME_DIR/src/v/cce/bp_cce_branch.sv
+#$BP_ME_DIR/src/v/cce/bp_cce_alu.sv
+#$BP_ME_DIR/src/v/cce/bp_cce_arbitrate.sv
+#$BP_ME_DIR/src/v/cce/bp_cce_branch.sv
 $BP_ME_DIR/src/v/cce/bp_cce_dir_lru_extract.sv
 $BP_ME_DIR/src/v/cce/bp_cce_dir_segment.sv
 $BP_ME_DIR/src/v/cce/bp_cce_dir_tag_checker.sv
 $BP_ME_DIR/src/v/cce/bp_cce_dir.sv
 $BP_ME_DIR/src/v/cce/bp_cce_gad.sv
-$BP_ME_DIR/src/v/cce/bp_cce_inst_decode.sv
-$BP_ME_DIR/src/v/cce/bp_cce_inst_predecode.sv
-$BP_ME_DIR/src/v/cce/bp_cce_inst_ram.sv
-$BP_ME_DIR/src/v/cce/bp_cce_inst_stall.sv
-$BP_ME_DIR/src/v/cce/bp_cce_msg.sv
+#$BP_ME_DIR/src/v/cce/bp_cce_inst_decode.sv
+#$BP_ME_DIR/src/v/cce/bp_cce_inst_predecode.sv
+#$BP_ME_DIR/src/v/cce/bp_cce_inst_ram.sv
+#$BP_ME_DIR/src/v/cce/bp_cce_inst_stall.sv
+#$BP_ME_DIR/src/v/cce/bp_cce_msg.sv
 $BP_ME_DIR/src/v/cce/bp_cce_pending_bits.sv
 $BP_ME_DIR/src/v/cce/bp_cce_pma.sv
-$BP_ME_DIR/src/v/cce/bp_cce_reg.sv
+#$BP_ME_DIR/src/v/cce/bp_cce_reg.sv
 $BP_ME_DIR/src/v/cce/bp_cce_spec_bits.sv
-$BP_ME_DIR/src/v/cce/bp_cce_src_sel.sv
-$BP_ME_DIR/src/v/cce/bp_cce.sv
+#$BP_ME_DIR/src/v/cce/bp_cce_src_sel.sv
+#$BP_ME_DIR/src/v/cce/bp_cce.sv
 $BP_ME_DIR/src/v/cce/bp_cce_fsm.sv
 $BP_ME_DIR/src/v/cce/bp_cce_wrapper.sv
 $BP_ME_DIR/src/v/cce/bp_io_cce.sv
@@ -186,6 +187,7 @@ $BP_ME_DIR/src/v/network/bp_me_stream_to_lite.sv
 $BP_ME_DIR/src/v/network/bp_me_cord_to_id.sv
 $BP_ME_DIR/src/v/network/bp_me_burst_to_lite.sv
 $BP_ME_DIR/src/v/network/bp_me_lite_to_burst.sv
+$BP_ME_DIR/src/v/network/bp_me_xbar_burst.sv
 
 # BSG Staging area
 $BP_COMMON_DIR/src/v/bsg_async_noc_link.sv

--- a/bp_me/test/tb/bp_cce/testbench.sv
+++ b/bp_me/test/tb/bp_cce/testbench.sv
@@ -30,7 +30,10 @@ module testbench
    // size of CCE-Memory buffers for cmd/resp messages
    // for this testbench (one LCE, one CCE, one memory) only need enough space to hold as many
    // cmds/responses can be generated for a single LCE request
-   , parameter mem_buffer_els_lp         = 4
+   // 32 = 4 * 8-beat messages
+   , parameter mem_buffer_els_lp         = 32
+
+   , localparam lg_num_lce_lp = `BSG_SAFE_CLOG2(num_lce_p)
 
    // LCE Trace Replay Width
    , localparam lce_opcode_width_lp=$bits(bp_me_nonsynth_lce_opcode_e)
@@ -44,24 +47,23 @@ module testbench
 
   export "DPI-C" function get_dram_period;
   export "DPI-C" function get_sim_period;
-  
+
   function int get_dram_period();
     return (`dram_pkg::tck_ps);
   endfunction
-  
+
   function int get_sim_period();
     return (`BP_SIM_CLK_PERIOD);
   endfunction
-  
+
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_bedrock_lce_if(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
   `declare_bp_bedrock_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce);
-  `declare_bp_bedrock_mem_if(paddr_width_p, dword_width_gp, lce_id_width_p, lce_assoc_p, xce);
-  
+
   // Bit to deal with initial X->0 transition detection
   bit clk_i;
   bit dram_clk_i, dram_reset_i;
-  
+
   `ifdef VERILATOR
     bsg_nonsynth_dpi_clock_gen
   `else
@@ -70,7 +72,7 @@ module testbench
     #(.cycle_time_p(`BP_SIM_CLK_PERIOD))
     clock_gen
     (.o(clk_i));
-  
+
   bsg_nonsynth_reset_gen
     #(.num_clocks_p(1)
       ,.reset_cycles_lo_p(0)
@@ -80,7 +82,7 @@ module testbench
     (.clk_i(clk_i)
       ,.async_reset_o(reset_i)
       );
-  
+
   `ifdef VERILATOR
     bsg_nonsynth_dpi_clock_gen
   `else
@@ -89,7 +91,7 @@ module testbench
     #(.cycle_time_p(`dram_pkg::tck_ps))
     dram_clock_gen
     (.o(dram_clk_i));
-  
+
   bsg_nonsynth_reset_gen
     #(.num_clocks_p(1)
       ,.reset_cycles_lo_p(0)
@@ -99,98 +101,578 @@ module testbench
     (.clk_i(dram_clk_i)
       ,.async_reset_o(dram_reset_i)
       );
-  
-  // CFG IF
+
+  // Config bus
   bp_cfg_bus_s             cfg_bus_lo;
-  bp_bedrock_cce_mem_msg_s cfg_mem_cmd_lo;
-  bp_bedrock_xce_mem_msg_s cfg_mem_cmd;
-  logic                    cfg_mem_cmd_v_lo, cfg_mem_cmd_ready_and_li;
-  assign cfg_mem_cmd = '{header: cfg_mem_cmd_lo.header
-                        ,data: cfg_mem_cmd_lo.data[0+:dword_width_gp]
-                        };
-  
-  // CCE-MEM IF
-  bp_bedrock_cce_mem_msg_s mem_resp;
-  logic                    mem_resp_v, mem_resp_yumi;
-  bp_bedrock_cce_mem_msg_s mem_cmd;
-  logic                    mem_cmd_v, mem_cmd_ready_and;
-  
-  // LCE-CCE IF
-  bp_bedrock_lce_req_msg_s  lce_req_lo;
-  bp_bedrock_lce_resp_msg_s lce_resp_lo;
-  bp_bedrock_lce_cmd_msg_s  lce_cmd_lo, lce_cmd_out_lo;
-  logic                  lce_req_v_lo, lce_req_ready_and_li;
-  logic                  lce_resp_v_lo, lce_resp_ready_and_li;
-  logic                  lce_cmd_v_lo, lce_cmd_ready_and_li;
-  logic                  lce_cmd_out_v_lo, lce_cmd_out_ready_and_li;
-  // Single LCE setup - LCE should never send a Data Command
-  assign lce_cmd_out_ready_and_li = '0;
-  
-  // Trace Replay for LCE
-  logic                        tr_v_li, tr_ready_lo;
-  logic [tr_ring_width_lp-1:0] tr_data_li;
-  logic                        tr_v_lo, tr_yumi_li;
-  logic [tr_ring_width_lp-1:0] tr_data_lo;
-  logic tr_done_lo;
-  
-  bsg_trace_node_master #(
-    .id_p('0)
-    ,.ring_width_p(tr_ring_width_lp)
-    ,.rom_addr_width_p(tr_rom_addr_width_p)
-  ) trace_node_master (
-    .clk_i(clk_i)
+
+  // CCE ucode interface
+  logic cce_ucode_v_li;
+  logic cce_ucode_w_li;
+  logic [cce_pc_width_p-1:0] cce_ucode_addr_li;
+  logic [cce_instr_width_gp-1:0] cce_ucode_data_li;
+  logic [cce_instr_width_gp-1:0] cce_ucode_data_lo;
+
+  // CCE Memory Interface - BedRock Stream
+  bp_bedrock_cce_mem_msg_header_s mem_resp_header, mem_cmd_header;
+  logic [dword_width_gp-1:0] mem_cmd_data, mem_resp_data;
+  logic mem_resp_v, mem_resp_ready_and;
+  logic mem_cmd_v, mem_cmd_ready_and;
+  logic mem_cmd_last, mem_resp_last;
+
+  // LCE trace replay interface
+  logic [num_lce_p-1:0]                       tr_v_li, tr_ready_lo;
+  logic [num_lce_p-1:0][tr_ring_width_lp-1:0] tr_data_li;
+  logic [num_lce_p-1:0]                       tr_v_lo, tr_yumi_li;
+  logic [num_lce_p-1:0][tr_ring_width_lp-1:0] tr_data_lo;
+  logic [num_lce_p-1:0]tr_done_lo;
+
+  // LCE-CCE request interface (from LCE to buffer) - BedRock Lite
+  bp_bedrock_lce_req_msg_s  [num_lce_p-1:0] lce_req_lo;
+  logic [num_lce_p-1:0]                     lce_req_v_lo, lce_req_ready_and_li;
+  // LCE-CCE request interface (from buffer to lite-to-burst)
+  bp_bedrock_lce_req_msg_s [num_lce_p-1:0] lce_req_l2b;
+  logic [num_lce_p-1:0]                    lce_req_l2b_v, lce_req_l2b_ready_and;
+  // LCE-CCE request interface (from lite-to-burst converter to xbar)
+  bp_bedrock_lce_req_msg_header_s [num_lce_p-1:0] lce_req_header;
+  logic [num_lce_p-1:0] lce_req_header_v, lce_req_header_ready_and;
+  logic [num_lce_p-1:0] lce_req_has_data;
+  logic [num_lce_p-1:0][dword_width_gp-1:0] lce_req_data;
+  logic [num_lce_p-1:0] lce_req_data_v, lce_req_data_ready_and;
+  logic [num_lce_p-1:0] lce_req_last;
+  logic [num_lce_p-1:0] lce_req_dst;
+  assign lce_req_dst = '0;
+  // LCE-CCE request interface (from xbar to CCE)
+  bp_bedrock_lce_req_msg_header_s lce_req_header_li;
+  logic lce_req_header_v_li, lce_req_header_ready_and_lo;
+  logic lce_req_has_data_li;
+  logic [dword_width_gp-1:0] lce_req_data_li;
+  logic lce_req_data_v_li, lce_req_data_ready_and_lo;
+  logic lce_req_last_li;
+
+
+  // LCE-CCE response interface (from LCE to buffer) - BedRock Lite
+  bp_bedrock_lce_resp_msg_s [num_lce_p-1:0] lce_resp_lo;
+  logic [num_lce_p-1:0]                     lce_resp_v_lo, lce_resp_ready_and_li;
+  // LCE-CCE response interface (from buffer to lite-to-burst)
+  bp_bedrock_lce_resp_msg_s [num_lce_p-1:0] lce_resp_l2b;
+  logic [num_lce_p-1:0]                     lce_resp_l2b_v, lce_resp_l2b_ready_and;
+  // LCE-CCE response interface (from lite-to-burst converter to xbar)
+  bp_bedrock_lce_resp_msg_header_s [num_lce_p-1:0] lce_resp_header;
+  logic [num_lce_p-1:0] lce_resp_header_v, lce_resp_header_ready_and;
+  logic [num_lce_p-1:0] lce_resp_has_data;
+  logic [num_lce_p-1:0][dword_width_gp-1:0] lce_resp_data;
+  logic [num_lce_p-1:0] lce_resp_data_v, lce_resp_data_ready_and;
+  logic [num_lce_p-1:0] lce_resp_last;
+  logic [num_lce_p-1:0] lce_resp_dst;
+  assign lce_resp_dst = '0;
+  // LCE-CCE response interface (from xbar to CCE)
+  bp_bedrock_lce_resp_msg_header_s lce_resp_header_li;
+  logic lce_resp_header_v_li, lce_resp_header_ready_and_lo;
+  logic lce_resp_has_data_li;
+  logic [dword_width_gp-1:0] lce_resp_data_li;
+  logic lce_resp_data_v_li, lce_resp_data_ready_and_lo;
+  logic lce_resp_last_li;
+
+  // LCE-CCE command interface (from xbar to burst-to-lite)
+  bp_bedrock_lce_cmd_msg_header_s [num_lce_p-1:0] lce_cmd_header_li;
+  logic [num_lce_p-1:0] lce_cmd_header_v_li, lce_cmd_header_ready_and_lo;
+  logic [num_lce_p-1:0] lce_cmd_has_data_li;
+  logic [num_lce_p-1:0][dword_width_gp-1:0] lce_cmd_data_li;
+  logic [num_lce_p-1:0] lce_cmd_data_v_li, lce_cmd_data_ready_and_lo;
+  logic [num_lce_p-1:0] lce_cmd_last_li;
+  // LCE-CCE command interface (from burst-to-lite to LCE) - BedRock Lite
+  bp_bedrock_lce_cmd_msg_s [num_lce_p-1:0] lce_cmd_li;
+  logic [num_lce_p-1:0]                    lce_cmd_v_li, lce_cmd_ready_and_lo;
+
+  // LCE-CCE command out interface (from LCE to buffer) - BedRock Lite
+  bp_bedrock_lce_cmd_msg_s  [num_lce_p-1:0] lce_cmd_out_lo;
+  logic [num_lce_p-1:0]                     lce_cmd_out_v_lo, lce_cmd_out_ready_and_li;
+  // LCE-CCE command out interface (from buffer to lite-to-burst)
+  bp_bedrock_lce_cmd_msg_s [num_lce_p-1:0]  lce_cmd_out_l2b;
+  logic [num_lce_p-1:0]                     lce_cmd_out_l2b_v, lce_cmd_out_l2b_ready_and;
+  // LCE-CCE command out interface (from lite-to-burst to xbar)
+  bp_bedrock_lce_cmd_msg_header_s [num_lce_p-1:0] lce_cmd_out_header;
+  logic [num_lce_p-1:0] lce_cmd_out_header_v, lce_cmd_out_header_ready_and;
+  logic [num_lce_p-1:0] lce_cmd_out_has_data;
+  logic [num_lce_p-1:0][dword_width_gp-1:0] lce_cmd_out_data;
+  logic [num_lce_p-1:0] lce_cmd_out_data_v, lce_cmd_out_data_ready_and;
+  logic [num_lce_p-1:0] lce_cmd_out_last;
+  logic [num_lce_p-1:0][lg_num_lce_lp-1:0] lce_cmd_out_dst;
+
+  // LCE-CCE command interface (from CCE to xbar)
+  bp_bedrock_lce_cmd_msg_header_s lce_cmd_header_lo;
+  logic lce_cmd_header_v_lo, lce_cmd_header_ready_and_li;
+  logic lce_cmd_has_data_lo;
+  logic [dword_width_gp-1:0] lce_cmd_data_lo;
+  logic lce_cmd_data_v_lo, lce_cmd_data_ready_and_li;
+  logic lce_cmd_last_lo;
+  logic [lg_num_lce_lp-1:0] lce_cmd_dst_lo;
+  assign lce_cmd_dst_lo = lce_cmd_header_lo.payload.dst_id;
+
+  // Req Crossbar
+  bp_me_xbar_burst
+   #(.data_width_p(dword_width_gp)
+     ,.payload_width_p(lce_req_payload_width_lp)
+     ,.num_source_p(num_lce_p)
+     ,.num_sink_p(num_cce_p)
+     )
+   req_xbar
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.msg_header_i(lce_req_header)
+     ,.msg_header_v_i(lce_req_header_v)
+     ,.msg_header_yumi_o(lce_req_header_ready_and)
+     ,.msg_has_data_i(lce_req_has_data)
+     ,.msg_data_i(lce_req_data)
+     ,.msg_data_v_i(lce_req_data_v)
+     ,.msg_data_yumi_o(lce_req_data_ready_and)
+     ,.msg_last_i(lce_req_last)
+     ,.msg_dst_i(lce_req_dst)
+
+     ,.msg_header_o(lce_req_header_li)
+     ,.msg_header_v_o(lce_req_header_v_li)
+     ,.msg_header_ready_and_i(lce_req_header_ready_and_lo)
+     ,.msg_has_data_o(lce_req_has_data_li)
+     ,.msg_data_o(lce_req_data_li)
+     ,.msg_data_v_o(lce_req_data_v_li)
+     ,.msg_data_ready_and_i(lce_req_data_ready_and_lo)
+     ,.msg_last_o(lce_req_last_li)
+     );
+
+  // Resp Crossbar
+  bp_me_xbar_burst
+   #(.data_width_p(dword_width_gp)
+     ,.payload_width_p(lce_resp_payload_width_lp)
+     ,.num_source_p(num_lce_p)
+     ,.num_sink_p(num_cce_p)
+     )
+   resp_xbar
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.msg_header_i(lce_resp_header)
+     ,.msg_header_v_i(lce_resp_header_v)
+     ,.msg_header_yumi_o(lce_resp_header_ready_and)
+     ,.msg_has_data_i(lce_resp_has_data)
+     ,.msg_data_i(lce_resp_data)
+     ,.msg_data_v_i(lce_resp_data_v)
+     ,.msg_data_yumi_o(lce_resp_data_ready_and)
+     ,.msg_last_i(lce_resp_last)
+     ,.msg_dst_i(lce_resp_dst)
+
+     ,.msg_header_o(lce_resp_header_li)
+     ,.msg_header_v_o(lce_resp_header_v_li)
+     ,.msg_header_ready_and_i(lce_resp_header_ready_and_lo)
+     ,.msg_has_data_o(lce_resp_has_data_li)
+     ,.msg_data_o(lce_resp_data_li)
+     ,.msg_data_v_o(lce_resp_data_v_li)
+     ,.msg_data_ready_and_i(lce_resp_data_ready_and_lo)
+     ,.msg_last_o(lce_resp_last_li)
+     );
+
+  // Cmd Crossbar
+  // from CCE and LCE cmd out to LCE cmd in
+  bp_me_xbar_burst
+   #(.data_width_p(dword_width_gp)
+     ,.payload_width_p(lce_cmd_payload_width_lp)
+     ,.num_source_p(num_cce_p+num_lce_p)
+     ,.num_sink_p(num_lce_p)
+     )
+   cmd_xbar
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.msg_header_i({lce_cmd_header_lo, lce_cmd_out_header})
+     ,.msg_header_v_i({lce_cmd_header_v_lo, lce_cmd_out_header_v})
+     ,.msg_header_yumi_o({lce_cmd_header_ready_and_li, lce_cmd_out_header_ready_and})
+     ,.msg_has_data_i({lce_cmd_has_data_lo, lce_cmd_out_has_data})
+     ,.msg_data_i({lce_cmd_data_lo, lce_cmd_out_data})
+     ,.msg_data_v_i({lce_cmd_data_v_lo, lce_cmd_out_data_v})
+     ,.msg_data_yumi_o({lce_cmd_data_ready_and_li, lce_cmd_out_data_ready_and})
+     ,.msg_last_i({lce_cmd_last_lo, lce_cmd_out_last})
+     ,.msg_dst_i({lce_cmd_dst_lo, lce_cmd_out_dst})
+
+     ,.msg_header_o(lce_cmd_header_li)
+     ,.msg_header_v_o(lce_cmd_header_v_li)
+     ,.msg_header_ready_and_i(lce_cmd_header_ready_and_lo)
+     ,.msg_has_data_o(lce_cmd_has_data_li)
+     ,.msg_data_o(lce_cmd_data_li)
+     ,.msg_data_v_o(lce_cmd_data_v_li)
+     ,.msg_data_ready_and_i(lce_cmd_data_ready_and_lo)
+     ,.msg_last_o(lce_cmd_last_li)
+     );
+
+  for (genvar i = 0; i < num_lce_p; i++) begin : lce
+    // Trace Replay Driver
+    bsg_trace_node_master
+     #(.id_p(i)
+       ,.ring_width_p(tr_ring_width_lp)
+       ,.rom_addr_width_p(tr_rom_addr_width_p)
+       )
+     trace_replay
+      (.clk_i(clk_i)
+       ,.reset_i(reset_i)
+       ,.en_i(1'b1)
+
+       ,.v_i(tr_v_li[i])
+       ,.data_i(tr_data_li[i])
+       ,.ready_o(tr_ready_lo[i])
+
+       ,.v_o(tr_v_lo[i])
+       ,.yumi_i(tr_yumi_li[i])
+       ,.data_o(tr_data_lo[i])
+
+       ,.done_o(tr_done_lo[i])
+       );
+
+    // Mock LCE
+    bp_me_nonsynth_mock_lce
+     #(.bp_params_p(bp_params_p)
+       ,.axe_trace_p(axe_trace_p)
+       ,.skip_init_p(cce_mode_p)
+       )
+     lce
+      (.clk_i(clk_i)
+       ,.reset_i(reset_i)
+       ,.freeze_i(cfg_bus_lo.freeze)
+
+       ,.lce_id_i(lce_id_width_p'(i))
+
+       ,.tr_pkt_i(tr_data_lo[i])
+       ,.tr_pkt_v_i(tr_v_lo[i])
+       ,.tr_pkt_yumi_o(tr_yumi_li[i])
+
+       ,.tr_pkt_v_o(tr_v_li[i])
+       ,.tr_pkt_o(tr_data_li[i])
+       ,.tr_pkt_ready_i(tr_ready_lo[i])
+
+       ,.lce_req_o(lce_req_lo[i])
+       ,.lce_req_v_o(lce_req_v_lo[i])
+       ,.lce_req_ready_and_i(lce_req_ready_and_li[i])
+
+       ,.lce_resp_o(lce_resp_lo[i])
+       ,.lce_resp_v_o(lce_resp_v_lo[i])
+       ,.lce_resp_ready_and_i(lce_resp_ready_and_li[i])
+
+       ,.lce_cmd_i(lce_cmd_li[i])
+       ,.lce_cmd_v_i(lce_cmd_v_li[i])
+       ,.lce_cmd_ready_and_o(lce_cmd_ready_and_lo[i])
+
+       ,.lce_cmd_o(lce_cmd_out_lo[i])
+       ,.lce_cmd_v_o(lce_cmd_out_v_lo[i])
+       ,.lce_cmd_ready_and_i(lce_cmd_out_ready_and_li[i])
+       );
+
+    // LCE Request Buffer
+    bsg_two_fifo
+    #(.width_p($bits(bp_bedrock_lce_req_msg_s)))
+    lce_req_buffer
+     (.clk_i(clk_i)
+      ,.reset_i(reset_i)
+      // from LCE
+      ,.v_i(lce_req_v_lo[i])
+      ,.data_i(lce_req_lo[i])
+      ,.ready_o(lce_req_ready_and_li[i])
+      // to lite to burst
+      ,.v_o(lce_req_l2b_v[i])
+      ,.data_o(lce_req_l2b[i])
+      ,.yumi_i(lce_req_l2b_v[i] & lce_req_l2b_ready_and[i])
+      );
+
+    // LCE Request
+    bp_me_lite_to_burst
+     #(.bp_params_p(bp_params_p)
+       ,.in_data_width_p(cce_block_width_p)
+       ,.out_data_width_p(dword_width_gp)
+       ,.payload_width_p(lce_req_payload_width_lp)
+       ,.payload_mask_p(lce_req_payload_mask_gp)
+       )
+     lce_req_lite2burst
+      (.clk_i(clk_i)
+       ,.reset_i(reset_i)
+
+       ,.in_msg_i(lce_req_l2b[i])
+       ,.in_msg_v_i(lce_req_l2b_v[i])
+       ,.in_msg_ready_and_o(lce_req_l2b_ready_and[i])
+
+       ,.out_msg_header_o(lce_req_header[i])
+       ,.out_msg_header_v_o(lce_req_header_v[i])
+       ,.out_msg_header_ready_and_i(lce_req_header_ready_and[i])
+       ,.out_msg_has_data_o(lce_req_has_data[i])
+
+       ,.out_msg_data_o(lce_req_data[i])
+       ,.out_msg_data_v_o(lce_req_data_v[i])
+       ,.out_msg_data_ready_and_i(lce_req_data_ready_and[i])
+       ,.out_msg_last_o(lce_req_last[i])
+       );
+
+    // LCE Response Buffer
+    bsg_two_fifo
+    #(.width_p($bits(bp_bedrock_lce_resp_msg_s)))
+    lce_resp_buffer
+     (.clk_i(clk_i)
+      ,.reset_i(reset_i)
+      // from LCE
+      ,.v_i(lce_resp_v_lo[i])
+      ,.data_i(lce_resp_lo[i])
+      ,.ready_o(lce_resp_ready_and_li[i])
+      // to lite to burst
+      ,.v_o(lce_resp_l2b_v[i])
+      ,.data_o(lce_resp_l2b[i])
+      ,.yumi_i(lce_resp_l2b_v[i] & lce_resp_l2b_ready_and[i])
+      );
+
+    // LCE Response
+    bp_me_lite_to_burst
+     #(.bp_params_p(bp_params_p)
+       ,.in_data_width_p(cce_block_width_p)
+       ,.out_data_width_p(dword_width_gp)
+       ,.payload_width_p(lce_resp_payload_width_lp)
+       ,.payload_mask_p(lce_resp_payload_mask_gp)
+       )
+     lce_resp_lite2burst
+      (.clk_i(clk_i)
+       ,.reset_i(reset_i)
+
+       ,.in_msg_i(lce_resp_l2b[i])
+       ,.in_msg_v_i(lce_resp_l2b_v[i])
+       ,.in_msg_ready_and_o(lce_resp_l2b_ready_and[i])
+
+       ,.out_msg_header_o(lce_resp_header[i])
+       ,.out_msg_header_v_o(lce_resp_header_v[i])
+       ,.out_msg_header_ready_and_i(lce_resp_header_ready_and[i])
+       ,.out_msg_has_data_o(lce_resp_has_data[i])
+
+       ,.out_msg_data_o(lce_resp_data[i])
+       ,.out_msg_data_v_o(lce_resp_data_v[i])
+       ,.out_msg_data_ready_and_i(lce_resp_data_ready_and[i])
+       ,.out_msg_last_o(lce_resp_last[i])
+       );
+
+    // LCE Command In (from xbar to LCE)
+    bp_me_burst_to_lite
+     #(.bp_params_p(bp_params_p)
+       ,.in_data_width_p(dword_width_gp)
+       ,.out_data_width_p(cce_block_width_p)
+       ,.payload_width_p(lce_cmd_payload_width_lp)
+       ,.payload_mask_p(lce_cmd_payload_mask_gp)
+       )
+     lce_cmd_burst2lite
+      (.clk_i(clk_i)
+       ,.reset_i(reset_i)
+
+       ,.in_msg_header_i(lce_cmd_header_li[i])
+       ,.in_msg_header_v_i(lce_cmd_header_v_li[i])
+       ,.in_msg_header_ready_and_o(lce_cmd_header_ready_and_lo[i])
+       ,.in_msg_has_data_i(lce_cmd_has_data_li[i])
+
+       ,.in_msg_data_i(lce_cmd_data_li[i])
+       ,.in_msg_data_v_i(lce_cmd_data_v_li[i])
+       ,.in_msg_data_ready_and_o(lce_cmd_data_ready_and_lo[i])
+       ,.in_msg_last_i(lce_cmd_last_li[i])
+
+       ,.out_msg_o(lce_cmd_li[i])
+       ,.out_msg_v_o(lce_cmd_v_li[i])
+       ,.out_msg_ready_and_i(lce_cmd_ready_and_lo[i])
+       );
+
+    // LCE Command Out Buffer
+    bsg_two_fifo
+    #(.width_p($bits(bp_bedrock_lce_cmd_msg_s)))
+    lce_cmd_out_buffer
+     (.clk_i(clk_i)
+      ,.reset_i(reset_i)
+      // from LCE
+      ,.v_i(lce_cmd_out_v_lo[i])
+      ,.data_i(lce_cmd_out_lo[i])
+      ,.ready_o(lce_cmd_out_ready_and_li[i])
+      // to lite to burst
+      ,.v_o(lce_cmd_out_l2b_v[i])
+      ,.data_o(lce_cmd_out_l2b[i])
+      ,.yumi_i(lce_cmd_out_l2b_v[i] & lce_cmd_out_l2b_ready_and[i])
+      );
+
+    // LCE Command Out
+    bp_me_lite_to_burst
+     #(.bp_params_p(bp_params_p)
+       ,.in_data_width_p(cce_block_width_p)
+       ,.out_data_width_p(dword_width_gp)
+       ,.payload_width_p(lce_cmd_payload_width_lp)
+       ,.payload_mask_p(lce_cmd_payload_mask_gp)
+       )
+     lce_cmd_lite2burst
+      (.clk_i(clk_i)
+       ,.reset_i(reset_i)
+
+       ,.in_msg_i(lce_cmd_out_l2b[i])
+       ,.in_msg_v_i(lce_cmd_out_l2b_v[i])
+       ,.in_msg_ready_and_o(lce_cmd_out_l2b_ready_and[i])
+       ,.out_msg_header_o(lce_cmd_out_header[i])
+       ,.out_msg_header_v_o(lce_cmd_out_header_v[i])
+       ,.out_msg_header_ready_and_i(lce_cmd_out_header_ready_and[i])
+       ,.out_msg_has_data_o(lce_cmd_out_has_data[i])
+       ,.out_msg_data_o(lce_cmd_out_data[i])
+       ,.out_msg_data_v_o(lce_cmd_out_data_v[i])
+       ,.out_msg_data_ready_and_i(lce_cmd_out_data_ready_and[i])
+       ,.out_msg_last_o(lce_cmd_out_last[i])
+       );
+
+    assign lce_cmd_out_dst[i] = lce_cmd_out_header[i].payload.dst_id;
+  end
+
+  // CCE
+  wrapper
+  #(.bp_params_p(bp_params_p)
+    ,.cce_trace_p(cce_trace_p)
+   )
+  wrapper
+   (.clk_i(clk_i)
     ,.reset_i(reset_i)
-    ,.en_i(1'b1)
-  
-    ,.v_i(tr_v_li)
-    ,.data_i(tr_data_li)
-    ,.ready_o(tr_ready_lo)
-  
-    ,.v_o(tr_v_lo)
-    ,.yumi_i(tr_yumi_li)
-    ,.data_o(tr_data_lo)
-  
-    ,.done_o(tr_done_lo)
+
+    ,.cfg_bus_i(cfg_bus_lo)
+
+    ,.ucode_v_i(cce_ucode_v_li)
+    ,.ucode_w_i(cce_ucode_w_li)
+    ,.ucode_addr_i(cce_ucode_addr_li)
+    ,.ucode_data_i(cce_ucode_data_li)
+    ,.ucode_data_o(cce_ucode_data_lo)
+
+    // LCE-CCE Interface
+    // BedRock Burst protocol: ready&valid
+    ,.lce_req_header_i(lce_req_header_li)
+    ,.lce_req_header_v_i(lce_req_header_v_li)
+    ,.lce_req_header_ready_and_o(lce_req_header_ready_and_lo)
+    ,.lce_req_has_data_i(lce_req_has_data_li)
+    ,.lce_req_data_i(lce_req_data_li)
+    ,.lce_req_data_v_i(lce_req_data_v_li)
+    ,.lce_req_data_ready_and_o(lce_req_data_ready_and_lo)
+    ,.lce_req_last_i(lce_req_last_li)
+
+    ,.lce_resp_header_i(lce_resp_header_li)
+    ,.lce_resp_header_v_i(lce_resp_header_v_li)
+    ,.lce_resp_header_ready_and_o(lce_resp_header_ready_and_lo)
+    ,.lce_resp_has_data_i(lce_resp_has_data_li)
+    ,.lce_resp_data_i(lce_resp_data_li)
+    ,.lce_resp_data_v_i(lce_resp_data_v_li)
+    ,.lce_resp_data_ready_and_o(lce_resp_data_ready_and_lo)
+    ,.lce_resp_last_i(lce_resp_last_li)
+
+    ,.lce_cmd_header_o(lce_cmd_header_lo)
+    ,.lce_cmd_header_v_o(lce_cmd_header_v_lo)
+    ,.lce_cmd_header_ready_and_i(lce_cmd_header_ready_and_li)
+    ,.lce_cmd_has_data_o(lce_cmd_has_data_lo)
+    ,.lce_cmd_data_o(lce_cmd_data_lo)
+    ,.lce_cmd_data_v_o(lce_cmd_data_v_lo)
+    ,.lce_cmd_data_ready_and_i(lce_cmd_data_ready_and_li)
+    ,.lce_cmd_last_o(lce_cmd_last_lo)
+
+    // CCE-MEM Interface
+    // BedRock Stream protocol: ready&valid
+    ,.mem_resp_header_i(mem_resp_header)
+    ,.mem_resp_data_i(mem_resp_data)
+    ,.mem_resp_v_i(mem_resp_v)
+    ,.mem_resp_ready_and_o(mem_resp_ready_and)
+    ,.mem_resp_last_i(mem_resp_last)
+
+    ,.mem_cmd_header_o(mem_cmd_header)
+    ,.mem_cmd_data_o(mem_cmd_data)
+    ,.mem_cmd_v_o(mem_cmd_v)
+    ,.mem_cmd_ready_and_i(mem_cmd_ready_and)
+    ,.mem_cmd_last_o(mem_cmd_last)
   );
-  
-  
-  // LCE
-  bp_me_nonsynth_mock_lce #(
-    .bp_params_p(bp_params_p)
-    ,.axe_trace_p(axe_trace_p)
-    ,.skip_init_p(cce_mode_p)
-  ) lce (
-    .clk_i(clk_i)
+
+  // Memory Command Buffer
+  bp_bedrock_cce_mem_msg_header_s mem_cmd_lo;
+  logic [dword_width_gp-1:0] mem_cmd_data_lo;
+  logic mem_cmd_v_lo, mem_cmd_ready_and_li, mem_cmd_yumi_li, mem_cmd_last_lo;
+  bsg_fifo_1r1w_small
+  #(.width_p($bits(bp_bedrock_cce_mem_msg_header_s)+dword_width_gp+1)
+    ,.els_p(mem_buffer_els_lp)
+    )
+  mem_cmd_stream_buffer
+   (.clk_i(clk_i)
     ,.reset_i(reset_i)
-    ,.freeze_i(cfg_bus_lo.freeze)
-  
-    ,.lce_id_i('0)
-  
-    ,.tr_pkt_i(tr_data_lo)
-    ,.tr_pkt_v_i(tr_v_lo)
-    ,.tr_pkt_yumi_o(tr_yumi_li)
-  
-    ,.tr_pkt_v_o(tr_v_li)
-    ,.tr_pkt_o(tr_data_li)
-    ,.tr_pkt_ready_i(tr_ready_lo)
-  
-    ,.lce_req_o(lce_req_lo)
-    ,.lce_req_v_o(lce_req_v_lo)
-    ,.lce_req_ready_and_i(lce_req_ready_and_li)
-  
-    ,.lce_resp_o(lce_resp_lo)
-    ,.lce_resp_v_o(lce_resp_v_lo)
-    ,.lce_resp_ready_and_i(lce_resp_ready_and_li)
-  
-    ,.lce_cmd_i(lce_cmd_lo)
-    ,.lce_cmd_v_i(lce_cmd_v_lo)
-    ,.lce_cmd_ready_and_o(lce_cmd_ready_and_li)
-  
-    ,.lce_cmd_o(lce_cmd_out_lo)
-    ,.lce_cmd_v_o(lce_cmd_out_v_lo)
-    ,.lce_cmd_ready_and_i(lce_cmd_out_ready_and_li)
-  );
-  
+    // from CCE
+    ,.v_i(mem_cmd_v)
+    ,.ready_o(mem_cmd_ready_and)
+    ,.data_i({mem_cmd_last, mem_cmd_data, mem_cmd_header})
+    // to memory
+    ,.v_o(mem_cmd_v_lo)
+    ,.yumi_i(mem_cmd_yumi_li)
+    ,.data_o({mem_cmd_last_lo, mem_cmd_data_lo, mem_cmd_lo})
+    );
+  assign mem_cmd_yumi_li = mem_cmd_v_lo & mem_cmd_ready_and_li;
+
+  // Memory Response Buffer
+  bp_bedrock_cce_mem_msg_header_s mem_resp_li;
+  logic [dword_width_gp-1:0] mem_resp_data_li;
+  logic mem_resp_v_li, mem_resp_ready_and_lo, mem_resp_last_li, mem_resp_yumi_lo;
+  bsg_fifo_1r1w_small
+  #(.width_p($bits(bp_bedrock_cce_mem_msg_header_s)+dword_width_gp+1)
+    ,.els_p(mem_buffer_els_lp)
+    )
+  mem_resp_stream_buffer
+   (.clk_i(clk_i)
+    ,.reset_i(reset_i)
+    // from memory
+    ,.v_i(mem_resp_v_li)
+    ,.ready_o(mem_resp_ready_and_lo)
+    ,.data_i({mem_resp_last_li, mem_resp_data_li, mem_resp_li})
+    // to CCE
+    ,.v_o(mem_resp_v)
+    ,.yumi_i(mem_resp_yumi_lo)
+    ,.data_o({mem_resp_last, mem_resp_data, mem_resp_header})
+    );
+  assign mem_resp_yumi_lo = mem_resp_v & mem_resp_ready_and;
+
+  bp_nonsynth_mem
+   #(.bp_params_p(bp_params_p)
+     ,.preload_mem_p(0)
+     ,.dram_type_p(dram_type_p)
+     ,.mem_els_p(2**20)
+     )
+   mem
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.mem_cmd_header_i(mem_cmd_lo)
+     ,.mem_cmd_data_i(mem_cmd_data_lo)
+     ,.mem_cmd_v_i(mem_cmd_v_lo)
+     ,.mem_cmd_ready_and_o(mem_cmd_ready_and_li)
+     ,.mem_cmd_last_i(mem_cmd_last_lo)
+
+     ,.mem_resp_header_o(mem_resp_li)
+     ,.mem_resp_data_o(mem_resp_data_li)
+     ,.mem_resp_v_o(mem_resp_v_li)
+     ,.mem_resp_ready_and_i(mem_resp_ready_and_lo)
+     ,.mem_resp_last_o(mem_resp_last_li)
+
+     ,.dram_clk_i(dram_clk_i)
+     ,.dram_reset_i(dram_reset_i)
+     );
+
+  // Tracers and binds
+
+  bp_mem_nonsynth_tracer
+   #(.bp_params_p(bp_params_p))
+   bp_mem_tracer
+    (.clk_i(clk_i & (testbench.dram_trace_p == 1))
+     ,.reset_i(reset_i)
+
+     ,.mem_cmd_header_i(mem_cmd_lo)
+     ,.mem_cmd_data_i(mem_cmd_data_lo)
+     ,.mem_cmd_v_i(mem_cmd_v_lo)
+     ,.mem_cmd_ready_and_i(mem_cmd_ready_and_li)
+     ,.mem_cmd_last_i(mem_cmd_last_lo)
+
+     ,.mem_resp_header_i(mem_resp_li)
+     ,.mem_resp_data_i(mem_resp_data_li)
+     ,.mem_resp_v_i(mem_resp_v_li)
+     ,.mem_resp_ready_and_i(mem_resp_ready_and_lo)
+     ,.mem_resp_last_i(mem_resp_last_li)
+     );
+
   bind bp_me_nonsynth_mock_lce
     bp_me_nonsynth_lce_tracer
       #(.bp_params_p(bp_params_p)
@@ -215,7 +697,7 @@ module testbench
         ,.lce_cmd_o_v_i(lce_cmd_v_o)
         ,.lce_cmd_o_ready_and_i(lce_cmd_ready_and_i)
         );
-  
+
   bind bp_me_nonsynth_mock_lce
     bp_me_nonsynth_lce_tr_tracer
       #(.bp_params_p(bp_params_p)
@@ -233,17 +715,16 @@ module testbench
         ,.tr_pkt_v_o_i(tr_pkt_v_o)
         ,.tr_pkt_ready_i(tr_pkt_ready_i)
         );
-  
+
   bind bp_cce_wrapper
     bp_me_nonsynth_cce_tracer
       #(.bp_params_p(bp_params_p))
       cce_tracer
        (.clk_i(clk_i & (testbench.cce_trace_p == 1))
         ,.reset_i(reset_i)
-        ,.freeze_i(cfg_bus_cast_i.freeze)
-  
+
         ,.cce_id_i(cfg_bus_cast_i.cce_id)
-  
+
         // LCE-CCE Interface
         // BedRock Burst protocol: ready&valid
         ,.lce_req_header_i(lce_req_header_i)
@@ -252,46 +733,43 @@ module testbench
         ,.lce_req_data_i(lce_req_data_i)
         ,.lce_req_data_v_i(lce_req_data_v_i)
         ,.lce_req_data_ready_and_i(lce_req_data_ready_and_o)
-  
+
         ,.lce_resp_header_i(lce_resp_header_i)
         ,.lce_resp_header_v_i(lce_resp_header_v_i)
         ,.lce_resp_header_ready_and_i(lce_resp_header_ready_and_o)
         ,.lce_resp_data_i(lce_resp_data_i)
         ,.lce_resp_data_v_i(lce_resp_data_v_i)
         ,.lce_resp_data_ready_and_i(lce_resp_data_ready_and_o)
-  
+
         ,.lce_cmd_header_i(lce_cmd_header_o)
         ,.lce_cmd_header_v_i(lce_cmd_header_v_o)
         ,.lce_cmd_header_ready_and_i(lce_cmd_header_ready_and_i)
         ,.lce_cmd_data_i(lce_cmd_data_o)
         ,.lce_cmd_data_v_i(lce_cmd_data_v_o)
         ,.lce_cmd_data_ready_and_i(lce_cmd_data_ready_and_i)
-  
+
         // CCE-MEM Interface
         // BedRock Burst protocol: ready&valid
         ,.mem_resp_header_i(mem_resp_header_i)
-        ,.mem_resp_header_v_i(mem_resp_header_v_i)
-        ,.mem_resp_header_ready_and_i(mem_resp_header_ready_and_o)
         ,.mem_resp_data_i(mem_resp_data_i)
-        ,.mem_resp_data_v_i(mem_resp_data_v_i)
-        ,.mem_resp_data_ready_and_i(mem_resp_data_ready_and_o)
-  
+        ,.mem_resp_v_i(mem_resp_v_i)
+        ,.mem_resp_ready_and_i(mem_resp_ready_and_o)
+        ,.mem_resp_last_i(mem_resp_last_i)
+
         ,.mem_cmd_header_i(mem_cmd_header_o)
-        ,.mem_cmd_header_v_i(mem_cmd_header_v_o)
-        ,.mem_cmd_header_ready_and_i(mem_cmd_header_ready_and_i)
         ,.mem_cmd_data_i(mem_cmd_data_o)
-        ,.mem_cmd_data_v_i(mem_cmd_data_v_o)
-        ,.mem_cmd_data_ready_and_i(mem_cmd_data_ready_and_i)
-  
+        ,.mem_cmd_v_i(mem_cmd_v_o)
+        ,.mem_cmd_ready_and_i(mem_cmd_ready_and_i)
+        ,.mem_cmd_last_i(mem_cmd_last_o)
         );
-  
+
   bind bp_cce_dir
     bp_me_nonsynth_cce_dir_tracer
       #(.bp_params_p(bp_params_p))
       cce_dir_tracer
        (.clk_i(clk_i & (testbench.cce_dir_trace_p == 1))
         ,.reset_i(reset_i)
-  
+
         ,.cce_id_i(cce_id_i)
         ,.addr_i(addr_i)
         ,.addr_bypass_i(addr_bypass_i)
@@ -315,393 +793,13 @@ module testbench
         ,.addr_o_i(addr_o)
         ,.addr_dst_gpr_o_i(addr_dst_gpr_o)
         );
-  
-  logic cce_ucode_v_li;
-  logic cce_ucode_w_li;
-  logic [cce_pc_width_p-1:0] cce_ucode_addr_li;
-  logic [cce_instr_width_gp-1:0] cce_ucode_data_li;
-  logic [cce_instr_width_gp-1:0] cce_ucode_data_lo;
-  
-  logic lce_req_header_v, lce_req_header_ready_and;
-  logic lce_req_data_v, lce_req_data_ready_and;
-  logic lce_resp_header_v, lce_resp_header_ready_and;
-  logic lce_resp_data_v, lce_resp_data_ready_and;
-  logic lce_cmd_header_v, lce_cmd_header_ready_and;
-  logic lce_cmd_data_v, lce_cmd_data_ready_and;
-  logic mem_resp_header_v, mem_resp_header_ready_and;
-  logic mem_resp_data_v, mem_resp_data_ready_and;
-  logic mem_cmd_header_v, mem_cmd_header_ready_and;
-  logic mem_cmd_data_v, mem_cmd_data_ready_and;
-  logic [dword_width_gp-1:0] lce_req_data, lce_resp_data, lce_cmd_data, mem_cmd_data, mem_resp_data;
-  bp_bedrock_cce_mem_msg_header_s mem_resp_header, mem_cmd_header;
-  bp_bedrock_lce_req_msg_header_s lce_req_header;
-  bp_bedrock_lce_resp_msg_header_s lce_resp_header;
-  bp_bedrock_lce_cmd_msg_header_s lce_cmd_header;
-  logic lce_req_last, lce_resp_last, lce_cmd_last, mem_cmd_last, mem_resp_last;
-  logic lce_req_has_data, lce_resp_has_data, lce_cmd_has_data, mem_cmd_has_data, mem_resp_has_data;
-  
-  // LCE Request Buffer
-  bp_bedrock_lce_req_msg_s lce_req_l2b;
-  logic                    lce_req_l2b_v, lce_req_l2b_ready_and;
-  bsg_two_fifo
-  #(.width_p($bits(bp_bedrock_lce_req_msg_s)))
-  lce_req_buffer
-   (.clk_i(clk_i)
-    ,.reset_i(reset_i)
-    // from LCE
-    ,.v_i(lce_req_v_lo)
-    ,.data_i(lce_req_lo)
-    ,.ready_o(lce_req_ready_and_li)
-    // to lite to burst
-    ,.v_o(lce_req_l2b_v)
-    ,.data_o(lce_req_l2b)
-    ,.yumi_i(lce_req_l2b_v & lce_req_l2b_ready_and)
-    );
-  
-  // LCE Request
-  bp_me_lite_to_burst
-   #(.bp_params_p(bp_params_p)
-     ,.in_data_width_p(cce_block_width_p)
-     ,.out_data_width_p(dword_width_gp)
-     ,.payload_width_p(lce_req_payload_width_lp)
-     ,.payload_mask_p(lce_req_payload_mask_gp)
-     )
-   lce_req_lite2burst
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-  
-     ,.in_msg_i(lce_req_l2b)
-     ,.in_msg_v_i(lce_req_l2b_v)
-     ,.in_msg_ready_and_o(lce_req_l2b_ready_and)
-  
-     ,.out_msg_header_o(lce_req_header)
-     ,.out_msg_header_v_o(lce_req_header_v)
-     ,.out_msg_header_ready_and_i(lce_req_header_ready_and)
-     ,.out_msg_has_data_o(lce_req_has_data)
-  
-     ,.out_msg_data_o(lce_req_data)
-     ,.out_msg_data_v_o(lce_req_data_v)
-     ,.out_msg_data_ready_and_i(lce_req_data_ready_and)
-     ,.out_msg_last_o(lce_req_last)
-     );
-  
-  // LCE Response Buffer
-  bp_bedrock_lce_resp_msg_s lce_resp_l2b;
-  logic                    lce_resp_l2b_v, lce_resp_l2b_ready_and;
-  bsg_two_fifo
-  #(.width_p($bits(bp_bedrock_lce_resp_msg_s)))
-  lce_resp_buffer
-   (.clk_i(clk_i)
-    ,.reset_i(reset_i)
-    // from LCE
-    ,.v_i(lce_resp_v_lo)
-    ,.data_i(lce_resp_lo)
-    ,.ready_o(lce_resp_ready_and_li)
-    // to lite to burst
-    ,.v_o(lce_resp_l2b_v)
-    ,.data_o(lce_resp_l2b)
-    ,.yumi_i(lce_resp_l2b_v & lce_resp_l2b_ready_and)
-    );
-  
-  // LCE Response
-  bp_me_lite_to_burst
-   #(.bp_params_p(bp_params_p)
-     ,.in_data_width_p(cce_block_width_p)
-     ,.out_data_width_p(dword_width_gp)
-     ,.payload_width_p(lce_resp_payload_width_lp)
-     ,.payload_mask_p(lce_resp_payload_mask_gp)
-     )
-   lce_resp_lite2burst
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-  
-     ,.in_msg_i(lce_resp_l2b)
-     ,.in_msg_v_i(lce_resp_l2b_v)
-     ,.in_msg_ready_and_o(lce_resp_l2b_ready_and)
-  
-     ,.out_msg_header_o(lce_resp_header)
-     ,.out_msg_header_v_o(lce_resp_header_v)
-     ,.out_msg_header_ready_and_i(lce_resp_header_ready_and)
-     ,.out_msg_has_data_o(lce_resp_has_data)
-  
-     ,.out_msg_data_o(lce_resp_data)
-     ,.out_msg_data_v_o(lce_resp_data_v)
-     ,.out_msg_data_ready_and_i(lce_resp_data_ready_and)
-     ,.out_msg_last_o(lce_resp_last)
-     );
-  
-  // LCE Command
-  bp_me_burst_to_lite
-   #(.bp_params_p(bp_params_p)
-     ,.in_data_width_p(dword_width_gp)
-     ,.out_data_width_p(cce_block_width_p)
-     ,.payload_width_p(lce_cmd_payload_width_lp)
-     ,.payload_mask_p(lce_cmd_payload_mask_gp)
-     )
-   lce_cmd_burst2lite
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-  
-     ,.in_msg_header_i(lce_cmd_header)
-     ,.in_msg_header_v_i(lce_cmd_header_v)
-     ,.in_msg_header_ready_and_o(lce_cmd_header_ready_and)
-     ,.in_msg_has_data_i(lce_cmd_has_data)
-  
-     ,.in_msg_data_i(lce_cmd_data)
-     ,.in_msg_data_v_i(lce_cmd_data_v)
-     ,.in_msg_data_ready_and_o(lce_cmd_data_ready_and)
-     ,.in_msg_last_i(lce_cmd_last)
-  
-     ,.out_msg_o(lce_cmd_lo)
-     ,.out_msg_v_o(lce_cmd_v_lo)
-     ,.out_msg_ready_and_i(lce_cmd_ready_and_li)
-     );
 
-  // CCE
-  wrapper
-  #(.bp_params_p(bp_params_p)
-    ,.cce_trace_p(cce_trace_p)
-   )
-  wrapper
-   (.clk_i(clk_i)
-    ,.reset_i(reset_i)
-  
-    ,.cfg_bus_i(cfg_bus_lo)
-  
-    ,.ucode_v_i(cce_ucode_v_li)
-    ,.ucode_w_i(cce_ucode_w_li)
-    ,.ucode_addr_i(cce_ucode_addr_li)
-    ,.ucode_data_i(cce_ucode_data_li)
-    ,.ucode_data_o(cce_ucode_data_lo)
-  
-    // LCE-CCE Interface
-    // BedRock Burst protocol: ready&valid
-    ,.lce_req_header_i(lce_req_header)
-    ,.lce_req_header_v_i(lce_req_header_v)
-    ,.lce_req_header_ready_and_o(lce_req_header_ready_and)
-    ,.lce_req_has_data_i(lce_req_has_data)
-    ,.lce_req_data_i(lce_req_data)
-    ,.lce_req_data_v_i(lce_req_data_v)
-    ,.lce_req_data_ready_and_o(lce_req_data_ready_and)
-    ,.lce_req_last_i(lce_req_last)
-  
-    ,.lce_resp_header_i(lce_resp_header)
-    ,.lce_resp_header_v_i(lce_resp_header_v)
-    ,.lce_resp_header_ready_and_o(lce_resp_header_ready_and)
-    ,.lce_resp_has_data_i(lce_resp_has_data)
-    ,.lce_resp_data_i(lce_resp_data)
-    ,.lce_resp_data_v_i(lce_resp_data_v)
-    ,.lce_resp_data_ready_and_o(lce_resp_data_ready_and)
-    ,.lce_resp_last_i(lce_resp_last)
-  
-    ,.lce_cmd_header_o(lce_cmd_header)
-    ,.lce_cmd_header_v_o(lce_cmd_header_v)
-    ,.lce_cmd_header_ready_and_i(lce_cmd_header_ready_and)
-    ,.lce_cmd_has_data_o(lce_cmd_has_data)
-    ,.lce_cmd_data_o(lce_cmd_data)
-    ,.lce_cmd_data_v_o(lce_cmd_data_v)
-    ,.lce_cmd_data_ready_and_i(lce_cmd_data_ready_and)
-    ,.lce_cmd_last_o(lce_cmd_last)
-  
-    // CCE-MEM Interface
-    // BedRock Burst protocol: ready&valid
-    ,.mem_resp_header_i(mem_resp_header)
-    ,.mem_resp_header_v_i(mem_resp_header_v)
-    ,.mem_resp_header_ready_and_o(mem_resp_header_ready_and)
-    ,.mem_resp_has_data_i(mem_resp_has_data)
-    ,.mem_resp_data_i(mem_resp_data)
-    ,.mem_resp_data_v_i(mem_resp_data_v)
-    ,.mem_resp_data_ready_and_o(mem_resp_data_ready_and)
-    ,.mem_resp_last_i(mem_resp_last)
-  
-    ,.mem_cmd_header_o(mem_cmd_header)
-    ,.mem_cmd_header_v_o(mem_cmd_header_v)
-    ,.mem_cmd_header_ready_and_i(mem_cmd_header_ready_and)
-    ,.mem_cmd_has_data_o(mem_cmd_has_data)
-    ,.mem_cmd_data_o(mem_cmd_data)
-    ,.mem_cmd_data_v_o(mem_cmd_data_v)
-    ,.mem_cmd_data_ready_and_i(mem_cmd_data_ready_and)
-    ,.mem_cmd_last_o(mem_cmd_last)
-  );
-  
-  // MEM Command
-  bp_me_burst_to_lite
-   #(.bp_params_p(bp_params_p)
-     ,.in_data_width_p(dword_width_gp)
-     ,.out_data_width_p(cce_block_width_p)
-     ,.payload_width_p(cce_mem_payload_width_lp)
-     ,.payload_mask_p(mem_cmd_payload_mask_gp)
-     )
-   mem_cmd_burst2lite
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-  
-     ,.in_msg_header_i(mem_cmd_header)
-     ,.in_msg_header_v_i(mem_cmd_header_v)
-     ,.in_msg_header_ready_and_o(mem_cmd_header_ready_and)
-     ,.in_msg_has_data_i(mem_cmd_has_data)
-  
-     ,.in_msg_data_i(mem_cmd_data)
-     ,.in_msg_data_v_i(mem_cmd_data_v)
-     ,.in_msg_data_ready_and_o(mem_cmd_data_ready_and)
-     ,.in_msg_last_i(mem_cmd_last)
-  
-     ,.out_msg_o(mem_cmd)
-     ,.out_msg_v_o(mem_cmd_v)
-     ,.out_msg_ready_and_i(mem_cmd_ready_and)
-     );
-  
-  // Memory Command Buffer
-  bp_bedrock_cce_mem_msg_s mem_cmd_lo;
-  logic                    mem_cmd_v_lo, mem_cmd_ready_lo;
-  bsg_fifo_1r1w_small
-  #(.width_p($bits(bp_bedrock_cce_mem_msg_s))
-    ,.els_p(mem_buffer_els_lp)
-    )
-  mem_cmd_buffer
-   (.clk_i(clk_i)
-    ,.reset_i(reset_i)
-    // from CCE burst to lite converter
-    ,.v_i(mem_cmd_v)
-    ,.data_i(mem_cmd)
-    ,.ready_o(mem_cmd_ready_and)
-    // to memory
-    ,.v_o(mem_cmd_v_lo)
-    ,.data_o(mem_cmd_lo)
-    ,.yumi_i(mem_cmd_ready_lo & mem_cmd_v_lo)
-    );
-  
-  // Memory Response Buffer
-  bp_bedrock_cce_mem_msg_s mem_resp_lo;
-  logic                    mem_resp_v_lo, mem_resp_ready_lo;
-  bsg_fifo_1r1w_small
-  #(.width_p($bits(bp_bedrock_cce_mem_msg_s))
-    ,.els_p(mem_buffer_els_lp)
-    )
-  mem_resp_buffer
-   (.clk_i(clk_i)
-    ,.reset_i(reset_i)
-    // from memory
-    ,.v_i(mem_resp_v_lo)
-    ,.data_i(mem_resp_lo)
-    ,.ready_o(mem_resp_ready_lo)
-    // to CCE lite to burst converter
-    ,.v_o(mem_resp_v)
-    ,.data_o(mem_resp)
-    ,.yumi_i(mem_resp_yumi)
-    );
-  
-  // MEM Response
-  logic mem_resp_ready_and;
-  assign mem_resp_yumi = mem_resp_v & mem_resp_ready_and;
-  bp_me_lite_to_burst
-   #(.bp_params_p(bp_params_p)
-     ,.in_data_width_p(cce_block_width_p)
-     ,.out_data_width_p(dword_width_gp)
-     ,.payload_width_p(cce_mem_payload_width_lp)
-     ,.payload_mask_p(mem_resp_payload_mask_gp)
-     )
-   mem_resp_lite2burst
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-  
-     ,.in_msg_i(mem_resp)
-     ,.in_msg_v_i(mem_resp_v)
-     ,.in_msg_ready_and_o(mem_resp_ready_and)
-  
-     ,.out_msg_header_o(mem_resp_header)
-     ,.out_msg_header_v_o(mem_resp_header_v)
-     ,.out_msg_header_ready_and_i(mem_resp_header_ready_and)
-     ,.out_msg_has_data_o(mem_resp_has_data)
-  
-     ,.out_msg_data_o(mem_resp_data)
-     ,.out_msg_data_v_o(mem_resp_data_v)
-     ,.out_msg_data_ready_and_i(mem_resp_data_ready_and)
-     ,.out_msg_last_o(mem_resp_last)
-     );
+  // Config
+  bp_bedrock_cce_mem_msg_header_s cfg_mem_cmd_lo;
+  logic [dword_width_gp-1:0] cfg_mem_cmd_data_lo;
+  logic cfg_mem_cmd_v_lo, cfg_mem_cmd_ready_and_li, cfg_mem_cmd_last_lo;
+  logic cfg_mem_resp_v_lo;
 
-  bp_nonsynth_mem
-   #(.bp_params_p(bp_params_p)
-     ,.preload_mem_p(0)
-     ,.dram_type_p(dram_type_p)
-     ,.mem_els_p(2**20)
-     )
-   mem
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     // TODO: unstub
-     ,.mem_cmd_header_i(mem_cmd_lo.header)
-     ,.mem_cmd_data_i(mem_cmd_lo.data)
-     ,.mem_cmd_v_i(mem_cmd_v_lo)
-     ,.mem_cmd_ready_and_o(mem_cmd_ready_and_li)
-     ,.mem_cmd_last_i(mem_cmd_v_lo)
-
-     // TODO: unstub
-     ,.mem_resp_header_o(mem_resp_lo.header)
-     ,.mem_resp_data_o(mem_resp_lo.data)
-     ,.mem_resp_v_o(mem_resp_v_lo)
-     ,.mem_resp_ready_and_i(mem_resp_ready_lo)
-     ,.mem_resp_last_o()
-
-     ,.dram_clk_i(dram_clk_i)
-     ,.dram_reset_i(dram_reset_i)
-     );
-
-  bp_mem_nonsynth_tracer
-   #(.bp_params_p(bp_params_p))
-   bp_mem_tracer
-    (.clk_i(clk_i & (testbench.dram_trace_p == 1))
-     ,.reset_i(reset_i)
-
-     // TODO: unstub
-     ,.mem_cmd_header_i(mem_cmd_lo.header)
-     ,.mem_cmd_data_i(mem_cmd_lo.data)
-     ,.mem_cmd_v_i(mem_cmd_v_lo)
-     ,.mem_cmd_ready_and_i(mem_cmd_ready_and_li)
-     ,.mem_cmd_last_i(mem_cmd_v_lo)
-
-     // TODO: unstub
-     ,.mem_resp_header_i(mem_resp_lo.header)
-     ,.mem_resp_data_i(mem_resp_lo.data)
-     ,.mem_resp_v_i(mem_resp_v_lo)
-     ,.mem_resp_ready_and_i(mem_resp_ready_lo)
-     ,.mem_resp_last_i(mem_resp_v_lo)
-     );
-
-  logic [coh_noc_cord_width_p-1:0] cord_li = {{coh_noc_y_cord_width_p'(1'b1)}, {coh_noc_x_cord_width_p'('0)}};
-  logic cfg_resp_v_lo;
-  bp_me_cfg
-   #(.bp_params_p(bp_params_p))
-   cfg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-  
-     ,.mem_cmd_header_i(cfg_mem_cmd.header)
-     ,.mem_cmd_data_i(cfg_mem_cmd.data)
-     ,.mem_cmd_v_i(cfg_mem_cmd_v_lo)
-     ,.mem_cmd_ready_and_o(cfg_mem_cmd_ready_and_li)
-     ,.mem_cmd_last_i(cfg_mem_cmd_v_lo)
-  
-     ,.mem_resp_header_o()
-     ,.mem_resp_data_o()
-     ,.mem_resp_v_o(cfg_resp_v_lo)
-     ,.mem_resp_ready_and_i(cfg_resp_v_lo)
-     ,.mem_resp_last_o()
-  
-     ,.cfg_bus_o(cfg_bus_lo)
-     ,.did_i('0)
-     ,.host_did_i('0)
-     ,.cord_i(cord_li)
-  
-     ,.cce_ucode_v_o(cce_ucode_v_li)
-     ,.cce_ucode_w_o(cce_ucode_w_li)
-     ,.cce_ucode_addr_o(cce_ucode_addr_li)
-     ,.cce_ucode_data_o(cce_ucode_data_li)
-     ,.cce_ucode_data_i(cce_ucode_data_lo)
-     );
-  
-  // CFG loader
   logic cfg_loader_done_lo;
   localparam cce_instr_ram_addr_width_lp = `BSG_SAFE_CLOG2(num_cce_instr_ram_els_p);
   bp_cce_mmio_cfg_loader
@@ -715,30 +813,66 @@ module testbench
     cfg_loader
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
-  
+
      ,.lce_id_i('0)
-  
-     ,.io_cmd_o(cfg_mem_cmd_lo)
+
+     ,.io_cmd_header_o(cfg_mem_cmd_lo)
+     ,.io_cmd_data_o(cfg_mem_cmd_data_lo)
      ,.io_cmd_v_o(cfg_mem_cmd_v_lo)
      ,.io_cmd_yumi_i(cfg_mem_cmd_ready_and_li & cfg_mem_cmd_v_lo)
-  
-     ,.io_resp_i('0)
-     ,.io_resp_v_i(cfg_resp_v_lo)
-     ,.io_resp_ready_o()
-  
+     ,.io_cmd_last_o(cfg_mem_cmd_last_lo)
+
+     ,.io_resp_header_i('0)
+     ,.io_resp_data_i('0)
+     ,.io_resp_v_i(cfg_mem_resp_v_lo)
+     ,.io_resp_ready_and_o()
+     ,.io_resp_last_i('0)
+
      ,.done_o(cfg_loader_done_lo)
-    );
-  
+     );
+
+  logic [coh_noc_cord_width_p-1:0] cord_li = {{coh_noc_y_cord_width_p'(1'b1)}, {coh_noc_x_cord_width_p'('0)}};
+  bp_me_cfg
+   #(.bp_params_p(bp_params_p))
+   cfg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.mem_cmd_header_i(cfg_mem_cmd_lo)
+     ,.mem_cmd_data_i(cfg_mem_cmd_data_lo)
+     ,.mem_cmd_v_i(cfg_mem_cmd_v_lo)
+     ,.mem_cmd_ready_and_o(cfg_mem_cmd_ready_and_li)
+     ,.mem_cmd_last_i(cfg_mem_cmd_last_lo)
+
+     ,.mem_resp_header_o()
+     ,.mem_resp_data_o()
+     ,.mem_resp_v_o(cfg_mem_resp_v_lo)
+     ,.mem_resp_ready_and_i(cfg_mem_resp_v_lo)
+     ,.mem_resp_last_o()
+
+     ,.cfg_bus_o(cfg_bus_lo)
+     ,.did_i('0)
+     ,.host_did_i('0)
+     ,.cord_i(cord_li)
+
+     ,.cce_ucode_v_o(cce_ucode_v_li)
+     ,.cce_ucode_w_o(cce_ucode_w_li)
+     ,.cce_ucode_addr_o(cce_ucode_addr_li)
+     ,.cce_ucode_data_o(cce_ucode_data_li)
+     ,.cce_ucode_data_i(cce_ucode_data_lo)
+     );
+
+  // Parameter Verification
   bp_nonsynth_if_verif
    #(.bp_params_p(bp_params_p))
    if_verif
     ();
-  
+
   // Program done info
   localparam max_clock_cnt_lp    = 2**30-1;
   localparam lg_max_clock_cnt_lp = `BSG_SAFE_CLOG2(max_clock_cnt_lp);
   logic [lg_max_clock_cnt_lp-1:0] clock_cnt;
-  
+
   bsg_counter_clear_up
    #(.max_val_p(max_clock_cnt_lp)
      ,.init_val_p(0)
@@ -746,15 +880,15 @@ module testbench
    clock_counter
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
-  
+
      ,.clear_i(reset_i)
      ,.up_i(1'b1)
-  
+
      ,.count_o(clock_cnt)
      );
-  
+
   always_ff @(negedge clk_i) begin
-    if (tr_done_lo) begin
+    if (&tr_done_lo) begin
       $display("Bytes: %d Clocks: %d mBPC: %d "
                , instr_count*64
                , clock_cnt
@@ -764,7 +898,7 @@ module testbench
       $finish(0);
     end
   end
-  
+
   `ifndef VERILATOR
     initial
       begin

--- a/bp_me/test/tb/bp_cce/wrapper.sv
+++ b/bp_me/test/tb/bp_cce/wrapper.sv
@@ -63,21 +63,15 @@ module wrapper
    // CCE-MEM Interface
    // BedRock Burst protocol: ready&valid
    , input [cce_mem_msg_header_width_lp-1:0]        mem_resp_header_i
-   , input                                          mem_resp_header_v_i
-   , output logic                                   mem_resp_header_ready_and_o
-   , input                                          mem_resp_has_data_i
    , input [dword_width_gp-1:0]                     mem_resp_data_i
-   , input                                          mem_resp_data_v_i
-   , output logic                                   mem_resp_data_ready_and_o
+   , input                                          mem_resp_v_i
+   , output logic                                   mem_resp_ready_and_o
    , input                                          mem_resp_last_i
 
    , output logic [cce_mem_msg_header_width_lp-1:0] mem_cmd_header_o
-   , output logic                                   mem_cmd_header_v_o
-   , input                                          mem_cmd_header_ready_and_i
-   , output logic                                   mem_cmd_has_data_o
    , output logic [dword_width_gp-1:0]              mem_cmd_data_o
-   , output logic                                   mem_cmd_data_v_o
-   , input                                          mem_cmd_data_ready_and_i
+   , output logic                                   mem_cmd_v_o
+   , input                                          mem_cmd_ready_and_i
    , output logic                                   mem_cmd_last_o
   );
 

--- a/bp_top/src/v/bp_tile.sv
+++ b/bp_top/src/v/bp_tile.sv
@@ -17,13 +17,16 @@ module bp_tile
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_bedrock_lce_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, dword_width_gp, lce_id_width_p, lce_assoc_p, xce)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, dword_width_gp, lce_id_width_p, lce_assoc_p, cce)
 
-    , localparam cfg_bus_width_lp        = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp        = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+
    // Wormhole parameters
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
+
+   // LCE-CCE network wormhole adapter length input/output field size
+   , localparam pr_len_width_lp = 8
    )
   (input                                                      clk_i
    , input                                                    reset_i
@@ -49,28 +52,29 @@ module bp_tile
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_bedrock_lce_if(paddr_width_p, cce_block_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
   `declare_bp_bedrock_mem_if(paddr_width_p, cce_block_width_p, lce_id_width_p, lce_assoc_p, cce);
-  `declare_bp_bedrock_mem_if(paddr_width_p, dword_width_gp, lce_id_width_p, lce_assoc_p, xce);
   `declare_bp_memory_map(paddr_width_p, caddr_width_p);
-
-  // Cast the routing links
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, bp_coh_ready_and_link_s);
-  `declare_bsg_ready_and_link_sif_s(mem_noc_flit_width_p, bp_mem_ready_and_link_s);
 
+  // Reset
+  logic reset_r;
+  always_ff @(posedge clk_i)
+    reset_r <= reset_i;
+
+  // Config bus
+  bp_cfg_bus_s cfg_bus_lo;
+
+  // LCE-CCE coherence network links
   bp_coh_ready_and_link_s lce_req_link_cast_i, lce_req_link_cast_o;
   bp_coh_ready_and_link_s lce_resp_link_cast_i, lce_resp_link_cast_o;
   bp_coh_ready_and_link_s lce_cmd_link_cast_i, lce_cmd_link_cast_o;
-
   assign lce_req_link_cast_i  = lce_req_link_i;
   assign lce_cmd_link_cast_i  = lce_cmd_link_i;
   assign lce_resp_link_cast_i = lce_resp_link_i;
-
   assign lce_req_link_o  = lce_req_link_cast_o;
   assign lce_cmd_link_o  = lce_cmd_link_cast_o;
   assign lce_resp_link_o = lce_resp_link_cast_o;
 
-  logic timer_irq_li, software_irq_li, external_irq_li;
-
-  // Proc-side connections network connections
+  // Core-side LCE-CCE network connections
   bp_bedrock_lce_req_msg_s [1:0] lce_req_lo;
   logic [1:0] lce_req_v_lo, lce_req_ready_li;
   bp_bedrock_lce_resp_msg_s [1:0] lce_resp_lo;
@@ -80,7 +84,7 @@ module bp_tile
   bp_bedrock_lce_cmd_msg_s [1:0] lce_cmd_lo;
   logic [1:0] lce_cmd_v_lo, lce_cmd_ready_li;
 
-  // CCE connections
+  // CCE-side LCE-CCE network connections
   logic cce_lce_req_header_v, cce_lce_req_header_ready_and;
   logic cce_lce_req_data_v, cce_lce_req_data_ready_and;
   logic cce_lce_req_has_data, cce_lce_req_last;
@@ -94,224 +98,6 @@ module bp_tile
   bp_bedrock_lce_resp_msg_header_s cce_lce_resp_header;
   bp_bedrock_lce_cmd_msg_header_s cce_lce_cmd_header;
   logic [dword_width_gp-1:0] cce_lce_req_data, cce_lce_resp_data, cce_lce_cmd_data;
-
-  // Mem connections
-
-  // to/from CCE
-  logic cce_mem_resp_header_v, cce_mem_resp_header_ready_and;
-  logic cce_mem_resp_data_v, cce_mem_resp_data_ready_and;
-  logic cce_mem_resp_has_data, cce_mem_resp_last;
-  logic cce_mem_cmd_header_v, cce_mem_cmd_header_ready_and;
-  logic cce_mem_cmd_data_v, cce_mem_cmd_data_ready_and;
-  logic cce_mem_cmd_has_data, cce_mem_cmd_last;
-  bp_bedrock_cce_mem_msg_header_s cce_mem_resp_header, cce_mem_cmd_header;
-  logic [dword_width_gp-1:0] cce_mem_cmd_data, cce_mem_resp_data;
-
-  // to/from Burst-Lite converters
-  bp_bedrock_cce_mem_msg_s cce_mem_cmd_lo;
-  logic cce_mem_cmd_v_lo, cce_mem_cmd_yumi_li;
-  bp_bedrock_cce_mem_msg_s cce_mem_resp_li;
-  logic cce_mem_resp_v_li, cce_mem_resp_yumi_lo;
-
-  bp_bedrock_cce_mem_msg_s loopback_mem_cmd_li;
-  bp_bedrock_xce_mem_msg_s loopback_mem_cmd;
-  logic loopback_mem_cmd_v_li, loopback_mem_cmd_ready_and_lo;
-  bp_bedrock_cce_mem_msg_s loopback_mem_resp_lo;
-  bp_bedrock_xce_mem_msg_s loopback_mem_resp;
-  logic loopback_mem_resp_v_lo, loopback_mem_resp_yumi_li;
-  assign loopback_mem_cmd = '{header: loopback_mem_cmd_li.header
-                             ,data: loopback_mem_cmd_li.data[0+:dword_width_gp]
-                             };
-  assign loopback_mem_resp_lo = '{header: loopback_mem_resp.header
-                                 ,data: {cce_block_width_p/dword_width_gp{loopback_mem_resp.data}}
-                                 };
-
-  bp_bedrock_cce_mem_msg_s cache_mem_cmd_li;
-  logic cache_mem_cmd_v_li, cache_mem_cmd_ready_and_lo;
-  bp_bedrock_cce_mem_msg_s cache_mem_resp_lo;
-  logic cache_mem_resp_v_lo, cache_mem_resp_yumi_li;
-
-  bp_bedrock_cce_mem_msg_s cfg_mem_cmd_li;
-  bp_bedrock_xce_mem_msg_s cfg_mem_cmd;
-  logic cfg_mem_cmd_v_li, cfg_mem_cmd_ready_and_lo, cfg_mem_cmd_last_li;
-  bp_bedrock_cce_mem_msg_s cfg_mem_resp_lo;
-  bp_bedrock_xce_mem_msg_s cfg_mem_resp;
-  logic cfg_mem_resp_v_lo, cfg_mem_resp_yumi_li, cfg_mem_resp_last_lo;
-  assign cfg_mem_cmd = '{header: cfg_mem_cmd_li.header
-                        ,data: cfg_mem_cmd_li.data[0+:dword_width_gp]
-                        };
-  assign cfg_mem_resp_lo = '{header: cfg_mem_resp.header
-                            ,data: {cce_block_width_p/dword_width_gp{cfg_mem_resp.data}}
-                            };
-
-  bp_bedrock_cce_mem_msg_s clint_mem_cmd_li;
-  bp_bedrock_xce_mem_msg_s clint_mem_cmd;
-  logic clint_mem_cmd_v_li, clint_mem_cmd_ready_and_lo;
-  bp_bedrock_cce_mem_msg_s clint_mem_resp_lo;
-  bp_bedrock_xce_mem_msg_s clint_mem_resp;
-  logic clint_mem_resp_v_lo, clint_mem_resp_yumi_li;
-  assign clint_mem_cmd = '{header: clint_mem_cmd_li.header
-                          ,data: clint_mem_cmd_li.data[0+:dword_width_gp]
-                          };
-  assign clint_mem_resp_lo = '{header: clint_mem_resp.header
-                              ,data: {cce_block_width_p/dword_width_gp{clint_mem_resp.data}}
-                              };
-
-  logic reset_r;
-  always_ff @(posedge clk_i)
-    reset_r <= reset_i;
-
-  bp_cfg_bus_s cfg_bus_lo;
-  logic cce_ucode_v_lo;
-  logic cce_ucode_w_lo;
-  logic [cce_pc_width_p-1:0] cce_ucode_addr_lo;
-  logic [cce_instr_width_gp-1:0] cce_ucode_data_lo, cce_ucode_data_li;
-  bp_me_cfg
-   #(.bp_params_p(bp_params_p))
-   cfg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_r)
-
-     ,.mem_cmd_header_i(cfg_mem_cmd.header)
-     ,.mem_cmd_data_i(cfg_mem_cmd.data)
-     ,.mem_cmd_v_i(cfg_mem_cmd_v_li)
-     ,.mem_cmd_ready_and_o(cfg_mem_cmd_ready_and_lo)
-     ,.mem_cmd_last_i(cfg_mem_cmd_last_li)
-
-     ,.mem_resp_header_o(cfg_mem_resp.header)
-     ,.mem_resp_data_o(cfg_mem_resp.data)
-     ,.mem_resp_v_o(cfg_mem_resp_v_lo)
-     ,.mem_resp_ready_and_i(cfg_mem_resp_yumi_li)
-     ,.mem_resp_last_o(cfg_mem_resp_last_lo)
-
-     ,.cfg_bus_o(cfg_bus_lo)
-     ,.did_i(my_did_i)
-     ,.host_did_i(host_did_i)
-     ,.cord_i(my_cord_i)
-
-     ,.cce_ucode_v_o(cce_ucode_v_lo)
-     ,.cce_ucode_w_o(cce_ucode_w_lo)
-     ,.cce_ucode_addr_o(cce_ucode_addr_lo)
-     ,.cce_ucode_data_o(cce_ucode_data_lo)
-     ,.cce_ucode_data_i(cce_ucode_data_li)
-     );
-
-  bp_me_clint_slice
-   #(.bp_params_p(bp_params_p))
-   clint
-    (.clk_i(clk_i)
-     ,.reset_i(reset_r)
-
-     ,.mem_cmd_header_i(clint_mem_cmd.header)
-     ,.mem_cmd_data_i(clint_mem_cmd.data)
-     ,.mem_cmd_v_i(clint_mem_cmd_v_li)
-     ,.mem_cmd_ready_and_o(clint_mem_cmd_ready_and_lo)
-     ,.mem_cmd_last_i(clint_mem_cmd_v_li)
-
-     ,.mem_resp_header_o(clint_mem_resp.header)
-     ,.mem_resp_data_o(clint_mem_resp.data)
-     ,.mem_resp_v_o(clint_mem_resp_v_lo)
-     ,.mem_resp_ready_and_i(clint_mem_resp_yumi_li)
-     ,.mem_resp_last_o()
-
-     ,.timer_irq_o(timer_irq_li)
-     ,.software_irq_o(software_irq_li)
-     ,.external_irq_o(external_irq_li)
-     );
-
-  // Module instantiations
-  bp_core
-   #(.bp_params_p(bp_params_p))
-   core
-    (.clk_i(clk_i)
-     ,.reset_i(reset_r)
-
-     ,.cfg_bus_i(cfg_bus_lo)
-
-     ,.lce_req_o(lce_req_lo)
-     ,.lce_req_v_o(lce_req_v_lo)
-     ,.lce_req_ready_then_i(lce_req_ready_li)
-
-     ,.lce_cmd_i(lce_cmd_li)
-     ,.lce_cmd_v_i(lce_cmd_v_li)
-     ,.lce_cmd_yumi_o(lce_cmd_yumi_lo)
-
-     ,.lce_cmd_o(lce_cmd_lo)
-     ,.lce_cmd_v_o(lce_cmd_v_lo)
-     ,.lce_cmd_ready_then_i(lce_cmd_ready_li)
-
-     ,.lce_resp_o(lce_resp_lo)
-     ,.lce_resp_v_o(lce_resp_v_lo)
-     ,.lce_resp_ready_then_i(lce_resp_ready_li)
-
-     ,.timer_irq_i(timer_irq_li)
-     ,.software_irq_i(software_irq_li)
-     ,.external_irq_i(external_irq_li)
-     );
-
-  bp_cce_wrapper
-   #(.bp_params_p(bp_params_p))
-   cce
-    (.clk_i(clk_i)
-     ,.reset_i(reset_r)
-
-     ,.cfg_bus_i(cfg_bus_lo)
-
-     ,.ucode_v_i(cce_ucode_v_lo)
-     ,.ucode_w_i(cce_ucode_w_lo)
-     ,.ucode_addr_i(cce_ucode_addr_lo)
-     ,.ucode_data_i(cce_ucode_data_lo)
-     ,.ucode_data_o(cce_ucode_data_li)
-
-     // LCE-CCE Interface
-     // BedRock Burst protocol: ready&valid
-     ,.lce_req_header_i(cce_lce_req_header)
-     ,.lce_req_header_v_i(cce_lce_req_header_v)
-     ,.lce_req_header_ready_and_o(cce_lce_req_header_ready_and)
-     ,.lce_req_has_data_i(cce_lce_req_has_data)
-     ,.lce_req_data_i(cce_lce_req_data)
-     ,.lce_req_data_v_i(cce_lce_req_data_v)
-     ,.lce_req_data_ready_and_o(cce_lce_req_data_ready_and)
-     ,.lce_req_last_i(cce_lce_req_last)
-
-     ,.lce_resp_header_i(cce_lce_resp_header)
-     ,.lce_resp_header_v_i(cce_lce_resp_header_v)
-     ,.lce_resp_header_ready_and_o(cce_lce_resp_header_ready_and)
-     ,.lce_resp_has_data_i(cce_lce_resp_has_data)
-     ,.lce_resp_data_i(cce_lce_resp_data)
-     ,.lce_resp_data_v_i(cce_lce_resp_data_v)
-     ,.lce_resp_data_ready_and_o(cce_lce_resp_data_ready_and)
-     ,.lce_resp_last_i(cce_lce_resp_last)
-
-     ,.lce_cmd_header_o(cce_lce_cmd_header)
-     ,.lce_cmd_header_v_o(cce_lce_cmd_header_v)
-     ,.lce_cmd_header_ready_and_i(cce_lce_cmd_header_ready_and)
-     ,.lce_cmd_has_data_o(cce_lce_cmd_has_data)
-     ,.lce_cmd_data_o(cce_lce_cmd_data)
-     ,.lce_cmd_data_v_o(cce_lce_cmd_data_v)
-     ,.lce_cmd_data_ready_and_i(cce_lce_cmd_data_ready_and)
-     ,.lce_cmd_last_o(cce_lce_cmd_last)
-
-     // CCE-MEM Interface
-     // BedRock Burst protocol: ready&valid
-     ,.mem_resp_header_i(cce_mem_resp_header)
-     ,.mem_resp_header_v_i(cce_mem_resp_header_v)
-     ,.mem_resp_header_ready_and_o(cce_mem_resp_header_ready_and)
-     ,.mem_resp_has_data_i(cce_mem_resp_has_data)
-     ,.mem_resp_data_i(cce_mem_resp_data)
-     ,.mem_resp_data_v_i(cce_mem_resp_data_v)
-     ,.mem_resp_data_ready_and_o(cce_mem_resp_data_ready_and)
-     ,.mem_resp_last_i(cce_mem_resp_last)
-
-     ,.mem_cmd_header_o(cce_mem_cmd_header)
-     ,.mem_cmd_header_v_o(cce_mem_cmd_header_v)
-     ,.mem_cmd_header_ready_and_i(cce_mem_cmd_header_ready_and)
-     ,.mem_cmd_has_data_o(cce_mem_cmd_has_data)
-     ,.mem_cmd_data_o(cce_mem_cmd_data)
-     ,.mem_cmd_data_v_o(cce_mem_cmd_data_v)
-     ,.mem_cmd_data_ready_and_i(cce_mem_cmd_data_ready_and)
-     ,.mem_cmd_last_o(cce_mem_cmd_last)
-     );
 
   `declare_bp_lce_req_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_bedrock_lce_req_msg_header_s, cce_block_width_p);
   localparam lce_req_wh_payload_width_lp = `bp_coh_wormhole_payload_width(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, $bits(bp_bedrock_lce_req_msg_header_s), cce_block_width_p);
@@ -329,6 +115,7 @@ module bp_tile
   bp_lce_resp_wormhole_packet_s [1:0] lce_resp_packet_lo;
   bp_lce_resp_wormhole_header_s [1:0] lce_resp_header_lo;
 
+  // LCE-CCE network links - unconcentrated
   bp_coh_ready_and_link_s [1:0] lce_req_link_li, lce_req_link_lo;
   bp_coh_ready_and_link_s [1:0] lce_cmd_link_li, lce_cmd_link_lo;
   bp_coh_ready_and_link_s [1:0] lce_resp_link_li, lce_resp_link_lo;
@@ -432,11 +219,7 @@ module bp_tile
          );
     end
 
-  // CCE wormhole connections
-
   // LCE to CCE request
-  localparam pr_len_width_lp = 8;
-
   logic [pr_len_width_lp-1:0] cce_lce_req_pr_len;
   bp_bedrock_size_to_len
    #(.len_width_p(pr_len_width_lp)
@@ -477,7 +260,6 @@ module bp_tile
     );
 
   // CCE to LCE command
-  // encode the header into WH format
   bp_lce_cmd_wormhole_header_s cce_lce_cmd_wh_header_lo;
   bp_me_wormhole_packet_encode_lce_cmd
    #(.bp_params_p(bp_params_p))
@@ -553,62 +335,7 @@ module bp_tile
     ,.pr_last_o(cce_lce_resp_last)
     );
 
-  // Mem Command
-  logic cce_mem_cmd_v_and_lo;
-  bp_me_burst_to_lite
-   #(.bp_params_p(bp_params_p)
-     ,.in_data_width_p(dword_width_gp)
-     ,.out_data_width_p(cce_block_width_p)
-     ,.payload_width_p(cce_mem_payload_width_lp)
-     ,.payload_mask_p(mem_cmd_payload_mask_gp)
-     )
-   mem_cmd_burst2lite
-    (.clk_i(clk_i)
-     ,.reset_i(reset_r)
-
-     ,.in_msg_header_i(cce_mem_cmd_header)
-     ,.in_msg_header_v_i(cce_mem_cmd_header_v)
-     ,.in_msg_header_ready_and_o(cce_mem_cmd_header_ready_and)
-     ,.in_msg_has_data_i(cce_mem_cmd_has_data)
-
-     ,.in_msg_data_i(cce_mem_cmd_data)
-     ,.in_msg_data_v_i(cce_mem_cmd_data_v)
-     ,.in_msg_data_ready_and_o(cce_mem_cmd_data_ready_and)
-     ,.in_msg_last_i(cce_mem_cmd_last)
-
-     ,.out_msg_o(cce_mem_cmd_lo)
-     ,.out_msg_v_o(cce_mem_cmd_v_lo)
-     ,.out_msg_ready_and_i(cce_mem_cmd_yumi_li)
-     );
-
-  // Mem Response
-  logic cce_mem_resp_ready_lo;
-  assign cce_mem_resp_yumi_lo = cce_mem_resp_v_li & cce_mem_resp_ready_lo;
-  bp_me_lite_to_burst
-   #(.bp_params_p(bp_params_p)
-     ,.in_data_width_p(cce_block_width_p)
-     ,.out_data_width_p(dword_width_gp)
-     ,.payload_width_p(cce_mem_payload_width_lp)
-     ,.payload_mask_p(mem_resp_payload_mask_gp)
-     )
-   mem_resp_lite2burst
-    (.clk_i(clk_i)
-     ,.reset_i(reset_r)
-
-     ,.in_msg_i(cce_mem_resp_li)
-     ,.in_msg_v_i(cce_mem_resp_v_li)
-     ,.in_msg_ready_and_o(cce_mem_resp_ready_lo)
-
-     ,.out_msg_header_o(cce_mem_resp_header)
-     ,.out_msg_header_v_o(cce_mem_resp_header_v)
-     ,.out_msg_header_ready_and_i(cce_mem_resp_header_ready_and)
-     ,.out_msg_has_data_o(cce_mem_resp_has_data)
-
-     ,.out_msg_data_o(cce_mem_resp_data)
-     ,.out_msg_data_v_o(cce_mem_resp_data_v)
-     ,.out_msg_data_ready_and_i(cce_mem_resp_data_ready_and)
-     ,.out_msg_last_o(cce_mem_resp_last)
-     );
+  // LCE-CCE Network Concentrators
 
   bp_coh_ready_and_link_s req_concentrated_link_li, req_concentrated_link_lo;
   bp_coh_ready_and_link_s cmd_concentrated_link_li, cmd_concentrated_link_lo;
@@ -680,100 +407,256 @@ module bp_tile
      ,.concentrated_link_o(resp_concentrated_link_lo)
      );
 
-  bp_local_addr_s local_addr_cast;
-  assign local_addr_cast = cce_mem_cmd_lo.header.addr;
-  wire [dev_id_width_gp-1:0] device_cmd_li = local_addr_cast.dev;
-
-  wire local_cmd_li        = (cce_mem_cmd_lo.header.addr < dram_base_addr_gp);
-  wire is_cfg_cmd          = local_cmd_li & (device_cmd_li == cfg_dev_gp);
-  wire is_clint_cmd        = local_cmd_li & (device_cmd_li == clint_dev_gp);
-  wire is_cache_cmd        = ~local_cmd_li || (local_cmd_li & (device_cmd_li == cache_dev_gp));
-  wire is_loopback_cmd     = local_cmd_li & ~is_cfg_cmd & ~is_clint_cmd & ~is_cache_cmd;
-
-  wire cmd_grant_li = cce_mem_cmd_v_lo;
-
-  assign cfg_mem_cmd_v_li      = cmd_grant_li & cfg_mem_cmd_ready_and_lo & is_cfg_cmd;
-  assign clint_mem_cmd_v_li    = cmd_grant_li & clint_mem_cmd_ready_and_lo & is_clint_cmd;
-  assign cache_mem_cmd_v_li    = cmd_grant_li & cache_mem_cmd_ready_and_lo & is_cache_cmd;
-  assign loopback_mem_cmd_v_li = cmd_grant_li & loopback_mem_cmd_ready_and_lo & is_loopback_cmd;
-
-  wire any_cmd_li = |{cfg_mem_cmd_v_li, clint_mem_cmd_v_li, cache_mem_cmd_v_li, loopback_mem_cmd_v_li};
-
-  assign cce_mem_cmd_yumi_li = cmd_grant_li & any_cmd_li;
-
-  assign {loopback_mem_cmd_li, cache_mem_cmd_li, clint_mem_cmd_li, cfg_mem_cmd_li} = {4{cce_mem_cmd_lo}};
-
-  logic loopback_mem_resp_grant_li, clint_mem_resp_grant_li, cfg_mem_resp_grant_li, cache_mem_resp_grant_li;
-  bsg_arb_fixed
-   #(.inputs_p(4), .lo_to_hi_p(1))
-   resp_arb
-    (.ready_i(1'b1)
-     ,.reqs_i({loopback_mem_resp_v_lo, clint_mem_resp_v_lo, cfg_mem_resp_v_lo, cache_mem_resp_v_lo})
-     ,.grants_o({loopback_mem_resp_grant_li, clint_mem_resp_grant_li, cfg_mem_resp_grant_li, cache_mem_resp_grant_li})
-     );
-
-  bsg_mux_one_hot
-   #(.width_p($bits(bp_bedrock_cce_mem_msg_s)), .els_p(4))
-   resp_select
-    (.data_i({loopback_mem_resp_lo, clint_mem_resp_lo, cfg_mem_resp_lo, cache_mem_resp_lo})
-     ,.sel_one_hot_i({loopback_mem_resp_grant_li, clint_mem_resp_grant_li, cfg_mem_resp_grant_li, cache_mem_resp_grant_li})
-     ,.data_o(cce_mem_resp_li)
-     );
-  assign cce_mem_resp_v_li = |{loopback_mem_resp_v_lo, clint_mem_resp_v_lo, cfg_mem_resp_v_lo, cache_mem_resp_v_lo};
-  assign cache_mem_resp_yumi_li    = cce_mem_resp_yumi_lo & cache_mem_resp_grant_li;
-  assign cfg_mem_resp_yumi_li      = cce_mem_resp_yumi_lo & cfg_mem_resp_grant_li;
-  assign clint_mem_resp_yumi_li    = cce_mem_resp_yumi_lo & clint_mem_resp_grant_li;
-  assign loopback_mem_resp_yumi_li = cce_mem_resp_yumi_lo & loopback_mem_resp_grant_li;
-
-  bp_bedrock_cce_mem_msg_header_s cache_mem_cmd_header_lo;
-  logic [l2_data_width_p-1:0] cache_mem_cmd_data_lo;
-  logic cache_mem_cmd_v_lo, cache_mem_cmd_ready_and_li, cache_mem_cmd_last_lo;
-  bp_bedrock_cce_mem_msg_header_s cache_mem_resp_header_li;
-  logic [l2_data_width_p-1:0] cache_mem_resp_data_li;
-  logic cache_mem_resp_v_li, cache_mem_resp_ready_and_lo, cache_mem_resp_last_li;
-
-  bp_me_lite_to_stream
-   #(.bp_params_p(bp_params_p)
-   ,.in_data_width_p(cce_block_width_p)
-   ,.out_data_width_p(l2_data_width_p)
-   ,.payload_width_p(cce_mem_payload_width_lp)
-   ,.payload_mask_p(mem_cmd_payload_mask_gp))
-   lite2stream
+  // Processor
+  logic timer_irq_li, software_irq_li, external_irq_li;
+  bp_core
+   #(.bp_params_p(bp_params_p))
+   core
     (.clk_i(clk_i)
      ,.reset_i(reset_r)
 
-     ,.in_msg_i(cache_mem_cmd_li)
-     ,.in_msg_v_i(cache_mem_cmd_v_li)
-     ,.in_msg_ready_and_o(cache_mem_cmd_ready_and_lo)
+     ,.cfg_bus_i(cfg_bus_lo)
 
-     ,.out_msg_header_o(cache_mem_cmd_header_lo)
-     ,.out_msg_data_o(cache_mem_cmd_data_lo)
-     ,.out_msg_v_o(cache_mem_cmd_v_lo)
-     ,.out_msg_ready_and_i(cache_mem_cmd_ready_and_li)
-     ,.out_msg_last_o(cache_mem_cmd_last_lo)
+     ,.lce_req_o(lce_req_lo)
+     ,.lce_req_v_o(lce_req_v_lo)
+     ,.lce_req_ready_then_i(lce_req_ready_li)
+
+     ,.lce_cmd_i(lce_cmd_li)
+     ,.lce_cmd_v_i(lce_cmd_v_li)
+     ,.lce_cmd_yumi_o(lce_cmd_yumi_lo)
+
+     ,.lce_cmd_o(lce_cmd_lo)
+     ,.lce_cmd_v_o(lce_cmd_v_lo)
+     ,.lce_cmd_ready_then_i(lce_cmd_ready_li)
+
+     ,.lce_resp_o(lce_resp_lo)
+     ,.lce_resp_v_o(lce_resp_v_lo)
+     ,.lce_resp_ready_then_i(lce_resp_ready_li)
+
+     ,.timer_irq_i(timer_irq_li)
+     ,.software_irq_i(software_irq_li)
+     ,.external_irq_i(external_irq_li)
      );
 
-  bp_me_stream_to_lite
-   #(.bp_params_p(bp_params_p)
-   ,.in_data_width_p(l2_data_width_p)
-   ,.out_data_width_p(cce_block_width_p)
-   ,.payload_width_p(cce_mem_payload_width_lp)
-   ,.payload_mask_p(mem_resp_payload_mask_gp))
-   stream2lite
+  // CCE-side CCE-Mem network connections
+  bp_bedrock_cce_mem_msg_header_s cce_mem_cmd_header_lo;
+  logic [dword_width_gp-1:0] cce_mem_cmd_data_lo;
+  logic cce_mem_cmd_v_lo, cce_mem_cmd_last_lo, cce_mem_cmd_yumi_li;
+  bp_bedrock_cce_mem_msg_header_s cce_mem_resp_header_li;
+  logic [dword_width_gp-1:0] cce_mem_resp_data_li;
+  logic cce_mem_resp_v_li, cce_mem_resp_ready_and_lo, cce_mem_resp_last_li;
+
+  // Device-side CCE-Mem network connections
+  // dev_cmd[3:0] = {CCE loopback, CLINT, CFG, memory (cache)}
+  bp_bedrock_cce_mem_msg_header_s [3:0] dev_cmd_header_li;
+  logic [3:0][dword_width_gp-1:0] dev_cmd_data_li;
+  logic [3:0] dev_cmd_v_li, dev_cmd_ready_and_lo, dev_cmd_last_li;
+  bp_bedrock_cce_mem_msg_header_s [3:0] dev_resp_header_lo;
+  logic [3:0][dword_width_gp-1:0] dev_resp_data_lo;
+  logic [3:0] dev_resp_v_lo, dev_resp_ready_and_li, dev_resp_last_lo;
+
+  // Config
+  logic cce_ucode_v_lo;
+  logic cce_ucode_w_lo;
+  logic [cce_pc_width_p-1:0] cce_ucode_addr_lo;
+  logic [cce_instr_width_gp-1:0] cce_ucode_data_lo, cce_ucode_data_li;
+  logic [dword_width_gp-1:0] cfg_data_lo, cfg_data_li;
+  bp_me_cfg
+   #(.bp_params_p(bp_params_p))
+   cfg
     (.clk_i(clk_i)
      ,.reset_i(reset_r)
 
-     ,.in_msg_header_i(cache_mem_resp_header_li)
-     ,.in_msg_data_i(cache_mem_resp_data_li)
-     ,.in_msg_v_i(cache_mem_resp_v_li)
-     ,.in_msg_ready_and_o(cache_mem_resp_ready_and_lo)
-     ,.in_msg_last_i(cache_mem_resp_last_li)
+     ,.mem_cmd_header_i(dev_cmd_header_li[1])
+     ,.mem_cmd_data_i(dev_cmd_data_li[1])
+     ,.mem_cmd_v_i(dev_cmd_v_li[1])
+     ,.mem_cmd_ready_and_o(dev_cmd_ready_and_lo[1])
+     ,.mem_cmd_last_i(dev_cmd_last_li[1])
 
-     ,.out_msg_o(cache_mem_resp_lo)
-     ,.out_msg_v_o(cache_mem_resp_v_lo)
-     ,.out_msg_ready_and_i(cache_mem_resp_yumi_li)
+     ,.mem_resp_header_o(dev_resp_header_lo[1])
+     ,.mem_resp_data_o(dev_resp_data_lo[1])
+     ,.mem_resp_v_o(dev_resp_v_lo[1])
+     ,.mem_resp_ready_and_i(dev_resp_ready_and_li[1])
+     ,.mem_resp_last_o(dev_resp_last_lo[1])
+
+     ,.cfg_bus_o(cfg_bus_lo)
+     ,.did_i(my_did_i)
+     ,.host_did_i(host_did_i)
+     ,.cord_i(my_cord_i)
+
+     ,.cce_ucode_v_o(cce_ucode_v_lo)
+     ,.cce_ucode_w_o(cce_ucode_w_lo)
+     ,.cce_ucode_addr_o(cce_ucode_addr_lo)
+     ,.cce_ucode_data_o(cce_ucode_data_lo)
+     ,.cce_ucode_data_i(cce_ucode_data_li)
      );
 
+  // CLINT
+  bp_me_clint_slice
+   #(.bp_params_p(bp_params_p))
+   clint
+    (.clk_i(clk_i)
+     ,.reset_i(reset_r)
+
+     ,.mem_cmd_header_i(dev_cmd_header_li[2])
+     ,.mem_cmd_data_i(dev_cmd_data_li[2])
+     ,.mem_cmd_v_i(dev_cmd_v_li[2])
+     ,.mem_cmd_ready_and_o(dev_cmd_ready_and_lo[2])
+     ,.mem_cmd_last_i(dev_cmd_last_li[2])
+
+     ,.mem_resp_header_o(dev_resp_header_lo[2])
+     ,.mem_resp_data_o(dev_resp_data_lo[2])
+     ,.mem_resp_v_o(dev_resp_v_lo[2])
+     ,.mem_resp_ready_and_i(dev_resp_ready_and_li[2])
+     ,.mem_resp_last_o(dev_resp_last_lo[2])
+
+     ,.timer_irq_o(timer_irq_li)
+     ,.software_irq_o(software_irq_li)
+     ,.external_irq_o(external_irq_li)
+     );
+
+  // CCE-Mem Loopback
+  bp_me_loopback
+   #(.bp_params_p(bp_params_p))
+   loopback
+    (.clk_i(clk_i)
+     ,.reset_i(reset_r)
+
+     ,.mem_cmd_header_i(dev_cmd_header_li[3])
+     ,.mem_cmd_data_i(dev_cmd_data_li[3])
+     ,.mem_cmd_v_i(dev_cmd_v_li[3])
+     ,.mem_cmd_ready_and_o(dev_cmd_ready_and_lo[3])
+     ,.mem_cmd_last_i(dev_cmd_last_li[3])
+
+     ,.mem_resp_header_o(dev_resp_header_lo[3])
+     ,.mem_resp_data_o(dev_resp_data_lo[3])
+     ,.mem_resp_v_o(dev_resp_v_lo[3])
+     ,.mem_resp_ready_and_i(dev_resp_ready_and_li[3])
+     ,.mem_resp_last_o(dev_resp_last_lo[3])
+     );
+
+  // Select destination of CCE-Mem command from CCE
+  logic [`BSG_SAFE_CLOG2(4)-1:0] cce_mem_cmd_dst_lo;
+  bp_local_addr_s local_addr;
+  assign local_addr = cce_mem_cmd_header_lo.addr;
+  wire [dev_id_width_gp-1:0] device_cmd_li = local_addr.dev;
+  wire local_cmd_li    = (cce_mem_cmd_header_lo.addr < dram_base_addr_gp);
+
+  wire is_cfg_cmd      = local_cmd_li & (device_cmd_li == cfg_dev_gp);
+  wire is_clint_cmd    = local_cmd_li & (device_cmd_li == clint_dev_gp);
+  wire is_mem_cmd      = ~local_cmd_li || (local_cmd_li & (device_cmd_li == cache_dev_gp));
+  wire is_loopback_cmd = local_cmd_li & ~is_cfg_cmd & ~is_clint_cmd & ~is_mem_cmd;
+
+  bsg_encode_one_hot
+   #(.width_p(4), .lo_to_hi_p(1))
+   cmd_pe
+    (.i({is_loopback_cmd, is_clint_cmd, is_cfg_cmd, is_mem_cmd})
+     ,.addr_o(cce_mem_cmd_dst_lo)
+     ,.v_o()
+     );
+
+  // All CCE-Mem network responses go to the CCE on this tile (id = 0 in xbar)
+  logic [3:0] dev_resp_dst_lo = '0;
+
+  bp_me_xbar_stream_bidir
+   #(.bp_params_p(bp_params_p)
+     ,.data_width_p(dword_width_gp)
+     ,.payload_width_p(cce_mem_payload_width_lp)
+     ,.num_source_p(1)
+     ,.num_sink_p(4)
+     )
+   stream_arb
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.cmd_header_i(cce_mem_cmd_header_lo)
+     ,.cmd_data_i(cce_mem_cmd_data_lo)
+     ,.cmd_v_i(cce_mem_cmd_v_lo)
+     ,.cmd_yumi_o(cce_mem_cmd_yumi_li)
+     ,.cmd_last_i(cce_mem_cmd_last_lo)
+     ,.cmd_dst_i(cce_mem_cmd_dst_lo)
+
+     ,.resp_header_o(cce_mem_resp_header_li)
+     ,.resp_data_o(cce_mem_resp_data_li)
+     ,.resp_v_o(cce_mem_resp_v_li)
+     ,.resp_ready_and_i(cce_mem_resp_ready_and_lo)
+     ,.resp_last_o(cce_mem_resp_last_li)
+
+     ,.cmd_header_o(dev_cmd_header_li)
+     ,.cmd_data_o(dev_cmd_data_li)
+     ,.cmd_v_o(dev_cmd_v_li)
+     ,.cmd_ready_and_i(dev_cmd_ready_and_lo)
+     ,.cmd_last_o(dev_cmd_last_li)
+
+     ,.resp_header_i(dev_resp_header_lo)
+     ,.resp_data_i(dev_resp_data_lo)
+     ,.resp_v_i(dev_resp_v_lo)
+     ,.resp_yumi_o(dev_resp_ready_and_li)
+     ,.resp_last_i(dev_resp_last_lo)
+     ,.resp_dst_i(dev_resp_dst_lo)
+     );
+
+  // CCE: Cache Coherence Engine
+  bp_cce_wrapper
+   #(.bp_params_p(bp_params_p))
+   cce
+    (.clk_i(clk_i)
+     ,.reset_i(reset_r)
+
+     ,.cfg_bus_i(cfg_bus_lo)
+
+     ,.ucode_v_i(cce_ucode_v_lo)
+     ,.ucode_w_i(cce_ucode_w_lo)
+     ,.ucode_addr_i(cce_ucode_addr_lo)
+     ,.ucode_data_i(cce_ucode_data_lo)
+     ,.ucode_data_o(cce_ucode_data_li)
+
+     // LCE-CCE Interface
+     // BedRock Burst protocol: ready&valid
+     ,.lce_req_header_i(cce_lce_req_header)
+     ,.lce_req_header_v_i(cce_lce_req_header_v)
+     ,.lce_req_header_ready_and_o(cce_lce_req_header_ready_and)
+     ,.lce_req_has_data_i(cce_lce_req_has_data)
+     ,.lce_req_data_i(cce_lce_req_data)
+     ,.lce_req_data_v_i(cce_lce_req_data_v)
+     ,.lce_req_data_ready_and_o(cce_lce_req_data_ready_and)
+     ,.lce_req_last_i(cce_lce_req_last)
+
+     ,.lce_resp_header_i(cce_lce_resp_header)
+     ,.lce_resp_header_v_i(cce_lce_resp_header_v)
+     ,.lce_resp_header_ready_and_o(cce_lce_resp_header_ready_and)
+     ,.lce_resp_has_data_i(cce_lce_resp_has_data)
+     ,.lce_resp_data_i(cce_lce_resp_data)
+     ,.lce_resp_data_v_i(cce_lce_resp_data_v)
+     ,.lce_resp_data_ready_and_o(cce_lce_resp_data_ready_and)
+     ,.lce_resp_last_i(cce_lce_resp_last)
+
+     ,.lce_cmd_header_o(cce_lce_cmd_header)
+     ,.lce_cmd_header_v_o(cce_lce_cmd_header_v)
+     ,.lce_cmd_header_ready_and_i(cce_lce_cmd_header_ready_and)
+     ,.lce_cmd_has_data_o(cce_lce_cmd_has_data)
+     ,.lce_cmd_data_o(cce_lce_cmd_data)
+     ,.lce_cmd_data_v_o(cce_lce_cmd_data_v)
+     ,.lce_cmd_data_ready_and_i(cce_lce_cmd_data_ready_and)
+     ,.lce_cmd_last_o(cce_lce_cmd_last)
+
+     // CCE-MEM Interface
+     // BedRock Burst protocol: ready&valid
+     ,.mem_resp_header_i(cce_mem_resp_header_li)
+     ,.mem_resp_data_i(cce_mem_resp_data_li)
+     ,.mem_resp_v_i(cce_mem_resp_v_li)
+     ,.mem_resp_ready_and_o(cce_mem_resp_ready_and_lo)
+     ,.mem_resp_last_i(cce_mem_resp_last_li)
+
+     ,.mem_cmd_header_o(cce_mem_cmd_header_lo)
+     ,.mem_cmd_data_o(cce_mem_cmd_data_lo)
+     ,.mem_cmd_v_o(cce_mem_cmd_v_lo)
+     // TODO: should this be fixed?
+     ,.mem_cmd_ready_and_i(cce_mem_cmd_yumi_li)
+     ,.mem_cmd_last_o(cce_mem_cmd_last_lo)
+     );
+
+  // CCE-Mem network to L2 Cache adapter
   `declare_bsg_cache_pkt_s(caddr_width_p, l2_data_width_p);
   bsg_cache_pkt_s cache_pkt_li;
   logic cache_pkt_v_li, cache_pkt_ready_lo;
@@ -785,17 +668,17 @@ module bp_tile
     (.clk_i(clk_i)
      ,.reset_i(reset_r)
 
-     ,.mem_cmd_header_i(cache_mem_cmd_header_lo)
-     ,.mem_cmd_data_i(cache_mem_cmd_data_lo)
-     ,.mem_cmd_v_i(cache_mem_cmd_v_lo)
-     ,.mem_cmd_ready_and_o(cache_mem_cmd_ready_and_li)
-     ,.mem_cmd_last_i(cache_mem_cmd_last_lo)
+     ,.mem_cmd_header_i(dev_cmd_header_li[0])
+     ,.mem_cmd_data_i(dev_cmd_data_li[0])
+     ,.mem_cmd_v_i(dev_cmd_v_li[0])
+     ,.mem_cmd_ready_and_o(dev_cmd_ready_and_lo[0])
+     ,.mem_cmd_last_i(dev_cmd_last_li[0])
 
-     ,.mem_resp_header_o(cache_mem_resp_header_li)
-     ,.mem_resp_data_o(cache_mem_resp_data_li)
-     ,.mem_resp_v_o(cache_mem_resp_v_li)
-     ,.mem_resp_ready_and_i(cache_mem_resp_ready_and_lo)
-     ,.mem_resp_last_o(cache_mem_resp_last_li)
+     ,.mem_resp_header_o(dev_resp_header_lo[0])
+     ,.mem_resp_data_o(dev_resp_data_lo[0])
+     ,.mem_resp_v_o(dev_resp_v_lo[0])
+     ,.mem_resp_ready_and_i(dev_resp_ready_and_li[0])
+     ,.mem_resp_last_o(dev_resp_last_lo[0])
 
      ,.cache_pkt_o(cache_pkt_li)
      ,.cache_pkt_v_o(cache_pkt_v_li)
@@ -806,6 +689,7 @@ module bp_tile
      ,.cache_yumi_o(cache_data_yumi_li)
      );
 
+  // L2 Cache
   `declare_bsg_cache_dma_pkt_s(caddr_width_p);
   bsg_cache_dma_pkt_s dma_pkt_lo;
   logic dma_pkt_v_lo, dma_pkt_yumi_li;
@@ -858,6 +742,7 @@ module bp_tile
      ,.v_we_o()
      );
 
+  // L2 Cache to Memory Links adapter
   bsg_cache_dma_to_wormhole
    #(.dma_addr_width_p(caddr_width_p)
      ,.dma_burst_len_p(l2_block_size_in_fill_p)
@@ -890,25 +775,6 @@ module bp_tile
      ,.my_wh_cid_i('0)
      ,.dest_wh_cord_i('1)
      ,.dest_wh_cid_i('0)
-     );
-
-  bp_me_loopback
-   #(.bp_params_p(bp_params_p))
-   loopback
-    (.clk_i(clk_i)
-     ,.reset_i(reset_r)
-
-     ,.mem_cmd_header_i(loopback_mem_cmd.header)
-     ,.mem_cmd_data_i(loopback_mem_cmd.data)
-     ,.mem_cmd_v_i(loopback_mem_cmd_v_li)
-     ,.mem_cmd_ready_and_o(loopback_mem_cmd_ready_and_lo)
-     ,.mem_cmd_last_i(loopback_mem_cmd_v_li)
-
-     ,.mem_resp_header_o(loopback_mem_resp.header)
-     ,.mem_resp_data_o(loopback_mem_resp.data)
-     ,.mem_resp_v_o(loopback_mem_resp_v_lo)
-     ,.mem_resp_ready_and_i(loopback_mem_resp_yumi_li)
-     ,.mem_resp_last_o()
      );
 
 endmodule

--- a/bp_top/src/v/bp_unicore.sv
+++ b/bp_top/src/v/bp_unicore.sv
@@ -62,8 +62,6 @@ module bp_unicore
    );
 
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
-  `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache);
-  `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache);
   `declare_bp_bedrock_mem_if(paddr_width_p, uce_mem_data_width_lp, lce_id_width_p, lce_assoc_p, uce);
 
   bp_bedrock_uce_mem_msg_header_s mem_cmd_header_lo;

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -377,9 +377,10 @@ module bp_unicore_lite
   assign dev_resp_dst_lo[1] = dev_resp_header_lo[1].payload.lce_id;
   assign dev_resp_dst_lo[0] = dev_resp_header_lo[0].payload.lce_id;
 
-  bp_me_xbar_stream
+  bp_me_xbar_stream_bidir
    #(.bp_params_p(bp_params_p)
      ,.data_width_p(uce_mem_data_width_lp)
+     ,.payload_width_p(uce_mem_payload_width_lp)
      ,.num_source_p(3)
      ,.num_sink_p(5)
      )

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -282,6 +282,7 @@ $BP_ME_DIR/src/v/network/bp_me_burst_to_lite.sv
 $BP_ME_DIR/src/v/network/bp_me_wormhole_to_burst.sv
 $BP_ME_DIR/src/v/network/bp_me_burst_to_wormhole.sv
 $BP_ME_DIR/src/v/network/bp_me_xbar_stream.sv
+$BP_ME_DIR/src/v/network/bp_me_xbar_stream_bidir.sv
 $BP_ME_DIR/src/v/network/bp_me_stream_to_burst.sv
 $BP_ME_DIR/src/v/network/bp_me_burst_to_stream.sv
 $BP_ME_DIR/src/v/network/bp_me_stream_pump_in.sv

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -560,7 +560,6 @@ module testbench
              cce_tracer
               (.clk_i(clk_i & testbench.cce_trace_en_lo)
               ,.reset_i(reset_i)
-              ,.freeze_i(cfg_bus_cast_i.freeze)
 
               ,.cce_id_i(cfg_bus_cast_i.cce_id)
 
@@ -588,20 +587,18 @@ module testbench
               ,.lce_cmd_data_ready_and_i(lce_cmd_data_ready_and_i)
 
               // CCE-MEM Interface
-              // BedRock Burst protocol: ready&valid
+              // BedRock Stream protocol: ready&valid
               ,.mem_resp_header_i(mem_resp_header_i)
-              ,.mem_resp_header_v_i(mem_resp_header_v_i)
-              ,.mem_resp_header_ready_and_i(mem_resp_header_ready_and_o)
               ,.mem_resp_data_i(mem_resp_data_i)
-              ,.mem_resp_data_v_i(mem_resp_data_v_i)
-              ,.mem_resp_data_ready_and_i(mem_resp_data_ready_and_o)
+              ,.mem_resp_v_i(mem_resp_v_i)
+              ,.mem_resp_ready_and_i(mem_resp_ready_and_o)
+              ,.mem_resp_last_i(mem_resp_last_i)
 
               ,.mem_cmd_header_i(mem_cmd_header_o)
-              ,.mem_cmd_header_v_i(mem_cmd_header_v_o)
-              ,.mem_cmd_header_ready_and_i(mem_cmd_header_ready_and_i)
               ,.mem_cmd_data_i(mem_cmd_data_o)
-              ,.mem_cmd_data_v_i(mem_cmd_data_v_o)
-              ,.mem_cmd_data_ready_and_i(mem_cmd_data_ready_and_i)
+              ,.mem_cmd_v_i(mem_cmd_v_o)
+              ,.mem_cmd_ready_and_i(mem_cmd_ready_and_i)
+              ,.mem_cmd_last_i(mem_cmd_last_o)
               );
 
           bind bp_lce


### PR DESCRIPTION
This PR updates the FSM CCE to use BedRock Stream on its memory ports.

For now, this is a draft for viewing the diffs.
