### PR TITLE
Fix inferred latches

### DIFF
--- a/bp_me/src/v/network/bp_me_axil_client.sv
+++ b/bp_me/src/v/network/bp_me_axil_client.sv
@@ -74,6 +74,8 @@ module bp_me_axil_client
 
   always_comb
     begin
+      state_n = state_r;
+
       // BP side
       io_cmd_header_cast_o = '0;
       io_cmd_data_o        = '0;

--- a/bp_me/src/v/network/bp_me_axil_master.sv
+++ b/bp_me/src/v/network/bp_me_axil_master.sv
@@ -82,6 +82,8 @@ module bp_me_axil_master
   // combinational Logic
   always_comb
     begin
+      state_n = state_r;
+
       io_cmd_ready_and_o    = 1'b0;
       io_resp_header_cast_o = io_cmd_header_r;
       io_resp_data_o        = m_axil_rdata_i;


### PR DESCRIPTION
## Summary
Removing inferred latches from bp_me_axil_master and bp_me_axil_client. state_n didn't have a default value so it was becoming a latch.

## Issue Fixed
fixes #972 

## Area
AXI master and client subcomponents

