### PR TITLE
Adding reset_i X gate to assertions

### DIFF
--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -1362,7 +1362,7 @@ module bp_be_dcache
 
   always_ff @(negedge clk_i)
     begin
-      assert(~v_tv_r || $countones(load_hit_tl) <= 1)
+      assert(reset_i !== '0 || ~v_tv_r || $countones(load_hit_tl) <= 1)
         else $error("multiple hit: %b. id = %0d. addr = %H", load_hit_tl, cfg_bus_cast_i.dcache_id, ptag_i);
     end
 

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache_wbuf.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache_wbuf.sv
@@ -185,7 +185,7 @@ module bp_be_dcache_wbuf
 
   //synopsys translate_off
   always_ff @(negedge clk_i) begin
-    assert (~reset_i || num_els_r < 2'd3) else $error("Write buffer overflow\n");
+    assert(reset_i !== '0 || num_els_r < 2'd3) else $error("Write buffer overflow\n");
   end
   //synopsys translate_on
 

--- a/bp_me/src/v/cce/bp_cce_dir.sv
+++ b/bp_me/src/v/cce/bp_cce_dir.sv
@@ -368,9 +368,9 @@ module bp_cce_dir
   //synopsys translate_off
   always_ff @(negedge clk_i) begin
     if (~reset_i) begin
-      assert($countones({icache_lru_v, dcache_lru_v, acache_lru_v}) <= 1)
+      assert(reset_i !== '0 || $countones({icache_lru_v, dcache_lru_v, acache_lru_v}) <= 1)
         else $error("Multiple directory segments attempting to output LRU information in same cycle");
-      assert($countones({icache_addr_v, dcache_addr_v, acache_addr_v}) <= 1)
+      assert(reset_i !== '0 || $countones({icache_addr_v, dcache_addr_v, acache_addr_v}) <= 1)
         else $error("Multiple directory segments attempting to output addr information in same cycle");
     end
   end

--- a/bp_me/src/v/cce/bp_cce_fsm.sv
+++ b/bp_me/src/v/cce/bp_cce_fsm.sv
@@ -387,7 +387,8 @@ module bp_cce_fsm
   always @(negedge clk_i) begin
     if (~reset_i) begin
       // Cacheable requests must target cacheable memory
-      assert(!(lce_req_v && ~req_pma_cacheable_addr_lo
+      assert(reset_i !== '0 ||
+             !(lce_req_v && ~req_pma_cacheable_addr_lo
                && ((lce_req.msg_type.req == e_bedrock_req_rd_miss)
                    || (lce_req.msg_type.req == e_bedrock_req_wr_miss))
               )

--- a/bp_me/src/v/cce/bp_cce_reg.sv
+++ b/bp_me/src/v/cce/bp_cce_reg.sv
@@ -121,7 +121,8 @@ module bp_cce_reg
   always @(negedge clk_i) begin
     if (~reset_i) begin
       // Cacheable requests must target cacheable memory
-      assert(!(lce_req_v_i && ~req_pma_cacheable_addr_lo
+      assert(reset_i !== '0 ||
+             !(lce_req_v_i && ~req_pma_cacheable_addr_lo
                && ((lce_req_hdr.msg_type.req == e_bedrock_req_rd_miss)
                    || (lce_req_hdr.msg_type.req == e_bedrock_req_wr_miss))
               )

--- a/bp_me/src/v/cce/bp_uce.sv
+++ b/bp_me/src/v/cce/bp_uce.sv
@@ -787,7 +787,7 @@ module bp_uce
   //synopsys translate_off
   always_ff @(negedge clk_i)
     begin
-      assert ((l1_writethrough_p == 0) || !(state_r inside {e_uc_writeback_evict, e_writeback_evict, e_uc_writeback_write_req, e_writeback_read_req, e_writeback_write_req}))
+      assert(reset_i !== '0 || (l1_writethrough_p == 0) || !(state_r inside {e_uc_writeback_evict, e_writeback_evict, e_uc_writeback_write_req, e_writeback_read_req, e_writeback_write_req}))
         else $error("writethrough cache should not be in writeback states");
     end
   //synopsys translate_on

--- a/bp_me/src/v/dev/bp_me_bedrock_register.sv
+++ b/bp_me/src/v/dev/bp_me_bedrock_register.sv
@@ -130,10 +130,10 @@ module bp_me_bedrock_register
   //synopsys translate_off
   always_ff @(negedge clk_i)
     begin
-      assert (~mem_cmd_v_li | (v_r | ~wr_not_rd | |w_v_o) | (v_r | ~rd_not_wr | |r_v_o))
+      assert(reset_i !== '0 || ~mem_cmd_v_li | (v_r | ~wr_not_rd | |w_v_o) | (v_r | ~rd_not_wr | |r_v_o))
         else $fatal("Command to non-existent register: %x", addr_o);
 
-      assert (~(mem_cmd_v_i & mem_cmd_ready_and_o) || mem_cmd_last_i)
+      assert(reset_i !== '0 || ~(mem_cmd_v_i & mem_cmd_ready_and_o) || mem_cmd_last_i)
         else $fatal("Multi-beat memory command detected");
     end
   //synopsys translate_on

--- a/bp_me/src/v/dev/bp_me_cce_to_cache.sv
+++ b/bp_me/src/v/dev/bp_me_cce_to_cache.sv
@@ -444,7 +444,7 @@ module bp_me_cce_to_cache
   always_ff @(negedge clk_i)
     begin
       if (mem_cmd_v_lo & mem_cmd_header_lo.msg_type inside {e_bedrock_mem_wr, e_bedrock_mem_uc_wr})
-        assert (~(mem_cmd_header_lo.subop inside {e_bedrock_amolr, e_bedrock_amosc}))
+        assert(reset_i !== '0 || ~(mem_cmd_header_lo.subop inside {e_bedrock_amolr, e_bedrock_amosc}))
           else $error("LR/SC not supported in bsg_cache");
     end
   //synopsys translate_on

--- a/bp_me/src/v/network/axi_fifo.sv
+++ b/bp_me/src/v/network/axi_fifo.sv
@@ -286,11 +286,13 @@ module axi_fifo
 	end
     end
 
+  if (axi_data_width_p != 32 && axi_data_width_p != 64)
+    $error("AXI4-LITE only supports a data width of 32 or 64bits.");
+
   //synopsys translate_off
   initial
     begin
-      assert (axi_data_width_p==64 || axi_data_width_p==32) else $error("AXI4-LITE only supports a data width of 32 or 64bits.");
-      assert (in_axi_lite_awprot_i == 3'b000) else $info("AXI4-LITE access permission mode is not supported.");
+      assert(reset_i !== '0 || in_axi_lite_awprot_i == 3'b000) else $info("AXI4-LITE access permission mode is not supported.");
     end
   //synopsys translate_on
 endmodule

--- a/bp_me/src/v/network/bp_me_axil_master.sv
+++ b/bp_me/src/v/network/bp_me_axil_master.sv
@@ -186,15 +186,15 @@ module bp_me_axil_master
         state_r <= state_n;
     end
 
+  if (axil_data_width_p != 32 && axil_data_width_p != 64)
+    $error("AXI4-LITE only supports a data width of 32 or 64bits");
+
   //synopsys translate_off
   initial
     begin
-      assert (axil_data_width_p==64 || axil_data_width_p==32) else $error("AXI4-LITE only supports a data width of 32 or 64bits");
       // give a warning if the client device has an error response
-      if (m_axil_rvalid_i)
-        assert (m_axil_rresp_i == '0) else $warning("Client device has an error response to reads");
-      if (m_axil_bvalid_i)
-        assert (m_axil_bresp_i == '0) else $warning("Client device has an error response to writes");
+      assert(reset_i !== '0 || ~m_axil_rvalid_i || m_axil_rresp_i == '0) else $warning("Client device has an error response to reads");
+      assert(reset_i !== '0 || ~m_axil_bvalid_i || m_axil_bresp_i == '0) else $warning("Client device has an error response to writes");
     end
   //synopsys translate_on
 

--- a/bp_me/test/common/bp_me_nonsynth_lce_tracer.sv
+++ b/bp_me/test/common/bp_me_nonsynth_lce_tracer.sv
@@ -116,7 +116,7 @@ module bp_me_nonsynth_lce_tracer
 
       // request to CCE
       if (lce_req_v_i & lce_req_ready_and_i) begin
-        assert(lce_req_payload.src_id == lce_id_i) else $error("Bad LCE Request - source mismatch");
+        assert(reset_i !== '0 || lce_req_payload.src_id == lce_id_i) else $error("Bad LCE Request - source mismatch");
         $fdisplay(file, "%12t |: LCE[%0d] REQ addr[%H] cce[%0d] msg[%b] set[%0d] ne[%b] lru[%0d] size[%b] %H"
                   , $time, lce_req_payload.src_id, lce_req_header_cast_i.addr, lce_req_payload.dst_id, lce_req_header_cast_i.msg_type
                   , lce_req_header_cast_i.addr[block_offset_bits_lp+:lg_sets_lp]
@@ -128,7 +128,7 @@ module bp_me_nonsynth_lce_tracer
 
       // response to CCE
       if (lce_resp_v_i & lce_resp_ready_and_i) begin
-        assert(lce_resp_payload.src_id == lce_id_i) else $error("Bad LCE Response - source mismatch");
+        assert(reset_i !== '0 || lce_resp_payload.src_id == lce_id_i) else $error("Bad LCE Response - source mismatch");
         $fdisplay(file, "%12t |: LCE[%0d] RESP addr[%H] cce[%0d] msg[%b] set[%0d] len[%b] %H"
                   , $time, lce_resp_payload.src_id, lce_resp_header_cast_i.addr, lce_resp_payload.dst_id, lce_resp_header_cast_i.msg_type
                   , lce_resp_header_cast_i.addr[block_offset_bits_lp+:lg_sets_lp]
@@ -138,7 +138,7 @@ module bp_me_nonsynth_lce_tracer
 
       // command to LCE
       if (lce_cmd_v_i & lce_cmd_ready_and_i) begin
-        assert(lce_cmd_payload.dst_id == lce_id_i) else $error("Bad LCE Command - destination mismatch");
+        assert(reset_i !== '0 || lce_cmd_payload.dst_id == lce_id_i) else $error("Bad LCE Command - destination mismatch");
         $fdisplay(file, "%12t |: LCE[%0d] CMD IN addr[%H] cce[%0d] msg[%b] set[%0d] way[%0d] state[%b] tgt[%0d] tgt_way[%0d] len[%b] %H"
                   , $time, lce_cmd_payload.dst_id, lce_cmd_header_cast_i.addr, lce_cmd_payload.src_id, lce_cmd_header_cast_i.msg_type
                   , lce_cmd_header_cast_i.addr[block_offset_bits_lp+:lg_sets_lp], lce_cmd_payload.way_id, lce_cmd_payload.state, lce_cmd_payload.target

--- a/bp_me/test/common/bp_me_nonsynth_mock_lce.sv
+++ b/bp_me/test/common/bp_me_nonsynth_mock_lce.sv
@@ -88,12 +88,15 @@ module bp_me_nonsynth_mock_lce
     ,input                                                  lce_cmd_ready_and_i
   );
 
-  initial begin
-    assert(dword_width_gp == 64) else
-      $error("dword_width_gp must be 64");
-    assert(cce_block_width_p >= 64) else $error("cce_block_width_p must be at least 64-bits");
-    assert(`BSG_IS_POW2(cce_block_width_p)) else $error("cce_block_width_p must be a power of two");
-  end
+
+  if (dword_width_gp != 64)
+    $error("dword_width_gp must be 64");
+
+  if (cce_block_width_p < 64)
+    $error("cce_block_width_p must be at least 64-bits");
+
+  if (!`BSG_IS_POW2(cce_block_width_p))
+    $error("cce_block_width_p must be a power of two");
 
   wire axe_trace_en = !(axe_trace_p == 0);
 
@@ -568,7 +571,7 @@ module bp_me_nonsynth_mock_lce
           lce_state_n = INIT;
         end else if (~freeze_i & tr_pkt_v_i & ~mshr_r.miss) begin
           // Freeze went low without receiving any syncs. Operate in uncached only mode.
-          assert(tr_cmd_pkt.uncached) else $error("LCE in uncached only mode but received cached TR request.");
+          assert(reset_i !== '0 || tr_cmd_pkt.uncached) else $error("LCE in uncached only mode but received cached TR request.");
           tr_pkt_yumi_o = tr_pkt_v_i;
           cmd_n = tr_cmd_pkt;
           lce_state_n = UNCACHED_TR_CMD;
@@ -580,7 +583,7 @@ module bp_me_nonsynth_mock_lce
         // uncached access - treat as miss
         mshr_n.miss = 1'b1;
         mshr_n.uncached = cmd.uncached;
-        assert(cmd.uncached) else $error("LCE received cached access command while uncached only");
+        assert(reset_i !== '0 || cmd.uncached) else $error("LCE received cached access command while uncached only");
         mshr_n.cce[0+:lg_num_cce_lp] = cce_dst_id_lo;
         mshr_n.paddr = cmd.paddr;
         mshr_n.dirty = '0;
@@ -770,7 +773,7 @@ module bp_me_nonsynth_mock_lce
           lce_cmd_header_n = lce_cmd_header_lo;
           lce_cmd_data_n = lce_cmd_data_lo;
 
-          assert(lce_cmd_header_lo.payload.dst_id == lce_id_i) else $error("[%0d]: command delivered to wrong LCE", lce_id_i);
+          assert(reset_i !== '0 || lce_cmd_header_lo.payload.dst_id == lce_id_i) else $error("[%0d]: command delivered to wrong LCE", lce_id_i);
 
           // uncached data or data command
           if (lce_cmd_header_lo.msg_type.cmd == e_bedrock_cmd_data | lce_cmd_header_lo.msg_type.cmd == e_bedrock_cmd_uc_data) begin
@@ -840,7 +843,7 @@ module bp_me_nonsynth_mock_lce
         // write the full cache block on data command
         data_w_mask_li[lce_cmd_header_r.payload.way_id[0+:lg_assoc_lp]] = '1;
 
-        assert (mshr_r.paddr[paddr_width_p-1 : block_offset_bits_lp] == lce_cmd_header_r.addr[paddr_width_p-1 : block_offset_bits_lp]) else
+        assert(reset_i !== '0 || mshr_r.paddr[paddr_width_p-1 : block_offset_bits_lp] == lce_cmd_header_r.addr[paddr_width_p-1 : block_offset_bits_lp]) else
           $error("[%0d]: DATA_CMD address mismatch [%H] != [%H]", lce_id_i, mshr_r.paddr, lce_cmd_header_r.addr);
 
         // update mshr

--- a/bp_top/test/common/bp_nonsynth_nbf_loader.sv
+++ b/bp_top/test/common/bp_nonsynth_nbf_loader.sv
@@ -178,11 +178,11 @@ module bp_nonsynth_nbf_loader
     begin
       if (state_r != e_done && state_n == e_done)
         $display("NBF loader done!");
-      assert (~read_return || read_data_r == io_resp_data_i[0+:dword_width_gp])
+      assert(reset_i !== '0 || ~read_return || read_data_r == io_resp_data_i[0+:dword_width_gp])
         else $error("Validation mismatch: addr: %d %d %d", io_resp.addr, io_resp_data_i, read_data_r);
 
       if (io_resp_v_i & io_resp_ready_and_o)
-        assert(io_resp_last_i)
+        assert(reset_i !== '0 || ~(io_resp_v_i & io_resp_ready_and_o & ~io_resp_last_i))
           else $error("Multi-beat IO response detected");
     end
   //synopsys translate_on

--- a/bp_top/test/common/bp_nonsynth_watchdog.sv
+++ b/bp_top/test/common/bp_nonsynth_watchdog.sv
@@ -98,12 +98,12 @@ module bp_nonsynth_watchdog
         begin
           $display("Core %x halt detected!", mhartid_i);
         end
-      assert (reset_i !== '0 || (stall_cnt < stall_cycles_p)) else
+      assert(reset_i !== '0 || (stall_cnt < stall_cycles_p)) else
         begin
           $display("FAIL! Core %x stalled for %d cycles!", mhartid_i, stall_cnt);
           $finish();
         end
-      assert (reset_i !== '0 || (npc_r !== 'X)) else
+      assert(reset_i !== '0 || (npc_r !== 'X)) else
         begin
           $display("FAIL! Core %x PC has become X!", mhartid_i);
           $finish();


### PR DESCRIPTION
## Summary
This change adds a check to assertions to gate them on reset == 1 or X. This is useful for systems which bringup reset after a while (ASIC emulation). In these cases, spurious assertions may fire before reset has been raised for the first time
