### PR TITLE
Fixes for multicore cosimulation with a non-replay D$

### DIFF
--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -333,6 +333,9 @@ module testbench
            ,.frd_w_v_i(scheduler.fwb_pkt_cast_i.frd_w_v)
            ,.frd_addr_i(scheduler.fwb_pkt_cast_i.rd_addr)
            ,.frd_data_i(scheduler.fwb_pkt_cast_i.rd_data)
+
+           ,.wbuf_v(calculator.pipe_mem.dcache.wbuf_v_li)
+           ,.uc_st_v(calculator.pipe_mem.dcache.uncached_store_req & calculator.pipe_mem.dcache.cache_req_yumi_i)
            );
 
       bind bp_be_dcache


### PR DESCRIPTION
This PR prevents non-replay D$ from appearing to break SC when stores commit before they are put in the write buffer. Figuring out a cleaner way to address this