### PR TITLE
fix LCE uncached store overflow - #945

### DIFF
--- a/bp_me/src/v/lce/bp_lce_req.sv
+++ b/bp_me/src/v/lce/bp_lce_req.sv
@@ -122,13 +122,14 @@ module bp_lce_req
   assign lce_req_o = lce_req;
 
   logic cache_req_v_r;
-  bsg_dff_reset
+  bsg_dff_reset_set_clear
    #(.width_p(1))
-   req_v_reg
+   cache_req_v_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.data_i(cache_req_yumi_o)
+     ,.set_i(cache_req_yumi_o)
+     ,.clear_i(lce_req_v_o & lce_req_ready_then_i)
      ,.data_o(cache_req_v_r)
      );
 
@@ -169,8 +170,8 @@ module bp_lce_req
 
   // Outstanding request credit counter
   logic [`BSG_WIDTH(credits_p)-1:0] credit_count_lo;
-  wire credit_v_li = lce_req_v_o;
-  wire credit_ready_li = lce_req_ready_then_i;
+  wire credit_v_li = cache_req_v_i;
+  wire credit_ready_li = cache_req_yumi_o;
   wire credit_returned_li = cache_req_complete_i | uc_store_req_complete_i;
   bsg_flow_counter
     #(.els_p(credits_p))
@@ -193,6 +194,15 @@ module bp_lce_req
     (.paddr_i(lce_req.header.addr)
      ,.cce_id_o(req_cce_id_lo)
      );
+
+  //synopsys translate_off
+  always_ff @(negedge clk_i) begin
+    if (~reset_i & cache_req_v_r & cache_req_yumi_o
+                 & ~(lce_req_v_o & lce_req_ready_then_i)
+       )
+      $fatal("Cache request overwritten before sending");
+  end
+  //synopsys translate_on
 
   always_comb begin
     state_n = state_r;


### PR DESCRIPTION
Thanks for contributing to BlackParrot! Check out the CONTRIBUTING guide, if this is your first
time. A few details to check:

## Summary
This PR adjusts the cache request valid register in the LCE Request module and tweaks the credit counting to prevent overwriting and dropping of uncached store requests.

## Issue Fixed
Fixes #945

## Area
LCE Request

## Reasoning (outdated, confusing, verbose, etc.)
Functional bug fix

## Additional Changes Required (if any)
None

## Verification
Newly added `mc_uc_store` test in[ bp-tests](https://github.com/black-parrot-sdk/bp-tests/tree/dev_mc_tests) exposes this bug, although the test still reports PASS. With LCE_TRACE_P=1 set, counting the number of uncached stores in the LCE trace file to the putchar address shows that ~25% of stores were dropped in a sequence of 100 consecutive stores. With fix applied, all stores are accounted for.

The added debug check should catch the issue in simulation, too, if it rematerializes. 


