### PR TITLE
Minor ME cleanup and CCE way group calculation fix

### DIFF
--- a/bp_common/src/include/bp_common_aviary_defines.svh
+++ b/bp_common/src/include/bp_common_aviary_defines.svh
@@ -96,7 +96,7 @@
     , localparam cce_pc_width_p             = proc_param_lp.cce_pc_width                           \
     , localparam num_cce_instr_ram_els_p    = 2**cce_pc_width_p                                    \
     , localparam cce_way_groups_p           =                                                      \
-        `BSG_MAX(dcache_sets_p, `BSG_MAX(icache_sets_p, num_cacc_p ? acache_sets_p : '0))          \
+        `BSG_MIN(dcache_sets_p, `BSG_MIN(icache_sets_p, num_cacc_p ? acache_sets_p : icache_sets_p)) \
     , localparam cce_type_p                 = proc_param_lp.cce_type                               \
                                                                                                    \
     , localparam l2_en_p                  = proc_param_lp.l2_en                                    \

--- a/bp_me/src/v/cce/bp_uce.sv
+++ b/bp_me/src/v/cce/bp_uce.sv
@@ -397,10 +397,9 @@ module bp_uce
   // Outstanding Requests Counter - counts all requests, cached and uncached
   //
   logic [`BSG_WIDTH(coh_noc_max_credits_p)-1:0] credit_count_lo;
+  // credit consumed when memory command sends
   wire credit_v_li = fsm_cmd_done;
-  // credit is returned when request completes
-  // UC store done for UC Store, UC Data for UC Load, Set Tag Wakeup for
-  // a miss that is actually an upgrade, and data and tag for normal requests.
+  // credit returned when memory response fully consumed
   wire credit_returned_li = fsm_resp_done;
   bsg_flow_counter
    #(.els_p(coh_noc_max_credits_p)

--- a/bp_me/src/v/dev/bp_me_bedrock_register.sv
+++ b/bp_me/src/v/dev/bp_me_bedrock_register.sv
@@ -88,7 +88,7 @@ module bp_me_bedrock_register
 
   logic v_r;
   wire wr_not_rd  = (mem_cmd_header_li.msg_type inside {e_bedrock_mem_wr, e_bedrock_mem_uc_wr});
-  wire rd_not_wr  = (mem_cmd_header_li.msg_type inside {e_bedrock_mem_wr, e_bedrock_mem_uc_wr});
+  wire rd_not_wr  = (mem_cmd_header_li.msg_type inside {e_bedrock_mem_rd, e_bedrock_mem_uc_rd});
   wire v_n = mem_cmd_v_li & ~v_r;
   logic [els_p-1:0] r_v_r;
   bsg_dff_reset_set_clear
@@ -117,9 +117,10 @@ module bp_me_bedrock_register
       assign r_v_o[i] = ~v_r & addr_match & ~wr_not_rd;
       assign w_v_o[i] = ~v_r & addr_match &  wr_not_rd;
     end
-      assign addr_o = (mem_cmd_header_li.addr);
-      assign size_o = (mem_cmd_header_li.size);
-      assign data_o = (mem_cmd_data_li);
+
+  assign addr_o = (mem_cmd_header_li.addr);
+  assign size_o = (mem_cmd_header_li.size);
+  assign data_o = (mem_cmd_data_li);
 
   assign mem_resp_header_o = mem_cmd_header_li;
   assign mem_resp_data_o = rdata_lo;

--- a/bp_me/src/v/network/bp_me_stream_pump_in.sv
+++ b/bp_me/src/v/network/bp_me_stream_pump_in.sv
@@ -123,24 +123,23 @@ module bp_me_stream_pump_in
   logic [stream_cnt_width_lp-1:0] stream_cnt, wrap_cnt;
   logic cnt_up;
   wire cnt_set = fsm_new_o;
-  wire [stream_cnt_width_lp-1:0] cnt_max = fsm_stream ? stream_size : '0;
-  wire [stream_cnt_width_lp-1:0] cnt_val = msg_base_header_li.addr[stream_offset_width_lp+:stream_cnt_width_lp];
+  wire [stream_cnt_width_lp-1:0] size_li = fsm_stream ? stream_size : '0;
+  wire [stream_cnt_width_lp-1:0] first_cnt = msg_base_header_li.addr[stream_offset_width_lp+:stream_cnt_width_lp];
   bp_me_stream_wraparound
    #(.max_val_p(stream_words_lp-1))
    wraparound_cnt
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.max_i(cnt_max)
+     ,.size_i(size_li)
      ,.set_i(cnt_set)
-     ,.val_i(cnt_val)
+     ,.val_i(first_cnt)
      ,.en_i(cnt_up)
 
      ,.full_o(stream_cnt)
      ,.wrap_o(wrap_cnt)
      );
 
-  wire [stream_cnt_width_lp-1:0] first_cnt = msg_base_header_li.addr[stream_offset_width_lp+:stream_cnt_width_lp];
   wire [stream_cnt_width_lp-1:0] last_cnt  = first_cnt + stream_size;
   wire is_last_cnt = (is_stream & (stream_cnt == last_cnt)) | (~fsm_stream & ~msg_stream);
 

--- a/bp_me/src/v/network/bp_me_stream_wraparound.sv
+++ b/bp_me/src/v/network/bp_me_stream_wraparound.sv
@@ -1,10 +1,34 @@
+/**
+ *
+ * Name:
+ *   bp_me_stream_wraparound.sv
+ *
+ * Description:
+ *   Generates the stream word/cnt portion of a BedRock Stream protocol message address given
+ *   an initial stream word and transaction size in stream words (both zero-based).
+ *
+ *   max_val_p is equal to (block width / stream width) - 1 (i.e., zero-based).
+ *   max_val_p+1 must be a power of two for the wrap-around counting to work properly
+ *   E.g., if a block is divided into 8 stream words, max_val_p = 7.
+ *
+ *   size_i is the zero-based transaction size (e.g., a transaction of 4 stream words has size_i = 3)
+ *   - size_i+1 should be a power of two
+ *   val_i is the zero-based initial stream word in [0, max_val_p] of the transaction
+ *   Both size_i and val_i must be held constant throughout the transaction.
+ *
+ *   Two outputs are generated:
+ *   1. full_o is a count that wraps around at the end of the full block
+ *   2. wrap_o is a count that wraps around at the end of the naturally aligned sub-block with
+ *      size size_i targeted by the transaction. wrap_o is typically used directed in the stream
+ *      message address.
+ *
+ */
 
 `include "bsg_defines.v"
 
 module bp_me_stream_wraparound
  #(parameter `BSG_INV_PARAM(max_val_p)
    , localparam width_lp = `BSG_WIDTH(max_val_p)
-   , localparam size_lp = `BSG_SAFE_CLOG2(width_lp)
    )
   (input                                          clk_i
    , input                                        reset_i
@@ -13,12 +37,19 @@ module bp_me_stream_wraparound
    , input                                        set_i
    // Increment counter
    , input                                        en_i
-   , input [`BSG_SAFE_MINUS(width_lp,1):0]        max_i
+   , input [`BSG_SAFE_MINUS(width_lp,1):0]        size_i
    , input [`BSG_SAFE_MINUS(width_lp,1):0]        val_i
 
+   // full width count, wraps at end of block
    , output logic [`BSG_SAFE_MINUS(width_lp,1):0] full_o
+   // wrap-around count, used to construct proper stream beat address
+   // wraps within sub-block aligned portion of block targeted by request
    , output logic [`BSG_SAFE_MINUS(width_lp,1):0] wrap_o
    );
+
+  // parameter check
+  if ((max_val_p > 0) && !`BSG_IS_POW2(max_val_p+1))
+    $error("max_val_p+1 of %0d is not a power of two...wrap-around counting will break.", max_val_p+1);
 
   if (max_val_p == 0)
     begin : z
@@ -41,26 +72,56 @@ module bp_me_stream_wraparound
          ,.count_o(cnt_r)
          );
 
-      // Generate proper wrap-around address for different incoming msg size dynamically.
-      // __________________________________________________________
-      // |                |          block offset                  |  input address
-      // |  upper address |________________________________________|
-      // |                |     stream count   |  stream offset    |  output address
-      // |________________|____________________|___________________|
-      // Block size = stream count * stream size, with a request smaller than block_width_p,
-      // a narrower stream_cnt is required to generate address for each sub-stream pkt.
-      // Eg. block_width_p = 512, stream_data_witdh_p = 64, then counter width = log2(512/64) = 3
-      // size = 512: a wrapped around seq: 2, 3, 4, 5, 6, 7, 0, 1  all 3-bit of cnt is used
-      // size = 256: a wrapped around seq: 2, 3, 0, 1              only lower 2-bit of cnt is used
-
+      // block-wrapped count (stream word)
       assign full_o = cnt_r;
 
+      // Dynamically generate sub-block wrapped stream count
+      // The count is wrapped within the size_i aligned portion of the block containing val_i
+      //
+      // A canonical block address can be viewed as:
+      // __________________________________________________________
+      // |                |          block offset                  |  block address
+      // |  upper address |________________________________________|
+      // |                |     stream count   |  stream offset    |  stream word address
+      // |________________|____________________|___________________|
+      // where stream offset is a byte offset of the current stream word and stream count is
+      // the current stream word portion of the block, having width = stream data channel width
+      //
+      // stream count is further divided into:
+      // __________________________________________________
+      // |    sub-block number     |    sub-block count    |
+      // |_________________________|_______________________|
+      //
+      // To produce wrap_o, which is the sub-block aligned and wrapped count, the sub-block number
+      // field is held constant while sub-block count comes from the counter. The number of bits
+      // derived from the counter versus the initial stream word input (val_i) is determined by
+      // the transaction size (size_i) input. A transaction with size_i == max_val_p uses the
+      // stream count (full_o) directly as it already handles block-aligned wrapping.
+      //
+      // For example, consider a system with max_val_p = 7 (8 stream words per block), where a block
+      // comprises stream words [7, 6, 5, 4, 3, 2, 1, 0], listed most to least significant.
+      // An exampe system like this could have 512 bit blocks with a stream data width of 64 bits.
+      // 3 bits = log2(512/64) are required for the stream count. The transaction size (size_i)
+      // determines how many bits are used from val_i and full_o (cnt_r) to produce wrap_o.
+
+      // E.g., max_val_p = 7 for a system with 512-bit blocks and 64-bit stream data width
+      // A 512-bit transaction sets size_i = 7 and a 256-bit transactions sets size_i = 3
+      // 512-bit, size_i = 7, val_i = 2: full_o and wrap_o = 2, 3, 4, 5, 6, 7, 0, 1
+      // 256-bit, size_i = 3, val_i = 2: full_o = 2, 3, 4, 5 and wrap_o = 2, 3, 0, 1
+      // 512-bit, size_i = 7, val_i = 6: full_o and wrap_o = 6, 7, 0, 1, 2, 3, 4, 5
+      // 256-bit, size_i = 3, val_i = 6: full_o = 6, 7, 0, 1 and wrap_o = 6, 7, 4, 5
+
+      // if size_i+1 is not a power of two, the transaction wraps as if size_i+1 is the next
+      // power of two (e.g., max_val_p = 3, then size_i = 2 wraps same as size_i = 3)
+
+      // selection input used to pick bits from block-wrapped and sub-block wrapped counts
       logic [width_lp-1:0] cnt_sel_li;
       for (genvar i = 0; i < width_lp; i++)
         begin : cnt_sel
-          assign cnt_sel_li[i] = max_i >= 2**i;
+          assign cnt_sel_li[i] = size_i >= 2**i;
         end
 
+      // sub-block wrapped and aligned count (stream word)
       bsg_mux_bitwise
        #(.width_p(width_lp))
        wrap_mux
@@ -73,3 +134,4 @@ module bp_me_stream_wraparound
 
 endmodule
 
+`BSG_ABSTRACT_MODULE(bp_me_stream_wraparound)


### PR DESCRIPTION
This change includes:

- cleanup / comment clarification in stream pumps
- small bug fix in bedrock register rd_not_wr logic (only used by assertion)
- fix CCE way group calculation for correctness in configs with differing L1 I$ and D$ organizations
- comment fix in UCE