### PR TITLE
Enables local off-core I/O in bp_unicore_lite

### DIFF
--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -356,11 +356,13 @@ module bp_unicore_lite
       assign local_addr = proc_cmd_header_lo[i].addr;
       wire [dev_id_width_gp-1:0] device_cmd_li = local_addr.dev;
       wire local_cmd_li    = (proc_cmd_header_lo[i].addr < dram_base_addr_gp);
+      wire is_other_core   = local_cmd_li & (local_addr.tile != cfg_bus_lo.core_id);
       wire is_other_hio    = (proc_cmd_header_lo[i].addr[paddr_width_p-1-:hio_width_p] != 0);
 
       wire is_cfg_cmd      = local_cmd_li & (device_cmd_li == cfg_dev_gp);
       wire is_clint_cmd    = local_cmd_li & (device_cmd_li == clint_dev_gp);
-      wire is_io_cmd       = (local_cmd_li & (device_cmd_li inside {boot_dev_gp, host_dev_gp})) | is_other_hio;
+      wire is_io_cmd       = (local_cmd_li & (device_cmd_li inside {boot_dev_gp, host_dev_gp}))
+                             | is_other_hio | is_other_core;
       wire is_mem_cmd      = (~local_cmd_li & ~is_other_hio) || (local_cmd_li & (device_cmd_li == cache_dev_gp));
       wire is_loopback_cmd = local_cmd_li & ~is_cfg_cmd & ~is_clint_cmd & ~is_io_cmd & ~is_mem_cmd;
 

--- a/docs/platform_guide.md
+++ b/docs/platform_guide.md
@@ -30,8 +30,8 @@ BlackParrot supports the following CSRs:
 
 ## Memory-mapped Devices
 BlackParrot supports having a number of devices in each tile. In a standard BlackParrot tile there is:
-* CLINT (Core Local Interrupt Controller)
 * CFG (Tile Configuration Controller)
+* CLINT (Core Local Interrupt Controller)
 * L2S (L2 cache slice)
 
 The map for configuration registers within these devices is shown below.
@@ -116,6 +116,9 @@ addresses as they see fit. For instance, aliasing some of the DRAM space between
 that both cached and uncached are physically contiguous on the same DRAM.
 
 ### Local Address Map
+For a BlackParrots in a multicore, the local address space is sliced among all the tiles as shown
+below.
+
 * 0x00_0000_0000 - 0x00_0(nnnN)(D)(A_AAAA)
   * nnnN -> 7 bits = 128 max tiles
   * D -> 4 bits = 16 max devices
@@ -124,6 +127,10 @@ that both cached and uncached are physically contiguous on the same DRAM.
   * Devices: Configuration Link, CLINT
   * 0x00_0420_0002 -> tile 2, device 2, address 0008 -> Freeze register
   * 0x00_0030_bff8 -> tile 0, device 3, address bff8 -> CLINT mtime
+
+For a BlackParrot unicore, all addresses outside of N=k in this scheme are considered as I/O. This
+local space is useful for address-space constrained systems where this local space can be reused for
+accelerators, co-processors, etc.
 
 ### Full Listing of BlackParrot Configuration Registers
 Following is a list of the memory-mapped registers contained within a BlackParrot Unicore or BlackParrot Multicore Tile.


### PR DESCRIPTION
This PR changes the I/O logic in unicore lite to send non-local I/O requests outside of the unicore. This is useful for adding accelerators, coprocessors, etc.