### PR TITLE
update FSM CCE to MOESIF protocol

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - me_dev_feature_fsm_moesif
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:
@@ -357,7 +356,6 @@ top-linux-vcs:
 
 top-accelerator-vcs:
   <<: *job_definition
-  when: manual
   stage: test-medium
   tags:
     - vcs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -357,6 +357,7 @@ top-linux-vcs:
 
 top-accelerator-vcs:
   <<: *job_definition
+  when: manual
   stage: test-medium
   tags:
     - vcs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - me_dev_feature_fsm_moesif
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/bp_me/test/tb/bp_cce/Makefile.params
+++ b/bp_me/test/tb/bp_cce/Makefile.params
@@ -31,7 +31,7 @@ else
 export ME_DEBUG_FLAG =
 endif
 
-COH_PROTO   ?= mesi
+COH_PROTO   ?= moesif
 CCE_MEM      = $(COH_PROTO).mem
 
 export BP_SIM_CLK_PERIOD ?= 1000

--- a/bp_top/test/tb/bp_tethered/Makefile.params
+++ b/bp_top/test/tb/bp_tethered/Makefile.params
@@ -1,4 +1,4 @@
-export COH_PROTO   ?= mesi
+export COH_PROTO   ?= moesif
 export CCE_MEM      = $(COH_PROTO).mem
 
 export CCE_TRACE_P    ?= 0

--- a/ci/me_regress.sh
+++ b/ci/me_regress.sh
@@ -39,8 +39,8 @@ echo "Running ${JOBS} jobs with 1 core per job"
 
 # ucode CCE (EI, MSI, MESI, MSI-nonspec, MESI-nonspec)
 parallel --jobs ${JOBS} --results regress_logs --progress "$cmd_base COH_PROTO={} CFG=e_bp_test_multicore_half_cce_ucode_cfg" ::: ${protos[@]}
-# FSM CCE (MESI)
-parallel --jobs ${JOBS} --results regress_logs --progress "$cmd_base COH_PROTO=mesi CFG={}" ::: e_bp_test_multicore_half_cfg
+# FSM CCE (MOESIF)
+parallel --jobs ${JOBS} --results regress_logs --progress "$cmd_base CFG={}" ::: e_bp_test_multicore_half_cfg
 
 # Check for failures in the report directory
 grep -cr "FAIL" bp_me/syn/reports/ && echo "[CI CHECK] $0: FAILED" && exit 1


### PR DESCRIPTION
## Summary
Updating coherence protocol of the FSM CCE from MESI to MOESIF, with minor bug fix in cacc vdp accelerator that was exposed by the protocol update. Also bumping ucode CCE to use MOESIF by default.

## Area
ME and CACC VDP accelerator

## Reasoning (outdated, confusing, verbose, etc.)
ucode CCE supports full MOESIF protocol, bringing FSM CCE to parity.

## Additional Changes Required (if any)
Next steps, downstream modules affected, etc.

## Verification
Regular CI


