### PR TITLE
Converting to bsg_sign_extend

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -198,7 +198,7 @@ module bp_be_csr
   bsg_priority_encode
    #(.width_p($bits(exception_dec_li)), .lo_to_hi_p(1))
    m_interrupt_enc
-    (.i(interrupt_icode_dec_li & ~mideleg_lo[0+:$bits(exception_dec_li)] & $bits(exception_dec_li)'($signed(mgie)))
+    (.i(interrupt_icode_dec_li & ~mideleg_lo[0+:$bits(exception_dec_li)])
      ,.addr_o(m_interrupt_icode_li)
      ,.v_o(m_interrupt_icode_v_li)
      );
@@ -206,7 +206,7 @@ module bp_be_csr
   bsg_priority_encode
    #(.width_p($bits(exception_dec_li)), .lo_to_hi_p(1))
    s_interrupt_enc
-    (.i(interrupt_icode_dec_li & mideleg_lo[0+:$bits(exception_dec_li)] & $bits(exception_dec_li)'($signed(sgie)))
+    (.i(interrupt_icode_dec_li & mideleg_lo[0+:$bits(exception_dec_li)])
      ,.addr_o(s_interrupt_icode_li)
      ,.v_o(s_interrupt_icode_v_li)
      );
@@ -492,7 +492,7 @@ module bp_be_csr
 
       if (retire_pkt_cast_i.exception._interrupt)
         begin
-          if (m_interrupt_icode_v_li)
+          if (m_interrupt_icode_v_li & mgie)
             begin
               priv_mode_n          = `PRIV_MODE_M;
 
@@ -500,14 +500,14 @@ module bp_be_csr
               mstatus_li.mpie      = mstatus_lo.mie;
               mstatus_li.mie       = 1'b0;
 
-              mepc_li              = paddr_width_p'($signed(apc_r));
+              mepc_li              = `BSG_SIGN_EXTEND(apc_r, paddr_width_p);
               mtval_li             = '0;
               mcause_li._interrupt = 1'b1;
               mcause_li.ecode      = m_interrupt_icode_li;
 
               interrupt_v_lo        = 1'b1;
             end
-          else if (s_interrupt_icode_v_li)
+          else if (s_interrupt_icode_v_li & sgie)
             begin
               priv_mode_n          = `PRIV_MODE_S;
 
@@ -515,7 +515,7 @@ module bp_be_csr
               mstatus_li.spie      = mstatus_lo.sie;
               mstatus_li.sie       = 1'b0;
 
-              sepc_li              = paddr_width_p'($signed(apc_r));
+              sepc_li              = `BSG_SIGN_EXTEND(apc_r, paddr_width_p);
               stval_li             = '0;
               scause_li._interrupt = 1'b1;
               scause_li.ecode      = s_interrupt_icode_li;
@@ -533,10 +533,10 @@ module bp_be_csr
               mstatus_li.spie      = mstatus_lo.sie;
               mstatus_li.sie       = 1'b0;
 
-              sepc_li              = paddr_width_p'($signed(apc_r));
+              sepc_li              = `BSG_SIGN_EXTEND(apc_r, paddr_width_p);
               stval_li             = (exception_ecode_li == 2)
                                     ? retire_pkt_cast_i.instr
-                                    : paddr_width_p'($signed(retire_pkt_cast_i.vaddr));
+                                    : `BSG_SIGN_EXTEND(retire_pkt_cast_i.vaddr, paddr_width_p);
 
               scause_li._interrupt = 1'b0;
               scause_li.ecode      = exception_ecode_li;
@@ -551,10 +551,10 @@ module bp_be_csr
               mstatus_li.mpie      = mstatus_lo.mie;
               mstatus_li.mie       = 1'b0;
 
-              mepc_li              = paddr_width_p'($signed(apc_r));
+              mepc_li              = `BSG_SIGN_EXTEND(apc_r, paddr_width_p);
               mtval_li             = (exception_ecode_li == 2)
                                     ? retire_pkt_cast_i.instr
-                                    : paddr_width_p'($signed(retire_pkt_cast_i.vaddr));
+                                    : `BSG_SIGN_EXTEND(retire_pkt_cast_i.vaddr, paddr_width_p);
 
               mcause_li._interrupt = 1'b0;
               mcause_li.ecode      = exception_ecode_li;
@@ -566,7 +566,7 @@ module bp_be_csr
       if (retire_pkt_cast_i.special.dbreak)
         begin
           enter_debug    = 1'b1;
-          dpc_li         = paddr_width_p'($signed(apc_r));
+          dpc_li         = `BSG_SIGN_EXTEND(apc_r, paddr_width_p);
           dcsr_li.cause  = 1; // Ebreak
           dcsr_li.prv    = priv_mode_r;
         end
@@ -601,7 +601,7 @@ module bp_be_csr
       if (~is_debug_mode & retire_pkt_cast_i.queue_v & dcsr_lo.step)
         begin
           enter_debug   = 1'b1;
-          dpc_li        = paddr_width_p'($signed(retire_pkt_cast_i.npc));
+          dpc_li        = `BSG_SIGN_EXTEND(retire_pkt_cast_i.npc, paddr_width_p);
           dcsr_li.cause = 4;
           dcsr_li.prv   = priv_mode_r;
         end
@@ -612,7 +612,7 @@ module bp_be_csr
     end
 
   // Debug Mode masks all interrupts
-  assign irq_pending_o = ~is_debug_mode & (m_interrupt_icode_v_li | s_interrupt_icode_v_li);
+  assign irq_pending_o = ~is_debug_mode & ((m_interrupt_icode_v_li & mgie) | (s_interrupt_icode_v_li & sgie));
 
   assign csr_data_o = dword_width_gp'(csr_data_lo);
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_int.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_int.sv
@@ -48,7 +48,7 @@ module bp_be_pipe_int
   wire [dword_width_gp-1:0] imm = reservation.imm[0+:dword_width_gp];
 
   // Sign-extend PC for calculation
-  wire [dword_width_gp-1:0] pc_sext_li = dword_width_gp'($signed(pc));
+  wire [dword_width_gp-1:0] pc_sext_li = `BSG_SIGN_EXTEND(pc, dword_width_gp);
   wire [dword_width_gp-1:0] pc_plus4   = pc_sext_li + dword_width_gp'(4);
 
   wire [dword_width_gp-1:0] src1  = decode.src1_sel  ? pc_sext_li : rs1;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
@@ -78,6 +78,8 @@ module bp_be_pipe_long
      ,.v_o(idiv_v_lo)
      ,.yumi_i(idiv_v_lo & iwb_yumi_i)
      );
+  wire [word_width_gp-1:0] quotient_w_lo = quotient_lo[0+:word_width_gp];
+  wire [word_width_gp-1:0] remainder_w_lo = remainder_lo[0+:word_width_gp];
 
   bp_be_fp_reg_s frs1, frs2;
   assign frs1 = reservation.rs1;
@@ -235,7 +237,7 @@ module bp_be_pipe_long
   logic [dword_width_gp-1:0] rd_data_lo;
   always_comb
     if (opw_v_r && fu_op_r inside {e_mul_op_div, e_mul_op_divu})
-      rd_data_lo = $signed(quotient_lo[0+:word_width_gp]);
+      rd_data_lo = `BSG_SIGN_EXTEND(quotient_w_lo, dword_width_gp);
     else if (opw_v_r && fu_op_r inside {e_mul_op_rem, e_mul_op_remu})
       rd_data_lo = $signed(remainder_lo) >>> word_width_gp;
     else if (~opw_v_r && fu_op_r inside {e_mul_op_div, e_mul_op_divu})

--- a/bp_common/src/include/bp_common_rv64_csr_defines.svh
+++ b/bp_common/src/include/bp_common_rv64_csr_defines.svh
@@ -699,7 +699,7 @@
     '{word_addr: data_cast_mp.base[0+:`BSG_MAX(vaddr_width_mp, paddr_width_mp)-2]}
 
   `define decompress_stvec_s(data_comp_mp) \
-    '{base : 62'($signed(data_comp_mp.word_addr)) \
+    '{base : `BSG_SIGN_EXTEND(data_comp_mp.word_addr, 62) \
       ,mode: 2'b00                           \
       }
 
@@ -728,7 +728,7 @@
     bp_sepc_s'(data_cast_mp[0+:`BSG_MAX(vaddr_width_mp, paddr_width_mp)])
 
   `define decompress_sepc_s(data_comp_mp) \
-    64'($signed(data_comp_mp))
+    `BSG_SIGN_EXTEND(data_comp_mp, 64)
 
   `define compress_scause_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) \
     '{_interrupt: data_cast_mp._interrupt \
@@ -744,7 +744,7 @@
     bp_stval_s'(data_cast_mp[0+:`BSG_MAX(vaddr_width_mp, paddr_width_mp)])
 
   `define decompress_stval_s(data_comp_mp) \
-    64'($signed(data_comp_mp))
+    `BSG_SIGN_EXTEND(data_comp_mp, 64)
 
   `define bp_satp_width ($bits(bp_satp_s))
 
@@ -851,7 +851,7 @@
     '{word_addr: data_cast_mp.base[0+:`BSG_MAX(vaddr_width_mp, paddr_width_mp)-2]}
 
   `define decompress_mtvec_s(data_comp_mp) \
-    '{base : 62'($signed(data_comp_mp.word_addr)) \
+    '{base : `BSG_SIGN_EXTEND(data_comp_mp.word_addr, 62) \
       ,mode: 2'b00                                \
       }
 
@@ -901,13 +901,13 @@
     bp_mtval_s'(data_cast_mp[0+:`BSG_MAX(vaddr_width_mp, paddr_width_mp)])
 
   `define decompress_mtval_s(data_comp_mp) \
-    64'($signed(data_comp_mp))
+    `BSG_SIGN_EXTEND(data_comp_mp, 64)
 
   `define compress_mepc_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) \
     bp_mepc_s'(data_cast_mp[0+:`BSG_MAX(vaddr_width_mp, paddr_width_mp)])
 
   `define decompress_mepc_s(data_comp_mp) \
-    64'($signed(data_comp_mp))
+    `BSG_SIGN_EXTEND(data_comp_mp, 64)
 
   `define compress_pmpcfg_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) \
     '{pmpcfg: data_cast_mp.pmpcfg[0+:4]}
@@ -1012,7 +1012,7 @@
     bp_dpc_s'(data_cast_mp[0+:`BSG_MAX(vaddr_width_mp, paddr_width_mp)])
 
   `define decompress_dpc_s(data_comp_mp) \
-    64'($signed(data_comp_mp))
+    `BSG_SIGN_EXTEND(data_comp_mp, 64)
 
   `define compress_dscratch0_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) \
     data_cast_mp[0+:64]

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -218,7 +218,7 @@ module bp_fe_top
   wire [vtag_width_p-1:0] w_vtag_li = fe_cmd_cast_i.vaddr[vaddr_width_p-1-:vtag_width_p];
   assign w_tlb_entry_li = fe_cmd_cast_i.operands.itlb_fill_response.pte_leaf;
 
-  wire [dword_width_gp-1:0] r_eaddr_li = dword_width_gp'($signed(next_pc_lo));
+  wire [dword_width_gp-1:0] r_eaddr_li = `BSG_SIGN_EXTEND(next_pc_lo, dword_width_gp);
   bp_mmu
    #(.bp_params_p(bp_params_p)
      ,.tlb_els_4k_p(itlb_els_4k_p)

--- a/bp_top/test/common/bp_nonsynth_cosim.sv
+++ b/bp_top/test/common/bp_nonsynth_cosim.sv
@@ -216,7 +216,7 @@ module bp_nonsynth_cosim
         dromajo_trap(mhartid_i, cause_r);
       end
     else if (~commit_debug_r & cosim_en_i & commit_fifo_yumi_li & instret_v_r & commit_pc_r != '0)
-      if (dromajo_step(mhartid_i, 64'($signed(commit_pc_r)), commit_instr_r, commit_frd_li ? frd_raw_li[commit_instr_r.rd_addr] : ird_data_r[commit_instr_r.rd_addr], mstatus_r))
+      if (dromajo_step(mhartid_i, `BSG_SIGN_EXTEND(commit_pc_r, dword_width_gp), commit_instr_r, commit_frd_li ? frd_raw_li[commit_instr_r.rd_addr] : ird_data_r[commit_instr_r.rd_addr], mstatus_r))
         begin
           $display("COSIM_FAIL");
           $finish();


### PR DESCRIPTION
Converting to BSG_SIGN_EXTEND as shown in this PR: https://github.com/bespoke-silicon-group/basejump_stl/pull/474

This fixes vivado bugs which intermittently drop some of the bits of a sign extension
