### PR TITLE
ME device tracer

### DIFF
--- a/bp_me/src/v/dev/bp_me_clint_slice.sv
+++ b/bp_me/src/v/dev/bp_me_clint_slice.sv
@@ -14,6 +14,8 @@ module bp_me_clint_slice
   (input                                                clk_i
    , input                                              reset_i
 
+   , input [core_id_width_p-1:0]                        id_i
+
    , input [xce_mem_header_width_lp-1:0]                mem_cmd_header_i
    , input [dword_width_gp-1:0]                         mem_cmd_data_i
    , input                                              mem_cmd_v_i

--- a/bp_me/test/common/bp_me_nonsynth_dev_tracer.sv
+++ b/bp_me/test/common/bp_me_nonsynth_dev_tracer.sv
@@ -1,0 +1,92 @@
+/**
+ *
+ * Name:
+ *   bp_me_nonsynth_dev_tracer.sv
+ *
+ * Description:
+ *
+ */
+
+`include "bp_common_defines.svh"
+`include "bp_me_defines.svh"
+
+module bp_me_nonsynth_dev_tracer
+  import bp_common_pkg::*;
+  import bp_me_pkg::*;
+  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+    `declare_bp_proc_params(bp_params_p)
+
+    , parameter trace_file_p = "dev"
+
+    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, xce)
+  )
+  (input                                            clk_i
+   , input                                          reset_i
+
+   , input [core_id_width_p-1:0]                    id_i
+
+   // CCE-MEM Interface
+   // BedRock Stream protocol: ready&valid
+   , input [xce_mem_header_width_lp-1:0]            mem_cmd_header_i
+   , input [dword_width_gp-1:0]                     mem_cmd_data_i
+   , input                                          mem_cmd_v_i
+   , input                                          mem_cmd_ready_and_i
+   , input                                          mem_cmd_last_i
+
+   , input [xce_mem_header_width_lp-1:0]            mem_resp_header_i
+   , input [dword_width_gp-1:0]                     mem_resp_data_i
+   , input                                          mem_resp_v_i
+   , input                                          mem_resp_ready_and_i
+   , input                                          mem_resp_last_i
+  );
+
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, xce);
+
+  `bp_cast_i(bp_bedrock_xce_mem_header_s, mem_cmd_header);
+  `bp_cast_i(bp_bedrock_xce_mem_header_s, mem_resp_header);
+
+  integer file;
+  string file_name;
+
+  always_ff @(negedge reset_i) begin
+    file_name = $sformatf("%s_%x.trace", trace_file_p, id_i);
+    file      = $fopen(file_name, "w");
+  end
+
+  // Tracer
+  always_ff @(negedge clk_i) begin
+    if (~reset_i) begin
+      if (mem_cmd_v_i & mem_cmd_ready_and_i) begin
+        $fdisplay(file, "%12t |: MEM CMD addr[%H] msg[%b] size[%b]"
+                 , $time
+                 , mem_cmd_header_cast_i.addr
+                 , mem_cmd_header_cast_i.msg_type.mem
+                 , mem_cmd_header_cast_i.size
+                 );
+        if (mem_cmd_header_cast_i.msg_type.mem inside {e_bedrock_mem_uc_wr, e_bedrock_mem_wr}) begin
+          $fdisplay(file, "%12t |: MEM CMD DATA last[%0b] %H"
+                   , $time
+                   , mem_cmd_last_i
+                   , mem_cmd_data_i
+                   );
+        end
+      end
+      if (mem_resp_v_i & mem_resp_ready_and_i) begin
+        $fdisplay(file, "%12t |: MEM RESP addr[%H] msg[%b] size[%b]"
+                 , $time
+                 , mem_resp_header_cast_i.addr
+                 , mem_resp_header_cast_i.msg_type.mem
+                 , mem_resp_header_cast_i.size
+                 );
+        if (mem_resp_header_cast_i.msg_type.mem inside {e_bedrock_mem_uc_rd, e_bedrock_mem_rd}) begin
+          $fdisplay(file, "%12t |: MEM RESP DATA last[%0b] %H"
+                   , $time
+                   , mem_resp_last_i
+                   , mem_resp_data_i
+                   );
+        end
+      end
+    end // reset & trace
+  end // always_ff
+
+endmodule

--- a/bp_top/src/v/bp_tile.sv
+++ b/bp_top/src/v/bp_tile.sv
@@ -508,6 +508,7 @@ module bp_tile
    clint
     (.clk_i(clk_i)
      ,.reset_i(reset_r)
+     ,.id_i(cfg_bus_lo.core_id)
 
      ,.mem_cmd_header_i(dev_cmd_header_li[2])
      ,.mem_cmd_data_i(dev_cmd_data_li[2])

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -473,6 +473,7 @@ module bp_unicore_lite
    clint
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
+     ,.id_i(cfg_bus_lo.core_id)
 
      ,.mem_cmd_header_i(dev_cmd_header_li[1])
      ,.mem_cmd_data_i(clint_data_li)

--- a/bp_top/test/common/bp_nonsynth_host.sv
+++ b/bp_top/test/common/bp_nonsynth_host.sv
@@ -23,6 +23,7 @@ module bp_nonsynth_host
    , parameter pc_profile_p           = 0
    , parameter br_profile_p           = 0
    , parameter cosim_p                = 0
+   , parameter dev_trace_p            = 0
    )
   (input                                            clk_i
    , input                                          reset_i
@@ -50,6 +51,7 @@ module bp_nonsynth_host
    , output logic                                   pc_profile_en_o
    , output logic                                   branch_profile_en_o
    , output logic                                   cosim_en_o
+   , output logic                                   dev_trace_en_o
    , output logic [num_core_p-1:0]                  finish_o
    );
 
@@ -242,6 +244,7 @@ module bp_nonsynth_host
   assign pc_profile_en_o     = pc_profile_p;
   assign branch_profile_en_o = br_profile_p;
   assign cosim_en_o          = cosim_p;
+  assign dev_trace_en_o      = dev_trace_p;
 
   assign data_li[0] = '0;
   assign data_li[1] = '0;

--- a/bp_top/test/tb/bp_tethered/Makefile.params
+++ b/bp_top/test/tb/bp_tethered/Makefile.params
@@ -14,6 +14,7 @@ export BR_PROFILE_P   ?= 0
 export CHECKPOINT_P   ?= 0
 export COSIM_P        ?= 0
 export NBF_CONFIG_P   ?= 1
+export DEV_TRACE_P    ?= 0
 
 export PRELOAD_MEM_P  ?= 0
 
@@ -44,6 +45,7 @@ export TB_PARAMS  = \
                     -pvalue+cosim_instr_p=$(SAMPLE_INSTR_P) \
                     -pvalue+warmup_instr_p=$(SAMPLE_WARMUP_P) \
                     -pvalue+amo_en_p=$(AMOEN) \
+                    -pvalue+dev_trace_p=$(DEV_TRACE_P) \
 					-pvalue+preload_mem_p=$(PRELOAD_MEM_P) \
                     -pvalue+no_bind_p=$(NO_BIND_P)
 

--- a/bp_top/test/tb/bp_tethered/flist.vcs
+++ b/bp_top/test/tb/bp_tethered/flist.vcs
@@ -39,6 +39,7 @@ $BP_ME_DIR/test/common/bp_me_nonsynth_pkg.sv
 $BP_ME_DIR/test/common/bp_me_nonsynth_cce_tracer.sv
 $BP_ME_DIR/test/common/bp_me_nonsynth_cce_inst_tracer.sv
 $BP_ME_DIR/test/common/bp_me_nonsynth_cce_perf.sv
+$BP_ME_DIR/test/common/bp_me_nonsynth_dev_tracer.sv
 $BP_ME_DIR/test/common/bp_me_nonsynth_lce_tracer.sv
 $BP_BE_DIR/test/common/bp_be_nonsynth_dcache_tracer.sv
 $BP_FE_DIR/test/common/bp_fe_nonsynth_icache_tracer.sv

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -31,6 +31,7 @@ module testbench
    , parameter pc_profile_p                = 0
    , parameter br_profile_p                = 0
    , parameter cosim_p                     = 0
+   , parameter dev_trace_p                 = 0
 
    // COSIM parameters
    , parameter checkpoint_p                = 0
@@ -266,6 +267,7 @@ module testbench
   logic core_profile_en_lo;
   logic pc_profile_en_lo;
   logic branch_profile_en_lo;
+  logic dev_trace_en_lo;
   bp_nonsynth_host
    #(.bp_params_p(bp_params_p)
      ,.icache_trace_p(icache_trace_p)
@@ -279,6 +281,7 @@ module testbench
      ,.pc_profile_p(pc_profile_p)
      ,.br_profile_p(br_profile_p)
      ,.cosim_p(cosim_p)
+     ,.dev_trace_p(dev_trace_p)
      )
    host
     (.clk_i(clk_i)
@@ -308,6 +311,7 @@ module testbench
      ,.branch_profile_en_o(branch_profile_en_lo)
      ,.pc_profile_en_o(pc_profile_en_lo)
      ,.cosim_en_o(cosim_en_lo)
+     ,.dev_trace_en_o(dev_trace_en_lo)
      ,.finish_o(finish_lo)
      );
 
@@ -530,6 +534,31 @@ module testbench
            ,.fe_cmd_yumi_i(director.fe_cmd_yumi_i)
 
            ,.commit_v_i(calculator.commit_pkt_cast_o.instret)
+           );
+
+      // note: the device tracer could be specialized to trace bp_me_bedrock_register, but
+      // requires passing a unique ID to each instance of the module/tracer
+      bind bp_me_clint_slice
+        bp_me_nonsynth_dev_tracer
+         #(.bp_params_p(bp_params_p)
+           ,.trace_file_p("clint")
+           )
+         clint_tracer
+          (.clk_i(clk_i & testbench.dev_trace_en_lo)
+           ,.reset_i(reset_i)
+           ,.id_i(id_i)
+
+           ,.mem_cmd_header_i(mem_cmd_header_i)
+           ,.mem_cmd_data_i(mem_cmd_data_i)
+           ,.mem_cmd_v_i(mem_cmd_v_i)
+           ,.mem_cmd_ready_and_i(mem_cmd_ready_and_o)
+           ,.mem_cmd_last_i(mem_cmd_last_i)
+
+           ,.mem_resp_header_i(mem_resp_header_o)
+           ,.mem_resp_data_i(mem_resp_data_o)
+           ,.mem_resp_v_i(mem_resp_v_o)
+           ,.mem_resp_ready_and_i(mem_resp_ready_and_i)
+           ,.mem_resp_last_i(mem_resp_last_o)
            );
 
       if (multicore_p)


### PR DESCRIPTION
Add a ME device tracer module (CLINT, CFG, loopback, cce_to_mem). Module traces only the BedRock Stream cmd/resp interface.

Instantiate for CLINT in multicore and unicore, controlled by `dev_trace_p` parameter in testbench.