### PR TITLE
Adding buffered crossbar

### DIFF
--- a/bp_me/src/v/network/bp_me_xbar_stream_buffered.sv
+++ b/bp_me/src/v/network/bp_me_xbar_stream_buffered.sv
@@ -1,7 +1,7 @@
 /**
  *
  * Name:
- *   bp_me_xbar_stream.sv
+ *   bp_me_xbar_stream_buffered.sv
  *
  * Description:
  *   This xbar arbitrates BedRock Stream messages between N sources and M sinks.
@@ -11,7 +11,7 @@
 `include "bp_common_defines.svh"
 `include "bp_me_defines.svh"
 
-module bp_me_xbar_stream
+module bp_me_xbar_stream_buffered
  import bp_common_pkg::*;
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
@@ -32,7 +32,7 @@ module bp_me_xbar_stream
    , input [num_source_p-1:0][xbar_msg_header_width_lp-1:0]           msg_header_i
    , input [num_source_p-1:0][data_width_p-1:0]                       msg_data_i
    , input [num_source_p-1:0]                                         msg_v_i
-   , output logic [num_source_p-1:0]                                  msg_yumi_o
+   , output logic [num_source_p-1:0]                                  msg_ready_and_o
    , input [num_source_p-1:0]                                         msg_last_i
    , input [num_source_p-1:0][lg_num_sink_lp-1:0]                     msg_dst_i
 
@@ -44,53 +44,51 @@ module bp_me_xbar_stream
    );
 
   `declare_bp_bedrock_if(paddr_width_p, payload_width_p, data_width_p, lce_id_width_p, lce_assoc_p, xbar);
+  bp_bedrock_xbar_msg_header_s [num_source_p-1:0] msg_header_li;
+  logic [num_source_p-1:0][data_width_p-1:0] msg_data_li;
+  logic [num_source_p-1:0] msg_v_li, msg_yumi_lo, msg_last_li;
+  logic [num_source_p-1:0][lg_num_sink_lp-1:0] msg_dst_li;
 
-  // msg arbitration logic
-  logic [num_source_p-1:0] msg_grants_lo;
-  wire msg_arb_unlock_li = |{msg_yumi_o & msg_last_i} | reset_i;
-  bsg_locking_arb_fixed
-   #(.inputs_p(num_source_p), .lo_to_hi_p(0))
-   msg_arbiter
+  for (genvar i = 0; i < num_source_p; i++)
+    begin : buffer
+      bsg_two_fifo
+       #(.width_p(lg_num_sink_lp+1+data_width_p+xbar_msg_header_width_lp))
+       in_fifo
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+
+         ,.data_i({msg_dst_i[i], msg_last_i[i], msg_data_i[i], msg_header_i[i]})
+         ,.v_i(msg_v_i[i])
+         ,.ready_o(msg_ready_and_o[i])
+
+         ,.data_o({msg_dst_li[i], msg_last_li[i], msg_data_li[i], msg_header_li[i]})
+         ,.v_o(msg_v_li[i])
+         ,.yumi_i(msg_yumi_lo[i])
+         );
+    end
+
+  bp_me_xbar_stream
+   #(.bp_params_p(bp_params_p)
+     ,.data_width_p(data_width_p)
+     ,.payload_width_p(payload_width_p)
+     ,.num_source_p(num_source_p)
+     ,.num_sink_p(num_sink_p)
+     )
+   cmd_xbar
     (.clk_i(clk_i)
-     ,.ready_i(1'b1)
+     ,.reset_i(reset_i)
 
-     ,.unlock_i(msg_arb_unlock_li)
-     ,.reqs_i(msg_v_i)
-     ,.grants_o(msg_grants_lo)
-     );
-  logic [lg_num_source_lp-1:0] msg_grants_sel_li;
-  logic msg_grants_v_li;
-  bsg_encode_one_hot
-   #(.width_p(num_source_p), .lo_to_hi_p(1))
-   msg_sel
-    (.i(msg_grants_lo)
-     ,.addr_o(msg_grants_sel_li)
-     ,.v_o(msg_grants_v_li)
-     );
+     ,.msg_header_i(msg_header_li)
+     ,.msg_data_i(msg_data_li)
+     ,.msg_v_i(msg_v_li)
+     ,.msg_yumi_o(msg_yumi_lo)
+     ,.msg_last_i(msg_last_li)
+     ,.msg_dst_i(msg_dst_li)
 
-  bp_bedrock_xbar_msg_header_s msg_header_selected_lo;
-  bsg_mux_one_hot
-   #(.width_p($bits(bp_bedrock_xbar_msg_header_s)), .els_p(num_source_p))
-   msg_header_select
-    (.data_i(msg_header_i)
-     ,.sel_one_hot_i(msg_grants_lo)
-     ,.data_o(msg_header_selected_lo)
+     ,.*
      );
-  logic [data_width_p-1:0] msg_data_selected_lo;
-  bsg_mux_one_hot
-   #(.width_p(data_width_p), .els_p(num_source_p))
-   msg_data_select
-    (.data_i(msg_data_i)
-     ,.sel_one_hot_i(msg_grants_lo)
-     ,.data_o(msg_data_selected_lo)
-     );
-  assign msg_header_o = {num_sink_p{msg_header_selected_lo}};
-  assign msg_data_o   = {num_sink_p{msg_data_selected_lo}};
-  assign msg_v_o      = msg_grants_v_li ? (1'b1 << msg_dst_i[msg_grants_sel_li]) : '0;
-  assign msg_yumi_o   = msg_grants_lo & {num_source_p{|{msg_v_o & msg_ready_and_i}}};
-  assign msg_last_o   = msg_v_o & {num_sink_p{msg_last_i[msg_grants_sel_li]}};
 
 endmodule
 
-`BSG_ABSTRACT_MODULE(bp_me_xbar_stream)
+`BSG_ABSTRACT_MODULE(bp_me_xbar_stream_buffered)
 

--- a/bp_top/src/v/bp_tile.sv
+++ b/bp_top/src/v/bp_tile.sv
@@ -444,7 +444,7 @@ module bp_tile
   // CCE-side CCE-Mem network connections
   bp_bedrock_cce_mem_msg_header_s cce_mem_cmd_header_lo;
   logic [dword_width_gp-1:0] cce_mem_cmd_data_lo;
-  logic cce_mem_cmd_v_lo, cce_mem_cmd_last_lo, cce_mem_cmd_yumi_li;
+  logic cce_mem_cmd_v_lo, cce_mem_cmd_last_lo, cce_mem_cmd_ready_and_li;
   bp_bedrock_cce_mem_msg_header_s cce_mem_resp_header_li;
   logic [dword_width_gp-1:0] cce_mem_resp_data_li;
   logic cce_mem_resp_v_li, cce_mem_resp_ready_and_lo, cce_mem_resp_last_li;
@@ -561,7 +561,7 @@ module bp_tile
   // All CCE-Mem network responses go to the CCE on this tile (id = 0 in xbar)
   wire [3:0] dev_resp_dst_lo = '0;
 
-  bp_me_xbar_stream
+  bp_me_xbar_stream_buffered
    #(.bp_params_p(bp_params_p)
      ,.data_width_p(dword_width_gp)
      ,.payload_width_p(cce_mem_payload_width_lp)
@@ -575,7 +575,7 @@ module bp_tile
      ,.msg_header_i(cce_mem_cmd_header_lo)
      ,.msg_data_i(cce_mem_cmd_data_lo)
      ,.msg_v_i(cce_mem_cmd_v_lo)
-     ,.msg_yumi_o(cce_mem_cmd_yumi_li)
+     ,.msg_ready_and_o(cce_mem_cmd_ready_and_li)
      ,.msg_last_i(cce_mem_cmd_last_lo)
      ,.msg_dst_i(cce_mem_cmd_dst_lo)
 
@@ -586,7 +586,7 @@ module bp_tile
      ,.msg_last_o(dev_cmd_last_li)
      );
 
-  bp_me_xbar_stream
+  bp_me_xbar_stream_buffered
    #(.bp_params_p(bp_params_p)
      ,.data_width_p(dword_width_gp)
      ,.payload_width_p(cce_mem_payload_width_lp)
@@ -600,7 +600,7 @@ module bp_tile
      ,.msg_header_i(dev_resp_header_lo)
      ,.msg_data_i(dev_resp_data_lo)
      ,.msg_v_i(dev_resp_v_lo)
-     ,.msg_yumi_o(dev_resp_ready_and_li)
+     ,.msg_ready_and_o(dev_resp_ready_and_li)
      ,.msg_last_i(dev_resp_last_lo)
      ,.msg_dst_i(dev_resp_dst_lo)
 
@@ -666,7 +666,7 @@ module bp_tile
      ,.mem_cmd_header_o(cce_mem_cmd_header_lo)
      ,.mem_cmd_data_o(cce_mem_cmd_data_lo)
      ,.mem_cmd_v_o(cce_mem_cmd_v_lo)
-     ,.mem_cmd_ready_and_i(cce_mem_cmd_yumi_li)
+     ,.mem_cmd_ready_and_i(cce_mem_cmd_ready_and_li)
      ,.mem_cmd_last_o(cce_mem_cmd_last_lo)
      );
 

--- a/bp_top/src/v/bp_unicore.sv
+++ b/bp_top/src/v/bp_unicore.sv
@@ -51,14 +51,14 @@ module bp_unicore
    , input [uce_mem_msg_header_width_lp-1:0]           io_resp_header_i
    , input [uce_mem_data_width_lp-1:0]                 io_resp_data_i
    , input                                             io_resp_v_i
-   , output logic                                      io_resp_yumi_o
+   , output logic                                      io_resp_ready_and_o
    , input                                             io_resp_last_i
 
    // Incoming I/O
    , input [uce_mem_msg_header_width_lp-1:0]           io_cmd_header_i
    , input [uce_mem_data_width_lp-1:0]                 io_cmd_data_i
    , input                                             io_cmd_v_i
-   , output logic                                      io_cmd_yumi_o
+   , output logic                                      io_cmd_ready_and_o
    , input                                             io_cmd_last_i
 
    , output logic [uce_mem_msg_header_width_lp-1:0]    io_resp_header_o

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -28,14 +28,14 @@ module bp_unicore_lite
    , input [uce_mem_msg_header_width_lp-1:0]           io_resp_header_i
    , input [uce_mem_data_width_lp-1:0]                 io_resp_data_i
    , input                                             io_resp_v_i
-   , output logic                                      io_resp_yumi_o
+   , output logic                                      io_resp_ready_and_o
    , input                                             io_resp_last_i
 
    // Incoming I/O
    , input [uce_mem_msg_header_width_lp-1:0]           io_cmd_header_i
    , input [uce_mem_data_width_lp-1:0]                 io_cmd_data_i
    , input                                             io_cmd_v_i
-   , output logic                                      io_cmd_yumi_o
+   , output logic                                      io_cmd_ready_and_o
    , input                                             io_cmd_last_i
 
    , output logic [uce_mem_msg_header_width_lp-1:0]    io_resp_header_o
@@ -113,7 +113,7 @@ module bp_unicore_lite
   // proc_cmd[2:0] = {IO cmd, BE UCE, FE UCE}
   bp_bedrock_uce_mem_msg_header_s [2:0] proc_cmd_header_lo;
   logic [2:0][uce_mem_data_width_lp-1:0] proc_cmd_data_lo;
-  logic [2:0] proc_cmd_v_lo, proc_cmd_yumi_li, proc_cmd_last_lo;
+  logic [2:0] proc_cmd_v_lo, proc_cmd_ready_and_li, proc_cmd_last_lo;
   bp_bedrock_uce_mem_msg_header_s [2:0] proc_resp_header_li;
   logic [2:0][uce_mem_data_width_lp-1:0] proc_resp_data_li;
   logic [2:0] proc_resp_v_li, proc_resp_ready_and_lo, proc_resp_last_li;
@@ -241,7 +241,7 @@ module bp_unicore_lite
     ,.mem_cmd_header_o(proc_cmd_header_lo[1])
     ,.mem_cmd_data_o(proc_cmd_data_lo[1])
     ,.mem_cmd_v_o(proc_cmd_v_lo[1])
-    ,.mem_cmd_ready_and_i(proc_cmd_yumi_li[1])
+    ,.mem_cmd_ready_and_i(proc_cmd_ready_and_li[1])
     ,.mem_cmd_last_o(proc_cmd_last_lo[1])
 
     ,.mem_resp_header_i(proc_resp_header_li[1])
@@ -296,7 +296,7 @@ module bp_unicore_lite
      ,.mem_cmd_header_o(proc_cmd_header_lo[0])
      ,.mem_cmd_data_o(proc_cmd_data_lo[0])
      ,.mem_cmd_v_o(proc_cmd_v_lo[0])
-     ,.mem_cmd_ready_and_i(proc_cmd_yumi_li[0])
+     ,.mem_cmd_ready_and_i(proc_cmd_ready_and_li[0])
      ,.mem_cmd_last_o(proc_cmd_last_lo[0])
 
      ,.mem_resp_header_i(proc_resp_header_li[0])
@@ -310,7 +310,7 @@ module bp_unicore_lite
   assign proc_cmd_header_lo[2] = io_cmd_header_cast_i;
   assign proc_cmd_data_lo[2] = io_cmd_data_i;
   assign proc_cmd_v_lo[2] = io_cmd_v_i;
-  assign io_cmd_yumi_o = proc_cmd_yumi_li[2];
+  assign io_cmd_ready_and_o = proc_cmd_ready_and_li[2];
   assign proc_cmd_last_lo[2] = io_cmd_last_i;
 
   assign io_resp_header_cast_o = proc_resp_header_li[2];
@@ -335,7 +335,7 @@ module bp_unicore_lite
   assign dev_resp_header_lo[2] = io_resp_header_cast_i;
   assign dev_resp_data_lo[2] = io_resp_data_i;
   assign dev_resp_v_lo[2] = io_resp_v_i;
-  assign io_resp_yumi_o = dev_resp_ready_and_li[2] & dev_resp_v_lo[2];
+  assign io_resp_ready_and_o = dev_resp_ready_and_li[2];
   assign dev_resp_last_lo[2] = io_resp_last_i;
 
   assign dev_resp_header_lo[3] = mem_resp_header_cast_i;
@@ -379,7 +379,7 @@ module bp_unicore_lite
   assign dev_resp_dst_lo[1] = dev_resp_header_lo[1].payload.lce_id[0+:lg_num_proc_lp];
   assign dev_resp_dst_lo[0] = dev_resp_header_lo[0].payload.lce_id[0+:lg_num_proc_lp];
 
-  bp_me_xbar_stream
+  bp_me_xbar_stream_buffered
    #(.bp_params_p(bp_params_p)
      ,.data_width_p(uce_mem_data_width_lp)
      ,.payload_width_p(uce_mem_payload_width_lp)
@@ -393,7 +393,7 @@ module bp_unicore_lite
      ,.msg_header_i(proc_cmd_header_lo)
      ,.msg_data_i(proc_cmd_data_lo)
      ,.msg_v_i(proc_cmd_v_lo)
-     ,.msg_yumi_o(proc_cmd_yumi_li)
+     ,.msg_ready_and_o(proc_cmd_ready_and_li)
      ,.msg_last_i(proc_cmd_last_lo)
      ,.msg_dst_i(proc_cmd_dst_lo)
 
@@ -404,7 +404,7 @@ module bp_unicore_lite
      ,.msg_last_o(dev_cmd_last_li)
      );
 
-  bp_me_xbar_stream
+  bp_me_xbar_stream_buffered
    #(.bp_params_p(bp_params_p)
      ,.data_width_p(uce_mem_data_width_lp)
      ,.payload_width_p(uce_mem_payload_width_lp)
@@ -418,7 +418,7 @@ module bp_unicore_lite
      ,.msg_header_i(dev_resp_header_lo)
      ,.msg_data_i(dev_resp_data_lo)
      ,.msg_v_i(dev_resp_v_lo)
-     ,.msg_yumi_o(dev_resp_ready_and_li)
+     ,.msg_ready_and_o(dev_resp_ready_and_li)
      ,.msg_last_i(dev_resp_last_lo)
      ,.msg_dst_i(dev_resp_dst_lo)
 

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -287,6 +287,7 @@ $BP_ME_DIR/src/v/network/bp_me_burst_to_lite.sv
 $BP_ME_DIR/src/v/network/bp_me_wormhole_to_burst.sv
 $BP_ME_DIR/src/v/network/bp_me_burst_to_wormhole.sv
 $BP_ME_DIR/src/v/network/bp_me_xbar_stream.sv
+$BP_ME_DIR/src/v/network/bp_me_xbar_stream_buffered.sv
 $BP_ME_DIR/src/v/network/bp_me_stream_to_burst.sv
 $BP_ME_DIR/src/v/network/bp_me_burst_to_stream.sv
 $BP_ME_DIR/src/v/network/bp_me_stream_pump_in.sv

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -114,12 +114,12 @@ module testbench
   logic proc_io_cmd_v_lo, proc_io_cmd_ready_and_li, proc_io_cmd_last_lo;
   bp_bedrock_io_mem_msg_header_s proc_io_resp_li;
   logic [io_data_width_p-1:0] proc_io_resp_data_li;
-  logic proc_io_resp_v_li, proc_io_resp_yumi_lo;
+  logic proc_io_resp_v_li, proc_io_resp_ready_and_lo;
   logic proc_io_resp_last_li;
 
   bp_bedrock_io_mem_msg_header_s load_cmd_lo;
   logic [io_data_width_p-1:0] load_cmd_data_lo;
-  logic load_cmd_v_lo, load_cmd_yumi_li, load_cmd_last_lo;
+  logic load_cmd_v_lo, load_cmd_ready_and_li, load_cmd_last_lo;
   bp_bedrock_io_mem_msg_header_s load_resp_li;
   logic [io_data_width_p-1:0] load_resp_data_li;
   logic load_resp_v_li, load_resp_ready_and_lo, load_resp_last_li;
@@ -146,13 +146,13 @@ module testbench
      ,.io_resp_header_i(proc_io_resp_li)
      ,.io_resp_data_i(proc_io_resp_data_li)
      ,.io_resp_v_i(proc_io_resp_v_li)
-     ,.io_resp_yumi_o(proc_io_resp_yumi_lo)
+     ,.io_resp_ready_and_o(proc_io_resp_ready_and_lo)
      ,.io_resp_last_i(proc_io_resp_last_li)
 
      ,.io_cmd_header_i(load_cmd_lo)
      ,.io_cmd_data_i(load_cmd_data_lo)
      ,.io_cmd_v_i(load_cmd_v_lo)
-     ,.io_cmd_yumi_o(load_cmd_yumi_li)
+     ,.io_cmd_ready_and_o(load_cmd_ready_and_li)
      ,.io_cmd_last_i(load_cmd_last_lo)
 
      ,.io_resp_header_o(load_resp_li)
@@ -213,7 +213,7 @@ module testbench
      ,.io_cmd_header_o(load_cmd_lo)
      ,.io_cmd_data_o(load_cmd_data_lo)
      ,.io_cmd_v_o(load_cmd_v_lo)
-     ,.io_cmd_yumi_i(load_cmd_yumi_li)
+     ,.io_cmd_yumi_i(load_cmd_ready_and_li & load_cmd_v_lo)
      ,.io_cmd_last_o(load_cmd_last_lo)
 
      // NOTE: IO response ready_o is always high - acts as sink
@@ -266,7 +266,7 @@ module testbench
      ,.mem_resp_header_o(proc_io_resp_li)
      ,.mem_resp_data_o(proc_io_resp_data_li[0+:dword_width_gp])
      ,.mem_resp_v_o(proc_io_resp_v_li)
-     ,.mem_resp_ready_and_i(proc_io_resp_yumi_lo)
+     ,.mem_resp_ready_and_i(proc_io_resp_ready_and_lo)
      ,.mem_resp_last_o(proc_io_resp_last_li)
 
      ,.icache_trace_en_o(icache_trace_en_lo)

--- a/bp_top/test/tb/bp_tethered/wrapper.sv
+++ b/bp_top/test/tb/bp_tethered/wrapper.sv
@@ -37,14 +37,14 @@ module wrapper
    , input [io_mem_msg_header_width_lp-1:0]                 io_resp_header_i
    , input [io_data_width_p-1:0]                            io_resp_data_i
    , input                                                  io_resp_v_i
-   , output logic                                           io_resp_yumi_o
+   , output logic                                           io_resp_ready_and_o
    , input                                                  io_resp_last_i
 
    // Incoming I/O
    , input [io_mem_msg_header_width_lp-1:0]                 io_cmd_header_i
    , input [io_data_width_p-1:0]                            io_cmd_data_i
    , input                                                  io_cmd_v_i
-   , output logic                                           io_cmd_yumi_o
+   , output logic                                           io_cmd_ready_and_o
    , input                                                  io_cmd_last_i
 
    , output logic [io_mem_msg_header_width_lp-1:0]          io_resp_header_o
@@ -116,9 +116,6 @@ module wrapper
          ,.dram_resp_link_i(dram_resp_link_li)
          );
 
-      logic io_cmd_ready_and_lo, io_resp_ready_and_lo;
-      assign io_cmd_yumi_o = io_cmd_ready_and_lo & io_cmd_v_i;
-      assign io_resp_yumi_o = io_resp_ready_and_lo & io_resp_v_i;
       wire [io_noc_cord_width_p-1:0] dst_cord_lo = 1;
 
       `declare_bp_bedrock_mem_if(paddr_width_p, io_data_width_p, lce_id_width_p, lce_assoc_p, io);
@@ -141,7 +138,7 @@ module wrapper
          ,.mem_cmd_header_i(io_cmd_header_i)
          ,.mem_cmd_data_i(io_cmd_data_i)
          ,.mem_cmd_v_i(io_cmd_v_i)
-         ,.mem_cmd_ready_and_o(io_cmd_ready_and_lo)
+         ,.mem_cmd_ready_and_o(io_cmd_ready_and_o)
          ,.mem_cmd_last_i(io_cmd_last_i)
 
          ,.mem_resp_header_o(io_resp_header_o)
@@ -164,7 +161,7 @@ module wrapper
          ,.mem_resp_header_i(io_resp_header_i)
          ,.mem_resp_data_i(io_resp_data_i)
          ,.mem_resp_v_i(io_resp_v_i)
-         ,.mem_resp_ready_and_o(io_resp_ready_and_lo)
+         ,.mem_resp_ready_and_o(io_resp_ready_and_o)
          ,.mem_resp_last_i(io_resp_last_i)
 
          ,.cmd_link_i(proc_cmd_link_lo)


### PR DESCRIPTION
## Summary
This PR adds a new module, bp_me_stream_xbar_buffered, which wraps the xbar with twofers to break timing paths.

## Issue Fixed
This fixes the timing regression from #915, at the cost of additional buffers in the crossbar. 

## Area
The crossbars in bp_tile and bp_unicore_lite, notably the paths to/from the stream pumps.

## Reasoning (outdated, confusing, verbose, etc.)
While buffers are not functionally required, even for helpfulness, a medium-sized crossbar will require these fifos. Additionally, in the unicore these paths include I/O paths, which can be severely late-arriving.

## Analysis
Increased area and 2 additional cycles to L1 cache fill.

## Verification
Normal regression, as this is not a functional change.

