### PR TITLE
Adding hartid to unicore

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - top_dev_feature_unicorehartid
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - top_dev_feature_unicorehartid
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/bp_common/src/include/bp_common_aviary_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_pkgdef.svh
@@ -210,7 +210,7 @@
     '{multicore : 0
       ,cc_x_dim : 1
       ,cc_y_dim : 1
-      ,ic_y_dim : 1
+      ,ic_y_dim : 0
       ,mc_y_dim : 0
       ,cac_x_dim: 0
       ,sac_x_dim: 0
@@ -494,6 +494,7 @@
 
   localparam bp_proc_param_s bp_multicore_1_override_p =
     '{multicore      : 1
+      ,ic_y_dim      : 1
       ,num_cce       : 1
       ,num_lce       : 2
       ,l1_coherent   : 1

--- a/bp_top/src/v/bp_unicore.sv
+++ b/bp_top/src/v/bp_unicore.sv
@@ -41,6 +41,10 @@ module bp_unicore
   (input                                               clk_i
    , input                                             reset_i
 
+   , input [io_noc_did_width_p-1:0]                    my_did_i
+   , input [io_noc_did_width_p-1:0]                    host_did_i
+   , input [coh_noc_cord_width_p-1:0]                  my_cord_i
+
    // Outgoing I/O
    , output logic [uce_mem_msg_header_width_lp-1:0]    io_cmd_header_o
    , output logic [uce_mem_data_width_lp-1:0]          io_cmd_data_o
@@ -97,6 +101,10 @@ module bp_unicore
    unicore_lite
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
+
+     ,.my_did_i(my_did_i)
+     ,.host_did_i(host_did_i)
+     ,.my_cord_i(my_cord_i)
 
      ,.mem_cmd_header_o(mem_cmd_header_lo)
      ,.mem_cmd_data_o(mem_cmd_data_lo)

--- a/bp_top/src/v/bp_unicore_complex.sv
+++ b/bp_top/src/v/bp_unicore_complex.sv
@@ -1,0 +1,124 @@
+/**
+ *
+ * wrapper.sv
+ *
+ */
+
+`include "bsg_noc_links.vh"
+
+module bp_unicore_complex
+ import bsg_wormhole_router_pkg::*;
+ import bp_common_pkg::*;
+ import bp_be_pkg::*;
+ import bp_me_pkg::*;
+ import bsg_noc_pkg::*;
+ #(parameter bp_params_e bp_params_p = BP_CFG_FLOWVAR
+   `declare_bp_proc_params(bp_params_p)
+
+   , localparam uce_mem_data_width_lp = `BSG_MAX(icache_fill_width_p, dcache_fill_width_p)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, uce_mem_data_width_lp, lce_id_width_p, lce_assoc_p, uce)
+
+   , localparam dma_pkt_width_lp = `bsg_cache_dma_pkt_width(caddr_width_p)
+   )
+  (input                                                     clk_i
+   , input                                                   reset_i
+
+   , input [io_noc_did_width_p-1:0]                          my_did_i
+   , input [io_noc_did_width_p-1:0]                          host_did_i
+
+   // Outgoing I/O
+   , output logic [uce_mem_msg_header_width_lp-1:0]          io_cmd_header_o
+   , output logic [uce_mem_data_width_lp-1:0]                io_cmd_data_o
+   , output logic                                            io_cmd_v_o
+   , input                                                   io_cmd_ready_and_i
+   , output logic                                            io_cmd_last_o
+
+   , input [uce_mem_msg_header_width_lp-1:0]                 io_resp_header_i
+   , input [uce_mem_data_width_lp-1:0]                       io_resp_data_i
+   , input                                                   io_resp_v_i
+   , output logic                                            io_resp_ready_and_o
+   , input                                                   io_resp_last_i
+
+   // Incoming I/O
+   , input [uce_mem_msg_header_width_lp-1:0]                 io_cmd_header_i
+   , input [uce_mem_data_width_lp-1:0]                       io_cmd_data_i
+   , input                                                   io_cmd_v_i
+   , output logic                                            io_cmd_ready_and_o
+   , input                                                   io_cmd_last_i
+
+   , output logic [uce_mem_msg_header_width_lp-1:0]          io_resp_header_o
+   , output logic [uce_mem_data_width_lp-1:0]                io_resp_data_o
+   , output logic                                            io_resp_v_o
+   , input                                                   io_resp_ready_and_i
+   , output logic                                            io_resp_last_o
+
+   // DRAM interface
+   , output logic [num_core_p-1:0][dma_pkt_width_lp-1:0]     dma_pkt_o
+   , output logic [num_core_p-1:0]                           dma_pkt_v_o
+   , input [num_core_p-1:0]                                  dma_pkt_yumi_i
+
+   , input [num_core_p-1:0][l2_fill_width_p-1:0]             dma_data_i
+   , input [num_core_p-1:0]                                  dma_data_v_i
+   , output logic [num_core_p-1:0]                           dma_data_ready_and_o
+
+   , output logic [num_core_p-1:0][l2_fill_width_p-1:0]      dma_data_o
+   , output logic [num_core_p-1:0]                           dma_data_v_o
+   , input [num_core_p-1:0]                                  dma_data_yumi_i
+   );
+
+  // Currently, this complex is flat, since we end up in a crossbar on top anyway
+  for (genvar i = 0; i < cc_x_dim_p*cc_y_dim_p; i++)
+    begin : c
+      wire [coh_noc_cord_width_p-1:0] cord_li = {coh_noc_y_cord_width_p'(ic_y_dim_p+j)
+                                                 ,coh_noc_x_cord_width_p'(sac_x_dim_p+i)
+                                                 };
+      bp_unicore
+       #(.bp_params_p(bp_params_p))
+       dut
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+
+         ,.my_did_i(my_did_i)
+         ,.host_did_i(host_did_i)
+         ,.my_cord_i(cord_li)
+
+         ,.io_cmd_header_o(io_cmd_header_o[i])
+         ,.io_cmd_data_o(io_cmd_data_o[i])
+         ,.io_cmd_v_o(io_cmd_v_o[i])
+         ,.io_cmd_ready_and_i(io_cmd_ready_and_i[i])
+         ,.io_cmd_last_o(io_cmd_last_o[i])
+
+         ,.io_resp_header_i(io_resp_header_i[i])
+         ,.io_resp_data_i(io_resp_data_i[i])
+         ,.io_resp_v_i(io_resp_v_i[i])
+         ,.io_resp_ready_and_o(io_resp_ready_and_o[i])
+         ,.io_resp_last_i(io_resp_last_i[i])
+
+         ,.io_cmd_header_i(io_cmd_header_i[i])
+         ,.io_cmd_data_i(io_cmd_data_i[i])
+         ,.io_cmd_v_i(io_cmd_v_i[i])
+         ,.io_cmd_ready_and_o(io_cmd_ready_and_o[i])
+         ,.io_cmd_last_o(io_cmd_last_o[i])
+
+         ,.io_resp_header_o(io_resp_header_o[i])
+         ,.io_resp_data_o(io_resp_data_o[i])
+         ,.io_resp_v_o(io_resp_v_o[i])
+         ,.io_resp_ready_and_i(io_resp_ready_and_i[i])
+         ,.io_resp_last_o(io_resp_last_o[i])
+
+         ,.dma_pkt_o(dma_pkt_o[i])
+         ,.dma_pkt_v_o(dma_pkt_v_o[i])
+         ,.dma_pkt_yumi_i(dma_pkt_yumi_i[i])
+
+         ,.dma_data_i(dma_data_i[i])
+         ,.dma_data_v_i(dma_data_v_i[i])
+         ,.dma_data_ready_and_o(dma_data_ready_and_o[i])
+
+         ,.dma_data_o(dma_data_o[i])
+         ,.dma_data_v_o(dma_data_v_o[i])
+         ,.dma_data_yumi_i(dma_data_yumi_i[i])
+         );
+    end
+
+endmodule
+

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -18,6 +18,10 @@ module bp_unicore_lite
   (input                                               clk_i
    , input                                             reset_i
 
+   , input [io_noc_did_width_p-1:0]                    my_did_i
+   , input [io_noc_did_width_p-1:0]                    host_did_i
+   , input [coh_noc_cord_width_p-1:0]                  my_cord_i
+
    // Outgoing I/O
    , output logic [uce_mem_msg_header_width_lp-1:0]    io_cmd_header_o
    , output logic [uce_mem_data_width_lp-1:0]          io_cmd_data_o
@@ -449,10 +453,9 @@ module bp_unicore_lite
      ,.mem_resp_last_o(dev_resp_last_lo[0])
 
      ,.cfg_bus_o(cfg_bus_lo)
-     ,.did_i('0)
-     ,.host_did_i('0)
-     // TODO: Bring in top level from multi-unicore setup
-     ,.cord_i({coh_noc_y_cord_width_p'(1), coh_noc_x_cord_width_p'(0)})
+     ,.did_i(my_did)
+     ,.host_did_i(host_did_i)
+     ,.cord_i(my_cord_i)
 
      ,.cce_ucode_v_o()
      ,.cce_ucode_w_o()

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -453,7 +453,7 @@ module bp_unicore_lite
      ,.mem_resp_last_o(dev_resp_last_lo[0])
 
      ,.cfg_bus_o(cfg_bus_lo)
-     ,.did_i(my_did)
+     ,.did_i(my_did_i)
      ,.host_did_i(host_did_i)
      ,.cord_i(my_cord_i)
 

--- a/bp_top/test/common/bp_nonsynth_if_verif.sv
+++ b/bp_top/test/common/bp_nonsynth_if_verif.sv
@@ -57,8 +57,8 @@ module bp_nonsynth_if_verif
 
     end
 
-  if (ic_y_dim_p != 1)
-    $fatal("Error: Must have exactly 1 row of I/O routers");
+  if (ic_y_dim_p != 1 && multicore_p == 1)
+    $fatal("Error: Must have exactly 1 row of I/O routers for multicore");
   if (mc_y_dim_p > 2)
     $fatal("Error: Multi-row L2 expansion nodes not yet supported");
   if (sac_x_dim_p > 1)

--- a/bp_top/test/tb/bp_tethered/wrapper.sv
+++ b/bp_top/test/tb/bp_tethered/wrapper.sv
@@ -211,10 +211,16 @@ module wrapper
     end
   else
     begin : unicore
+      wire [io_noc_did_width_p-1:0] proc_did_li = 1;
+      wire [io_noc_did_width_p-1:0] dram_did_li = '1;
       bp_unicore
        #(.bp_params_p(bp_params_p))
        dut
-        (.*);
+        (.my_did_i(proc_did_li)
+         ,.host_did_i(dram_did_li)
+         ,.my_cord_i({coh_noc_y_cord_width_p'(0), coh_noc_x_cord_width_p'(0)})
+         ,.*
+         );
     end
 
 endmodule


### PR DESCRIPTION
## Summary
This PR adds hartid to unicore, allowing more than one unicore per system. Would have been nice in previous systems, but looking forward will be essential to multi-unicore systems.

## Area
Unicore

## Additional Changes Required (if any)
Would be nice to have a test configuration with multiple unicores, but not essential for this change.

## Verification
Regular regressions suffice. Has been tested with multiple coordinate configurations.

