### PR TITLE
Making cosimulation fifo asynchronous for faster draining

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - be_dev_fix_asynccosim
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - be_dev_fix_asynccosim
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/bp_top/test/common/bp_nonsynth_cosim.sv
+++ b/bp_top/test/common/bp_nonsynth_cosim.sv
@@ -45,6 +45,9 @@ module bp_nonsynth_cosim
     , input                                   frd_w_v_i
     , input [rv64_reg_addr_width_gp-1:0]      frd_addr_i
     , input [dpath_width_gp-1:0]              frd_data_i
+
+    , input                                   cosim_clk_i
+    , input                                   cosim_reset_i
     );
 
   import "DPI-C" context function void dromajo_init(string cfg_f_name, int hartid, int ncpus, int memory_size, bit checkpoint, bit amo_en);
@@ -64,9 +67,7 @@ module bp_nonsynth_cosim
 
   bp_be_decode_s decode_r;
   bsg_dff_chain
-   #(.width_p($bits(bp_be_decode_s))
-     ,.num_stages_p(4)
-     )
+   #(.width_p($bits(bp_be_decode_s)), .num_stages_p(4))
    reservation_pipe
     (.clk_i(clk_i)
      ,.data_i(decode_i)
@@ -75,16 +76,16 @@ module bp_nonsynth_cosim
 
   bp_be_commit_pkt_s commit_pkt_r;
   logic is_debug_mode_r;
-  bsg_dff_reset
-   #(.width_p(1+$bits(commit_pkt)))
+  bsg_dff_chain
+   #(.width_p(1+$bits(commit_pkt)), .num_stages_p(1))
    commit_pkt_reg
     (.clk_i(clk_i)
-     ,.reset_i(reset_i)
 
      ,.data_i({is_debug_mode_i, commit_pkt})
      ,.data_o({is_debug_mode_r, commit_pkt_r})
      );
 
+  logic                     commit_fifo_full_lo;
   logic                     commit_debug_r;
   logic                     instret_v_r;
   logic                     trap_v_r;
@@ -102,19 +103,21 @@ module bp_nonsynth_cosim
   wire trap_v_li = commit_pkt_r.exception | commit_pkt_r._interrupt;
   wire [dword_width_gp-1:0] cause_li = (priv_mode_i == `PRIV_MODE_M) ? mcause_i : scause_i;
   wire [dword_width_gp-1:0] mstatus_li = mstatus_i;
-  bsg_fifo_1r1w_small
-   #(.width_p(3+vaddr_width_p+instr_width_gp+2+2*dword_width_gp), .els_p(128))
+  wire commit_fifo_v_li = instret_v_li | trap_v_li;
+  bsg_async_fifo
+   #(.width_p(3+vaddr_width_p+instr_width_gp+2+2*dword_width_gp), .lg_size_p(10))
    commit_fifo
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+    (.w_clk_i(clk_i)
+     ,.w_reset_i(reset_i)
+     ,.w_enq_i(commit_fifo_v_li & ~commit_fifo_full_lo)
+     ,.w_data_i({is_debug_mode_r, instret_v_li, trap_v_li, commit_pc_li, commit_instr_li, commit_ird_w_v_li, commit_frd_w_v_li, cause_li, mstatus_li})
+     ,.w_full_o(commit_fifo_full_lo)
 
-     ,.data_i({is_debug_mode_r, instret_v_li, trap_v_li, commit_pc_li, commit_instr_li, commit_ird_w_v_li, commit_frd_w_v_li, cause_li, mstatus_li})
-     ,.v_i(instret_v_li | trap_v_li)
-     ,.ready_o()
-
-     ,.data_o({commit_debug_r, instret_v_r, trap_v_r, commit_pc_r, commit_instr_r, commit_ird_w_v_r, commit_frd_w_v_r, cause_r, mstatus_r})
-     ,.v_o(commit_fifo_v_lo)
-     ,.yumi_i(commit_fifo_yumi_li)
+     ,.r_clk_i(cosim_clk_i)
+     ,.r_reset_i(cosim_reset_i)
+     ,.r_deq_i(commit_fifo_v_lo & commit_fifo_yumi_li)
+     ,.r_data_o({commit_debug_r, instret_v_r, trap_v_r, commit_pc_r, commit_instr_r, commit_ird_w_v_r, commit_frd_w_v_r, cause_r, mstatus_r})
+     ,.r_valid_o(commit_fifo_v_lo)
      );
 
   localparam rf_els_lp = 2**reg_addr_width_gp;
@@ -127,40 +130,42 @@ module bp_nonsynth_cosim
     begin : iwb
       wire fill       = ird_w_v_i & (ird_addr_i == i);
       wire deallocate = commit_ird_w_v_r & (commit_instr_r.rd_addr == i) & commit_fifo_yumi_li;
-      bsg_fifo_1r1w_small
-        #(.width_p(dword_width_gp), .els_p(128))
-        ird_fifo
-         (.clk_i(clk_i)
-          ,.reset_i(reset_i)
+      bsg_async_fifo
+       #(.width_p(dword_width_gp), .lg_size_p(6))
+       ird_fifo
+        (.w_clk_i(clk_i)
+         ,.w_reset_i(reset_i)
+         ,.w_enq_i(fill)
+         ,.w_data_i(ird_data_i[0+:dword_width_gp])
+         ,.w_full_o()
 
-          ,.data_i(ird_data_i[0+:dword_width_gp])
-          ,.v_i(fill)
-          ,.ready_o()
-
-          ,.data_o(ird_data_r[i])
-          ,.v_o(ird_fifo_v_lo[i])
-          ,.yumi_i(deallocate)
-          );
+         ,.r_clk_i(cosim_clk_i)
+         ,.r_reset_i(cosim_reset_i)
+         ,.r_deq_i(deallocate)
+         ,.r_data_o(ird_data_r[i])
+         ,.r_valid_o(ird_fifo_v_lo[i])
+         );
     end
 
   for (genvar i = 0; i < rf_els_lp; i++)
     begin : fwb
       wire fill       = frd_w_v_i & (frd_addr_i == i);
       wire deallocate = commit_frd_w_v_r & (commit_instr_r.rd_addr == i) & commit_fifo_yumi_li;
-      bsg_fifo_1r1w_small
-        #(.width_p(dpath_width_gp), .els_p(128))
-        ird_fifo
-         (.clk_i(clk_i)
-          ,.reset_i(reset_i)
+      bsg_async_fifo
+       #(.width_p(dpath_width_gp), .lg_size_p(6))
+       ird_fifo
+        (.w_clk_i(clk_i)
+         ,.w_reset_i(reset_i)
+         ,.w_enq_i(fill)
+         ,.w_data_i(frd_data_i)
+         ,.w_full_o()
 
-          ,.data_i(frd_data_i)
-          ,.v_i(fill)
-          ,.ready_o()
-
-          ,.data_o(frd_data_r[i])
-          ,.v_o(frd_fifo_v_lo[i])
-          ,.yumi_i(deallocate)
-          );
+         ,.r_clk_i(cosim_clk_i)
+         ,.r_reset_i(cosim_reset_i)
+         ,.r_deq_i(deallocate)
+         ,.r_data_o(frd_data_r[i])
+         ,.r_valid_o(frd_fifo_v_lo[i])
+         );
 
       // The control bits control tininess, which is fixed in RISC-V
       wire [`floatControlWidth-1:0] control_li = `flControl_default;
@@ -175,9 +180,8 @@ module bp_nonsynth_cosim
          );
     end
 
-  assign commit_fifo_yumi_li = commit_fifo_v_lo & ((~commit_ird_w_v_r & ~commit_frd_w_v_r)
-                                                   | (commit_ird_w_v_r & ird_fifo_v_lo[commit_instr_r.rd_addr])
-                                                   | (commit_frd_w_v_r & frd_fifo_v_lo[commit_instr_r.rd_addr])
+  assign commit_fifo_yumi_li = commit_fifo_v_lo & ((~commit_ird_w_v_r | ird_fifo_v_lo[commit_instr_r.rd_addr])
+                                                   & (~commit_frd_w_v_r | frd_fifo_v_lo[commit_instr_r.rd_addr])
                                                    );
   wire commit_ird_li = commit_fifo_v_lo & (commit_ird_w_v_r & ird_fifo_v_lo[commit_instr_r.rd_addr]);
   wire commit_frd_li = commit_fifo_v_lo & (commit_frd_w_v_r & frd_fifo_v_lo[commit_instr_r.rd_addr]);
@@ -186,8 +190,8 @@ module bp_nonsynth_cosim
   bsg_counter_clear_up
    #(.max_val_p(max_instr_lp), .init_val_p(0))
    instr_counter
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i | freeze_i)
+    (.clk_i(cosim_clk_i)
+     ,.reset_i(cosim_reset_i | freeze_i)
 
      ,.clear_i(1'b0)
      ,.up_i(instret_v_r & commit_fifo_yumi_li & ~commit_debug_r)
@@ -198,8 +202,8 @@ module bp_nonsynth_cosim
   bsg_dff_reset_set_clear
    #(.width_p(1))
    finish_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+    (.clk_i(cosim_clk_i)
+     ,.reset_i(cosim_reset_i)
 
      ,.set_i((instr_cap_i != 0 && instr_cnt == instr_cap_i))
      ,.clear_i('0)
@@ -210,7 +214,7 @@ module bp_nonsynth_cosim
     if (cosim_en_i)
       dromajo_init(config_file_i, mhartid_i, num_core_i, memsize_i, checkpoint_i, amo_en_i);
 
-  always_ff @(negedge clk_i)
+  always_ff @(posedge cosim_clk_i)
     if (cosim_en_i & commit_fifo_yumi_li & trap_v_r)
       begin
         dromajo_trap(mhartid_i, cause_r);
@@ -218,7 +222,7 @@ module bp_nonsynth_cosim
     else if (~commit_debug_r & cosim_en_i & commit_fifo_yumi_li & instret_v_r & commit_pc_r != '0)
       if (dromajo_step(mhartid_i, `BSG_SIGN_EXTEND(commit_pc_r, dword_width_gp), commit_instr_r, commit_frd_li ? frd_raw_li[commit_instr_r.rd_addr] : ird_data_r[commit_instr_r.rd_addr], mstatus_r))
         begin
-          $display("COSIM_FAIL");
+          $display("COSIM_FAIL: instruction mismatch");
           $finish();
         end
     else if (terminate)
@@ -227,7 +231,7 @@ module bp_nonsynth_cosim
           $finish();
         end
 
-  always_ff @(negedge clk_i)
+  always_ff @(posedge cosim_clk_i)
     if (finish_r)
       begin
         set_finish(mhartid_i);
@@ -243,7 +247,7 @@ module bp_nonsynth_cosim
       file      = $fopen(file_name, "w");
     end
 
-  always_ff @(negedge clk_i)
+  always_ff @(posedge cosim_clk_i)
     if (trace_en_i & commit_fifo_yumi_li & instret_v_r & commit_pc_r != '0)
       begin
         $fwrite(file, "%x %x %x %x ", mhartid_i, commit_pc_r, commit_instr_r, instr_cnt);
@@ -252,6 +256,13 @@ module bp_nonsynth_cosim
         if (commit_fifo_yumi_li & commit_frd_w_v_r)
           $fwrite(file, "%x %x", commit_instr_r.rd_addr, frd_raw_li[commit_instr_r.rd_addr]);
         $fwrite(file, "\n");
+      end
+
+  always_ff @(posedge cosim_clk_i)
+    if (commit_fifo_v_li & commit_fifo_full_lo)
+      begin
+        $display("COSIM_FAIL: commit fifo overrun, core %x", mhartid_i);
+        $finish();
       end
 
 endmodule


### PR DESCRIPTION
This fixes a potential issue where cosimulation buffers fill up and overflow. The case that could cause this is if there are a large number of nonblocking OOO operations such as integer divides or cache misses, several completed entries could enter the cosimulation fifo. If the FIFO is committing at 1 IPC, then it can only "catch up" to the processor on processor stalls. If there aren't any catchup cycles, eventually the fifo may overrun.

This PR makes the cosimulation clock much faster than the core clock, enable it to drain as soon as dependencies are met. Additionally, this provides additional safety in the context of multicore cosimulation.

Last, it provides a hook to wait on coherence operations to complete. This is essential for ordering commits of stores in the context of a cosimulated SC multicore.

