### PR TITLE
Parameterized manual retiming for Zynq 7020

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - be_dev_fix_fmaretime
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - be_dev_fix_fmaretime
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -253,7 +253,7 @@ module bp_be_calculator_top
 
   // Aux pipe: 2 cycle latency
   bp_be_pipe_aux
-   #(.bp_params_p(bp_params_p), .latency_p(2))
+   #(.bp_params_p(bp_params_p))
    pipe_aux
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
@@ -335,7 +335,7 @@ module bp_be_calculator_top
 
   // Floating point pipe: 4/5 cycle latency
   bp_be_pipe_fma
-   #(.bp_params_p(bp_params_p), .imul_latency_p(4), .fma_latency_p(5))
+   #(.bp_params_p(bp_params_p))
    pipe_fma
     (.clk_i(clk_i)
      ,.reset_i(reset_i)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_aux.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_aux.sv
@@ -18,8 +18,6 @@ module bp_be_pipe_aux
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
 
-   , parameter `BSG_INV_PARAM(latency_p )
-
    , localparam dispatch_pkt_width_lp = `bp_be_dispatch_pkt_width(vaddr_width_p)
    )
   (input                               clk_i
@@ -496,7 +494,7 @@ module bp_be_pipe_aux
 
   wire faux_v_li = reservation.v & reservation.decode.pipe_aux_v;
   bsg_dff_chain
-   #(.width_p($bits(bp_be_fp_reg_s)+$bits(rv64_fflags_s)+1), .num_stages_p(latency_p-1))
+   #(.width_p($bits(bp_be_fp_reg_s)+$bits(rv64_fflags_s)+1), .num_stages_p(1))
    retiming_chain
     (.clk_i(clk_i)
 


### PR DESCRIPTION
Thanks for contributing to BlackParrot! Check out the CONTRIBUTING guide, if this is your first
time. A few details to check:

## Issue Fixed
Does this PR address a BlackParrot GitHub issue? Link it here:
dpetrisko: https://github.com/black-parrot/black-parrot/issues/784

## Area
Module/tool/makefile/script in question.
bp_be_pipe_fma.v, Vivado, Zynq 7020

## Reasoning (outdated, confusing, verbose, etc.)
Why is this change required?
For devices/tools that do not do the necessary retiming automatically

## Additional Changes Required (if any)
Next steps, downstream modules affected, etc.
Once HardFloat changes are pulled, we can set manual latency distribution; otherwise unchanged.
[Ref](https://github.com/bsg-external/HardFloat/pull/8)

## Analysis
Potential impact of the change.
None as is
dpetrisko: expected frequency boost from 25->50MHz in FPGA. Minimal area impact in ASIC/FPGA and no performance impact.

## Verification
Steps to taken to verify the change.
None, open to suggestions
dpetrisko: 
- [x] beebs suite
- [x] FPGA synthesis
- [ ] ASIC synthesis

## Additional Context
Add any other context about the problem here.
Logs, screenshots or videos that show the issue are very helpful.

