### PR TITLE
Various CSR fixes

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -356,13 +356,6 @@ module bp_be_csr
       csr_csrw_o           = '0;
       csr_data_lo          = '0;
 
-      // Accumulate FFLAGS
-      fcsr_li.fflags |= fflags_acc_i;
-
-      // Set FS to dirty if: fflags set, frf written, fcsr written
-      mstatus_li.fs |= {2{(csr_w_v_li & csr_fany_li)}};
-      mstatus_li.fs |= {2{(retire_pkt_cast_i.instret & instr_fany_li)}};
-
       if (csr_cmd_v_i)
         begin
           // Check for access violations
@@ -464,7 +457,6 @@ module bp_be_csr
                 {1'b1, `CSR_ADDR_MVENDORID    }: begin end
                 {1'b1, `CSR_ADDR_MARCHID      }: begin end
                 {1'b1, `CSR_ADDR_MIMPID       }: begin end
-                {1'b1, `CSR_ADDR_MHARTID      }: begin end
                 {1'b1, `CSR_ADDR_MSTATUS      }: begin mstatus_li = csr_data_li; csr_csrw_o = 1'b1; end
                 {1'b1, `CSR_ADDR_MISA         }: begin end
                 {1'b1, `CSR_ADDR_MEDELEG      }: medeleg_li = csr_data_li;
@@ -606,9 +598,17 @@ module bp_be_csr
           dcsr_li.prv   = priv_mode_r;
         end
 
+      // Accumulate interrupts
       mip_li.mtip = timer_irq_i;
       mip_li.msip = software_irq_i;
       mip_li.meip = external_irq_i;
+
+      // Accumulate FFLAGS
+      fcsr_li.fflags |= fflags_acc_i;
+
+      // Set FS to dirty if: fflags set, frf written, fcsr written
+      mstatus_li.fs |= {2{(csr_w_v_li & csr_fany_li & ~csr_illegal_instr_o)}};
+      mstatus_li.fs |= {2{(retire_pkt_cast_i.instret & instr_fany_li)}};
     end
 
   // Debug Mode masks all interrupts

--- a/bp_common/src/include/bp_common_rv64_csr_defines.svh
+++ b/bp_common/src/include/bp_common_rv64_csr_defines.svh
@@ -211,8 +211,15 @@
   typedef logic [63:0] rv64_sscratch_s;                                                    \
   typedef logic [63:0] bp_sscratch_s;                                                      \
                                                                                            \
-  typedef logic [63:0] rv64_sepc_s;                                                        \
-  typedef logic [`BSG_MAX(vaddr_width_mp, paddr_width_mp)-1:0] bp_sepc_s;                  \
+  typedef struct packed                                                                    \
+  {                                                                                        \
+    logic [63:2] word_addr;                                                                \
+    logic [1:0]  zero;                                                                     \
+  }  rv64_sepc_s;                                                                          \
+  typedef struct packed                                                                    \
+  {                                                                                        \
+    logic [(`BSG_MAX(vaddr_width_mp, paddr_width_mp))-3:0] word_addr;                      \
+  }  bp_sepc_s;                                                                            \
                                                                                            \
   typedef struct packed                                                                    \
   {                                                                                        \
@@ -499,13 +506,20 @@
                                                                                            \
     logic msip;                                                                            \
     logic ssip;                                                                            \
-  }   bp_mip_s;                                                                            \
+  }  bp_mip_s;                                                                             \
                                                                                            \
   typedef logic [63:0] rv64_mtval_s;                                                       \
   typedef logic [`BSG_MAX(vaddr_width_mp, paddr_width_mp)-1:0] bp_mtval_s;                 \
                                                                                            \
-  typedef logic [63:0] rv64_mepc_s;                                                        \
-  typedef logic [`BSG_MAX(vaddr_width_mp, paddr_width_mp)-1:0] bp_mepc_s;                  \
+  typedef struct packed                                                                    \
+  {                                                                                        \
+    logic [63:2] word_addr;                                                                \
+    logic [1:0]  zero;                                                                     \
+  }  rv64_mepc_s;                                                                          \
+  typedef struct packed                                                                    \
+  {                                                                                        \
+    logic [`BSG_MAX(vaddr_width_mp, paddr_width_mp)-3:0] word_addr;                        \
+  }  bp_mepc_s;                                                                            \
                                                                                            \
   typedef struct packed                                                                    \
   {                                                                                        \
@@ -725,10 +739,12 @@
   `define bp_sepc_width ($bits(bp_sepc_s))
 
   `define compress_sepc_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) \
-    bp_sepc_s'(data_cast_mp[0+:`BSG_MAX(vaddr_width_mp, paddr_width_mp)])
+    bp_sepc_s'(data_cast_mp.word_addr)
 
   `define decompress_sepc_s(data_comp_mp) \
-    `BSG_SIGN_EXTEND(data_comp_mp, 64)
+    '{word_addr: `BSG_SIGN_EXTEND(data_comp_mp.word_addr, 62) \
+      ,zero    : 2'b00                                        \
+      }
 
   `define compress_scause_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) \
     '{_interrupt: data_cast_mp._interrupt \
@@ -904,10 +920,12 @@
     `BSG_SIGN_EXTEND(data_comp_mp, 64)
 
   `define compress_mepc_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) \
-    bp_mepc_s'(data_cast_mp[0+:`BSG_MAX(vaddr_width_mp, paddr_width_mp)])
+    bp_mepc_s'(data_cast_mp.word_addr)
 
   `define decompress_mepc_s(data_comp_mp) \
-    `BSG_SIGN_EXTEND(data_comp_mp, 64)
+    '{word_addr: `BSG_SIGN_EXTEND(data_comp_mp.word_addr, 62) \
+      ,zero    : 2'b00                                        \
+      }
 
   `define compress_pmpcfg_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) \
     '{pmpcfg: data_cast_mp.pmpcfg[0+:4]}

--- a/bp_top/test/common/bp_nonsynth_cosim.sv
+++ b/bp_top/test/common/bp_nonsynth_cosim.sv
@@ -283,13 +283,15 @@ module bp_nonsynth_cosim
     end
 
   always_ff @(posedge cosim_clk_i)
-    if (trace_en_i & commit_fifo_yumi_li & instret_v_r & commit_pc_r != '0)
+    if (trace_en_i & commit_fifo_yumi_li & commit_pc_r != '0)
       begin
         $fwrite(file, "%x %x %x %x ", mhartid_i, commit_pc_r, commit_instr_r, instr_cnt);
-        if (commit_fifo_yumi_li & commit_ird_w_v_r)
+        if (instret_v_r & commit_ird_w_v_r)
           $fwrite(file, "%x %x", commit_instr_r.rd_addr, ird_data_r[commit_instr_r.rd_addr]);
-        if (commit_fifo_yumi_li & commit_frd_w_v_r)
+        if (instret_v_r & commit_frd_w_v_r)
           $fwrite(file, "%x %x", commit_instr_r.rd_addr, frd_raw_li[commit_instr_r.rd_addr]);
+        if (trap_v_r)
+          $fwrite(file, "   %x %x <- trap", cause_r, mstatus_r);
         $fwrite(file, "\n");
       end
 


### PR DESCRIPTION
This is a patch to fix: #967, #969, #970

Readonly CSRs must trap. That includes mhartid: https://groups.google.com/a/groups.riscv.org/g/isa-dev/c/gGRGSL2vOIo/m/R8SnwnpqBAAJ?utm_medium=email&utm_source=footer

There's also a fix so that FS is not dirtied during an illegal instruction trap.

There's also a patch to hardcode the low 2 bits of MEPC and SEPC

Tests for all in an incoming PR