### PR TITLE
Adding hardened stubs

### DIFF
--- a/bp_common/syn/v/bsg_mem_1r1w_sync.v
+++ b/bp_common/syn/v/bsg_mem_1r1w_sync.v
@@ -1,0 +1,60 @@
+
+`include "bsg_mem_1r1w_sync_macros.vh"
+
+module bsg_mem_1r1w_sync #( parameter `BSG_INV_PARAM(width_p )
+                          , parameter `BSG_INV_PARAM(els_p )
+                          , parameter read_write_same_addr_p = 0
+                          , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
+                          , parameter harden_p = 0
+                          // NOTE: unused
+                          , parameter substitute_1r1w_p = 0
+                          )
+  ( input clk_i
+  , input reset_i
+  
+  , input                     w_v_i
+  , input [addr_width_lp-1:0] w_addr_i
+  , input [width_p-1:0]       w_data_i
+  
+  , input                      r_v_i
+  , input [addr_width_lp-1:0]  r_addr_i
+  , output logic [width_p-1:0] r_data_o
+  );
+
+  wire unused = reset_i;
+
+  // TODO: Define more hardened macro configs here
+  `bsg_mem_1r1w_sync_macro(64,50) else
+  `bsg_mem_1r1w_sync_macro(1024,4) else
+
+  // no hardened version found
+    begin : notmacro
+      initial if (substitute_1r1w_p != 0) $warning("substitute_1r1w_p will have no effect");
+      bsg_mem_1r1w_sync_synth #(.width_p(width_p), .els_p(els_p), .read_write_same_addr_p(read_write_same_addr_p), .harden_p(harden_p))
+        synth
+          (.*);
+    end // block: notmacro
+
+  //synopsys translate_off
+  always_ff @(posedge clk_i)
+    if (w_v_i)
+    begin
+      assert (w_addr_i < els_p)
+        else $error("Invalid address %x to %m of size %x\n", w_addr_i, els_p);
+
+      assert (~(r0_addr_i == w_addr_i && w_v_i && r0_v_i && !read_write_same_addr_p))
+        else $error("%m: port 0 Attempt to read and write same address");
+
+      assert (~(r1_addr_i == w_addr_i && w_v_i && r1_v_i && !read_write_same_addr_p))
+        else $error("%m: port 1 Attempt to read and write same address");
+    end
+
+  initial
+    begin
+      $display("## %L: instantiating width_p=%d, els_p=%d, read_write_same_addr_p=%d, harden_p=%d (%m)",width_p,els_p,read_write_same_addr_p,harden_p);
+    end
+  //synopsys translate_on
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mem_1r1w_sync)

--- a/bp_common/syn/v/bsg_mem_1rw_sync.v
+++ b/bp_common/syn/v/bsg_mem_1rw_sync.v
@@ -1,0 +1,45 @@
+
+`include "bsg_mem_1rw_sync_macros.vh"
+
+module bsg_mem_1rw_sync #( parameter `BSG_INV_PARAM(width_p )
+                         , parameter `BSG_INV_PARAM(els_p )
+                         , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
+                         , parameter latch_last_read_p = 0
+                         // NOTE: unused
+                         , parameter substitute_1r1w_p = 0
+                         )
+  ( input                     clk_i
+  , input                     reset_i
+
+  , input [width_p-1:0]       data_i
+  , input [addr_width_lp-1:0] addr_i
+  , input                     v_i
+  , input                     w_i
+
+  , output logic [width_p-1:0]  data_o
+  );
+
+  wire unused = reset_i;
+
+  // TODO: Define more hardened macro configs here
+  `bsg_mem_1rw_sync_macro(512,64) else
+
+  // no hardened version found
+    begin : notmacro
+      initial if (substitute_1r1w_p != 0) $warning("substitute_1r1w_p will have no effect");
+      bsg_mem_1rw_sync_synth #(.width_p(width_p), .els_p(els_p), .latch_last_read_p(latch_last_read_p))
+        synth
+          (.*);
+    end // block: notmacro
+
+
+  // synopsys translate_off
+  initial
+    begin
+      $display("## %L: instantiating width_p=%d, els_p=%d, latch_last_read_p=%d (%m)",width_p,els_p,latch_last_read_p);
+    end
+  // synopsys translate_on
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mem_1rw_sync)

--- a/bp_common/syn/v/bsg_mem_1rw_sync_mask_write_bit.v
+++ b/bp_common/syn/v/bsg_mem_1rw_sync_mask_write_bit.v
@@ -1,0 +1,57 @@
+
+`include "bsg_mem_1rw_sync_mask_write_bit_macros.vh"
+
+module bsg_mem_1rw_sync_mask_write_bit #( parameter `BSG_INV_PARAM(width_p )
+                                        , parameter `BSG_INV_PARAM(els_p )
+                                        , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
+                                        , parameter latch_last_read_p = 0
+                                        )
+  ( input                       clk_i
+  , input                       reset_i
+  , input [width_p-1:0]         data_i
+  , input [addr_width_lp-1:0]   addr_i
+  , input                       v_i
+  , input [width_p-1:0]         w_mask_i
+  , input                       w_i
+  , output logic [width_p-1:0]  data_o
+  );
+
+  wire unused = reset_i;
+
+  // TODO: Define more hardened macro configs here
+  `bsg_mem_1rw_sync_mask_write_bit_macro(64,7) else
+  `bsg_mem_1rw_sync_mask_write_bit_macro(64,15) else
+  `bsg_mem_1rw_sync_mask_write_bit_macro(64,124) else
+  `bsg_mem_1rw_sync_mask_write_bit_macro(128,15) else
+  `bsg_mem_1rw_sync_mask_write_bit_macro(128,116) else
+  `bsg_mem_1rw_sync_mask_write_bit_macro(128,84) else
+  `bsg_mem_1rw_sync_mask_write_bit_macro(64,92) else
+  `bsg_mem_1rw_sync_mask_write_bit_banked_macro(64,248,2,1) else
+  `bsg_mem_1rw_sync_mask_write_bit_banked_macro(128,232,2,1) else
+  `bsg_mem_1rw_sync_mask_write_bit_banked_macro(128,168,2,1) else
+  `bsg_mem_1rw_sync_mask_write_bit_banked_macro(64,184,2,1) else
+
+    begin: notmacro
+      bsg_mem_1rw_sync_mask_write_bit_synth #(.width_p(width_p), .els_p(els_p), .latch_last_read_p(latch_last_read_p))
+        synth
+          (.*);
+    end // block: notmacro
+
+  // synopsys translate_off
+  always_ff @(posedge clk_i)
+    begin
+      if (v_i)
+        assert (addr_i < els_p)
+          else $error("Invalid address %x to %m of size %x\n", addr_i, els_p);
+    end
+
+  initial
+    begin
+      $display("## %L: instantiating width_p=%d, els_p=%d (%m)",width_p,els_p);
+    end
+// synopsys translate_on
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mem_1rw_sync_mask_write_bit)
+

--- a/bp_common/syn/v/bsg_mem_1rw_sync_mask_write_byte.v
+++ b/bp_common/syn/v/bsg_mem_1rw_sync_mask_write_byte.v
@@ -1,0 +1,50 @@
+
+`include "bsg_mem_1rw_sync_mask_write_byte_macros.vh"
+
+module bsg_mem_1rw_sync_mask_write_byte #( parameter `BSG_INV_PARAM(els_p )
+                                         , parameter `BSG_INV_PARAM(data_width_p )
+                                         , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
+                                         , parameter write_mask_width_lp = data_width_p>>3
+                                         , parameter latch_last_read_p = 0
+                                         )
+
+  ( input                           clk_i
+  , input                           reset_i
+  , input                           v_i
+  , input                           w_i
+  , input [addr_width_lp-1:0]       addr_i
+  , input [data_width_p-1:0]        data_i
+  , input [write_mask_width_lp-1:0] write_mask_i
+  , output logic [data_width_p-1:0] data_o
+  );
+
+  wire unused = reset_i;
+
+  // TODO: Define more hardened macro configs here
+  `bsg_mem_1rw_sync_mask_write_byte_macro(512,64) else
+  `bsg_mem_1rw_sync_mask_write_byte_banked_macro(1024,512,8,2) else
+  // no hardened version found
+    begin : notmacro
+      bsg_mem_1rw_sync_mask_write_byte_synth #(.data_width_p(data_width_p), .els_p(els_p), .latch_last_read_p(latch_last_read_p))
+        synth
+          (.*);
+    end // block: notmacro
+
+
+  // synopsys translate_off
+  always_comb
+    begin
+      assert (data_width_p % 8 == 0)
+        else $error("data width should be a multiple of 8 for byte masking");
+    end
+
+  initial
+    begin
+      $display("## bsg_mem_1rw_sync_mask_write_byte: instantiating data_width_p=%d, els_p=%d (%m)",data_width_p,els_p);
+    end
+  // synopsys translate_on
+   
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mem_1rw_sync_mask_write_byte)
+

--- a/bp_common/syn/v/bsg_mem_2r1w_sync.v
+++ b/bp_common/syn/v/bsg_mem_2r1w_sync.v
@@ -1,0 +1,63 @@
+
+`include "bsg_mem_2r1w_sync_macros.vh"
+
+module bsg_mem_2r1w_sync #( parameter `BSG_INV_PARAM(width_p )
+                          , parameter `BSG_INV_PARAM(els_p )
+                          , parameter read_write_same_addr_p = 0
+                          , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
+                          , parameter harden_p = 0
+                          // NOTE: unused
+                          , parameter substitute_2r1w_p = 0
+                          )
+  ( input clk_i
+  , input reset_i
+  
+  , input                     w_v_i
+  , input [addr_width_lp-1:0] w_addr_i
+  , input [width_p-1:0]       w_data_i
+  
+  , input                      r0_v_i
+  , input [addr_width_lp-1:0]  r0_addr_i
+  , output logic [width_p-1:0] r0_data_o
+  
+  , input                      r1_v_i
+  , input [addr_width_lp-1:0]  r1_addr_i
+  , output logic [width_p-1:0] r1_data_o
+  );
+
+  wire unused = reset_i;
+
+  // TODO: Define more hardened macro configs here
+  `bsg_mem_2r1w_sync_macro(32,64) else
+
+  // no hardened version found
+    begin : notmacro
+      initial if (substitute_2r1w_p != 0) $warning("substitute_2r1w_p will have no effect");
+      bsg_mem_2r1w_sync_synth #(.width_p(width_p), .els_p(els_p), .read_write_same_addr_p(read_write_same_addr_p), .harden_p(harden_p))
+        synth
+          (.*);
+    end // block: notmacro
+
+  //synopsys translate_off
+  always_ff @(posedge clk_i)
+    if (w_v_i)
+    begin
+      assert (w_addr_i < els_p)
+        else $error("Invalid address %x to %m of size %x\n", w_addr_i, els_p);
+
+      assert (~(r0_addr_i == w_addr_i && w_v_i && r0_v_i && !read_write_same_addr_p))
+        else $error("%m: port 0 Attempt to read and write same address");
+
+      assert (~(r1_addr_i == w_addr_i && w_v_i && r1_v_i && !read_write_same_addr_p))
+        else $error("%m: port 1 Attempt to read and write same address");
+    end
+
+  initial
+    begin
+      $display("## %L: instantiating width_p=%d, els_p=%d, read_write_same_addr_p=%d, harden_p=%d (%m)",width_p,els_p,read_write_same_addr_p,harden_p);
+    end
+  //synopsys translate_on
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mem_2r1w_sync)

--- a/bp_common/syn/v/bsg_mem_3r1w_sync.v
+++ b/bp_common/syn/v/bsg_mem_3r1w_sync.v
@@ -1,0 +1,70 @@
+
+`include "bsg_mem_3r1w_sync_macros.vh"
+
+module bsg_mem_3r1w_sync #( parameter `BSG_INV_PARAM(width_p )
+                          , parameter `BSG_INV_PARAM(els_p )
+                          , parameter read_write_same_addr_p = 0
+                          , parameter addr_width_lp = `BSG_SAFE_CLOG2(els_p)
+                          , parameter harden_p = 0
+                          // NOTE: unused
+                          , parameter substitute_3r1w_p = 0
+                          )
+  ( input clk_i
+  , input reset_i
+  
+  , input                     w_v_i
+  , input [addr_width_lp-1:0] w_addr_i
+  , input [width_p-1:0]       w_data_i
+  
+  , input                      r0_v_i
+  , input [addr_width_lp-1:0]  r0_addr_i
+  , output logic [width_p-1:0] r0_data_o
+  
+  , input                      r1_v_i
+  , input [addr_width_lp-1:0]  r1_addr_i
+  , output logic [width_p-1:0] r1_data_o
+
+  , input                      r2_v_i
+  , input [addr_width_lp-1:0]  r2_addr_i
+  , output logic [width_p-1:0] r2_data_o
+  );
+
+  wire unused = reset_i;
+
+  // TODO: Define more hardened macro configs here
+  `bsg_mem_3r1w_sync_macro(32,66) else
+
+  // no hardened version found
+    begin : notmacro
+      initial if (substitute_3r1w_p != 0) $warning("substitute_3r1w_p will have no effect");
+      bsg_mem_3r1w_sync_synth #(.width_p(width_p), .els_p(els_p), .read_write_same_addr_p(read_write_same_addr_p), .harden_p(harden_p))
+        synth
+          (.*);
+    end // block: notmacro
+
+  //synopsys translate_off
+  always_ff @(posedge clk_i)
+    if (w_v_i)
+    begin
+      assert (w_addr_i < els_p)
+        else $error("Invalid address %x to %m of size %x\n", w_addr_i, els_p);
+
+      assert (~(r0_addr_i == w_addr_i && w_v_i && r0_v_i && !read_write_same_addr_p))
+        else $error("%m: port 0 Attempt to read and write same address");
+
+      assert (~(r1_addr_i == w_addr_i && w_v_i && r1_v_i && !read_write_same_addr_p))
+        else $error("%m: port 1 Attempt to read and write same address");
+
+      assert (~(r2_addr_i == w_addr_i && w_v_i && r2_v_i && !read_write_same_addr_p))
+        else $error("%m: port 1 Attempt to read and write same address");
+    end
+
+  initial
+    begin
+      $display("## %L: instantiating width_p=%d, els_p=%d, read_write_same_addr_p=%d, harden_p=%d (%m)",width_p,els_p,read_write_same_addr_p,harden_p);
+    end
+  //synopsys translate_on
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mem_3r1w_sync)

--- a/bp_top/test/tb/bp_tethered/Makefile.sv2v
+++ b/bp_top/test/tb/bp_tethered/Makefile.sv2v
@@ -1,13 +1,24 @@
 $(CONVERT_DIR)/flist.vcs:
-	grep -v -e "^\#" $(SYN_PATH)/flist.vcs       > $@
-	echo $(CONVERT_DIR)/wrapper.sv              >> $@
+	grep -v -e "^\#" $(SYN_PATH)/flist.vcs                                        > $@
+	echo $(CONVERT_DIR)/wrapper.sv                                               >> $@
+	echo "+incdir+$(BASEJUMP_STL_DIR)/hard/pickle/bsg_mem"                       >> $@
+	echo "$(BASEJUMP_STL_DIR)/bsg_mem/bsg_mem_1rw_sync_banked.v"                 >> $@
+	echo "$(BASEJUMP_STL_DIR)/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_banked.v"  >> $@
+	echo "$(BASEJUMP_STL_DIR)/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_banked.v" >> $@
+	sed -i "/bsg_mem_3r1w_sync.v/d"                                                 $@
+	sed -i "/bsg_mem_2r1w_sync.v/d"                                                 $@
+	sed -i "/bsg_mem_1r1w_sync.v/d"                                                 $@
+	sed -i "/bsg_mem_1rw_sync.v/d"                                                  $@
+	sed -i "/bsg_mem_1rw_sync_mask_write_byte.v/d"                                  $@
+	sed -i "/bsg_mem_1rw_sync_mask_write_bit.v/d"                                   $@
+	echo "$(BP_COMMON_DIR)/syn/v/bsg_mem_3r1w_sync.v"                            >> $@
+	echo "$(BP_COMMON_DIR)/syn/v/bsg_mem_2r1w_sync.v"                            >> $@
+	echo "$(BP_COMMON_DIR)/syn/v/bsg_mem_1r1w_sync.v"                            >> $@
+	echo "$(BP_COMMON_DIR)/syn/v/bsg_mem_1rw_sync.v"                             >> $@
+	echo "$(BP_COMMON_DIR)/syn/v/bsg_mem_1rw_sync_mask_write_byte.v"             >> $@
+	echo "$(BP_COMMON_DIR)/syn/v/bsg_mem_1rw_sync_mask_write_bit.v"              >> $@
 
 $(CONVERT_DIR)/wrapper.sv:
 	@sed "s/BP_CFG_FLOWVAR/$(CFG)/g" $(TB_PATH)/$(TB)/$(@F) > $@
 
-$(CONVERT_DIR)/command.txt: $(CONVERT_DIR)/flist.vcs
-	cat $< | envsubst > $@
-	sed -i "s/+incdir+/--incdir=/g" $@
-	sed -i "s/+define+/--define=/g" $@
-
-CONVERT_COLLATERAL = $(addprefix $(CONVERT_DIR)/, flist.vcs wrapper.sv command.txt)
+CONVERT_COLLATERAL = $(addprefix $(CONVERT_DIR)/, flist.vcs wrapper.sv)


### PR DESCRIPTION
## Issue Fixed
#896 

## Area
Makefile.sv2v, adds common verilog files

## Reasoning (outdated, confusing, verbose, etc.)
The current SV2V flow does not substitute blackbox RAMs, leading to long runtimes and excessively long elaboration lists, causing issues in some tools.

## Additional Changes Required (if any)
none

## Analysis
No impact on PPA, some makefile complexity. 20m->1m bsg_sv2v runtime.

## Verification
Manual inspection of output netlist.

## Additional Context
none

