### PR TITLE
Separating out hash function in bsg_cache_to_axi

### DIFF
--- a/bp_me/test/common/bp_nonsynth_dram.sv
+++ b/bp_me/test/common/bp_nonsynth_dram.sv
@@ -204,7 +204,7 @@ module bp_nonsynth_dram
 
       logic [axi_id_width_p-1:0] axi_awid;
       logic [caddr_width_p-1:0] axi_awaddr_addr;
-      logic [`BSG_SAFE_CLOG2(num_dma_p)-1:0] axi_awaddr_tag;
+      logic [`BSG_SAFE_CLOG2(num_dma_p)-1:0] axi_awaddr_cache_id;
       logic [7:0] axi_awlen;
       logic [2:0] axi_awsize;
       logic [1:0] axi_awburst;
@@ -222,7 +222,7 @@ module bp_nonsynth_dram
 
       logic [axi_id_width_p-1:0] axi_arid;
       logic [caddr_width_p-1:0] axi_araddr_addr;
-      logic [`BSG_SAFE_CLOG2(num_dma_p)-1:0] axi_araddr_tag;
+      logic [`BSG_SAFE_CLOG2(num_dma_p)-1:0] axi_araddr_cache_id;
       logic [7:0] axi_arlen;
       logic [2:0] axi_arsize;
       logic [1:0] axi_arburst;

--- a/bp_me/test/common/bp_nonsynth_dram.sv
+++ b/bp_me/test/common/bp_nonsynth_dram.sv
@@ -203,7 +203,8 @@ module bp_nonsynth_dram
       localparam axi_burst_len_p = 1;
 
       logic [axi_id_width_p-1:0] axi_awid;
-      logic [axi_addr_width_p-1:0] axi_awaddr;
+      logic [caddr_width_p-1:0] axi_awaddr_addr;
+      logic [`BSG_SAFE_CLOG2(num_dma_p)-1:0] axi_awaddr_tag;
       logic [7:0] axi_awlen;
       logic [2:0] axi_awsize;
       logic [1:0] axi_awburst;
@@ -220,7 +221,8 @@ module bp_nonsynth_dram
       logic axi_bvalid, axi_bready;
 
       logic [axi_id_width_p-1:0] axi_arid;
-      logic [axi_addr_width_p-1:0] axi_araddr;
+      logic [caddr_width_p-1:0] axi_araddr_addr;
+      logic [`BSG_SAFE_CLOG2(num_dma_p)-1:0] axi_araddr_tag;
       logic [7:0] axi_arlen;
       logic [2:0] axi_arsize;
       logic [1:0] axi_arburst;
@@ -239,7 +241,6 @@ module bp_nonsynth_dram
          ,.block_size_in_words_p(l2_block_size_in_fill_p)
          ,.num_cache_p(num_dma_p)
          ,.axi_id_width_p(axi_id_width_p)
-         ,.axi_addr_width_p(axi_addr_width_p)
          ,.axi_data_width_p(axi_data_width_p)
          ,.axi_burst_len_p(axi_burst_len_p)
          )
@@ -260,7 +261,8 @@ module bp_nonsynth_dram
          ,.dma_data_yumi_o(dma_data_yumi_o)
 
          ,.axi_awid_o(axi_awid)
-         ,.axi_awaddr_o(axi_awaddr)
+         ,.axi_awaddr_addr_o(axi_awaddr_addr)
+         ,.axi_awaddr_cache_id_o(axi_awaddr_cache_id)
          ,.axi_awlen_o(axi_awlen)
          ,.axi_awsize_o(axi_awsize)
          ,.axi_awburst_o(axi_awburst)
@@ -281,7 +283,8 @@ module bp_nonsynth_dram
          ,.axi_bvalid_i(axi_bvalid)
          ,.axi_bready_o(axi_bready)
          ,.axi_arid_o(axi_arid)
-         ,.axi_araddr_o(axi_araddr)
+         ,.axi_araddr_addr_o(axi_araddr_addr)
+         ,.axi_araddr_cache_id_o(axi_araddr_cache_id)
          ,.axi_arlen_o(axi_arlen)
          ,.axi_arsize_o(axi_arsize)
          ,.axi_arburst_o(axi_arburst)
@@ -298,6 +301,9 @@ module bp_nonsynth_dram
          ,.axi_rvalid_i(axi_rvalid)
          ,.axi_rready_o(axi_rready)
          );
+
+      wire [axi_addr_width_p-1:0] axi_araddr = {axi_araddr_cache_id, (axi_araddr_addr-dram_base_addr_gp)};
+      wire [axi_addr_width_p-1:0] axi_awaddr = {axi_awaddr_cache_id, (axi_awaddr_addr-dram_base_addr_gp)};
 
       bsg_nonsynth_axi_mem
        #(.axi_id_width_p(axi_id_width_p)


### PR DESCRIPTION
## Area
AXI DRAM module, uncore.

## Reasoning (outdated, confusing, verbose, etc.)

Reasoning seen here: https://github.com/bespoke-silicon-group/basejump_stl/pull/480.

## Additional Changes Required (if any)
Depends on: https://github.com/bespoke-silicon-group/basejump_stl/pull/480.

## Analysis
May be minor PPA impact from crossing boundary before / after doing arithmetic, but AXI signals can easily be pipelined to mitigate this effect if necessary. AXI is not currently on any known critical paths.

## Verification
Passes general regression with DRAM=axi switch.

## Additional Context
External users demand more flexibility in address hashing.


