### PR TITLE
Late writeback for the D$

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - be_dev_project_latewriteback
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - be_dev_project_latewriteback
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/bp_be/src/include/bp_be_ctl_pkgdef.svh
+++ b/bp_be/src/include/bp_be_ctl_pkgdef.svh
@@ -241,9 +241,9 @@
     // BP "exceptions"
     logic itlb_miss;
     logic icache_miss;
+    logic dcache_fail;
     logic dtlb_load_miss;
     logic dtlb_store_miss;
-    logic dcache_miss;
     logic fencei_dirty;
     logic itlb_fill;
     logic dtlb_fill;
@@ -253,6 +253,7 @@
 
   typedef struct packed
   {
+    logic dcache_miss;
     logic fencei_clean;
     logic sfence_vma;
     logic dbreak;

--- a/bp_be/src/include/bp_be_defines.svh
+++ b/bp_be/src/include/bp_be_defines.svh
@@ -154,7 +154,6 @@
       logic                           dcache_miss;                                                 \
       logic                           itlb_fill_v;                                                 \
       logic                           dtlb_fill_v;                                                 \
-      logic                           rollback;                                                    \
     }  bp_be_commit_pkt_s;                                                                         \
                                                                                                    \
     typedef struct packed                                                                          \
@@ -246,7 +245,7 @@
     (paddr_width_mp - page_offset_width_gp + 7)
 
   `define bp_be_commit_pkt_width(vaddr_width_mp, paddr_width_mp) \
-    (3 + `bp_be_pte_leaf_width(paddr_width_mp) +  3*vaddr_width_mp + instr_width_gp + rv64_priv_width_gp + 16)
+    (3 + `bp_be_pte_leaf_width(paddr_width_mp) +  3*vaddr_width_mp + instr_width_gp + rv64_priv_width_gp + 15)
 
   `define bp_be_wb_pkt_width(vaddr_width_mp) \
     (3                                                                                             \

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -46,7 +46,6 @@ module bp_be_calculator_top
   , output logic                                    long_ready_o
   , output logic                                    mem_ready_o
   , output logic                                    ptw_busy_o
-  , output logic                                    replay_pending_o
   , output logic [decode_info_width_lp-1:0]         decode_info_o
   , input                                           cmd_full_n_i
 
@@ -113,7 +112,7 @@ module bp_be_calculator_top
 
   logic pipe_mem_dtlb_store_miss_lo;
   logic pipe_mem_dtlb_load_miss_lo;
-  logic pipe_mem_dcache_miss_lo;
+  logic pipe_mem_dcache_miss_lo, pipe_mem_dcache_fail_lo;
   logic pipe_mem_fencei_clean_lo, pipe_mem_fencei_dirty_lo;
   logic pipe_mem_load_misaligned_lo;
   logic pipe_mem_load_access_fault_lo;
@@ -128,6 +127,11 @@ module bp_be_calculator_top
   logic pipe_long_idata_lo_v, pipe_long_idata_lo_yumi, pipe_long_fdata_lo_v, pipe_long_fdata_lo_yumi;
   logic [dpath_width_gp-1:0] pipe_ctl_data_lo, pipe_int_data_lo, pipe_aux_data_lo, pipe_mem_early_data_lo, pipe_mem_final_data_lo, pipe_sys_data_lo, pipe_mul_data_lo, pipe_fma_data_lo;
   rv64_fflags_s pipe_aux_fflags_lo, pipe_fma_fflags_lo;
+
+  bp_be_wb_pkt_s pipe_mem_late_iwb_pkt;
+  logic pipe_mem_late_iwb_pkt_v, pipe_mem_late_iwb_pkt_yumi;
+  bp_be_wb_pkt_s pipe_mem_late_fwb_pkt;
+  logic pipe_mem_late_fwb_pkt_v, pipe_mem_late_fwb_pkt_yumi;
 
   // Generating match vector for bypass
   logic [2:0][pipe_stage_els_lp-1:0] match_rs;
@@ -315,6 +319,7 @@ module bp_be_calculator_top
 
      ,.tlb_store_miss_v_o(pipe_mem_dtlb_store_miss_lo)
      ,.tlb_load_miss_v_o(pipe_mem_dtlb_load_miss_lo)
+     ,.cache_fail_v_o(pipe_mem_dcache_fail_lo)
      ,.cache_miss_v_o(pipe_mem_dcache_miss_lo)
      ,.fencei_clean_v_o(pipe_mem_fencei_clean_lo)
      ,.fencei_dirty_v_o(pipe_mem_fencei_dirty_lo)
@@ -324,13 +329,21 @@ module bp_be_calculator_top
      ,.store_misaligned_v_o(pipe_mem_store_misaligned_lo)
      ,.store_access_fault_v_o(pipe_mem_store_access_fault_lo)
      ,.store_page_fault_v_o(pipe_mem_store_page_fault_lo)
+
      ,.early_data_o(pipe_mem_early_data_lo)
-     ,.final_data_o(pipe_mem_final_data_lo)
      ,.early_v_o(pipe_mem_early_data_lo_v)
+
+     ,.final_data_o(pipe_mem_final_data_lo)
      ,.final_v_o(pipe_mem_final_data_lo_v)
 
+     ,.late_iwb_pkt_o(pipe_mem_late_iwb_pkt)
+     ,.late_iwb_pkt_v_o(pipe_mem_late_iwb_pkt_v)
+     ,.late_iwb_pkt_yumi_i(pipe_mem_late_iwb_pkt_yumi)
+     ,.late_fwb_pkt_o(pipe_mem_late_fwb_pkt)
+     ,.late_fwb_pkt_v_o(pipe_mem_late_fwb_pkt_v)
+     ,.late_fwb_pkt_yumi_i(pipe_mem_late_fwb_pkt_yumi)
+
      ,.trans_info_i(trans_info_lo)
-     ,.replay_pending_o(replay_pending_o)
      );
 
   // Floating point pipe: 4/5 cycle latency
@@ -417,6 +430,10 @@ module bp_be_calculator_top
       comp_stage_n[1].fflags_w_v &= exc_stage_n[1].v;
       comp_stage_n[2].fflags_w_v &= exc_stage_n[2].v;
       comp_stage_n[3].fflags_w_v &= exc_stage_n[3].v;
+
+      // Inject D$ miss so we don't accidentally write back the data
+      comp_stage_n[2].ird_w_v    &= ~pipe_mem_dcache_miss_lo;
+      comp_stage_n[2].frd_w_v    &= ~pipe_mem_dcache_miss_lo;
     end
 
   bsg_dff
@@ -442,10 +459,10 @@ module bp_be_calculator_top
           exc_stage_n[3].v                      &= commit_pkt_cast_o.instret;
 
           exc_stage_n[0].queue_v                 = reservation_n.queue_v;
-          exc_stage_n[0].queue_v                &= ~commit_pkt_cast_o.rollback;
-          exc_stage_n[1].queue_v                &= ~commit_pkt_cast_o.rollback;
-          exc_stage_n[2].queue_v                &= ~commit_pkt_cast_o.rollback;
-          exc_stage_n[3].queue_v                &= ~commit_pkt_cast_o.rollback;
+          exc_stage_n[0].queue_v                &= ~commit_pkt_cast_o.npc_w_v;
+          exc_stage_n[1].queue_v                &= ~commit_pkt_cast_o.npc_w_v;
+          exc_stage_n[2].queue_v                &= ~commit_pkt_cast_o.npc_w_v;
+          exc_stage_n[3].queue_v                &= ~commit_pkt_cast_o.npc_w_v;
 
           exc_stage_n[0].spec                   |= reservation_n.special;
           exc_stage_n[0].exc                    |= reservation_n.exception;
@@ -462,9 +479,10 @@ module bp_be_calculator_top
           exc_stage_n[1].exc.store_access_fault |= pipe_mem_store_access_fault_lo;
           exc_stage_n[1].exc.store_page_fault   |= pipe_mem_store_page_fault_lo;
 
-          exc_stage_n[2].exc.dcache_miss        |= pipe_mem_dcache_miss_lo;
-          exc_stage_n[2].exc.fencei_dirty       |= pipe_mem_fencei_dirty_lo;
+          exc_stage_n[2].exc.dcache_fail        |= pipe_mem_dcache_fail_lo;
+          exc_stage_n[2].spec.dcache_miss       |= pipe_mem_dcache_miss_lo;
           exc_stage_n[2].spec.fencei_clean      |= pipe_mem_fencei_clean_lo;
+          exc_stage_n[2].exc.fencei_dirty       |= pipe_mem_fencei_dirty_lo;
           exc_stage_n[2].exc.cmd_full           |= |{exc_stage_r[2].exc, exc_stage_r[2].spec} & cmd_full_n_i;
     end
 
@@ -477,11 +495,14 @@ module bp_be_calculator_top
      ,.data_o(exc_stage_r)
      );
 
-  assign pipe_long_idata_lo_yumi = pipe_long_idata_lo_v & ~comp_stage_r[4].ird_w_v;
-  assign pipe_long_fdata_lo_yumi = pipe_long_fdata_lo_v & ~comp_stage_r[5].frd_w_v & ~comp_stage_r[5].fflags_w_v;
+  assign pipe_mem_late_iwb_pkt_yumi = pipe_mem_late_iwb_pkt_v & ~comp_stage_r[4].ird_w_v;
+  assign pipe_mem_late_fwb_pkt_yumi = pipe_mem_late_fwb_pkt_v & ~comp_stage_r[5].frd_w_v;
 
-  assign iwb_pkt_o = pipe_long_idata_lo_yumi ? long_iwb_pkt : comp_stage_r[4];
-  assign fwb_pkt_o = pipe_long_fdata_lo_yumi ? long_fwb_pkt : comp_stage_r[5];
+  assign pipe_long_idata_lo_yumi = pipe_long_idata_lo_v & ~pipe_mem_late_iwb_pkt_v & ~comp_stage_r[4].ird_w_v;
+  assign pipe_long_fdata_lo_yumi = pipe_long_fdata_lo_v & ~pipe_mem_late_fwb_pkt_v & ~comp_stage_r[5].frd_w_v & ~comp_stage_r[5].fflags_w_v;
+
+  assign iwb_pkt_o = pipe_mem_late_iwb_pkt_yumi ? pipe_mem_late_iwb_pkt : pipe_long_idata_lo_yumi ? long_iwb_pkt : comp_stage_r[4];
+  assign fwb_pkt_o = pipe_mem_late_fwb_pkt_yumi ? pipe_mem_late_fwb_pkt : pipe_long_fdata_lo_yumi ? long_fwb_pkt : comp_stage_r[5];
 
 endmodule
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -617,7 +617,7 @@ module bp_be_csr
   assign csr_data_o = dword_width_gp'(csr_data_lo);
 
   assign commit_pkt_cast_o.npc_w_v          = |{retire_pkt_cast_i.special, retire_pkt_cast_i.exception};
-  assign commit_pkt_cast_o.queue_v          = retire_pkt_cast_i.queue_v;
+  assign commit_pkt_cast_o.queue_v          = retire_pkt_cast_i.queue_v & ~|retire_pkt_cast_i.exception;
   assign commit_pkt_cast_o.instret          = retire_pkt_cast_i.instret;
   assign commit_pkt_cast_o.pc               = apc_r;
   assign commit_pkt_cast_o.npc              = apc_n;
@@ -637,10 +637,9 @@ module bp_be_csr
   assign commit_pkt_cast_o.icache_miss      = retire_pkt_cast_i.exception.icache_miss;
   assign commit_pkt_cast_o.dtlb_store_miss  = retire_pkt_cast_i.exception.dtlb_store_miss;
   assign commit_pkt_cast_o.dtlb_load_miss   = retire_pkt_cast_i.exception.dtlb_load_miss;
-  assign commit_pkt_cast_o.dcache_miss      = retire_pkt_cast_i.exception.dcache_miss;;
+  assign commit_pkt_cast_o.dcache_miss      = retire_pkt_cast_i.special.dcache_miss;
   assign commit_pkt_cast_o.itlb_fill_v      = retire_pkt_cast_i.exception.itlb_fill;
   assign commit_pkt_cast_o.dtlb_fill_v      = retire_pkt_cast_i.exception.dtlb_fill;
-  assign commit_pkt_cast_o.rollback         = |retire_pkt_cast_i.exception;
 
   assign trans_info_cast_o.priv_mode = priv_mode_r;
   assign trans_info_cast_o.satp_ppn  = satp_lo.ppn;

--- a/bp_be/src/v/bp_be_calculator/bp_be_ptw.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_ptw.sv
@@ -37,19 +37,21 @@ module bp_be_ptw
    , output logic                           dcache_ptag_v_o
    , input                                  dcache_ready_i
 
-   , input                                  dcache_early_v_i
+   , input                                  dcache_early_hit_v_i
+   , input                                  dcache_early_miss_v_i
    , input [dpath_width_gp-1:0]             dcache_early_data_i
   );
 
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
   `bp_cast_o(bp_be_dcache_pkt_s, dcache_pkt);
 
-  enum logic [2:0] {eIdle, eSendLoad, eWaitLoad, eRecvLoad, eWriteBack} state_n, state_r;
-  wire is_idle  = (state_r == eIdle);
-  wire is_send  = (state_r == eSendLoad);
-  wire is_wait  = (state_r == eWaitLoad);
-  wire is_recv  = (state_r == eRecvLoad);
-  wire is_write = (state_r == eWriteBack);
+  enum logic [2:0] {e_idle, e_send_load, e_send_tag, e_wait_load, e_recv_load, e_writeback} state_n, state_r;
+  wire is_idle  = (state_r == e_idle);
+  wire is_send  = (state_r == e_send_load);
+  wire is_tag   = (state_r == e_send_tag );
+  wire is_wait  = (state_r == e_wait_load);
+  wire is_recv  = (state_r == e_recv_load);
+  wire is_write = (state_r == e_writeback);
 
   bp_be_ptw_miss_pkt_s ptw_miss_pkt_cast_i;
   bp_be_ptw_fill_pkt_s ptw_fill_pkt_cast_o;
@@ -72,72 +74,72 @@ module bp_be_ptw
 
   logic tlb_miss_v, page_fault_v;
 
-  sv39_pte_s dcache_pte_r;
-  logic dcache_pte_v_r;
+  sv39_pte_s dcache_pte;
+  assign dcache_pte = dcache_early_data_i[0+:dword_width_gp];
 
    for(genvar i=0; i<page_table_depth_p; i++) begin : rof1
       assign partial_vpn[i] = vpn[page_idx_width_p*i +: page_idx_width_p];
     end
    for(genvar i=0; i<page_table_depth_p-1; i++) begin : rof2
       assign partial_ppn[i] = ppn_r[page_idx_width_p*i +: page_idx_width_p];
-      assign partial_pte_misaligned[i] = (level_cntr > i)? |dcache_pte_r.ppn[page_idx_width_p*i +: page_idx_width_p] : 1'b0;
+      assign partial_pte_misaligned[i] = (level_cntr > i)? |dcache_pte.ppn[page_idx_width_p*i +: page_idx_width_p] : 1'b0;
       assign writeback_ppn[page_idx_width_p*i +: page_idx_width_p] = (level_cntr > i)? partial_vpn[i] : partial_ppn[i];
     end
     assign writeback_ppn[ptag_width_p-1 : (page_table_depth_p-1)*page_idx_width_p] = ppn_r[ptag_width_p-1 : (page_table_depth_p-1)*page_idx_width_p];
 
   assign dcache_ptag_o          = ppn_r;
-  assign dcache_ptag_v_o        = (state_r == eWaitLoad);
+  assign dcache_ptag_v_o        = (state_r == e_send_tag);
 
   // PMA attributes
   localparam lg_pte_size_in_bytes_lp = `BSG_SAFE_CLOG2(pte_size_in_bytes_p);
-  assign dcache_v_o                    = dcache_ready_i & (state_r == eSendLoad);
-  assign dcache_pkt_cast_o.opcode      = e_dcache_op_ld;
+  assign dcache_v_o                    = (state_r == e_send_load);
+  assign dcache_pkt_cast_o.opcode      = e_dcache_op_ptw_ld;
   assign dcache_pkt_cast_o.page_offset = {partial_vpn[level_cntr], (lg_pte_size_in_bytes_lp)'(0)};
   assign dcache_pkt_cast_o.data        = '0;
   assign dcache_pkt_cast_o.rd_addr     = '0;
 
-  assign busy_o                 = (state_r != eIdle);
+  assign busy_o                 = ~is_idle;
 
-  assign start                  = (state_r == eIdle) & tlb_miss_v;
+  assign start                  = is_idle & tlb_miss_v;
 
-  wire pte_is_leaf              = dcache_pte_r.x | dcache_pte_r.w | dcache_pte_r.r;
+  wire pte_is_leaf              = dcache_pte.x | dcache_pte.w | dcache_pte.r;
   wire pte_is_megapage          = (level_cntr == 2'd1);
   wire pte_is_gigapage          = (level_cntr == 2'd2);
 
-  assign level_cntr_en          = busy_o & dcache_pte_v_r & ~pte_is_leaf & ~page_fault_v;
+  assign level_cntr_en          = is_recv & dcache_early_hit_v_i & ~pte_is_leaf & ~page_fault_v;
 
-  assign ppn_en                 = start | (busy_o & dcache_pte_v_r);
-  assign ppn_n                  = (state_r == eIdle)? base_ppn_i : dcache_pte_r.ppn[0+:ptag_width_p];
+  assign ppn_en                 = start | (is_recv & dcache_early_hit_v_i);
+  assign ppn_n                  = (state_r == e_idle)? base_ppn_i : dcache_pte.ppn[0+:ptag_width_p];
 
-  wire pte_invalid              = (~dcache_pte_r.v) | (~dcache_pte_r.r & dcache_pte_r.w);
+  wire pte_invalid              = (~dcache_pte.v) | (~dcache_pte.r & dcache_pte.w);
   wire leaf_not_found           = (level_cntr == '0) & (~pte_is_leaf);
-  wire priv_fault               = pte_is_leaf & ((dcache_pte_r.u & (priv_mode_i == `PRIV_MODE_S) & (ptw_miss_pkt_r.instr_miss_v | ~mstatus_sum_i)) | (~dcache_pte_r.u & (priv_mode_i == `PRIV_MODE_U)));
+  wire priv_fault               = pte_is_leaf & ((dcache_pte.u & (priv_mode_i == `PRIV_MODE_S) & (ptw_miss_pkt_r.instr_miss_v | ~mstatus_sum_i)) | (~dcache_pte.u & (priv_mode_i == `PRIV_MODE_U)));
   wire misaligned_superpage     = pte_is_leaf & (|partial_pte_misaligned);
-  wire ad_fault                 = pte_is_leaf & (~dcache_pte_r.a | (ptw_miss_pkt_r.store_miss_v & ~dcache_pte_r.d));
+  wire ad_fault                 = pte_is_leaf & (~dcache_pte.a | (ptw_miss_pkt_r.store_miss_v & ~dcache_pte.d));
   wire common_faults            = pte_invalid | leaf_not_found | priv_fault | misaligned_superpage | ad_fault;
 
   bp_be_pte_leaf_s tlb_w_entry;
   assign tlb_w_entry.ptag       = writeback_ppn;
   assign tlb_w_entry.gigapage   = pte_is_gigapage;
-  assign tlb_w_entry.a          = dcache_pte_r.a;
-  assign tlb_w_entry.d          = dcache_pte_r.d;
-  assign tlb_w_entry.u          = dcache_pte_r.u;
-  assign tlb_w_entry.x          = dcache_pte_r.x;
-  assign tlb_w_entry.w          = dcache_pte_r.w;
-  assign tlb_w_entry.r          = dcache_pte_r.r;
+  assign tlb_w_entry.a          = dcache_pte.a;
+  assign tlb_w_entry.d          = dcache_pte.d;
+  assign tlb_w_entry.u          = dcache_pte.u;
+  assign tlb_w_entry.x          = dcache_pte.x;
+  assign tlb_w_entry.w          = dcache_pte.w;
+  assign tlb_w_entry.r          = dcache_pte.r;
 
-  assign ptw_fill_pkt_cast_o.v                  = (state_r == eWriteBack) || page_fault_v;
-  assign ptw_fill_pkt_cast_o.itlb_fill_v        = (state_r == eWriteBack) &  ptw_miss_pkt_r.instr_miss_v;
-  assign ptw_fill_pkt_cast_o.dtlb_fill_v        = (state_r == eWriteBack) & ~ptw_miss_pkt_r.instr_miss_v;
-  assign ptw_fill_pkt_cast_o.instr_page_fault_v = busy_o
-    & dcache_pte_v_r & ptw_miss_pkt_r.instr_miss_v
-    & (common_faults | (pte_is_leaf & ~dcache_pte_r.x));
-  assign ptw_fill_pkt_cast_o.load_page_fault_v  = busy_o
-    & dcache_pte_v_r & ptw_miss_pkt_r.load_miss_v
-    & (common_faults | (pte_is_leaf & ~(dcache_pte_r.r | (dcache_pte_r.x & mstatus_mxr_i))));
-  assign ptw_fill_pkt_cast_o.store_page_fault_v = busy_o
-    & dcache_pte_v_r & ptw_miss_pkt_r.store_miss_v
-    & (common_faults | (pte_is_leaf & ~dcache_pte_r.w));
+  assign ptw_fill_pkt_cast_o.v                  = (state_r == e_writeback) || page_fault_v;
+  assign ptw_fill_pkt_cast_o.itlb_fill_v        = (state_r == e_writeback) &  ptw_miss_pkt_r.instr_miss_v;
+  assign ptw_fill_pkt_cast_o.dtlb_fill_v        = (state_r == e_writeback) & ~ptw_miss_pkt_r.instr_miss_v;
+  assign ptw_fill_pkt_cast_o.instr_page_fault_v = (state_r == e_recv_load)
+    & dcache_early_hit_v_i & ptw_miss_pkt_r.instr_miss_v
+    & (common_faults | (pte_is_leaf & ~dcache_pte.x));
+  assign ptw_fill_pkt_cast_o.load_page_fault_v  = (state_r == e_recv_load)
+    & dcache_early_hit_v_i & ptw_miss_pkt_r.load_miss_v
+    & (common_faults | (pte_is_leaf & ~(dcache_pte.r | (dcache_pte.x & mstatus_mxr_i))));
+  assign ptw_fill_pkt_cast_o.store_page_fault_v = (state_r == e_recv_load)
+    & dcache_early_hit_v_i & ptw_miss_pkt_r.store_miss_v
+    & (common_faults | (pte_is_leaf & ~dcache_pte.w));
   assign ptw_fill_pkt_cast_o.vaddr              = ptw_miss_pkt_r.vaddr;
   assign ptw_fill_pkt_cast_o.entry              = tlb_w_entry;
 
@@ -158,14 +160,6 @@ module bp_be_ptw
      ,.val_i(max_level_li)
      ,.down_i(level_cntr_en)
      ,.count_r_o(level_cntr)
-     );
-
-  bsg_dff_reset #(.width_p(1+dword_width_gp))
-    dcache_pte_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-     ,.data_i({dcache_early_v_i, dcache_early_data_i[0+:dword_width_gp]})
-     ,.data_o({dcache_pte_v_r, dcache_pte_r})
      );
 
   bsg_dff_reset_en
@@ -189,25 +183,29 @@ module bp_be_ptw
      ,.data_o(ppn_r)
      );
 
+  // If flushing is a possibility, then we need to manually replay. However, this should
+  //   not be the case, because the pipeline should not flush after TLB miss, since they
+  //   are non-speculative
   always_comb begin
     case(state_r)
-      eIdle:      state_n = tlb_miss_v ? eSendLoad : eIdle;
-      eSendLoad:  state_n = dcache_ready_i ? eWaitLoad : eSendLoad;
-      eWaitLoad:  state_n = eRecvLoad;
-      eRecvLoad:  state_n = (dcache_pte_v_r
-                             ? (page_fault_v
-                                ? eIdle
-                                : (pte_is_leaf ? eWriteBack : eSendLoad))
-                             : eSendLoad);
-      eWriteBack: state_n = eIdle;
-      default: state_n = eIdle;
+      e_idle     :  state_n = tlb_miss_v ? e_send_load : e_idle;
+      e_send_load:  state_n = (dcache_ready_i & dcache_v_o) ? e_send_tag : e_send_load;
+      e_send_tag :  state_n = e_recv_load;
+      e_wait_load:  state_n = e_recv_load;
+      e_recv_load:  state_n = dcache_early_hit_v_i
+                              ? page_fault_v
+                                ? e_idle
+                                : pte_is_leaf ? e_writeback : e_send_load
+                              : e_recv_load;
+      default: // e_writeback
+                    state_n = e_idle;
     endcase
   end
 
   //synopsys sync_set_reset "reset_i"
   always_ff @(posedge clk_i) begin
     if(reset_i) begin
-      state_r <= eIdle;
+      state_r <= e_idle;
     end
     else begin
       state_r <= state_n;

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -41,7 +41,6 @@ module bp_be_detector
    , input                             mem_ready_i
    , input                             ptw_busy_i
    , input                             irq_pending_i
-   , input                             replay_pending_i
 
    // Pipeline control signals from the checker to the calculator
    , output logic                      dispatch_v_o
@@ -79,7 +78,9 @@ module bp_be_detector
   logic long_haz_v;
   logic mem_in_pipe_v;
 
-  wire [reg_addr_width_gp-1:0] score_rd_li = dispatch_pkt_cast_i.instr.t.fmatype.rd_addr;
+  wire [reg_addr_width_gp-1:0] score_rd_li  = commit_pkt_cast_i.dcache_miss
+    ? commit_pkt_cast_i.instr.t.fmatype.rd_addr
+    : dispatch_pkt_cast_i.instr.t.fmatype.rd_addr;
   wire [reg_addr_width_gp-1:0] score_rs1_li = dispatch_pkt_cast_i.instr.t.fmatype.rs1_addr;
   wire [reg_addr_width_gp-1:0] score_rs2_li = dispatch_pkt_cast_i.instr.t.fmatype.rs2_addr;
   wire [reg_addr_width_gp-1:0] score_rs3_li = dispatch_pkt_cast_i.instr.t.fmatype.rs3_addr;
@@ -88,7 +89,8 @@ module bp_be_detector
 
   logic [1:0] irs_match_lo;
   logic       ird_match_lo;
-  wire score_int_v_li = dispatch_pkt_cast_i.v & dispatch_pkt_cast_i.decode.late_iwb_v;
+  wire score_int_v_li = (dispatch_pkt_cast_i.v & dispatch_pkt_cast_i.decode.late_iwb_v)
+    || (commit_pkt_cast_i.dcache_miss & commit_pkt_cast_i.instr.t.fmatype.opcode inside {`RV64_LOAD_OP, `RV64_AMO_OP});
   wire clear_int_v_li = iwb_pkt_cast_i.ird_w_v & iwb_pkt_cast_i.late;
   bp_be_scoreboard
    #(.bp_params_p(bp_params_p), .num_rs_p(2))
@@ -110,7 +112,8 @@ module bp_be_detector
 
   logic [2:0] frs_match_lo;
   logic       frd_match_lo;
-  wire score_fp_v_li = dispatch_pkt_cast_i.v & dispatch_pkt_cast_i.decode.late_fwb_v;
+  wire score_fp_v_li = (dispatch_pkt_cast_i.v & dispatch_pkt_cast_i.decode.late_fwb_v)
+    || (commit_pkt_cast_i.dcache_miss & commit_pkt_cast_i.instr.t.fmatype.opcode == `RV64_FLOAD_OP);
   wire clear_fp_v_li = fwb_pkt_cast_i.frd_w_v & fwb_pkt_cast_i.late;
   bp_be_scoreboard
    #(.bp_params_p(bp_params_p), .num_rs_p(3))
@@ -216,7 +219,7 @@ module bp_be_detector
                            & (dep_status_r[3].fma_fwb_v);
 
       mem_in_pipe_v      = dep_status_r[0].mem_v | dep_status_r[1].mem_v | dep_status_r[2].mem_v;
-      fence_haz_v        = (isd_status_cast_i.fence_v & (~credits_empty_i | mem_in_pipe_v))
+      fence_haz_v        = (isd_status_cast_i.fence_v & (~credits_empty_i | mem_in_pipe_v | ~mem_ready_i))
                            | (isd_status_cast_i.mem_v & credits_full_i);
       cmd_haz_v          = cmd_full_i;
 
@@ -260,13 +263,12 @@ module bp_be_detector
                      | ptw_busy_i
                      | (~mem_ready_i & isd_status_cast_i.mem_v)
                      | (~long_ready_i & isd_status_cast_i.long_v)
-                     | (irq_pending_i & ~replay_pending_i)
                      | cmd_haz_v;
     end
 
   // Generate calculator control signals
   assign dispatch_v_o  = ~(control_haz_v | data_haz_v | struct_haz_v);
-  assign interrupt_v_o = irq_pending_i & ~replay_pending_i & ~ptw_busy_i & ~cfg_bus_cast_i.freeze;
+  assign interrupt_v_o = irq_pending_i & ~ptw_busy_i & ~cfg_bus_cast_i.freeze;
 
   bp_be_dep_status_s dep_status_n;
   always_comb

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -70,8 +70,8 @@ module bp_be_scheduler
   bp_fe_queue_s fe_queue_lo;
   logic fe_queue_v_lo, fe_queue_yumi_li;
   wire fe_queue_clr_li  = suppress_iss_i;
-  wire fe_queue_deq_li  = commit_pkt_cast_i.queue_v & ~commit_pkt_cast_i.rollback;
-  wire fe_queue_roll_li = commit_pkt_cast_i.rollback;
+  wire fe_queue_deq_li  = commit_pkt_cast_i.queue_v;
+  wire fe_queue_roll_li = commit_pkt_cast_i.npc_w_v;
   bp_be_issue_pkt_s preissue_pkt, issue_pkt;
   bp_be_issue_queue
    #(.bp_params_p(bp_params_p))

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -133,15 +133,19 @@ module bp_be_dcache
    , input                            ptag_uncached_i
    , input                            ptag_dram_i
 
-   , output logic [dpath_width_gp-1:0] early_data_o
-   , output logic                      early_miss_v_o
-   , output logic                      early_hit_v_o
-   , output logic [dpath_width_gp-1:0] final_data_o
-   , output logic                      final_v_o
+   , output logic [dpath_width_gp-1:0]    early_data_o
+   , output logic                         early_miss_v_o
+   , output logic                         early_hit_v_o
+   , output logic [dpath_width_gp-1:0]    final_data_o
+   , output logic                         final_v_o
+   , output logic [reg_addr_width_gp-1:0] late_rd_addr_o
+   , output logic                         late_float_o
+   , output logic [dpath_width_gp-1:0]    late_data_o
+   , output logic                         late_v_o
+   , input                                late_yumi_i
 
    // ctrl
-   , input                             flush_i
-   , output logic                      replay_pending_o
+   , input                                flush_i
 
    // D$ Engine Interface
    , output logic [dcache_req_width_lp-1:0]          cache_req_o
@@ -190,19 +194,19 @@ module bp_be_dcache
     : byte_offset_width_lp;
 
   // State machine declaration
-  enum logic [2:0] {e_ready, e_miss, e_fence, e_req} state_n, state_r;
-  wire is_ready = (state_r == e_ready);
-  wire is_miss  = (state_r == e_miss);
-  wire is_fence = (state_r == e_fence);
-  wire is_req   = (state_r == e_req);
+  enum logic [2:0] {e_ready, e_miss, e_req, e_fence, e_resume, e_late} state_n, state_r;
+  wire is_ready  = (state_r == e_ready);
+  wire is_miss   = (state_r == e_miss);
+  wire is_req    = (state_r == e_req);
+  wire is_fence  = (state_r == e_fence);
+  wire is_resume = (state_r == e_resume);
+  wire is_late   = (state_r == e_late);
 
   // Global signals
   logic tl_we, tv_we, dm_we;
   logic safe_tl_we, safe_tv_we, safe_dm_we;
   logic v_tl_r, v_tv_r, v_dm_r;
   logic gdirty_r, cache_lock;
-  logic uncached_pending_r;
-  logic [dword_width_gp-1:0] uncached_load_data_r;
   logic sram_hazard_flush, miss_request_flush, engine_flush;
 
   wire posedge_clk =  clk_i;
@@ -356,7 +360,6 @@ module bp_be_dcache
     assign load_hit_tl[i]  = tag_match_tl & (tag_mem_data_lo[i].state != e_COH_I);
     assign store_hit_tl[i] = tag_match_tl & (tag_mem_data_lo[i].state inside {e_COH_M, e_COH_E});
   end
-    wire uncached_hit_tl = uncached_pending_r;
 
   logic [assoc_p-1:0] bank_sel_one_hot_tl;
   bsg_decode
@@ -387,7 +390,8 @@ module bp_be_dcache
   /////////////////////////////////////////////////////////////////////////////
   // TV Stage
   /////////////////////////////////////////////////////////////////////////////
-  logic uncached_hit_tv_r, uncached_op_tv_r, cached_op_tv_r, dram_op_tv_r;
+  localparam snoop_offset_width_lp = `BSG_SAFE_CLOG2(fill_width_p/dword_width_gp);
+  logic uncached_op_tv_r, cached_op_tv_r, dram_op_tv_r, uncached_hit_tv_r;
   logic [paddr_width_p-1:0] paddr_tv_r;
   logic [dword_width_gp-1:0] st_data_tv_r;
   logic [assoc_p-1:0][bank_width_lp-1:0] ld_data_tv_r;
@@ -405,17 +409,57 @@ module bp_be_dcache
    v_tv_reg
     (.clk_i(negedge_clk)
      ,.reset_i(reset_i)
-     ,.data_i(tv_we)
+     ,.data_i(tv_we | is_resume)
      ,.data_o(v_tv_r)
      );
 
+  logic [assoc_p-1:0] way_v_tv_n, store_hit_tv_n, load_hit_tv_n;
+  wire uncached_hit_tv_n = cache_req_critical_tag_i;
+  wire [assoc_p-1:0] tag_mem_pseudo_hit = 1'b1 << tag_mem_pkt_cast_i.way_id;
+  bsg_mux
+   #(.width_p(3*assoc_p), .els_p(2))
+   hit_mux
+    (.data_i({{3{tag_mem_pseudo_hit}}, {way_v_tl, store_hit_tl, load_hit_tl}})
+     ,.sel_i(cache_req_critical_tag_i)
+     ,.data_o({way_v_tv_n, store_hit_tv_n, load_hit_tv_n})
+     );
+
+  bsg_dff_reset_en
+   #(.width_p(1+3*assoc_p))
+   hit_tv_reg
+    (.clk_i(negedge_clk)
+     ,.reset_i(reset_i)
+     ,.en_i(tv_we | cache_req_critical_tag_i)
+     ,.data_i({uncached_hit_tv_n, way_v_tv_n, store_hit_tv_n, load_hit_tv_n})
+     ,.data_o({uncached_hit_tv_r, way_v_tv_r, store_hit_tv_r, load_hit_tv_r})
+     );
+
+  // Snoop logic
+  logic [dword_width_gp-1:0] snoop_word;
+  wire [snoop_offset_width_lp-1:0] snoop_word_offset = paddr_tv_r[3+:snoop_offset_width_lp];
+  bsg_mux
+   #(.width_p(dword_width_gp), .els_p(fill_width_p/dword_width_gp))
+   snoop_mux
+    (.data_i(data_mem_pkt_cast_i.data)
+     ,.sel_i(snoop_word_offset)
+     ,.data_o(snoop_word)
+     );
+  wire [block_width_p-1:0] snoop_data_lo = {block_width_p/dword_width_gp{snoop_word}};
+
   logic [block_width_p-1:0] ld_data_tv_n;
-  assign ld_data_tv_n = data_mem_data_lo;
+  bsg_mux
+   #(.width_p(block_width_p), .els_p(2))
+   ld_data_mux
+    (.data_i({snoop_data_lo, data_mem_data_lo})
+     ,.sel_i(cache_req_critical_data_i)
+     ,.data_o(ld_data_tv_n)
+     );
+
   bsg_dff_en
    #(.width_p(block_width_p))
    ld_data_tv_reg
     (.clk_i(negedge_clk)
-     ,.en_i(tv_we)
+     ,.en_i(tv_we | cache_req_critical_data_i)
      ,.data_i(ld_data_tv_n)
      ,.data_o(ld_data_tv_r)
      );
@@ -430,18 +474,18 @@ module bp_be_dcache
      );
 
   bsg_dff_en
-   #(.width_p(paddr_width_p+4*assoc_p+4+$bits(bp_be_dcache_decode_s)))
+   #(.width_p(paddr_width_p+assoc_p+3+$bits(bp_be_dcache_decode_s)))
    tv_stage_reg
     (.clk_i(negedge_clk)
      ,.en_i(tv_we)
      ,.data_i({paddr_tl
-               ,bank_sel_one_hot_tl, way_v_tl, load_hit_tl, store_hit_tl
-               ,uncached_hit_tl, uncached_op_tl, cached_op_tl, dram_op_tl
+               ,bank_sel_one_hot_tl
+               ,uncached_op_tl, cached_op_tl, dram_op_tl
                ,decode_tl_r
                })
      ,.data_o({paddr_tv_r
-               ,bank_sel_one_hot_tv_r, way_v_tv_r, load_hit_tv_r, store_hit_tv_r
-               ,uncached_hit_tv_r, uncached_op_tv_r, cached_op_tv_r, dram_op_tv_r
+               ,bank_sel_one_hot_tv_r
+               ,uncached_op_tv_r, cached_op_tv_r, dram_op_tv_r
                ,decode_tv_r
                })
      );
@@ -508,14 +552,7 @@ module bp_be_dcache
      );
 
   logic [dword_width_gp-1:0] ld_data_dword_merged;
-  logic [dword_width_gp-1:0] result_data;
-  bsg_mux
-   #(.width_p(dword_width_gp), .els_p(2))
-   final_data_mux
-    (.data_i({uncached_load_data_r, ld_data_dword_merged})
-     ,.sel_i(uncached_op_tv_r)
-     ,.data_o(result_data)
-     );
+  wire [dword_width_gp-1:0] result_data = ld_data_dword_merged;
 
   logic [3:2][dword_width_gp-1:0] sigext_word;
   for (genvar i = 2; i < 4; i++)
@@ -551,14 +588,13 @@ module bp_be_dcache
   // Fail if we have a store conditional without success
   wire sc_fail_tv = v_tv_r & decode_tv_r.sc_op & ~sc_success_tv;
 
-  wire load_miss_tv   = v_tv_r & decode_tv_r.load_op & ~load_hit_tv & ~uncached_op_tv_r;
-  wire store_miss_tv  = v_tv_r & decode_tv_r.store_op & ~decode_tv_r.sc_op & ~store_hit_tv & ~uncached_op_tv_r & (writethrough_p == 0);
-  wire lr_miss_tv     = v_tv_r & decode_tv_r.lr_op & ~store_hit_tv & ~uncached_op_tv_r;
-  wire fencei_miss_tv = v_tv_r & decode_tv_r.fencei_op & gdirty_r & (coherent_p == 0);
-  wire engine_miss_tv = v_tv_r & cache_req_v_o & ~cache_req_yumi_li;
-  wire wbuf_miss_tv   = v_tv_r & wbuf_fail_tv;
+  wire load_miss_tv   = decode_tv_r.load_op & ~load_hit_tv & ~uncached_op_tv_r;
+  wire store_miss_tv  = decode_tv_r.store_op & ~decode_tv_r.sc_op & ~store_hit_tv & ~uncached_op_tv_r & (writethrough_p == 0);
+  wire lr_miss_tv     = decode_tv_r.lr_op & ~store_hit_tv & ~uncached_op_tv_r;
+  wire fencei_miss_tv = decode_tv_r.fencei_op & gdirty_r & (coherent_p == 0);
+  wire wbuf_miss_tv   = wbuf_fail_tv;
 
-  wire any_miss_tv = load_miss_tv | store_miss_tv | lr_miss_tv | fencei_miss_tv | engine_miss_tv | wbuf_miss_tv;
+  wire any_miss_tv = load_miss_tv | store_miss_tv | lr_miss_tv | fencei_miss_tv | wbuf_miss_tv;
 
   assign early_data_o = (decode_tv_r.sc_op & ~uncached_op_tv_r)
     ? (sc_success_tv != 1'b1)
@@ -616,31 +652,31 @@ module bp_be_dcache
   /////////////////////////////////////////////////////////////////////////////
   // DM Stage
   /////////////////////////////////////////////////////////////////////////////
-  logic [dword_width_gp-1:0] st_data_dm_r, ld_data_dm_r;
+  logic [dword_width_gp-1:0] ld_data_dm_r;
   logic [paddr_width_p-1:0] paddr_dm_r;
   bp_be_dcache_decode_s decode_dm_r;
   wire [sindex_width_lp-1:0] paddr_index_dm = paddr_dm_r[block_offset_width_lp+:sindex_width_lp];
   wire [ctag_width_p-1:0]    paddr_tag_dm   = paddr_dm_r[block_offset_width_lp+sindex_width_lp+:ctag_width_p];
 
   assign safe_dm_we = v_tv_r;
-  assign dm_we = safe_dm_we & ~flush_self;
-  bsg_dff_reset
+  assign dm_we = safe_dm_we;
+  bsg_dff_reset_set_clear
    #(.width_p(1))
    v_dm_reg
     (.clk_i(posedge_clk)
      ,.reset_i(reset_i)
-     ,.data_i(dm_we)
+     ,.set_i(dm_we)
+     ,.clear_i(is_ready | late_yumi_i)
      ,.data_o(v_dm_r)
      );
 
-  wire [dword_width_gp-1:0] data_dm_n = decode_tv_r.load_op ? result_data : st_data_tv_r;
   bsg_dff_en
-   #(.width_p(2*dword_width_gp+paddr_width_p+$bits(bp_be_dcache_decode_s)))
+   #(.width_p(dword_width_gp+paddr_width_p+$bits(bp_be_dcache_decode_s)))
    dm_stage_reg
     (.clk_i(posedge_clk)
      ,.en_i(dm_we)
-     ,.data_i({st_data_tv_r, result_data, paddr_tv_r, decode_tv_r})
-     ,.data_o({st_data_dm_r, ld_data_dm_r, paddr_dm_r, decode_dm_r})
+     ,.data_i({result_data, paddr_tv_r, decode_tv_r})
+     ,.data_o({ld_data_dm_r, paddr_dm_r, decode_dm_r})
      );
 
   logic [3:0][dword_width_gp-1:0] sigext_byte;
@@ -682,7 +718,7 @@ module bp_be_dcache
      );
 
   assign final_data_o = decode_dm_r.float_op ? final_float_data : final_int_data;
-  assign final_v_o = v_dm_r;
+  assign final_v_o = is_ready & v_dm_r;
 
   ///////////////////////////
   // Write buffer
@@ -691,7 +727,9 @@ module bp_be_dcache
   bp_be_dcache_wbuf_entry_s wbuf_entry_in, wbuf_entry_out;
   logic wbuf_v_li, wbuf_ready_and_lo, wbuf_v_lo, wbuf_yumi_li;
 
-  assign wbuf_v_li = v_tv_r & decode_tv_r.store_op & store_hit_tv & ~sc_fail_tv & ~uncached_op_tv_r & ~flush_self;
+  assign wbuf_v_li = v_tv_r
+        & decode_tv_r.store_op & ~uncached_op_tv_r
+        & store_hit_tv & ~sc_fail_tv;
   assign wbuf_fail_tv = wbuf_v_li & ~wbuf_ready_and_lo;
 
   //
@@ -841,8 +879,8 @@ module bp_be_dcache
   // Uncached stores and writethrough requests are non-blocking
   wire nonblocking_req     = uncached_store_req | wt_req;
 
-  assign cache_req_v_o = is_req
-    | (v_tv_r & (|{cached_req, fencei_req, l2_amo_req, uncached_load_req, uncached_store_req, wt_req}));
+  assign cache_req_v_o = is_req ||
+    (is_ready & v_tv_r & (|{cached_req, fencei_req, l2_amo_req, uncached_load_req, uncached_store_req, wt_req}));
 
   always_comb
     begin
@@ -852,7 +890,7 @@ module bp_be_dcache
       cache_req_cast_o.hit = load_hit_tv;
 
       // Assigning sizes to cache miss packet
-      if (cached_req)
+      if (cached_req & ~wt_req)
         begin
             cache_req_cast_o.size = block_req_size;
         end
@@ -887,7 +925,7 @@ module bp_be_dcache
         cache_req_cast_o.msg_type = e_miss_load;
       else if (lr_miss_tv)
         cache_req_cast_o.msg_type = e_miss_store;
-      else if (store_miss_tv)
+      else if (store_miss_tv & (writethrough_p == 0))
         cache_req_cast_o.msg_type = e_miss_store;
       else if (fencei_miss_tv)
         cache_req_cast_o.msg_type = e_cache_flush;
@@ -897,7 +935,7 @@ module bp_be_dcache
         cache_req_cast_o.msg_type = e_uc_load;
       else if (uncached_store_req)
         cache_req_cast_o.msg_type = e_uc_store;
-      else if (wt_req)
+      else
         cache_req_cast_o.msg_type = e_wt_store;
     end
 
@@ -933,24 +971,28 @@ module bp_be_dcache
   //   e_ready  : Cache is ready to accept requests
   //   e_miss   : Cache is waiting for a miss to be serviced
   //   e_fence  : Cache is waiting for a fence to be resolved
-  //   e_req    : Cache is waiting to send a request, but the engine is blocked
+  //   e_resume : Cache is syncing up after a fill. This is due to negedge
+  //                nonsense and probably not strictly necessary
+  //   e_late   : Cache is waiting for a late acknowledgement
   /////////////////////////////////////////////////////////////////////////////
   always_comb
     case (state_r)
-      e_ready: state_n = (cache_req_yumi_li & decode_tv_r.fencei_op)
-                         ? e_fence
-                         : (cache_req_yumi_li & ~nonblocking_req)
-                           ? e_miss
-                           : (cache_req_v_o & ~cache_req_yumi_li)
-                             ? e_req
-                             : e_ready;
-      e_miss : state_n = cache_req_complete_i ? e_ready : e_miss;
-      e_fence: state_n = cache_req_complete_i ? e_ready : e_fence;
-      e_req  : state_n = (cache_req_yumi_li & ~nonblocking_req)
-                         ? e_miss
-                         : (cache_req_yumi_li & nonblocking_req)
-                           ? e_ready
-                           : e_req;
+      e_ready : state_n = (cache_req_yumi_li & decode_tv_r.fencei_op)
+                          ? e_fence
+                          : (cache_req_yumi_li & ~nonblocking_req)
+                            ? e_miss
+                            : (cache_req_v_o & ~cache_req_yumi_li)
+                              ? e_req
+                              : e_ready;
+      e_req   : state_n = (cache_req_yumi_li & ~nonblocking_req)
+                          ? e_miss
+                          : (cache_req_yumi_li & nonblocking_req)
+                            ? e_ready
+                            : e_req;
+      e_miss  : state_n = cache_req_complete_i ? e_resume : e_miss;
+      e_fence : state_n = cache_req_complete_i ? e_ready : e_fence;
+      e_resume: state_n = (decode_tv_r.load_op & ~decode_tv_r.ptw_op) ? e_late : e_ready;
+      e_late  : state_n = late_yumi_i ? e_ready : e_late;
       default: state_n = e_ready;
     endcase
 
@@ -962,7 +1004,7 @@ module bp_be_dcache
       state_r <= state_n;
 
   assign ready_o = ~cache_req_busy_i & is_ready;
-  assign miss_request_flush = cache_req_yumi_li & ~nonblocking_req;
+  assign miss_request_flush = cache_req_v_o & ~nonblocking_req;
   assign engine_flush = cache_req_v_o & ~cache_req_yumi_li;
 
   /////////////////////////////////////////////////////////////////////////////
@@ -975,7 +1017,8 @@ module bp_be_dcache
   wire tag_mem_fast_read = (safe_tl_we & ~decode_lo.fencei_op);
   wire tag_mem_slow_read = tag_mem_pkt_yumi_lo & (tag_mem_pkt_cast_i.opcode == e_cache_tag_mem_read);
   wire tag_mem_slow_write = tag_mem_pkt_yumi_lo & (tag_mem_pkt_cast_i.opcode != e_cache_tag_mem_read);
-  wire tag_mem_fast_write = v_tv_r & uncached_op_tv_r & dram_op_tv_r & load_hit_tv;
+  wire tag_mem_fast_write = ((writethrough_p == 1'b1) && wbuf_fail_tv)
+    || (v_tv_r & (uncached_op_tv_r & dram_op_tv_r & ~uncached_hit_tv_r & load_hit_tv));
   assign sram_hazard_flush = tag_mem_fast_write;
 
   assign tag_mem_v_li = tag_mem_fast_read | tag_mem_slow_read | tag_mem_slow_write | tag_mem_fast_write;
@@ -1124,7 +1167,7 @@ module bp_be_dcache
   // TODO: With blocking TL and TV, we really should implement snooping for performance
   assign data_mem_pkt_yumi_lo = (data_mem_pkt_cast_i.opcode == e_cache_data_mem_uncached)
     ? ~cache_lock & data_mem_pkt_v_i
-    : ~cache_lock & data_mem_pkt_v_i & ~|data_mem_fast_read & ~_wbuf_v_lo & ~(v_tl_r & decode_tl_r.store_op) & ~(v_tv_r & decode_tv_r.store_op);
+    : ~cache_lock & data_mem_pkt_v_i & ~|data_mem_fast_read & ~wbuf_v_lo & ~(v_tl_r & decode_tl_r.store_op) & ~(v_tv_r & decode_tv_r.store_op);
 
   logic [lg_dcache_assoc_lp-1:0] data_mem_pkt_way_r;
   bsg_dff
@@ -1251,7 +1294,7 @@ module bp_be_dcache
       logic load_reserved_v_r;
 
       // Set reservation on successful LR, without a cache miss or upgrade request
-      wire set_reservation = lr_hit_tv & ~flush_self;
+      wire set_reservation = lr_hit_tv;
       // All SCs clear the reservation (regardless of success)
       // Invalidates from other harts which match the reservation address clear the reservation
       // Also invalidate on trap
@@ -1308,36 +1351,10 @@ module bp_be_dcache
         assign cache_lock                = '0;
     end
 
-  ///////////////////////////
-  // Uncached Load Storage
-  ///////////////////////////
-  wire uncached_pending_set = cache_req_yumi_li & (uncached_load_req | l2_amo_req);
-  // Invalidate uncached data if the cache when we successfully complete the request
-  // TODO: We currently block interrupts until we have replayed a cache miss or
-  //   uncached load. We should decouple the cache writeback from replay in the future
-  wire uncached_pending_clear = early_hit_v_o;
-  bsg_dff_reset_set_clear
-   #(.width_p(1))
-   uncached_pending_reg
-    (.clk_i(posedge_clk)
-     ,.reset_i(reset_i)
-
-     ,.set_i(uncached_pending_set)
-     ,.clear_i(uncached_pending_clear)
-     ,.data_o(uncached_pending_r)
-     );
-  assign replay_pending_o = uncached_pending_r;
-
-  wire uncached_load_data_set = data_mem_pkt_yumi_lo & (data_mem_pkt_cast_i.opcode == e_cache_data_mem_uncached);
-  bsg_dff_en
-   #(.width_p(dword_width_gp))
-   uncached_load_data_reg
-    (.clk_i(posedge_clk)
-     ,.en_i(uncached_load_data_set)
-
-     ,.data_i(data_mem_pkt_cast_i.data[0+:dword_width_gp])
-     ,.data_o(uncached_load_data_r)
-     );
+  assign late_rd_addr_o = decode_dm_r.rd_addr;
+  assign late_float_o   = decode_dm_r.float_op;
+  assign late_data_o    = final_data_o;
+  assign late_v_o       = is_late & v_dm_r;
 
   // synopsys translate_off
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -81,7 +81,7 @@ module bp_be_top
   bp_be_branch_pkt_s   br_pkt;
 
   logic dispatch_v, interrupt_v;
-  logic irq_pending_lo, irq_waiting_lo, replay_pending_lo;
+  logic irq_pending_lo, irq_waiting_lo;
 
   bp_be_commit_pkt_s commit_pkt;
   bp_be_ptw_fill_pkt_s ptw_fill_pkt;
@@ -138,7 +138,6 @@ module bp_be_top
      ,.long_ready_i(long_ready_lo)
      ,.ptw_busy_i(ptw_busy_lo)
      ,.irq_pending_i(irq_pending_lo)
-     ,.replay_pending_i(replay_pending_lo)
 
      ,.dispatch_v_o(dispatch_v)
      ,.interrupt_v_o(interrupt_v)
@@ -227,7 +226,6 @@ module bp_be_top
      ,.external_irq_i(external_irq_i)
      ,.irq_pending_o(irq_pending_lo)
      ,.irq_waiting_o(irq_waiting_lo)
-     ,.replay_pending_o(replay_pending_lo)
      ,.cmd_full_n_i(cmd_full_n_lo)
      );
 

--- a/bp_be/test/tb/bp_be_dcache/flist.vcs
+++ b/bp_be/test/tb/bp_be_dcache/flist.vcs
@@ -15,7 +15,7 @@ $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_dramsim3_unmap.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_test_rom.v
 $BASEJUMP_STL_DIR/testing/bsg_cache/common/bsg_nonsynth_random_yumi_gen.v
 # top files
-$BP_TOP_DIR/test/common/bp_nonsynth_cache_tracer.sv
+$BP_BE_DIR/test/common/bp_be_nonsynth_dcache_tracer.sv
 # me files
 $BP_ME_DIR/test/common/bp_me_nonsynth_pkg.sv
 $BP_ME_DIR/test/common/bp_cce_mmio_cfg_loader.sv

--- a/bp_be/test/tb/bp_be_dcache/testbench.sv
+++ b/bp_be/test/tb/bp_be_dcache/testbench.sv
@@ -296,53 +296,18 @@ module testbench
 
   // Tracers
   bind bp_be_dcache
-    bp_nonsynth_cache_tracer
+    bp_be_nonsynth_dcache_tracer
      #(.bp_params_p(bp_params_p)
-      ,.sets_p(sets_p)
-      ,.assoc_p(assoc_p)
-      ,.block_width_p(block_width_p)
-      ,.fill_width_p(fill_width_p)
-      ,.trace_file_p("dcache"))
+       ,.assoc_p(assoc_p)
+       ,.sets_p(sets_p)
+       ,.block_width_p(block_width_p)
+       ,.fill_width_p(fill_width_p)
+       )
      dcache_tracer
       (.clk_i(clk_i & (testbench.dcache_trace_p == 1))
-       ,.reset_i(reset_i)
-
        ,.freeze_i(cfg_bus_cast_i.freeze)
        ,.mhartid_i(cfg_bus_cast_i.core_id)
-
-       ,.v_tl_r(v_tl_r)
-
-       ,.v_tv_r(v_tv_r)
-       ,.addr_tv_r(paddr_tv_r)
-       ,.lr_miss_tv(lr_miss_tv)
-       ,.sc_op_tv_r(decode_tv_r.sc_op)
-       ,.sc_success(sc_success_tv)
-
-       ,.cache_req_v_o(cache_req_v_o)
-       ,.cache_req_o(cache_req_o)
-       ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
-       ,.cache_req_metadata_o(cache_req_metadata_o)
-       ,.cache_req_complete_i(cache_req_complete_i)
-
-       ,.v_o(early_hit_v_o)
-       ,.load_data(early_data_o[0+:65])
-       ,.store_data(st_data_tv_r[0+:64])
-       ,.wt_req(wt_req)
-       ,.cache_miss_o('0)
-
-       ,.data_mem_v_i(data_mem_v_li)
-       ,.data_mem_pkt_v_i(data_mem_pkt_v_i)
-       ,.data_mem_pkt_i(data_mem_pkt_i)
-       ,.data_mem_pkt_yumi_o(data_mem_pkt_yumi_o)
-
-       ,.tag_mem_v_i(tag_mem_v_li)
-       ,.tag_mem_pkt_v_i(tag_mem_pkt_v_i)
-       ,.tag_mem_pkt_i(tag_mem_pkt_i)
-       ,.tag_mem_pkt_yumi_o(tag_mem_pkt_yumi_o)
-
-       ,.stat_mem_pkt_v_i(stat_mem_pkt_v_i)
-       ,.stat_mem_pkt_i(stat_mem_pkt_i)
-       ,.stat_mem_pkt_yumi_o(stat_mem_pkt_yumi_o)
+       ,.*
        );
 
   if (uce_p == 0) begin

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -98,12 +98,14 @@ module wrapper
 
    logic [num_caches_p-1:0][ptag_width_p-1:0] rolly_ptag_r;
    logic [num_caches_p-1:0] rolly_uncached_r;
-   logic [num_caches_p-1:0] is_store, is_store_rr, dcache_v_rr, poison_li;
+   logic [num_caches_p-1:0] is_store, is_store_rr, dcache_v_rr;
 
    logic [num_caches_p-1:0][dpath_width_gp-1:0] early_data_lo;
    logic [num_caches_p-1:0] early_v_lo;
    logic [num_caches_p-1:0][dpath_width_gp-1:0] final_data_lo;
    logic [num_caches_p-1:0] final_v_lo;
+   logic [num_caches_p-1:0][dpath_width_gp-1:0] late_data_lo;
+   logic [num_caches_p-1:0] late_v_lo;
 
    // LCE-CCE connections - to/from LCE
    logic [num_caches_p-1:0] lce_req_v_lo, lce_resp_v_lo;
@@ -159,7 +161,7 @@ module wrapper
 
         ,.roll_v_i(rollback_li[i])
         ,.clr_v_i(1'b0)
-        ,.deq_v_i(v_o[i])
+        ,.deq_v_i(dcache_v_rr[i])
 
         ,.data_i({uncached_i[i], ptag_i[i], dcache_pkt_i[i]})
         ,.v_i(v_i[i])
@@ -195,8 +197,7 @@ module wrapper
         ,.data_o({is_store_rr[i], dcache_v_rr[i]})
         );
 
-       assign poison_li[i] = dcache_v_rr[i] & ~v_o[i];
-       assign rollback_li[i] = poison_li[i];
+       assign rollback_li[i] = dcache_v_rr[i] & ~v_o[i];
 
        bp_be_dcache
        #(.bp_params_p(bp_params_p)
@@ -221,14 +222,18 @@ module wrapper
        ,.early_miss_v_o()
        ,.final_data_o(final_data_lo[i])
        ,.final_v_o(final_v_lo[i])
+       ,.late_rd_addr_o()
+       ,.late_float_o()
+       ,.late_data_o(late_data_lo[i])
+       ,.late_v_o(late_v_lo[i])
+       ,.late_yumi_i(late_v_lo[i])
 
        ,.ptag_v_i(1'b1)
        ,.ptag_i(rolly_ptag_r[i])
        ,.ptag_uncached_i(rolly_uncached_r[i])
        ,.ptag_dram_i(1'b1)
 
-       ,.flush_i(poison_li[i])
-       ,.replay_pending_o()
+       ,.flush_i('0)
 
        ,.cache_req_v_o(cache_req_v_lo[i])
        ,.cache_req_o(cache_req_lo[i])
@@ -259,8 +264,8 @@ module wrapper
        );
 
        // Stores "return" 0 to the trace replay module
-       assign data_o[i] = is_store_rr[i] ? '0 : final_data_lo[i];
-       assign v_o[i] = final_v_lo[i];
+       assign data_o[i] = late_v_lo[i] ? late_data_lo : is_store_rr[i] ? '0 : final_data_lo[i];
+       assign v_o[i] = late_v_lo[i] | final_v_lo[i];
 
        if (uce_p == 0)
          begin : lce

--- a/bp_common/src/include/bp_common_host_pkgdef.svh
+++ b/bp_common/src/include/bp_common_host_pkgdef.svh
@@ -2,7 +2,6 @@
 `ifndef BP_COMMON_HOST_PKGDEF_SVH
 `define BP_COMMON_HOST_PKGDEF_SVH
 
-
   localparam host_base_addr_gp         = (dev_id_width_gp+dev_addr_width_gp)'('h0010_0000);
   localparam host_match_addr_gp        = (dev_id_width_gp+dev_addr_width_gp)'('h001?_????);
 
@@ -17,6 +16,8 @@
 
   localparam putch_core_base_addr_gp   = (dev_addr_width_gp)'('h0_3000);
   localparam putch_core_match_addr_gp  = (dev_addr_width_gp)'('h0_3???);
+
+  localparam finish_all_addr_gp        = (dev_addr_width_gp)'('h0_4000);
 
   localparam bootrom_base_addr_gp      = (dev_addr_width_gp)'('h1_0000);
   localparam bootrom_match_addr_gp     = (dev_addr_width_gp)'('h1_????);

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -72,7 +72,6 @@ module bp_fe_icache
    , output logic [instr_width_gp-1:0]                data_o
    , output logic                                     data_v_o
    , output logic                                     miss_v_o
-   , input                                            poison_tv_i
 
    // Cache Engine Interface
    // This is considered the "slow path", handling uncached requests
@@ -387,7 +386,7 @@ module bp_fe_icache
   wire uncached_req = v_tv_r & uncached_op_tv_r & fill_tv_r & ~uncached_pending_r;
   wire fencei_req   = v_tv_r & fencei_op_tv_r & !coherent_p;
 
-  assign cache_req_v_o = |{uncached_req, cached_req, fencei_req} & ~poison_tv_i;
+  assign cache_req_v_o = |{uncached_req, cached_req, fencei_req};
   assign cache_req_cast_o =
    '{addr     : paddr_tv_r
      ,size    : cached_req ? block_req_size : uncached_req_size
@@ -659,7 +658,7 @@ module bp_fe_icache
   ///////////////////////////
   wire uncached_pending_set = cache_req_yumi_i & uncached_req;
   // Invalidate uncached data if the cache when we successfully complete the request
-  wire uncached_pending_clear = poison_tl_i | poison_tv_i | data_v_o;
+  wire uncached_pending_clear = poison_tl_i | data_v_o;
   bsg_dff_reset_set_clear
    #(.width_p(1), .clear_over_set_p(1))
    uncached_pending_reg

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -270,7 +270,7 @@ module bp_fe_top
   wire icache_v_li = next_pc_yumi_li | icache_fence_v;
   logic [instr_width_gp-1:0] icache_data_lo;
   logic icache_ready_lo, icache_data_v_lo, icache_miss_v_lo;
-  logic icache_poison_tl, icache_poison_tv;
+  logic icache_poison_tl;
   bp_fe_icache
    #(.bp_params_p(bp_params_p))
    icache
@@ -293,7 +293,6 @@ module bp_fe_top
      ,.data_o(icache_data_lo)
      ,.data_v_o(icache_data_v_lo)
      ,.miss_v_o(icache_miss_v_lo)
-     ,.poison_tv_i(icache_poison_tv)
 
      ,.cache_req_o(cache_req_o)
      ,.cache_req_v_o(cache_req_v_o)
@@ -354,7 +353,6 @@ module bp_fe_top
   assign fe_queue_v_o = fe_queue_ready_i & (fe_instr_v | fe_exception_v) & ~cmd_nonattaboy_v;
 
   assign icache_poison_tl = ovr_lo | fe_exception_v | queue_miss | cmd_nonattaboy_v;
-  assign icache_poison_tv = fe_exception_v | cmd_nonattaboy_v;
 
   assign fe_cmd_yumi_o = pc_gen_init_done_lo & (cmd_nonattaboy_v | attaboy_yumi_lo);
   assign next_pc_yumi_li = (state_n == e_run);

--- a/bp_fe/test/tb/bp_fe_icache/flist.vcs
+++ b/bp_fe/test/tb/bp_fe_icache/flist.vcs
@@ -15,7 +15,7 @@ $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_dramsim3_unmap.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_test_rom.v
 $BASEJUMP_STL_DIR/testing/bsg_cache/common/bsg_nonsynth_random_yumi_gen.v
 # top files
-$BP_TOP_DIR/test/common/bp_nonsynth_cache_tracer.sv
+$BP_FE_DIR/test/common/bp_fe_nonsynth_icache_tracer.sv
 # me files
 $BP_ME_DIR/test/common/bp_me_nonsynth_pkg.sv
 $BP_ME_DIR/test/common/bp_cce_mmio_cfg_loader.sv

--- a/bp_fe/test/tb/bp_fe_icache/testbench.sv
+++ b/bp_fe/test/tb/bp_fe_icache/testbench.sv
@@ -265,55 +265,19 @@ module testbench
 
   // I$ tracer
   bind bp_fe_icache
-    bp_nonsynth_cache_tracer
-    #(.bp_params_p(bp_params_p)
-     ,.assoc_p(assoc_p)
-     ,.sets_p(sets_p)
-     ,.block_width_p(block_width_p)
-     ,.fill_width_p(fill_width_p)
-     ,.trace_file_p("icache"))
-    icache_tracer
+    bp_fe_nonsynth_icache_tracer
+     #(.bp_params_p(bp_params_p)
+       ,.assoc_p(assoc_p)
+       ,.sets_p(sets_p)
+       ,.block_width_p(block_width_p)
+       ,.fill_width_p(fill_width_p)
+       )
+     icache_tracer
       (.clk_i(clk_i & (testbench.icache_trace_p == 1))
-      ,.reset_i(reset_i)
-
-      ,.freeze_i(cfg_bus_cast_i.freeze)
-      ,.mhartid_i(cfg_bus_cast_i.core_id)
-
-      ,.v_tl_r(v_tl_r)
-
-      ,.v_tv_r(v_tv_r)
-      ,.addr_tv_r(paddr_tv_r)
-      ,.lr_miss_tv(1'b0)
-      ,.sc_op_tv_r(1'b0)
-      ,.sc_success(1'b0)
-
-      ,.cache_req_o(cache_req_o)
-      ,.cache_req_v_o(cache_req_v_o)
-      ,.cache_req_metadata_o(cache_req_metadata_o)
-      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
-      ,.cache_req_complete_i(cache_req_complete_i)
-
-      ,.wt_req()
-
-      ,.v_o(data_v_o)
-      ,.load_data(65'(data_o))
-      ,.store_data(64'(0))
-      ,.cache_miss_o('0)
-
-      ,.data_mem_v_i(data_mem_v_li)
-      ,.data_mem_pkt_v_i(data_mem_pkt_v_i)
-      ,.data_mem_pkt_i(data_mem_pkt_i)
-      ,.data_mem_pkt_yumi_o(data_mem_pkt_yumi_o)
-
-      ,.tag_mem_v_i(tag_mem_v_li)
-      ,.tag_mem_pkt_v_i(tag_mem_pkt_v_i)
-      ,.tag_mem_pkt_i(tag_mem_pkt_i)
-      ,.tag_mem_pkt_yumi_o(tag_mem_pkt_yumi_o)
-
-      ,.stat_mem_pkt_v_i(stat_mem_pkt_v_i)
-      ,.stat_mem_pkt_i(stat_mem_pkt_i)
-      ,.stat_mem_pkt_yumi_o(stat_mem_pkt_yumi_o)
-      );
+       ,.freeze_i(cfg_bus_cast_i.freeze)
+       ,.mhartid_i(cfg_bus_cast_i.core_id)
+       ,.*
+       );
 
   // CCE tracer
   if (uce_p == 0) begin

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -193,7 +193,6 @@ module wrapper
      ,.data_o(data_o)
      ,.data_v_o(data_v_o)
      ,.miss_v_o()
-     ,.poison_tv_i(1'b0)
 
      ,.cache_req_o(cache_req_lo)
      ,.cache_req_v_o(cache_req_v_lo)

--- a/bp_me/src/v/cce/bp_uce.sv
+++ b/bp_me/src/v/cce/bp_uce.sv
@@ -147,8 +147,9 @@ module bp_uce
   wire is_writeback_wb    = (state_r == e_writeback_write_req); // send dirty data from UCE to L2
   wire is_write_request   = (state_r == e_write_wait);
   wire is_read_request    = (state_r == e_read_wait);
+  wire is_uc_read_wait    = (state_r == e_uc_read_wait);
 
-  logic cache_req_v_r;
+  logic cache_req_done, cache_req_v_r;
   bsg_dff_reset_set_clear
    #(.width_p(1))
    cache_req_v_reg
@@ -156,7 +157,7 @@ module bp_uce
      ,.reset_i(reset_i)
 
      ,.set_i(cache_req_yumi_o)
-     ,.clear_i(cache_req_complete_o)
+     ,.clear_i(cache_req_done)
      ,.data_o(cache_req_v_r)
      );
 
@@ -293,8 +294,8 @@ module bp_uce
      ,.fsm_ready_and_o(fsm_cmd_ready_and_li)
      ,.fsm_cnt_o(fsm_cmd_cnt)
      ,.fsm_new_o(fsm_cmd_new)
-     ,.fsm_last_o(/* unused */)
      ,.fsm_done_o(fsm_cmd_done)
+     ,.fsm_last_o(/* unused */)
      );
 
   bp_bedrock_uce_mem_msg_header_s fsm_resp_header_li;
@@ -353,6 +354,8 @@ module bp_uce
   wire uc_amo_v_r     = cache_req_v_r & cache_req_r.msg_type inside {e_uc_amo};
   wire uc_hit_v_r     = cache_req_v_r & cache_req_r.hit & (uc_load_v_r | uc_store_v_r | uc_amo_v_r);
 
+  assign cache_req_complete_o = cache_req_done & ~(uc_store_v_r | wt_store_v_r);
+
   wire [block_size_in_fill_lp-1:0] fill_index_shift = {{(assoc_p != 1){fsm_resp_addr_li[byte_offset_width_lp+:bank_offset_width_lp] >> bank_sub_offset_width_lp}}, {(assoc_p == 1){'0}}};
 
   logic [index_width_lp-1:0] index_cnt;
@@ -373,7 +376,7 @@ module bp_uce
      );
   wire index_done = (index_cnt == sets_p-1);
 
-  logic [way_width_lp-1:0] way_cnt;
+  logic [`BSG_SAFE_CLOG2(assoc_p)-1:0] way_cnt;
   logic way_up;
   bsg_counter_clear_up
    #(.max_val_p(assoc_p-1)
@@ -442,7 +445,9 @@ module bp_uce
      ,.data_o(critical_pending)
      );
   // This is sufficient for UCE because we only set tags on requests, not invalidation
-  assign cache_req_critical_tag_o = tag_mem_pkt_yumi_i & (tag_mem_pkt_cast_o.opcode == e_cache_tag_mem_set_tag);
+  assign cache_req_critical_tag_o =
+    (tag_mem_pkt_yumi_i & (tag_mem_pkt_cast_o.opcode == e_cache_tag_mem_set_tag))
+    || (is_uc_read_wait & data_mem_pkt_yumi_i);
   assign cache_req_critical_data_o = critical_pending & critical_recv;
 
   bp_cache_req_wr_subop_e cache_wr_subop;
@@ -484,7 +489,7 @@ module bp_uce
       stat_mem_pkt_cast_o = '0;
       stat_mem_pkt_v_o    = '0;
 
-      cache_req_complete_o = '0;
+      cache_req_done = '0;
 
       fsm_cmd_header_lo = '0;
       fsm_cmd_data_lo = '0;
@@ -511,7 +516,7 @@ module bp_uce
 
             index_up = tag_mem_pkt_yumi_i & stat_mem_pkt_yumi_i;
 
-            cache_req_complete_o = (index_done & index_up);
+            cache_req_done = (index_done & index_up);
 
             state_n = (index_done & index_up) ? e_ready : e_clear;
           end
@@ -583,28 +588,28 @@ module bp_uce
           end
         e_flush_fence:
           begin
-            cache_req_complete_o = cache_req_credits_empty_o;
+            cache_req_done = cache_req_credits_empty_o;
 
-            state_n = cache_req_complete_o ? e_ready : e_flush_fence;
+            state_n = cache_req_done ? e_ready : e_flush_fence;
           end
         e_ready:
           begin
             // Fire off a non-blocking request if we have one
-            if ((uc_store_v_r && (~uc_hit_v_r || (l1_writethrough_p == 1))) || wt_store_v_r)
+            if (uc_store_v_r || wt_store_v_r)
               begin
                 fsm_cmd_header_lo.msg_type       = e_bedrock_mem_uc_wr;
                 fsm_cmd_header_lo.addr           = cache_req_r.addr;
                 fsm_cmd_header_lo.size           = bp_bedrock_msg_size_e'(cache_req_r.size);
-                fsm_cmd_header_lo.payload.lce_id           = lce_id_i;
+                fsm_cmd_header_lo.payload.lce_id = lce_id_i;
                 fsm_cmd_header_lo.subop          = mem_wr_subop;
                 fsm_cmd_data_lo                  = cache_req_r.data;
                 fsm_cmd_v_lo = ~cache_req_credits_full_o;
 
-                cache_req_complete_o = mem_cmd_ready_and_i & mem_cmd_v_o;
+                cache_req_done = fsm_cmd_ready_and_li & fsm_cmd_v_lo;
               end
 
             // We can accept a new request as long as we send out an old one this cycle
-            cache_req_yumi_o = cache_req_v_i & (~cache_req_v_r | cache_req_complete_o);
+            cache_req_yumi_o = cache_req_v_i & (~cache_req_v_r | cache_req_done);
 
             state_n = cache_req_yumi_o
                       ? flush_v_li
@@ -613,7 +618,9 @@ module bp_uce
                           ? e_clear
                           : (uc_hit_v_li & (l1_writethrough_p == 0))
                             ? e_uc_writeback_evict
-                            : e_send_critical
+                            : (uc_store_v_li || wt_store_v_li)
+                              ? e_ready
+                              : e_send_critical
                       : e_ready;
           end
 
@@ -631,7 +638,7 @@ module bp_uce
             stat_mem_pkt_v_o = cache_req_metadata_v_r & cache_req_metadata_r.dirty;
 
             state_n = (cache_req_metadata_v_r & ~cache_req_metadata_r.dirty)
-                      ? e_send_critical
+                      ? uc_store_v_r ? e_ready : e_send_critical
                       : (data_mem_pkt_yumi_i & stat_mem_pkt_yumi_i)
                         ? e_uc_writeback_write_req
                         : e_uc_writeback_evict;
@@ -646,7 +653,7 @@ module bp_uce
             fsm_cmd_data_lo                  = writeback_data;
             fsm_cmd_v_lo = ~cache_req_credits_full_o;
 
-            state_n = fsm_cmd_done ? e_send_critical : e_uc_writeback_write_req;
+            state_n = fsm_cmd_done ? uc_store_v_r ? e_ready : e_send_critical : e_uc_writeback_write_req;
           end
 
         e_send_critical:
@@ -665,23 +672,18 @@ module bp_uce
                           : e_read_wait
                         : e_send_critical;
             end
-          else if (uc_load_v_r | uc_amo_v_r | uc_store_v_r | wt_store_v_r)
+          else if (uc_load_v_r | uc_amo_v_r)
             begin
-              fsm_cmd_header_lo.msg_type = uc_load_v_r ? e_bedrock_mem_uc_rd : uc_amo_v_r ? e_bedrock_mem_amo : e_bedrock_mem_uc_wr;
+              fsm_cmd_header_lo.msg_type = uc_load_v_r ? e_bedrock_mem_uc_rd : e_bedrock_mem_amo;
               fsm_cmd_header_lo.addr     = cache_req_r.addr;
               fsm_cmd_header_lo.size     = bp_bedrock_msg_size_e'(cache_req_r.size);
-              fsm_cmd_header_lo.payload.lce_id     = lce_id_i;
+              fsm_cmd_header_lo.payload.lce_id = lce_id_i;
               fsm_cmd_header_lo.subop    = mem_wr_subop;
               fsm_cmd_data_lo            = cache_req_r.data;
               fsm_cmd_v_lo = ~cache_req_credits_full_o;
 
-              // We filter cache_req_complete here
-              cache_req_complete_o = (fsm_cmd_ready_and_li & fsm_cmd_v_lo) & (uc_store_v_r | wt_store_v_r);
-
               state_n = (fsm_cmd_ready_and_li & fsm_cmd_v_lo)
-                        ? (uc_store_v_r | wt_store_v_r)
-                          ? e_ready
-                          : e_uc_read_wait
+                        ? e_uc_read_wait
                         : e_send_critical;
             end
 
@@ -724,8 +726,8 @@ module bp_uce
             data_mem_pkt_v_o = load_resp_v_li;
 
             load_resp_yumi_lo = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
-            cache_req_complete_o = fsm_resp_done & load_resp_yumi_lo;
-            state_n = cache_req_complete_o ? e_writeback_write_req : e_writeback_read_req;
+            cache_req_done = fsm_resp_done & load_resp_yumi_lo;
+            state_n = cache_req_done ? e_writeback_write_req : e_writeback_read_req;
           end
         e_writeback_write_req:
           begin
@@ -757,8 +759,8 @@ module bp_uce
             data_mem_pkt_v_o = load_resp_v_li;
 
             load_resp_yumi_lo = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
-            cache_req_complete_o = fsm_resp_done & load_resp_yumi_lo;
-            state_n = cache_req_complete_o ? e_ready : e_read_wait;
+            cache_req_done = fsm_resp_done & load_resp_yumi_lo;
+            state_n = cache_req_done ? e_ready : e_read_wait;
           end
         e_uc_read_wait:
           begin
@@ -766,10 +768,10 @@ module bp_uce
             data_mem_pkt_cast_o.data = {(fill_width_p/dword_width_gp){fsm_resp_data_li[0+:dword_width_gp]}};
             data_mem_pkt_v_o = load_resp_v_li;
 
-            cache_req_complete_o = data_mem_pkt_yumi_i;
-            load_resp_yumi_lo = cache_req_complete_o;
+            cache_req_done = data_mem_pkt_yumi_i;
+            load_resp_yumi_lo = cache_req_done;
 
-            state_n = cache_req_complete_o ? e_ready : e_uc_read_wait;
+            state_n = cache_req_done ? e_ready : e_uc_read_wait;
           end
         default: state_n = e_reset;
       endcase

--- a/bp_me/src/v/lce/bp_lce_cmd.sv
+++ b/bp_me/src/v/lce/bp_lce_cmd.sv
@@ -404,8 +404,8 @@ module bp_lce_cmd
 
               // TODO: This is sufficient for the critical signal when only
               //   line width fills
-              cache_req_critical_tag_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
-              cache_req_critical_data_o = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
+              cache_req_critical_tag_o = tag_mem_pkt_yumi_i;
+              cache_req_critical_data_o = data_mem_pkt_yumi_i;
 
               // send coherence ack after updating tag and data memories
               state_n = (tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i)
@@ -423,6 +423,8 @@ module bp_lce_cmd
               tag_mem_pkt.tag = lce_cmd_addr_tag;
               tag_mem_pkt.opcode = e_cache_tag_mem_set_state;
               tag_mem_pkt_v_o = lce_cmd_v_i;
+
+              cache_req_critical_tag_o = tag_mem_pkt_yumi_i;
 
               state_n = tag_mem_pkt_yumi_i
                         ? e_coh_ack
@@ -537,6 +539,7 @@ module bp_lce_cmd
 
               lce_cmd_yumi_o = data_mem_pkt_yumi_i;
 
+              cache_req_critical_tag_o = lce_cmd_yumi_o;
               cache_req_critical_data_o = lce_cmd_yumi_o;
               cache_req_complete_o = lce_cmd_yumi_o;
             end

--- a/bp_me/src/v/network/bp_me_burst_to_stream.sv
+++ b/bp_me/src/v/network/bp_me_burst_to_stream.sv
@@ -108,6 +108,7 @@ module bp_me_burst_to_stream
        ,.fsm_ready_and_o(fsm_ready_and_lo)
        ,.fsm_new_o(stream_new_lo)
        ,.fsm_cnt_o()
+       ,.fsm_last_o()
        ,.fsm_done_o(stream_done_lo)
        );
 

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -91,6 +91,9 @@ module bp_cacc_vdp
      ,.dram_o(dcache_dram)
      );
 
+  // TODO: Actually use the late signal, but we don't really care about performance
+  //   for the purposes of this demo
+  logic late_v;
   bp_be_dcache
    #(.bp_params_p(bp_params_p)
      ,.sets_p(acache_sets_p)
@@ -113,6 +116,11 @@ module bp_cacc_vdp
      ,.early_data_o(dcache_data)
      ,.final_v_o()
      ,.final_data_o()
+     ,.late_rd_addr_o()
+     ,.late_data_o()
+     ,.late_float_o()
+     ,.late_v_o(late_v)
+     ,.late_yumi_i(late_v)
 
      ,.ptag_v_i(1'b1)
      ,.ptag_i(dcache_ptag)
@@ -120,7 +128,6 @@ module bp_cacc_vdp
      ,.ptag_dram_i(dcache_dram)
 
      ,.flush_i(1'b0)
-     ,.replay_pending_o()
 
      // D$-LCE Interface
      ,.cache_req_complete_i(cache_req_complete_lo)

--- a/bp_top/test/common/bp_nonsynth_host.sv
+++ b/bp_top/test/common/bp_nonsynth_host.sv
@@ -165,6 +165,8 @@ module bp_nonsynth_host
       if (getchar_r_v_li)
         pop();
 
+      if (mem_cmd_ready_and_o & mem_cmd_v_i & (hio_id != '0))
+        $error("Warning: Accesing illegal hio %0h. Sending loopback message!", hio_id);
       for (integer i = 0; i < num_core_p; i++)
         begin
           // PASS when returned value in finish packet is zero

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -71,7 +71,11 @@ module testbench
   bit clk_i;
   bit cosim_clk_i, cosim_reset_i, dram_clk_i, dram_reset_i;
 
-  bsg_nonsynth_clock_gen
+  `ifdef VERILATOR
+    bsg_nonsynth_dpi_clock_gen
+  `else
+    bsg_nonsynth_clock_gen
+  `endif
    #(.cycle_time_p(`BP_SIM_CLK_PERIOD))
    clock_gen
     (.o(clk_i));
@@ -86,7 +90,11 @@ module testbench
      ,.async_reset_o(reset_i)
      );
 
-  bsg_nonsynth_clock_gen
+  `ifdef VERILATOR
+    bsg_nonsynth_dpi_clock_gen
+  `else
+    bsg_nonsynth_clock_gen
+  `endif
    #(.cycle_time_p(`dram_pkg::tck_ps))
    dram_clock_gen
     (.o(dram_clk_i));
@@ -101,10 +109,14 @@ module testbench
      ,.async_reset_o(dram_reset_i)
      );
 
-   bsg_nonsynth_clock_gen
-    #(.cycle_time_p(`BP_SIM_CLK_PERIOD/5))
-    cosim_clk_gen
-     (.o(cosim_clk_i));
+  `ifdef VERILATOR
+    bsg_nonsynth_dpi_clock_gen
+  `else
+    bsg_nonsynth_clock_gen
+  `endif
+   #(.cycle_time_p(`BP_SIM_CLK_PERIOD/5))
+   cosim_clk_gen
+    (.o(cosim_clk_i));
 
   bsg_nonsynth_reset_gen
    #(.num_clocks_p(1)
@@ -116,10 +128,10 @@ module testbench
      ,.async_reset_o(cosim_reset_i)
      );
 
-  bp_bedrock_io_mem_msg_header_s proc_io_cmd_lo;
+  bp_bedrock_io_mem_msg_header_s proc_io_cmd_header_lo;
   logic [io_data_width_p-1:0] proc_io_cmd_data_lo;
   logic proc_io_cmd_v_lo, proc_io_cmd_ready_and_li, proc_io_cmd_last_lo;
-  bp_bedrock_io_mem_msg_header_s proc_io_resp_li;
+  bp_bedrock_io_mem_msg_header_s proc_io_resp_header_li;
   logic [io_data_width_p-1:0] proc_io_resp_data_li;
   logic proc_io_resp_v_li, proc_io_resp_ready_and_lo;
   logic proc_io_resp_last_li;
@@ -144,13 +156,13 @@ module testbench
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.io_cmd_header_o(proc_io_cmd_lo)
+     ,.io_cmd_header_o(proc_io_cmd_header_lo)
      ,.io_cmd_data_o(proc_io_cmd_data_lo)
      ,.io_cmd_v_o(proc_io_cmd_v_lo)
      ,.io_cmd_ready_and_i(proc_io_cmd_ready_and_li)
      ,.io_cmd_last_o(proc_io_cmd_last_lo)
 
-     ,.io_resp_header_i(proc_io_resp_li)
+     ,.io_resp_header_i(proc_io_resp_header_li)
      ,.io_resp_data_i(proc_io_resp_data_li)
      ,.io_resp_v_i(proc_io_resp_v_li)
      ,.io_resp_ready_and_o(proc_io_resp_ready_and_lo)
@@ -264,13 +276,13 @@ module testbench
      ,.reset_i(reset_i)
 
      // data width = dword_width_gp on mem_cmd/resp ports
-     ,.mem_cmd_header_i(proc_io_cmd_lo)
+     ,.mem_cmd_header_i(proc_io_cmd_header_lo)
      ,.mem_cmd_data_i(proc_io_cmd_data_lo[0+:dword_width_gp])
      ,.mem_cmd_v_i(proc_io_cmd_v_lo)
      ,.mem_cmd_ready_and_o(proc_io_cmd_ready_and_li)
      ,.mem_cmd_last_i(proc_io_cmd_last_lo)
 
-     ,.mem_resp_header_o(proc_io_resp_li)
+     ,.mem_resp_header_o(proc_io_resp_header_li)
      ,.mem_resp_data_o(proc_io_resp_data_li[0+:dword_width_gp])
      ,.mem_resp_v_o(proc_io_resp_v_li)
      ,.mem_resp_ready_and_i(proc_io_resp_ready_and_lo)
@@ -310,7 +322,7 @@ module testbench
       bind bp_be_top
         bp_nonsynth_watchdog
          #(.bp_params_p(bp_params_p)
-           ,.stall_cycles_p(1000000)
+           ,.stall_cycles_p(100000)
            ,.halt_cycles_p(10000)
            ,.heartbeat_instr_p(100000)
            )
@@ -365,6 +377,11 @@ module testbench
            ,.frd_w_v_i(scheduler.fwb_pkt_cast_i.frd_w_v)
            ,.frd_addr_i(scheduler.fwb_pkt_cast_i.rd_addr)
            ,.frd_data_i(scheduler.fwb_pkt_cast_i.rd_data)
+
+           ,.cache_req_v_i(calculator.pipe_mem.dcache.cache_req_v_o)
+           ,.cache_req_ready_i(calculator.pipe_mem.dcache.is_ready)
+           ,.cache_req_complete_i(calculator.pipe_mem.dcache.cache_req_complete_i)
+           ,.cache_req_nonblocking_i(calculator.pipe_mem.dcache.nonblocking_req)
 
            ,.cosim_clk_i(testbench.cosim_clk_i)
            ,.cosim_reset_i(testbench.cosim_reset_i)
@@ -452,7 +469,7 @@ module testbench
 
            ,.dtlb_miss(be.calculator.pipe_mem.dtlb_miss_v)
            ,.dcache_miss(~be.calculator.pipe_mem.dcache.ready_o)
-           ,.dcache_rollback(be.scheduler.commit_pkt_cast_i.rollback)
+           ,.dcache_rollback(be.scheduler.commit_pkt_cast_i.npc_w_v)
            ,.long_haz(be.detector.long_haz_v)
            ,.exception(be.director.commit_pkt_cast_i.exception)
            ,.eret(be.director.commit_pkt_cast_i.eret)


### PR DESCRIPTION
## Summary
This PR more elegantly addresses non-idempotency issues in the replay D$.  Misses should be sent non-speculatively and immediately be followed by hits. This is especially important for L2 atomics, where replaying the action can result in hung locks, etc. Our implementation creates a "late" port for the D$ which can inject the miss into the register file and clear the scoreboard asynchronously with the rest of the pipeline. 

## Area
D$ and cache engines

## Analysis
Moderate increase in complexity and mild performance boost as we scoreboard D$ misses instead of stalling independent instructions. There should be an average energy decrease as we're also reducing the number of SRAM reads in the D$, but that's a secondary bonus

## Verification
Full regression and linux boot.

## Additional context
Builds on #938 