### PR TITLE
Minor refactor of PTW

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - be_dev_fix_ptwfinal
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - be_dev_fix_ptwfinal
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/bp_be/src/include/bp_be_ctl_pkgdef.svh
+++ b/bp_be/src/include/bp_be_ctl_pkgdef.svh
@@ -83,6 +83,8 @@
     ,e_dcache_op_fsw      = 6'b100100
     ,e_dcache_op_fsd      = 6'b100101
 
+    ,e_dcache_op_ptw_ld   = 6'b100110
+
     ,e_dcache_op_amoswapw = 6'b010000
     ,e_dcache_op_amoaddw  = 6'b010001
     ,e_dcache_op_amoxorw  = 6'b010010

--- a/bp_be/src/include/bp_be_dcache_pkgdef.svh
+++ b/bp_be/src/include/bp_be_dcache_pkgdef.svh
@@ -32,6 +32,7 @@
     logic                         l2_op;
     logic                         lr_op;
     logic                         sc_op;
+    logic                         ptw_op;
     logic                         amo_op;
     bp_be_amo_subop_e             amo_subop;
     logic [reg_addr_width_gp-1:0] rd_addr;

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache_decoder.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache_decoder.sv
@@ -72,10 +72,13 @@ module bp_be_dcache_decoder
       {e_dcache_op_flw, e_dcache_op_fld
        ,e_dcache_op_ld, e_dcache_op_lw, e_dcache_op_lh, e_dcache_op_lb
        ,e_dcache_op_lwu, e_dcache_op_lhu, e_dcache_op_lbu
+       ,e_dcache_op_ptw_ld
        };
 
     decode_cast_o.store_op = (decode_cast_o.amo_op & ~decode_cast_o.lr_op) || dcache_pkt.opcode inside
       {e_dcache_op_sd, e_dcache_op_sw, e_dcache_op_sh, e_dcache_op_sb, e_dcache_op_fsw, e_dcache_op_fsd};
+
+    decode_cast_o.ptw_op = dcache_pkt.opcode inside {e_dcache_op_ptw_ld};
 
     // Size decoding
     unique case (dcache_pkt.opcode)

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -79,7 +79,6 @@ module bp_be_top
   // Top-level interface connections
   bp_be_dispatch_pkt_s dispatch_pkt;
   bp_be_branch_pkt_s   br_pkt;
-  bp_be_ptw_miss_pkt_s ptw_miss_pkt;
 
   logic dispatch_v, interrupt_v;
   logic irq_pending_lo, irq_waiting_lo, replay_pending_lo;

--- a/bp_be/test/tb/bp_be_dcache/testbench.sv
+++ b/bp_be/test/tb/bp_be_dcache/testbench.sv
@@ -315,7 +315,7 @@ module testbench
        ,.cache_req_metadata_o(cache_req_metadata_o)
        ,.cache_req_complete_i(cache_req_complete_i)
 
-       ,.v_o(early_v_o)
+       ,.v_o(early_hit_v_o)
        ,.load_data(early_data_o[0+:65])
        ,.store_data(st_data_tv_r[0+:64])
        ,.wt_req(wt_req)

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -211,7 +211,8 @@ module wrapper
        ,.ready_o(dcache_ready_lo[i])
 
        ,.early_data_o(early_data_lo[i])
-       ,.early_v_o(early_v_lo[i])
+       ,.early_hit_v_o(early_v_lo[i])
+       ,.early_miss_v_o()
        ,.final_data_o(final_data_lo[i])
        ,.final_v_o(final_v_lo[i])
 

--- a/bp_common/src/v/bsg_deff_reset.v
+++ b/bp_common/src/v/bsg_deff_reset.v
@@ -1,0 +1,34 @@
+
+`include "bsg_defines.v"
+
+//
+// https://stackoverflow.com/questions/19605881/triggering-signal-on-both-edges-of-the-clock
+//
+
+module bsg_deff_reset
+ #(parameter `BSG_INV_PARAM(width_p))
+  (input                        clk_i
+   , input                      reset_i
+   , input  [width_p-1:0]       data_i
+   , output logic [width_p-1:0] data_o
+   );
+
+   logic [width_p-1:0] data_r_pr, data_r_nr;
+   always_ff @(posedge clk_i)
+     if (reset_i)
+       data_r_pr <= '0;
+     else
+       data_r_pr <= data_i ^ data_r_nr;
+
+   always_ff @(negedge clk_i)
+     if (reset_i)
+       data_r_nr <= '0;
+     else
+       data_r_nr <= data_i ^ data_r_pr;
+
+   assign data_o = data_r_pr ^ data_r_nr;
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_deff_reset)
+

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -110,7 +110,8 @@ module bp_cacc_vdp
      ,.v_i(dcache_pkt_v)
      ,.ready_o(dcache_ready)
 
-     ,.early_v_o(dcache_v)
+     ,.early_hit_v_o(dcache_v)
+     ,.early_miss_v_o()
      ,.early_data_o(dcache_data)
      ,.final_v_o()
      ,.final_data_o()

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -301,6 +301,7 @@ $BP_TOP_DIR/src/v/bp_tile_node.sv
 
 # BSG Staging area
 $BP_COMMON_DIR/src/v/bsg_async_noc_link.sv
+$BP_COMMON_DIR/src/v/bsg_deff_reset.v
 $BP_COMMON_DIR/src/v/bsg_dff_reset_half.v
 $BP_COMMON_DIR/src/v/bsg_cache_dma_to_wormhole.v
 $BP_COMMON_DIR/src/v/bsg_wormhole_to_cache_dma_fanout.v

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -366,7 +366,7 @@ module testbench
 
            ,.cache_req_complete_i(cache_req_complete_i)
 
-           ,.v_o(early_v_o)
+           ,.v_o(early_hit_v_o)
            ,.load_data(early_data_o[0+:65])
            ,.cache_miss_o('0)
            ,.wt_req(wt_req)


### PR DESCRIPTION
## Summary

This is a minor refactor of the PTW, for clarity

## Area
PTW, D$, LSU

## Reasoning (outdated, confusing, verbose, etc.)
The current setup is confusing and error prone. Additionally, by not differentiating between PTW and regular loads, non-blocking loads are complicated, since the PTW miss may also be scoreboarded.

## Additional Changes Required (if any)
Additionally added a true miss signal to the $, which will allow users to differentiate between a miss and a fail. Lastly, this PR introduces a double edge FF (scary), which will be used in future work for posedge/negedge D$ handshakes.

## Analysis
No PPA impact, just clarity.

## Verification
- [ ] Linux boot

