### PR TITLE
Add bedrock_data_width parameter to ME, update CCE

### DIFF
--- a/bp_be/test/tb/bp_be_dcache/testbench.sv
+++ b/bp_be/test/tb/bp_be_dcache/testbench.sv
@@ -345,7 +345,9 @@ module testbench
 
     bind bp_cce_fsm
       bp_me_nonsynth_cce_tracer
-        #(.bp_params_p(bp_params_p))
+        #(.bp_params_p(bp_params_p)
+          ,.bedrock_data_width_p(bedrock_data_width_p)
+          )
         bp_cce_tracer
          (.clk_i(clk_i & (testbench.cce_trace_p == 1))
           ,.reset_i(reset_i)

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -708,7 +708,9 @@ module wrapper
           );
 
        bp_cce_fsm
-        #(.bp_params_p(bp_params_p))
+        #(.bp_params_p(bp_params_p)
+          ,.bedrock_data_width_p(dword_width_gp)
+          )
         cce
          (.clk_i(clk_i)
           ,.reset_i(reset_i)

--- a/bp_fe/test/tb/bp_fe_icache/testbench.sv
+++ b/bp_fe/test/tb/bp_fe_icache/testbench.sv
@@ -315,7 +315,9 @@ module testbench
 
     bind bp_cce_fsm
       bp_me_nonsynth_cce_tracer
-        #(.bp_params_p(bp_params_p))
+        #(.bp_params_p(bp_params_p)
+          ,.bedrock_data_width_p(bedrock_data_width_p)
+          )
         bp_cce_tracer
          (.clk_i(clk_i & (testbench.cce_trace_p == 1))
           ,.reset_i(reset_i)

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -436,7 +436,9 @@ module wrapper
 
     // FSM CCE
     bp_cce_fsm
-     #(.bp_params_p(bp_params_p))
+     #(.bp_params_p(bp_params_p)
+       ,.bedrock_data_width_p(dword_width_gp)
+       )
      cce_fsm
       (.clk_i(clk_i)
        ,.reset_i(reset_i)

--- a/bp_me/src/v/cce/bp_cce.sv
+++ b/bp_me/src/v/cce/bp_cce.sv
@@ -16,6 +16,7 @@ module bp_cce
   import bp_me_pkg::*;
   #(parameter bp_params_e bp_params_p      = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
+    , parameter bedrock_data_width_p       = dword_width_gp
 
     // Derived parameters
     , localparam block_size_in_bytes_lp    = (cce_block_width_p/8)
@@ -50,7 +51,7 @@ module bp_cce
    , input                                          lce_req_header_v_i
    , output logic                                   lce_req_header_ready_and_o
    , input                                          lce_req_has_data_i
-   , input [dword_width_gp-1:0]                     lce_req_data_i
+   , input [bedrock_data_width_p-1:0]               lce_req_data_i
    , input                                          lce_req_data_v_i
    , output logic                                   lce_req_data_ready_and_o
    , input                                          lce_req_last_i
@@ -59,7 +60,7 @@ module bp_cce
    , input                                          lce_resp_header_v_i
    , output logic                                   lce_resp_header_ready_and_o
    , input                                          lce_resp_has_data_i
-   , input [dword_width_gp-1:0]                     lce_resp_data_i
+   , input [bedrock_data_width_p-1:0]               lce_resp_data_i
    , input                                          lce_resp_data_v_i
    , output logic                                   lce_resp_data_ready_and_o
    , input                                          lce_resp_last_i
@@ -68,7 +69,7 @@ module bp_cce
    , output logic                                   lce_cmd_header_v_o
    , input                                          lce_cmd_header_ready_and_i
    , output logic                                   lce_cmd_has_data_o
-   , output logic [dword_width_gp-1:0]              lce_cmd_data_o
+   , output logic [bedrock_data_width_p-1:0]        lce_cmd_data_o
    , output logic                                   lce_cmd_data_v_o
    , input                                          lce_cmd_data_ready_and_i
    , output logic                                   lce_cmd_last_o
@@ -76,36 +77,22 @@ module bp_cce
    // CCE-MEM Interface
    // BedRock Stream protocol: ready&valid
    , input [mem_header_width_lp-1:0]                mem_resp_header_i
-   , input [dword_width_gp-1:0]                     mem_resp_data_i
+   , input [bedrock_data_width_p-1:0]               mem_resp_data_i
    , input                                          mem_resp_v_i
    , output logic                                   mem_resp_ready_and_o
    , input                                          mem_resp_last_i
 
    , output logic [mem_header_width_lp-1:0]         mem_cmd_header_o
-   , output logic [dword_width_gp-1:0]              mem_cmd_data_o
+   , output logic [bedrock_data_width_p-1:0]        mem_cmd_data_o
    , output logic                                   mem_cmd_v_o
    , input                                          mem_cmd_ready_and_i
    , output logic                                   mem_cmd_last_o
   );
 
   // parameter checks
-  if (!(`BSG_IS_POW2(cce_way_groups_p))) $fatal(0,"Number of way groups must be a power of two");
-  if (!(`BSG_IS_POW2(dcache_assoc_p) && `BSG_IS_POW2(dcache_sets_p)))
-    $fatal(0,"D$ sets and assoc must be power of two");
-  if (!(`BSG_IS_POW2(icache_assoc_p) && `BSG_IS_POW2(icache_sets_p)))
-    $fatal(0,"I$ sets and assoc must be power of two");
-  if ((num_cacc_p > 0) && !(`BSG_IS_POW2(acache_assoc_p) || acache_assoc_p == 0))
-    $fatal(0,"A$ assoc must be power of two or 0");
-  if ((num_cacc_p > 0) && !(`BSG_IS_POW2(acache_sets_p) || acache_sets_p == 0))
-    $fatal(0,"A$ sets must be power of two or 0");
-  if (icache_block_width_p != cce_block_width_p)
-    $fatal(0,"icache block width must match cce block width");
-  if (dcache_block_width_p != cce_block_width_p)
-    $fatal(0,"dcache block width must match cce block width");
-  if ((num_cacc_p > 0) && (acache_block_width_p != cce_block_width_p))
-    $fatal(0,"acache block width must match cce block width");
-  if (!(`BSG_IS_POW2(cce_block_width_p) || cce_block_width_p < 64 || cce_block_width_p > 1024))
-    $fatal(0, "invalid CCE block width");
+  if (cce_block_width_p < `bp_cce_inst_gpr_width)
+    $fatal(0, "CCE block width must be greater than CCE GPR width");
+
 
   // LCE-CCE and Mem-CCE Interface
   `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
@@ -241,15 +228,15 @@ module bp_cce
   logic mem_resp_v_li, mem_resp_yumi_lo;
   logic mem_resp_stream_new_li, mem_resp_stream_last_li, mem_resp_stream_done_li;
   logic [paddr_width_p-1:0] mem_resp_addr_li;
-  logic [dword_width_gp-1:0] mem_resp_data_li;
+  logic [bedrock_data_width_p-1:0] mem_resp_data_li;
 
   // From CCE to memory command stream pump
-  localparam stream_words_lp = cce_block_width_p / dword_width_gp;
+  localparam stream_words_lp = cce_block_width_p / bedrock_data_width_p;
   localparam data_len_width_lp = `BSG_SAFE_CLOG2(stream_words_lp);
   bp_bedrock_mem_header_s mem_cmd_base_header_lo;
   logic mem_cmd_v_lo, mem_cmd_ready_and_li;
   logic mem_cmd_stream_new_li, mem_cmd_stream_done_li;
-  logic [dword_width_gp-1:0] mem_cmd_data_lo;
+  logic [bedrock_data_width_p-1:0] mem_cmd_data_lo;
   logic [data_len_width_lp-1:0] mem_cmd_stream_cnt_li;
 
   /*
@@ -303,7 +290,7 @@ module bp_cce
   // Memory Response Stream Pump
   bp_me_stream_pump_in
     #(.bp_params_p(bp_params_p)
-      ,.stream_data_width_p(dword_width_gp)
+      ,.stream_data_width_p(bedrock_data_width_p)
       ,.block_width_p(cce_block_width_p)
       ,.payload_width_p(mem_payload_width_lp)
       ,.msg_stream_mask_p(mem_resp_payload_mask_gp)
@@ -334,7 +321,7 @@ module bp_cce
   // Memory Command Stream Pump
   bp_me_stream_pump_out
     #(.bp_params_p(bp_params_p)
-      ,.stream_data_width_p(dword_width_gp)
+      ,.stream_data_width_p(bedrock_data_width_p)
       ,.block_width_p(cce_block_width_p)
       ,.payload_width_p(mem_payload_width_lp)
       ,.msg_stream_mask_p(mem_cmd_payload_mask_gp)

--- a/bp_me/src/v/cce/bp_cce.sv
+++ b/bp_me/src/v/cce/bp_cce.sv
@@ -430,6 +430,7 @@ module bp_cce
   // Source Select
   bp_cce_src_sel
     #(.bp_params_p(bp_params_p)
+      ,.bedrock_data_width_p(bedrock_data_width_p)
      )
     source_selector
      (.src_a_sel_i(decoded_inst_lo.src_a_sel)
@@ -665,6 +666,7 @@ module bp_cce
   // Message unit
   bp_cce_msg
     #(.bp_params_p(bp_params_p)
+      ,.bedrock_data_width_p(bedrock_data_width_p)
       )
     message
      (.clk_i(clk_i)

--- a/bp_me/src/v/cce/bp_cce_dir.sv
+++ b/bp_me/src/v/cce/bp_cce_dir.sv
@@ -23,9 +23,7 @@ module bp_cce_dir
 
     // Derived parameters
     , localparam block_size_in_bytes_lp = (cce_block_width_p/8)
-    , localparam lg_block_size_in_bytes_lp = `BSG_SAFE_CLOG2(block_size_in_bytes_lp)
 
-    // I$ ID to LCE ID mapping
     // I$ and D$ LCE ID's are [0, (2*num_core_p)-1]
     // A$ LCE ID's start at (2*num_core_p)
     , localparam acc_lce_id_offset_lp = (num_core_p*2)
@@ -70,12 +68,21 @@ module bp_cce_dir
    , input [cce_id_width_p-1:0]                                   cce_id_i
   );
 
+  // cce_id_i is used for debugging / tracing the directory
+  wire unused = &{cce_id_i};
+
   // Number of CCEs must be at least as large as the minimal number of sets in any of the
   // LCE types (dcache, icache, acache). This ensures that every tag set is wholly stored
-  // in a *single* CCE (equivalently, tag sets are not split across LCEs).
+  // in a *single* CCE (equivalently, tag sets are not split across CCEs).
   // LCEs and CCEs use the set index bits from the physical address to map address to CCE.
   if (lce_min_sets_lp < num_cce_p)
     $fatal(0, "Number of CCEs must be at least as large as the minimal number of LCE sets");
+
+  // directory does not support caches with only 1 set
+  if (dcache_sets_p <= 1) $fatal(0, "D$ must have more than 1 set");
+  if (icache_sets_p <= 1) $fatal(0, "I$ must have more than 1 set");
+  if ((num_cacc_p > 0) && (acache_sets_p <= 1)) $fatal(0, "A$ must have more than 1 set");
+
 
   wire lce_is_icache = (~lce_i[0] && (lce_i < acc_lce_id_offset_lp));
   wire lce_is_dcache = (lce_i[0] && (lce_i < acc_lce_id_offset_lp));
@@ -87,7 +94,6 @@ module bp_cce_dir
   localparam icache_dir_sets_lp = `BSG_CDIV(icache_sets_p, num_cce_p);
   localparam lg_icache_assoc_lp = `BSG_SAFE_CLOG2(icache_assoc_p);
   localparam icache_lce_id_width_lp = `BSG_SAFE_CLOG2(num_core_p);
-  localparam lg_icache_sets_lp = `BSG_SAFE_CLOG2(icache_sets_p);
 
   wire [icache_lce_id_width_lp-1:0] icache_lce_id = lce_i[1+:icache_lce_id_width_lp];
 
@@ -149,7 +155,6 @@ module bp_cce_dir
   localparam dcache_dir_sets_lp = `BSG_CDIV(dcache_sets_p, num_cce_p);
   localparam lg_dcache_assoc_lp = `BSG_SAFE_CLOG2(dcache_assoc_p);
   localparam dcache_lce_id_width_lp = `BSG_SAFE_CLOG2(num_core_p);
-  localparam lg_dcache_sets_lp = `BSG_SAFE_CLOG2(dcache_sets_p);
 
   // D$ segment signals
   logic                                                 dcache_sharers_v;
@@ -230,7 +235,6 @@ module bp_cce_dir
   localparam acache_dir_sets_lp = `BSG_CDIV(acache_sets_p, num_cce_p);
   localparam lg_acache_assoc_lp = `BSG_SAFE_CLOG2(acache_assoc_p);
   localparam acache_lce_id_width_lp = `BSG_SAFE_CLOG2(num_cacc_p);
-  localparam lg_acache_sets_lp = `BSG_SAFE_CLOG2(acache_sets_p);
   // local param that is set to 1 if there are 0 CACC's, so the acache_sharers vectors
   // are sized properly when there are no accelerators. This is only used to size the vectors
   // as 1 element vectors when there are no accelerators present.

--- a/bp_me/src/v/cce/bp_cce_dir.sv
+++ b/bp_me/src/v/cce/bp_cce_dir.sv
@@ -75,7 +75,7 @@ module bp_cce_dir
   // in a *single* CCE (equivalently, tag sets are not split across LCEs).
   // LCEs and CCEs use the set index bits from the physical address to map address to CCE.
   if (lce_min_sets_lp < num_cce_p)
-    $fatal(0,"Number of CCEs must be at least as large as the minimal number of LCE sets");
+    $fatal(0, "Number of CCEs must be at least as large as the minimal number of LCE sets");
 
   wire lce_is_icache = (~lce_i[0] && (lce_i < acc_lce_id_offset_lp));
   wire lce_is_dcache = (lce_i[0] && (lce_i < acc_lce_id_offset_lp));

--- a/bp_me/src/v/cce/bp_cce_dir_lru_extract.sv
+++ b/bp_me/src/v/cce/bp_cce_dir_lru_extract.sv
@@ -40,10 +40,6 @@ module bp_cce_dir_lru_extract
 
   );
 
-  // parameter checks
-  if (tag_sets_per_row_p != 2)
-    $fatal(0,"unsupported configuration: number of sets per row must equal 2");
-
   `declare_bp_cce_dir_entry_s(tag_width_p);
 
   // Directory RAM row cast

--- a/bp_me/src/v/cce/bp_cce_dir_lru_extract.sv
+++ b/bp_me/src/v/cce/bp_cce_dir_lru_extract.sv
@@ -41,20 +41,19 @@ module bp_cce_dir_lru_extract
   );
 
   `declare_bp_cce_dir_entry_s(tag_width_p);
-
-  // Directory RAM row cast
   dir_entry_s [tag_sets_per_row_p-1:0][assoc_p-1:0] row;
-  assign row = row_i;
 
-  // LRU output is valid if:
-  // 1. tag set input is valid
-  // 2. target LCE's tag set is stored on the input row
-  assign lru_v_o = (row_v_i[lce_i[0]]) & ((lce_i >> 1) == row_num_i);
+  always_comb begin
+    // cast directory row for easy access to state and tag
+    row = row_i;
 
-  bp_coh_states_e lru_coh_state;
-  assign lru_coh_state = row[lce_i[0]][lru_way_i].state;
-  assign lru_coh_state_o = lru_coh_state;
-  assign lru_tag_o = row[lce_i[0]][lru_way_i].tag;
+    // LRU output is valid if:
+    // 1. tag set input is valid
+    // 2. target LCE's tag set is stored on the input row
+    lru_v_o = (row_v_i[lce_i[0]]) & ((lce_i >> 1) == row_num_i);
+    lru_coh_state_o = row[lce_i[0]][lru_way_i].state;
+    lru_tag_o = row[lce_i[0]][lru_way_i].tag;
+  end
 
 endmodule
 

--- a/bp_me/src/v/cce/bp_cce_dir_segment.sv
+++ b/bp_me/src/v/cce/bp_cce_dir_segment.sv
@@ -117,11 +117,11 @@ module bp_cce_dir_segment
   // If value of tag_sets_per_row_lp changes (is no longer 2) the directory logic
   // needs to be re-written.
   if (tag_sets_per_row_lp != 2)
-    $fatal(0,"Unsupported configuration: number of sets per row must equal 2");
+    $fatal(0, "Unsupported configuration: number of sets per row must equal 2");
   if (sets_p <= 1)
-    $fatal(0,"Number of cache sets must be greater than 1; direct-mapped caches not supported");
+    $fatal(0, "Number of cache sets must be greater than 1; direct-mapped caches not supported");
   if (tag_sets_p < 1)
-    $fatal(0,"Number of tag sets must be at least 1");
+    $fatal(0, "Number of tag sets must be at least 1");
 
   // input address hashing
   logic [lg_num_cce_lp-1:0] cce_id_lo;

--- a/bp_me/src/v/cce/bp_cce_dir_tag_checker.sv
+++ b/bp_me/src/v/cce/bp_cce_dir_tag_checker.sv
@@ -31,10 +31,6 @@ module bp_cce_dir_tag_checker
    , output bp_coh_states_e [tag_sets_per_row_p-1:0]              sharers_coh_states_o
   );
 
-  // parameter checks
-  if (tag_sets_per_row_p != 2)
-    $fatal(0,"unsupported configuration: number of sets per row must equal 2");
-
   `declare_bp_cce_dir_entry_s(tag_width_p);
 
   // Directory RAM row cast

--- a/bp_me/src/v/cce/bp_cce_fsm.sv
+++ b/bp_me/src/v/cce/bp_cce_fsm.sv
@@ -1816,9 +1816,9 @@ module bp_cce_fsm
           lce_cmd.payload.dst_id = mshr_r.owner_lce_id;
           lce_cmd.payload.way_id = mshr_r.owner_way_id;
 
-          // TODO: should transfer commands set size field of command message to block size?
-          // burst and stream protocols indicate if data exists / last beat
-          // other converters should use payload masks to determine which messages have data
+          // note: transfer command causes a block-sized transfer from one LCE to another.
+          // the msg_size field is not set to the block size since the transfer command itself
+          // carries no data. The LCE sets the size of the data command it sends to the block size.
           lce_cmd.msg_type.cmd = mshr_r.flags.write_not_read | mshr_r.flags.cached_modified
                                  ? e_bedrock_cmd_st_tr
                                  : mshr_r.flags.cached_owned | mshr_r.flags.cached_forward

--- a/bp_me/src/v/cce/bp_cce_fsm.sv
+++ b/bp_me/src/v/cce/bp_cce_fsm.sv
@@ -106,6 +106,8 @@ module bp_cce_fsm
    , output logic                                   mem_cmd_last_o
    );
 
+  wire unused = &{lce_req_has_data_i, lce_req_last_i, lce_resp_has_data_i, lce_resp_last_i};
+
   // parameter checks
   if (counter_max_lp < num_way_groups_lp) $fatal(0, "Counter max value not large enough");
   if (counter_max_lp < max_tag_sets_lp) $fatal(0, "Counter max value not large enough");
@@ -1059,14 +1061,13 @@ module bp_cce_fsm
         // uncached store
         end else if (lce_req_v & (lce_req.msg_type.req == e_bedrock_req_uc_wr)) begin
           // first beat of memory command must include data
-          // handshake is r&v on both LCE request header and memory command stream, and
-          // valid->yumi on LCE request data
+          // handshake is r&v on both LCE request data and memory command stream, and
+          // valid->yumi on LCE request header
           mem_cmd_v_lo = lce_req_v & lce_req_data_v_i & ~mem_credits_empty;
           lce_req_data_ready_and_o = mem_cmd_ready_and_li;
           // LCE request header is only dequeued if stream pump indicates stream is done
           lce_req_yumi = mem_cmd_v_lo & mem_cmd_ready_and_li & mem_cmd_stream_done_li;
 
-          // form message
           mem_cmd_base_header_lo.addr = lce_req.addr;
           mem_cmd_base_header_lo.size = lce_req.size;
           mem_cmd_base_header_lo.msg_type.mem = e_bedrock_mem_uc_wr;
@@ -1221,8 +1222,8 @@ module bp_cce_fsm
         // uncached store
         if (mshr_r.flags.write_not_read) begin
           // first beat of memory command must include data
-          // handshake is r&v on both LCE request header and memory command stream, and
-          // valid->yumi on LCE request data
+          // handshake is r&v on both LCE request data and memory command stream, and
+          // valid->yumi on LCE request header
           mem_cmd_v_lo = lce_req_v & lce_req_data_v_i & ~mem_credits_empty;
           lce_req_data_ready_and_o = mem_cmd_ready_and_li;
           // LCE request header is only dequeued if stream pump indicates stream is done

--- a/bp_me/src/v/cce/bp_cce_fsm.sv
+++ b/bp_me/src/v/cce/bp_cce_fsm.sv
@@ -1558,7 +1558,7 @@ module bp_cce_fsm
             lce_resp_yumi = mem_cmd_stream_done_li;
 
             mem_cmd_base_header_lo.msg_type = e_bedrock_mem_wr;
-            mem_cmd_base_header_lo.addr = (lce_resp.addr >> lg_block_size_in_bytes_lp) << lg_block_size_in_bytes_lp;
+            mem_cmd_base_header_lo.addr = lce_resp.addr;
             mem_cmd_base_header_lo.size = lce_resp.size;
             mem_cmd_base_header_lo.payload.lce_id = mshr_r.lce_id;
             mem_cmd_base_header_lo.payload.way_id = '0;
@@ -1826,7 +1826,7 @@ module bp_cce_fsm
                                    // transfer & not cached in M, O, or F -> cached in E
                                    : e_bedrock_cmd_st_tr_wb;
 
-          lce_cmd.addr = mshr_r.paddr;
+          lce_cmd.addr = paddr_aligned;
 
           // either Invalidate or Downgrade Owner, depending on request type
           // write request invalidates owner (can only have 1 writer!)
@@ -1850,7 +1850,7 @@ module bp_cce_fsm
           dir_w_v = lce_cmd_header_v_o & lce_cmd_header_ready_and_i
                     & (mshr_r.flags.write_not_read | mshr_r.flags.cached_modified | mshr_r.flags.cached_exclusive);
           dir_cmd = e_wds_op;
-          dir_addr_li = mshr_r.paddr;
+          dir_addr_li = paddr_aligned;
           dir_lce_li = mshr_r.owner_lce_id;
           dir_way_li = mshr_r.owner_way_id;
           dir_coh_state_li = mshr_r.flags.write_not_read

--- a/bp_me/src/v/cce/bp_cce_fsm.sv
+++ b/bp_me/src/v/cce/bp_cce_fsm.sv
@@ -26,6 +26,7 @@ module bp_cce_fsm
   import bp_me_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
+    , parameter bedrock_data_width_p       = dword_width_gp
 
     // Derived parameters
     , localparam block_size_in_bytes_lp    = (cce_block_width_p/8)
@@ -43,6 +44,9 @@ module bp_cce_fsm
     , localparam max_tag_sets_lp           = `BSG_CDIV(lce_sets_p, num_cce_p)
     , localparam lg_max_tag_sets_lp        = `BSG_SAFE_CLOG2(max_tag_sets_lp)
 
+    // byte offset bits required per bedrock data channel beat
+    , localparam lg_bedrock_data_bytes_lp = `BSG_SAFE_CLOG2(bedrock_data_width_p/8)
+
     // interface widths
     `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
     `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
@@ -51,9 +55,6 @@ module bp_cce_fsm
     , localparam hash_index_width_lp=$clog2((2**lg_lce_sets_lp+num_cce_p-1)/num_cce_p)
 
     , localparam counter_width_lp = `BSG_SAFE_CLOG2(counter_max_lp+1)
-
-    // log2 of dword width bytes
-    , localparam lg_dword_width_bytes_lp = `BSG_SAFE_CLOG2(dword_width_gp/8)
   )
   (input                                            clk_i
    , input                                          reset_i
@@ -67,7 +68,7 @@ module bp_cce_fsm
    , input                                          lce_req_header_v_i
    , output logic                                   lce_req_header_ready_and_o
    , input                                          lce_req_has_data_i
-   , input [dword_width_gp-1:0]                     lce_req_data_i
+   , input [bedrock_data_width_p-1:0]               lce_req_data_i
    , input                                          lce_req_data_v_i
    , output logic                                   lce_req_data_ready_and_o
    , input                                          lce_req_last_i
@@ -76,7 +77,7 @@ module bp_cce_fsm
    , input                                          lce_resp_header_v_i
    , output logic                                   lce_resp_header_ready_and_o
    , input                                          lce_resp_has_data_i
-   , input [dword_width_gp-1:0]                     lce_resp_data_i
+   , input [bedrock_data_width_p-1:0]               lce_resp_data_i
    , input                                          lce_resp_data_v_i
    , output logic                                   lce_resp_data_ready_and_o
    , input                                          lce_resp_last_i
@@ -85,7 +86,7 @@ module bp_cce_fsm
    , output logic                                   lce_cmd_header_v_o
    , input                                          lce_cmd_header_ready_and_i
    , output logic                                   lce_cmd_has_data_o
-   , output logic [dword_width_gp-1:0]              lce_cmd_data_o
+   , output logic [bedrock_data_width_p-1:0]        lce_cmd_data_o
    , output logic                                   lce_cmd_data_v_o
    , input                                          lce_cmd_data_ready_and_i
    , output logic                                   lce_cmd_last_o
@@ -93,28 +94,21 @@ module bp_cce_fsm
    // CCE-MEM Interface
    // BedRock Stream protocol: ready&valid
    , input [mem_header_width_lp-1:0]                mem_resp_header_i
-   , input [dword_width_gp-1:0]                     mem_resp_data_i
+   , input [bedrock_data_width_p-1:0]               mem_resp_data_i
    , input                                          mem_resp_v_i
    , output logic                                   mem_resp_ready_and_o
    , input                                          mem_resp_last_i
 
    , output logic [mem_header_width_lp-1:0]         mem_cmd_header_o
-   , output logic [dword_width_gp-1:0]              mem_cmd_data_o
+   , output logic [bedrock_data_width_p-1:0]        mem_cmd_data_o
    , output logic                                   mem_cmd_v_o
    , input                                          mem_cmd_ready_and_i
    , output logic                                   mem_cmd_last_o
    );
 
   // parameter checks
-  if (lce_sets_p <= 1) $fatal(0,"Number of LCE sets must be greater than 1");
-  if (counter_max_lp < num_way_groups_lp) $fatal(0,"Counter max value not large enough");
-  if (counter_max_lp < max_tag_sets_lp) $fatal(0,"Counter max value not large enough");
-  if (icache_block_width_p != cce_block_width_p) $fatal(0,"icache block width must match cce block width");
-  if (dcache_block_width_p != cce_block_width_p) $fatal(0,"dcache block width must match cce block width");
-  if ((num_cacc_p) > 0 && (acache_block_width_p != cce_block_width_p)) $fatal(0,"acache block width must match cce block width");
-  if (dword_width_gp != 64) $fatal(0,"FSM CCE requires dword width of 64-bits");
-  if (!(`BSG_IS_POW2(cce_block_width_p) || cce_block_width_p < 64 || cce_block_width_p > 1024))
-    $fatal(0, "invalid CCE block width");
+  if (counter_max_lp < num_way_groups_lp) $fatal(0, "Counter max value not large enough");
+  if (counter_max_lp < max_tag_sets_lp) $fatal(0, "Counter max value not large enough");
 
   // Define structure variables for output queues
   `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
@@ -161,10 +155,10 @@ module bp_cce_fsm
   logic mem_resp_v_li, mem_resp_yumi_lo;
   logic mem_resp_stream_new_li, mem_resp_stream_last_li, mem_resp_stream_done_li;
   logic [paddr_width_p-1:0] mem_resp_addr_li;
-  logic [dword_width_gp-1:0] mem_resp_data_li;
+  logic [bedrock_data_width_p-1:0] mem_resp_data_li;
   bp_me_stream_pump_in
     #(.bp_params_p(bp_params_p)
-      ,.stream_data_width_p(dword_width_gp)
+      ,.stream_data_width_p(bedrock_data_width_p)
       ,.block_width_p(cce_block_width_p)
       ,.payload_width_p(mem_payload_width_lp)
       ,.msg_stream_mask_p(mem_resp_payload_mask_gp)
@@ -193,16 +187,16 @@ module bp_cce_fsm
       );
 
   // Memory Command Stream Pump
-  localparam stream_words_lp = cce_block_width_p / dword_width_gp;
+  localparam stream_words_lp = cce_block_width_p / bedrock_data_width_p;
   localparam data_len_width_lp = `BSG_SAFE_CLOG2(stream_words_lp);
   bp_bedrock_mem_header_s mem_cmd_base_header_lo;
   logic mem_cmd_v_lo, mem_cmd_ready_and_li;
   logic mem_cmd_stream_new_li, mem_cmd_stream_done_li;
-  logic [dword_width_gp-1:0] mem_cmd_data_lo;
+  logic [bedrock_data_width_p-1:0] mem_cmd_data_lo;
   logic [data_len_width_lp-1:0] mem_cmd_stream_cnt_li;
   bp_me_stream_pump_out
     #(.bp_params_p(bp_params_p)
-      ,.stream_data_width_p(dword_width_gp)
+      ,.stream_data_width_p(bedrock_data_width_p)
       ,.block_width_p(cce_block_width_p)
       ,.payload_width_p(mem_payload_width_lp)
       ,.msg_stream_mask_p(mem_cmd_payload_mask_gp)
@@ -408,10 +402,12 @@ module bp_cce_fsm
        ,.cacheable_addr_o(resp_pma_cacheable_addr_lo)
        );
 
-  // aligned address for block-based actions
+  // align request address to bedrock data width to support critical word first behavior
   wire [paddr_width_p-1:0] paddr_aligned =
-    {mshr_r.paddr[paddr_width_p-1:lg_block_size_in_bytes_lp]
-     , lg_block_size_in_bytes_lp'('0)};
+    {mshr_r.paddr[paddr_width_p-1:lg_bedrock_data_bytes_lp]
+     , lg_bedrock_data_bytes_lp'('0)};
+
+  // align lru address to block boundary - used for block replacement
   wire [paddr_width_p-1:0] lru_paddr_aligned =
     {mshr_r.lru_paddr[paddr_width_p-1:lg_block_size_in_bytes_lp]
      , lg_block_size_in_bytes_lp'('0)};
@@ -1335,7 +1331,7 @@ module bp_cce_fsm
           // handshake is r&v
           mem_cmd_v_lo = ~mem_credits_empty;
           mem_cmd_base_header_lo.msg_type.mem = e_bedrock_mem_rd;
-          mem_cmd_base_header_lo.addr = paddr_aligned;
+          mem_cmd_base_header_lo.addr = mshr_r.paddr;
           mem_cmd_base_header_lo.size = mshr_r.msg_size;
           mem_cmd_base_header_lo.payload.lce_id = mshr_r.lce_id;
           mem_cmd_base_header_lo.payload.way_id = mshr_r.lru_way_id;
@@ -1819,6 +1815,9 @@ module bp_cce_fsm
           lce_cmd.payload.dst_id = mshr_r.owner_lce_id;
           lce_cmd.payload.way_id = mshr_r.owner_way_id;
 
+          // TODO: should transfer commands set size field of command message to block size?
+          // burst and stream protocols indicate if data exists / last beat
+          // other converters should use payload masks to determine which messages have data
           lce_cmd.msg_type.cmd = mshr_r.flags.write_not_read | mshr_r.flags.cached_modified
                                  ? e_bedrock_cmd_st_tr
                                  : mshr_r.flags.cached_owned | mshr_r.flags.cached_forward
@@ -1826,7 +1825,7 @@ module bp_cce_fsm
                                    // transfer & not cached in M, O, or F -> cached in E
                                    : e_bedrock_cmd_st_tr_wb;
 
-          lce_cmd.addr = paddr_aligned;
+          lce_cmd.addr = mshr_r.paddr;
 
           // either Invalidate or Downgrade Owner, depending on request type
           // write request invalidates owner (can only have 1 writer!)
@@ -1850,7 +1849,7 @@ module bp_cce_fsm
           dir_w_v = lce_cmd_header_v_o & lce_cmd_header_ready_and_i
                     & (mshr_r.flags.write_not_read | mshr_r.flags.cached_modified | mshr_r.flags.cached_exclusive);
           dir_cmd = e_wds_op;
-          dir_addr_li = paddr_aligned;
+          dir_addr_li = mshr_r.paddr;
           dir_lce_li = mshr_r.owner_lce_id;
           dir_way_li = mshr_r.owner_way_id;
           dir_coh_state_li = mshr_r.flags.write_not_read
@@ -1916,7 +1915,7 @@ module bp_cce_fsm
           lce_cmd_has_data_o = 1'b0;
 
           lce_cmd.msg_type.cmd = e_bedrock_cmd_st_wakeup;
-          lce_cmd.addr = paddr_aligned;
+          lce_cmd.addr = mshr_r.paddr;
           lce_cmd.payload.dst_id = mshr_r.lce_id;
           lce_cmd.payload.way_id = mshr_r.way_id;
           lce_cmd.payload.state = mshr_r.next_coh_state;

--- a/bp_me/src/v/cce/bp_cce_inst_predecode.sv
+++ b/bp_me/src/v/cce/bp_cce_inst_predecode.sv
@@ -31,7 +31,7 @@ module bp_cce_inst_predecode
 
   // parameter checks
   if (width_p > `bp_cce_inst_addr_width)
-    $fatal(0,"Desired address width is larger than address width used in instruction encoding");
+    $fatal(0, "Desired address width is larger than address width used in instruction encoding");
 
   wire [width_p-1:0] pc_plus_one = width_p'(pc_i + 'd1);
   wire [width_p-1:0] branch_target = inst_i.type_u.btype.target[0+:width_p];

--- a/bp_me/src/v/cce/bp_cce_inst_ram.sv
+++ b/bp_me/src/v/cce/bp_cce_inst_ram.sv
@@ -52,7 +52,7 @@ module bp_cce_inst_ram
 
   // parameter checks
   if ($bits(bp_cce_inst_s) != cce_instr_width_gp)
-    $fatal(0,"Param cce_instr_width_gp does not match width of bp_cce_inst_s");
+    $fatal(0, "Param cce_instr_width_gp does not match width of bp_cce_inst_s");
 
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   bp_cfg_bus_s cfg_bus_cast_i;

--- a/bp_me/src/v/cce/bp_cce_msg.sv
+++ b/bp_me/src/v/cce/bp_cce_msg.sv
@@ -16,6 +16,7 @@ module bp_cce_msg
   import bp_me_pkg::*;
   #(parameter bp_params_e bp_params_p      = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
+    , parameter bedrock_data_width_p       = dword_width_gp
 
     // Derived parameters
     , localparam block_size_in_bytes_lp    = (cce_block_width_p/8)
@@ -29,17 +30,17 @@ module bp_cce_msg
     // counter width for memory command/response data packet counters
     , localparam counter_width_lp          = 8
 
+    // byte offset bits required per bedrock data channel beat
+    , localparam lg_bedrock_data_bytes_lp = `BSG_SAFE_CLOG2(bedrock_data_width_p/8)
+
     // Interface Widths
     , localparam mshr_width_lp             = `bp_cce_mshr_width(lce_id_width_p, lce_assoc_p, paddr_width_p)
     , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
     `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
     `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
-    // log2 of dword width bytes
-    , localparam lg_dword_width_bytes_lp = `BSG_SAFE_CLOG2(dword_width_gp/8)
-
     // stream pump
-    , localparam stream_words_lp = cce_block_width_p / dword_width_gp
+    , localparam stream_words_lp = cce_block_width_p / bedrock_data_width_p
     , localparam data_len_width_lp = `BSG_SAFE_CLOG2(stream_words_lp)
   )
   (input                                            clk_i
@@ -55,7 +56,7 @@ module bp_cce_msg
    , input                                          lce_req_header_v_i
    , output logic                                   lce_req_header_yumi_o
    , input                                          lce_req_has_data_i
-   , input [dword_width_gp-1:0]                     lce_req_data_i
+   , input [bedrock_data_width_p-1:0]               lce_req_data_i
    , input                                          lce_req_data_v_i
    , output logic                                   lce_req_data_ready_and_o
    , input                                          lce_req_last_i
@@ -64,7 +65,7 @@ module bp_cce_msg
    , input                                          lce_resp_header_v_i
    , output logic                                   lce_resp_header_yumi_o
    , input                                          lce_resp_has_data_i
-   , input [dword_width_gp-1:0]                     lce_resp_data_i
+   , input [bedrock_data_width_p-1:0]               lce_resp_data_i
    , input                                          lce_resp_data_v_i
    , output logic                                   lce_resp_data_ready_and_o
    , input                                          lce_resp_last_i
@@ -73,7 +74,7 @@ module bp_cce_msg
    , output logic                                   lce_cmd_header_v_o
    , input                                          lce_cmd_header_ready_and_i
    , output logic                                   lce_cmd_has_data_o
-   , output logic [dword_width_gp-1:0]              lce_cmd_data_o
+   , output logic [bedrock_data_width_p-1:0]        lce_cmd_data_o
    , output logic                                   lce_cmd_data_v_o
    , input                                          lce_cmd_data_ready_and_i
    , output logic                                   lce_cmd_last_o
@@ -82,7 +83,7 @@ module bp_cce_msg
    // memory response stream pump in
    , input [mem_header_width_lp-1:0]                mem_resp_header_i
    , input [paddr_width_p-1:0]                      mem_resp_addr_i
-   , input [dword_width_gp-1:0]                     mem_resp_data_i
+   , input [bedrock_data_width_p-1:0]               mem_resp_data_i
    , input                                          mem_resp_v_i
    , output logic                                   mem_resp_yumi_o
    , input                                          mem_resp_stream_new_i
@@ -91,7 +92,7 @@ module bp_cce_msg
 
    // memory command stream pump out
    , output logic [mem_header_width_lp-1:0]         mem_cmd_header_o
-   , output logic [dword_width_gp-1:0]              mem_cmd_data_o
+   , output logic [bedrock_data_width_p-1:0]        mem_cmd_data_o
    , output logic                                   mem_cmd_v_o
    , input                                          mem_cmd_ready_and_i
    , input [data_len_width_lp-1:0]                  mem_cmd_stream_cnt_i
@@ -179,11 +180,10 @@ module bp_cce_msg
   // memory command header register used to complete pushq mem_cmd
   bp_bedrock_mem_header_s mem_cmd_base_header_r, mem_cmd_base_header_n;
 
-  // Cache block aligned address mask
-  // TODO: should CCE ever align the address?
+  // align address to bedrock data width for critical word first behavior
   wire [paddr_width_p-1:0] addr_mask =
-    {{(paddr_width_p-lg_block_size_in_bytes_lp){1'b1}}
-     , {(lg_block_size_in_bytes_lp){1'b0}}
+    {{(paddr_width_p-lg_bedrock_data_bytes_lp){1'b1}}
+     , {(lg_bedrock_data_bytes_lp){1'b0}}
     };
 
   // Counter for message send/receive
@@ -877,8 +877,7 @@ module bp_cce_msg
               // cached read - send single beat, no data
               e_bedrock_mem_rd: begin
                 mem_cmd_v_o = ~mem_credits_empty;
-                // cached access masks the address to align to cache block
-                mem_cmd_base_header_lo.addr = (addr_i & addr_mask);
+                mem_cmd_base_header_lo.addr = addr_i;
                 // set uncached bit based on uncached flag in MSHR
                 // this bit indicates if the LCE should receive the data as cached or uncached
                 // when it returns from memory
@@ -915,8 +914,7 @@ module bp_cce_msg
                 // patch through data
                 mem_cmd_data_o = lce_resp_data_i;
 
-                // cached access masks the address to align to cache block
-                mem_cmd_base_header_lo.addr = (addr_i & addr_mask);
+                mem_cmd_base_header_lo.addr = addr_i;
                 // set uncached bit based on uncached flag in MSHR
                 // this bit indicates if the LCE should receive the data as cached or uncached
                 // when it returns from memory
@@ -1027,12 +1025,12 @@ module bp_cce_msg
           lce_cmd.payload.dst_id = pe_lce_id;
           lce_cmd.payload.way_id = sharers_ways_r[pe_lce_id];
 
-          lce_cmd.addr = addr_r;
+          lce_cmd.addr = addr_r & addr_mask;
 
           // Directory write command
           dir_w_v_o = lce_cmd_header_v_o & lce_cmd_header_ready_and_i;
           dir_w_cmd_o = e_wds_op;
-          dir_addr_o = addr_r;
+          dir_addr_o = addr_r & addr_mask;
           dir_addr_bypass_o = '0;
           dir_lce_o = {'0, pe_lce_id};
           dir_way_o = sharers_ways_r[pe_lce_id];

--- a/bp_me/src/v/cce/bp_cce_src_sel.sv
+++ b/bp_me/src/v/cce/bp_cce_src_sel.sv
@@ -63,7 +63,10 @@ module bp_cce_src_sel
    , input [lce_req_header_width_lp-1:0]                            lce_req_header_i
    , input [lce_resp_header_width_lp-1:0]                           lce_resp_header_i
    , input [mem_header_width_lp-1:0]                                mem_resp_header_i
-   // TODO: data inputs are not guarded by valid
+   // note: data inputs are not guarded by valid
+   // software must ensure data is valid before use
+   // note: if data width > cce gpr width, only least significant cce gpr width bits of
+   // data input are used and sent to src_a|b_o
    , input [bedrock_data_width_p-1:0]                               lce_req_data_i
    , input [bedrock_data_width_p-1:0]                               lce_resp_data_i
    , input [bedrock_data_width_p-1:0]                               mem_resp_data_i

--- a/bp_me/src/v/cce/bp_cce_src_sel.sv
+++ b/bp_me/src/v/cce/bp_cce_src_sel.sv
@@ -21,6 +21,7 @@ module bp_cce_src_sel
   import bp_me_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
+    , parameter bedrock_data_width_p = dword_width_gp
 
     // Derived parameters
     , localparam mshr_width_lp             = `bp_cce_mshr_width(lce_id_width_p, lce_assoc_p, paddr_width_p)

--- a/bp_me/src/v/cce/bp_cce_src_sel.sv
+++ b/bp_me/src/v/cce/bp_cce_src_sel.sv
@@ -64,9 +64,9 @@ module bp_cce_src_sel
    , input [lce_resp_header_width_lp-1:0]                           lce_resp_header_i
    , input [mem_header_width_lp-1:0]                                mem_resp_header_i
    // TODO: data inputs are not guarded by valid
-   , input [dword_width_gp-1:0]                                     lce_req_data_i
-   , input [dword_width_gp-1:0]                                     lce_resp_data_i
-   , input [dword_width_gp-1:0]                                     mem_resp_data_i
+   , input [bedrock_data_width_p-1:0]                               lce_req_data_i
+   , input [bedrock_data_width_p-1:0]                               lce_resp_data_i
+   , input [bedrock_data_width_p-1:0]                               mem_resp_data_i
 
    // Source A and B outputs
    , output logic [`bp_cce_inst_gpr_width-1:0]   src_a_o
@@ -80,12 +80,6 @@ module bp_cce_src_sel
    , output logic [lce_assoc_width_p-1:0]        lru_way_o
    , output bp_coh_states_e                      state_o
   );
-
-  // parameter checks
-  initial begin
-    if (cce_block_width_p < `bp_cce_inst_gpr_width)
-      $fatal(0,"CCE block width must be greater than CCE GPR width");
-  end
 
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   bp_cfg_bus_s cfg_bus_cast;

--- a/bp_me/src/v/cce/bp_cce_wrapper.sv
+++ b/bp_me/src/v/cce/bp_cce_wrapper.sv
@@ -119,12 +119,11 @@ module bp_cce_wrapper
   if (dcache_block_width_p != cce_block_width_p) $fatal(0, "dcache block width must match cce block width");
   if (!(`BSG_IS_POW2(dcache_assoc_p) && `BSG_IS_POW2(dcache_sets_p)))
     $fatal(0, "D$ sets and assoc must be power of two");
+  // acclereator caches
   if ((num_cacc_p) > 0 && (acache_block_width_p != cce_block_width_p)) $fatal(0, "acache block width must match cce block width");
-  // TODO: what is the 0 case?
-  if ((num_cacc_p > 0) && !(`BSG_IS_POW2(acache_assoc_p) || acache_assoc_p == 0))
+  if ((num_cacc_p > 0) && !(`BSG_IS_POW2(acache_assoc_p)))
     $fatal(0, "A$ assoc must be power of two or 0");
-  // TODO: what is the 0 case?
-  if ((num_cacc_p > 0) && !(`BSG_IS_POW2(acache_sets_p) || acache_sets_p == 0))
+  if ((num_cacc_p > 0) && !(`BSG_IS_POW2(acache_sets_p)))
     $fatal(0, "A$ sets must be power of two or 0");
 
   // coherence system block width is pow2 and between 64 and 1024 bits
@@ -135,14 +134,9 @@ module bp_cce_wrapper
   if (!(`BSG_IS_POW2(cce_way_groups_p))) $fatal(0, "Number of way groups must be a power of two");
   if (cce_way_groups_p < 1) $fatal(0, "There must be at least one way group");
 
-  // TODO: verify this params function
-  // direct-mapped caches not supported?
-  if (lce_sets_p <= 1) $fatal(0, "Number of LCE sets must be greater than 1");
-
   // bedrock data width must be pow2 between 64-bits and CCE block size
   if (bedrock_data_width_p < 64 || bedrock_data_width_p > cce_block_width_p
-      || !(`BSG_IS_POW2(bedrock_data_width_p))
-      )
+      || !(`BSG_IS_POW2(bedrock_data_width_p)))
       $fatal(0, "CCE requires bedrock data width of between 64-bits and block width and power of 2 bits");
 
 endmodule

--- a/bp_me/src/v/cce/bp_cce_wrapper.sv
+++ b/bp_me/src/v/cce/bp_cce_wrapper.sv
@@ -21,6 +21,7 @@ module bp_cce_wrapper
   import bp_me_pkg::*;
   #(parameter bp_params_e bp_params_p      = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
+    , parameter bedrock_data_width_p       = dword_width_gp
 
     // Interface Widths
     , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
@@ -46,7 +47,7 @@ module bp_cce_wrapper
    , input                                          lce_req_header_v_i
    , output logic                                   lce_req_header_ready_and_o
    , input                                          lce_req_has_data_i
-   , input [dword_width_gp-1:0]                     lce_req_data_i
+   , input [bedrock_data_width_p-1:0]               lce_req_data_i
    , input                                          lce_req_data_v_i
    , output logic                                   lce_req_data_ready_and_o
    , input                                          lce_req_last_i
@@ -55,7 +56,7 @@ module bp_cce_wrapper
    , input                                          lce_resp_header_v_i
    , output logic                                   lce_resp_header_ready_and_o
    , input                                          lce_resp_has_data_i
-   , input [dword_width_gp-1:0]                     lce_resp_data_i
+   , input [bedrock_data_width_p-1:0]               lce_resp_data_i
    , input                                          lce_resp_data_v_i
    , output logic                                   lce_resp_data_ready_and_o
    , input                                          lce_resp_last_i
@@ -64,7 +65,7 @@ module bp_cce_wrapper
    , output logic                                   lce_cmd_header_v_o
    , input                                          lce_cmd_header_ready_and_i
    , output logic                                   lce_cmd_has_data_o
-   , output logic [dword_width_gp-1:0]              lce_cmd_data_o
+   , output logic [bedrock_data_width_p-1:0]        lce_cmd_data_o
    , output logic                                   lce_cmd_data_v_o
    , input                                          lce_cmd_data_ready_and_i
    , output logic                                   lce_cmd_last_o
@@ -72,13 +73,13 @@ module bp_cce_wrapper
    // CCE-MEM Interface
    // BedRock Stream protocol: ready&valid
    , input [mem_header_width_lp-1:0]                mem_resp_header_i
-   , input [dword_width_gp-1:0]                     mem_resp_data_i
+   , input [bedrock_data_width_p-1:0]               mem_resp_data_i
    , input                                          mem_resp_v_i
    , output logic                                   mem_resp_ready_and_o
    , input                                          mem_resp_last_i
 
    , output logic [mem_header_width_lp-1:0]         mem_cmd_header_o
-   , output logic [dword_width_gp-1:0]              mem_cmd_data_o
+   , output logic [bedrock_data_width_p-1:0]        mem_cmd_data_o
    , output logic                                   mem_cmd_v_o
    , input                                          mem_cmd_ready_and_i
    , output logic                                   mem_cmd_last_o
@@ -93,14 +94,55 @@ module bp_cce_wrapper
 
   if (cce_type_p == e_cce_ucode) begin : ucode
     bp_cce
-    #(.bp_params_p(bp_params_p))
+    #(.bp_params_p(bp_params_p)
+      ,.bedrock_data_width_p(bedrock_data_width_p)
+      )
     cce
      (.*);
   end else if (cce_type_p == e_cce_fsm) begin : fsm
     bp_cce_fsm
-    #(.bp_params_p(bp_params_p))
+    #(.bp_params_p(bp_params_p)
+      ,.bedrock_data_width_p(bedrock_data_width_p)
+      )
     cce
      (.*);
   end
+
+  // parameter checks
+
+  // cache organization
+  // all caches must have the same block size, which must equal CCE block size
+  // cache assoc and sets must be pow2
+  if (icache_block_width_p != cce_block_width_p) $fatal(0, "icache block width must match cce block width");
+  if (!(`BSG_IS_POW2(icache_assoc_p) && `BSG_IS_POW2(icache_sets_p)))
+    $fatal(0, "I$ sets and assoc must be power of two");
+  if (dcache_block_width_p != cce_block_width_p) $fatal(0, "dcache block width must match cce block width");
+  if (!(`BSG_IS_POW2(dcache_assoc_p) && `BSG_IS_POW2(dcache_sets_p)))
+    $fatal(0, "D$ sets and assoc must be power of two");
+  if ((num_cacc_p) > 0 && (acache_block_width_p != cce_block_width_p)) $fatal(0, "acache block width must match cce block width");
+  // TODO: what is the 0 case?
+  if ((num_cacc_p > 0) && !(`BSG_IS_POW2(acache_assoc_p) || acache_assoc_p == 0))
+    $fatal(0, "A$ assoc must be power of two or 0");
+  // TODO: what is the 0 case?
+  if ((num_cacc_p > 0) && !(`BSG_IS_POW2(acache_sets_p) || acache_sets_p == 0))
+    $fatal(0, "A$ sets must be power of two or 0");
+
+  // coherence system block width is pow2 and between 64 and 1024 bits
+  if (!(`BSG_IS_POW2(cce_block_width_p) || cce_block_width_p < 64 || cce_block_width_p > 1024))
+    $fatal(0, "invalid CCE block width");
+
+  // way groups
+  if (!(`BSG_IS_POW2(cce_way_groups_p))) $fatal(0, "Number of way groups must be a power of two");
+  if (cce_way_groups_p < 1) $fatal(0, "There must be at least one way group");
+
+  // TODO: verify this params function
+  // direct-mapped caches not supported?
+  if (lce_sets_p <= 1) $fatal(0, "Number of LCE sets must be greater than 1");
+
+  // bedrock data width must be pow2 between 64-bits and CCE block size
+  if (bedrock_data_width_p < 64 || bedrock_data_width_p > cce_block_width_p
+      || !(`BSG_IS_POW2(bedrock_data_width_p))
+      )
+      $fatal(0, "CCE requires bedrock data width of between 64-bits and block width and power of 2 bits");
 
 endmodule

--- a/bp_me/src/v/dev/bp_me_bedrock_register.sv
+++ b/bp_me/src/v/dev/bp_me_bedrock_register.sv
@@ -118,9 +118,9 @@ module bp_me_bedrock_register
       assign w_v_o[i] = ~v_r & addr_match &  wr_not_rd;
     end
 
-  assign addr_o = (mem_cmd_header_li.addr);
-  assign size_o = (mem_cmd_header_li.size);
-  assign data_o = (mem_cmd_data_li);
+  assign addr_o = mem_cmd_header_li.addr[0+:reg_addr_width_p];
+  assign size_o = mem_cmd_header_li.size;
+  assign data_o = mem_cmd_data_li;
 
   assign mem_resp_header_o = mem_cmd_header_li;
   assign mem_resp_data_o = rdata_lo;

--- a/bp_me/src/v/dev/bp_me_loopback.sv
+++ b/bp_me/src/v/dev/bp_me_loopback.sv
@@ -29,6 +29,8 @@ module bp_me_loopback
     , output logic                                   mem_resp_last_o
     );
 
+  wire unused = &{mem_cmd_data_i};
+
   // Used to decouple to help prevent deadlock
   logic mem_resp_last_lo;
   bsg_one_fifo

--- a/bp_me/test/common/bp_me_nonsynth_cce_tracer.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cce_tracer.sv
@@ -15,6 +15,7 @@ module bp_me_nonsynth_cce_tracer
   import bp_me_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
+    , parameter bedrock_data_width_p = dword_width_gp
 
     , localparam cce_trace_file_p = "cce"
 
@@ -38,34 +39,34 @@ module bp_me_nonsynth_cce_tracer
    , input [lce_req_header_width_lp-1:0]            lce_req_header_i
    , input                                          lce_req_header_v_i
    , input                                          lce_req_header_ready_and_i
-   , input [dword_width_gp-1:0]                     lce_req_data_i
+   , input [bedrock_data_width_p-1:0]               lce_req_data_i
    , input                                          lce_req_data_v_i
    , input                                          lce_req_data_ready_and_i
 
    , input [lce_resp_header_width_lp-1:0]           lce_resp_header_i
    , input                                          lce_resp_header_v_i
    , input                                          lce_resp_header_ready_and_i
-   , input [dword_width_gp-1:0]                     lce_resp_data_i
+   , input [bedrock_data_width_p-1:0]               lce_resp_data_i
    , input                                          lce_resp_data_v_i
    , input                                          lce_resp_data_ready_and_i
 
    , input [lce_cmd_header_width_lp-1:0]            lce_cmd_header_i
    , input                                          lce_cmd_header_v_i
    , input                                          lce_cmd_header_ready_and_i
-   , input [dword_width_gp-1:0]                     lce_cmd_data_i
+   , input [bedrock_data_width_p-1:0]               lce_cmd_data_i
    , input                                          lce_cmd_data_v_i
    , input                                          lce_cmd_data_ready_and_i
 
    // CCE-MEM Interface
    // BedRock Stream protocol: ready&valid
    , input [mem_header_width_lp-1:0]                mem_resp_header_i
-   , input [dword_width_gp-1:0]                     mem_resp_data_i
+   , input [bedrock_data_width_p-1:0]               mem_resp_data_i
    , input                                          mem_resp_v_i
    , input                                          mem_resp_ready_and_i
    , input                                          mem_resp_last_i
 
    , input [mem_header_width_lp-1:0]                mem_cmd_header_i
-   , input [dword_width_gp-1:0]                     mem_cmd_data_i
+   , input [bedrock_data_width_p-1:0]               mem_cmd_data_i
    , input                                          mem_cmd_v_i
    , input                                          mem_cmd_ready_and_i
    , input                                          mem_cmd_last_i

--- a/bp_me/test/common/bp_me_nonsynth_lce_tracer.sv
+++ b/bp_me/test/common/bp_me_nonsynth_lce_tracer.sv
@@ -99,6 +99,8 @@ module bp_me_nonsynth_lce_tracer
      ,.count_o(req_cnt)
      );
 
+  wire uc_req = lce_req_header_cast_i.msg_type.req inside {e_bedrock_req_uc_rd, e_bedrock_req_uc_wr};
+
   always_ff @(posedge clk_i) begin
     if (reset_i) begin
       cnt_up <= 1'b0;
@@ -108,8 +110,9 @@ module bp_me_nonsynth_lce_tracer
 
       // request to CCE
       if (lce_req_v_i & lce_req_ready_and_i) begin
-        $fdisplay(file, "%12t |: LCE[%0d] REQ addr[%H] cce[%0d] msg[%b] set[%0d] ne[%b] lru[%0d] size[%b]"
-                  , $time, lce_req_header_cast_i.payload.src_id, lce_req_header_cast_i.addr, lce_req_header_cast_i.payload.dst_id, lce_req_header_cast_i.msg_type
+        $fdisplay(file, "%12t |: LCE[%0d] REQ addr[%H] cce[%0d] msg[%b] uc[%b] set[%0d] ne[%b] lru[%0d] size[%b]"
+                  , $time, lce_req_header_cast_i.payload.src_id, lce_req_header_cast_i.addr, lce_req_header_cast_i.payload.dst_id, lce_req_header_cast_i.msg_type.req
+                  , uc_req
                   , lce_req_header_cast_i.addr[block_offset_bits_lp+:lg_sets_lp]
                   , lce_req_header_cast_i.payload.non_exclusive, lce_req_header_cast_i.payload.lru_way_id
                   , lce_req_header_cast_i.size
@@ -126,7 +129,7 @@ module bp_me_nonsynth_lce_tracer
       // response to CCE
       if (lce_resp_v_i & lce_resp_ready_and_i) begin
         $fdisplay(file, "%12t |: LCE[%0d] RESP addr[%H] cce[%0d] msg[%b] set[%0d] len[%b]"
-                  , $time, lce_resp_header_cast_i.payload.src_id, lce_resp_header_cast_i.addr, lce_resp_header_cast_i.payload.dst_id, lce_resp_header_cast_i.msg_type
+                  , $time, lce_resp_header_cast_i.payload.src_id, lce_resp_header_cast_i.addr, lce_resp_header_cast_i.payload.dst_id, lce_resp_header_cast_i.msg_type.resp
                   , lce_resp_header_cast_i.addr[block_offset_bits_lp+:lg_sets_lp]
                   , lce_resp_header_cast_i.size
                   );
@@ -141,7 +144,7 @@ module bp_me_nonsynth_lce_tracer
       // command to LCE
       if (lce_cmd_v_i & lce_cmd_ready_and_i) begin
         $fdisplay(file, "%12t |: LCE[%0d] CMD IN addr[%H] cce[%0d] msg[%b] set[%0d] way[%0d] state[%b] tgt[%0d] tgt_way[%0d] len[%b]"
-                  , $time, lce_cmd_header_cast_i.payload.dst_id, lce_cmd_header_cast_i.addr, lce_cmd_header_cast_i.payload.src_id, lce_cmd_header_cast_i.msg_type
+                  , $time, lce_cmd_header_cast_i.payload.dst_id, lce_cmd_header_cast_i.addr, lce_cmd_header_cast_i.payload.src_id, lce_cmd_header_cast_i.msg_type.cmd
                   , lce_cmd_header_cast_i.addr[block_offset_bits_lp+:lg_sets_lp], lce_cmd_header_cast_i.payload.way_id, lce_cmd_header_cast_i.payload.state, lce_cmd_header_cast_i.payload.target
                   , lce_cmd_header_cast_i.payload.target_way_id, lce_cmd_header_cast_i.size
                   );
@@ -156,7 +159,7 @@ module bp_me_nonsynth_lce_tracer
       // command from LCE
       if (lce_cmd_o_v_i & lce_cmd_o_ready_and_i) begin
         $fdisplay(file, "%12t |: LCE[%0d] CMD OUT dst[%0d] addr[%H] CCE[%0d] msg[%b] set[%0d] way[%0d] state[%b] tgt[%0d] tgt_way[%0d] len[%b]"
-                  , $time, lce_id_i, lce_cmd_header_o_cast_i.payload.dst_id, lce_cmd_header_o_cast_i.addr, lce_cmd_header_o_cast_i.payload.src_id, lce_cmd_header_o_cast_i.msg_type
+                  , $time, lce_id_i, lce_cmd_header_o_cast_i.payload.dst_id, lce_cmd_header_o_cast_i.addr, lce_cmd_header_o_cast_i.payload.src_id, lce_cmd_header_o_cast_i.msg_type.cmd
                   , lce_cmd_header_o_cast_i.addr[block_offset_bits_lp+:lg_sets_lp]
                   , lce_cmd_header_o_cast_i.payload.way_id, lce_cmd_header_o_cast_i.payload.state, lce_cmd_header_o_cast_i.payload.target, lce_cmd_header_o_cast_i.payload.target_way_id
                   , lce_cmd_header_o_cast_i.size

--- a/bp_me/test/common/bp_me_nonsynth_mock_lce.sv
+++ b/bp_me/test/common/bp_me_nonsynth_mock_lce.sv
@@ -199,6 +199,16 @@ module bp_me_nonsynth_mock_lce
       ,.data_o(data_lo)
       );
 
+  logic [cce_block_width_p-1:0] rotated_data_lo;
+  wire [`BSG_SAFE_CLOG2(cce_block_width_p)-1:0] rot_li = (lce_cmd_header_r.addr[0+:block_offset_bits_lp] << 3);
+  bsg_rotate_right
+    #(.width_p(cce_block_width_p))
+    data_rotate
+    (.data_i(data_lo[lce_cmd_header_r.payload.way_id])
+     ,.rot_i(rot_li)
+     ,.o(rotated_data_lo)
+     );
+
   // miss status handling register definition for current trace replay command
   typedef struct packed {
     logic miss;
@@ -596,6 +606,7 @@ module bp_me_nonsynth_mock_lce
         mshr_n.transfer_received = '0;
 
         lce_state_n = UNCACHED_SEND_REQ;
+
       end
       UNCACHED_SEND_REQ: begin
         // uncached access - send LCE request
@@ -678,44 +689,47 @@ module bp_me_nonsynth_mock_lce
                                                    , state: lce_cmd_header_lo.payload.state};
           tag_w_mask_li[lce_cmd_header_lo.payload.way_id] = '{tag: '1, state: e_COH_O};
 
+          lce_cmd_yumi = lce_cmd_v;
+          lce_cmd_header_n = lce_cmd_header_lo;
+          lce_cmd_data_n = lce_cmd_data_lo;
+
           lce_state_n = UNCACHED_WB_RD;
         end
       end
       UNCACHED_WB_RD: begin
         tag_v_li = 1'b1;
-        tag_addr_li = lce_cmd_header_lo.addr[block_offset_bits_lp +: lg_sets_lp];
+        tag_addr_li = lce_cmd_header_r.addr[block_offset_bits_lp +: lg_sets_lp];
         data_v_li = 1'b1;
-        data_addr_li = lce_cmd_header_lo.addr[block_offset_bits_lp +: lg_sets_lp];
+        data_addr_li = lce_cmd_header_r.addr[block_offset_bits_lp +: lg_sets_lp];
         dirty_bits_v_li = 1'b1;
-        dirty_bits_addr_li = lce_cmd_header_lo.addr[block_offset_bits_lp +: lg_sets_lp];
+        dirty_bits_addr_li = lce_cmd_header_r.addr[block_offset_bits_lp +: lg_sets_lp];
         lce_state_n = UNCACHED_WB;
       end
       UNCACHED_WB: begin
 
         // handshake
-        lce_resp_v_o = lce_cmd_v;
-        lce_cmd_yumi = lce_resp_v_o & lce_resp_ready_and_i;
+        lce_resp_v_o = 1'b1;
 
         // reread tag, data, dirty bits if response does not send
         tag_v_li = ~(lce_resp_v_o & lce_resp_ready_and_i);
-        tag_addr_li = lce_cmd_header_lo.addr[block_offset_bits_lp +: lg_sets_lp];
+        tag_addr_li = lce_cmd_header_r.addr[block_offset_bits_lp +: lg_sets_lp];
 
         data_v_li = ~(lce_resp_v_o & lce_resp_ready_and_i);
-        data_addr_li = lce_cmd_header_lo.addr[block_offset_bits_lp +: lg_sets_lp];
+        data_addr_li = lce_cmd_header_r.addr[block_offset_bits_lp +: lg_sets_lp];
 
         // dirty bits are always used; either re-read or they are being written because response
         // message was sent
         dirty_bits_v_li = 1'b1;
-        dirty_bits_addr_li = lce_cmd_header_lo.addr[block_offset_bits_lp +: lg_sets_lp];
+        dirty_bits_addr_li = lce_cmd_header_r.addr[block_offset_bits_lp +: lg_sets_lp];
 
         // writeback cmd
 
-        lce_resp_header_cast_o.payload.dst_id = lce_cmd_header_lo.payload.src_id;
+        lce_resp_header_cast_o.payload.dst_id = lce_cmd_header_r.payload.src_id;
         lce_resp_header_cast_o.payload.src_id = lce_id_i;
-        lce_resp_header_cast_o.addr = lce_cmd_header_lo.addr;
+        lce_resp_header_cast_o.addr = lce_cmd_header_r.addr;
 
-        if (dirty_bits_data_lo[lce_cmd_header_lo.payload.way_id]) begin
-          lce_resp_data_o = data_lo[lce_cmd_header_lo.payload.way_id];
+        if (dirty_bits_data_lo[lce_cmd_header_r.payload.way_id]) begin
+          lce_resp_data_o = rotated_data_lo;
           lce_resp_header_cast_o.msg_type.resp = e_bedrock_resp_wb;
           lce_resp_header_cast_o.size = msg_block_size;
 
@@ -723,8 +737,8 @@ module bp_me_nonsynth_mock_lce
           // (this prevents the dirty bit from being cleared before the response is sent, which
           //  could result in a null_wb being sent when an actual wb should have been)
           dirty_bits_w_li = lce_resp_v_o;
-          dirty_bits_w_mask_li[lce_cmd_header_lo.payload.way_id] = 1'b1;
-          dirty_bits_data_li[lce_cmd_header_lo.payload.way_id] = 1'b0;
+          dirty_bits_w_mask_li[lce_cmd_header_r.payload.way_id] = 1'b1;
+          dirty_bits_data_li[lce_cmd_header_r.payload.way_id] = 1'b0;
 
         end else begin
           lce_resp_data_o = '0;
@@ -894,7 +908,7 @@ module bp_me_nonsynth_mock_lce
         lce_cmd_header_cast_o.payload.way_id = lce_cmd_header_r.payload.target_way_id;
 
         // Assign data command to msg field of LCE Cmd
-        lce_cmd_data_o = data_lo[lce_cmd_header_r.payload.way_id];
+        lce_cmd_data_o = rotated_data_lo;
         lce_cmd_header_cast_o.payload.state = lce_cmd_header_r.payload.target_state;
         lce_cmd_header_cast_o.addr = lce_cmd_header_r.addr;
         lce_cmd_header_cast_o.size = msg_block_size;
@@ -937,7 +951,7 @@ module bp_me_nonsynth_mock_lce
         lce_resp_header_cast_o.addr = lce_cmd_header_r.addr;
 
         if (dirty_bits_data_lo[lce_cmd_header_r.payload.way_id]) begin
-          lce_resp_data_o = data_lo[lce_cmd_header_r.payload.way_id];
+          lce_resp_data_o = rotated_data_lo;
           lce_resp_header_cast_o.msg_type.resp = e_bedrock_resp_wb;
           lce_resp_header_cast_o.size = msg_block_size;
 

--- a/bp_me/test/tb/bp_cce/testbench.sv
+++ b/bp_me/test/tb/bp_cce/testbench.sv
@@ -14,6 +14,7 @@ module testbench
  import bp_me_nonsynth_pkg::*;
  #(parameter bp_params_e bp_params_p = BP_CFG_FLOWVAR // Replaced by the flow with a specific bp_cfg
    `declare_bp_proc_params(bp_params_p)
+   , parameter bedrock_data_width_p = dword_width_gp
 
    , parameter cce_trace_p = 0
    , parameter cce_dir_trace_p = 0
@@ -117,7 +118,7 @@ module testbench
 
   // CCE Memory Interface - BedRock Stream
   bp_bedrock_mem_header_s mem_resp_header, mem_cmd_header;
-  logic [dword_width_gp-1:0] mem_cmd_data, mem_resp_data;
+  logic [bedrock_data_width_p-1:0] mem_cmd_data, mem_resp_data;
   logic mem_resp_v, mem_resp_ready_and;
   logic mem_cmd_v, mem_cmd_ready_and;
   logic mem_cmd_last, mem_resp_last;
@@ -141,13 +142,13 @@ module testbench
   // LCE-CCE request interface (from lite-to-burst converter to xbar)
   bp_bedrock_lce_req_header_s [num_lce_p-1:0] lce_req_header;
   logic [num_lce_p-1:0] lce_req_header_v, lce_req_header_ready_and, lce_req_has_data;
-  logic [num_lce_p-1:0][dword_width_gp-1:0] lce_req_data;
+  logic [num_lce_p-1:0][bedrock_data_width_p-1:0] lce_req_data;
   logic [num_lce_p-1:0] lce_req_data_v, lce_req_data_ready_and, lce_req_last;
   wire [num_lce_p-1:0] lce_req_dst = '0;
   // LCE-CCE request interface (from xbar to CCE)
   bp_bedrock_lce_req_header_s cce_lce_req_header_li;
   logic cce_lce_req_header_v_li, cce_lce_req_header_ready_and_lo, cce_lce_req_has_data_li;
-  logic [dword_width_gp-1:0] cce_lce_req_data_li;
+  logic [bedrock_data_width_p-1:0] cce_lce_req_data_li;
   logic cce_lce_req_data_v_li, cce_lce_req_data_ready_and_lo, cce_lce_req_last_li;
 
   // LCE-CCE response interface (from LCE to buffer) - BedRock Lite
@@ -161,19 +162,19 @@ module testbench
   // LCE-CCE response interface (from lite-to-burst converter to xbar)
   bp_bedrock_lce_resp_header_s [num_lce_p-1:0] lce_resp_header;
   logic [num_lce_p-1:0] lce_resp_header_v, lce_resp_header_ready_and, lce_resp_has_data;
-  logic [num_lce_p-1:0][dword_width_gp-1:0] lce_resp_data;
+  logic [num_lce_p-1:0][bedrock_data_width_p-1:0] lce_resp_data;
   logic [num_lce_p-1:0] lce_resp_data_v, lce_resp_data_ready_and, lce_resp_last;
   wire [num_lce_p-1:0] lce_resp_dst = '0;
   // LCE-CCE response interface (from xbar to CCE)
   bp_bedrock_lce_resp_header_s cce_lce_resp_header_li;
   logic cce_lce_resp_header_v_li, cce_lce_resp_header_ready_and_lo, cce_lce_resp_has_data_li;
-  logic [dword_width_gp-1:0] cce_lce_resp_data_li;
+  logic [bedrock_data_width_p-1:0] cce_lce_resp_data_li;
   logic cce_lce_resp_data_v_li, cce_lce_resp_data_ready_and_lo, cce_lce_resp_last_li;
 
   // LCE-CCE command interface (from xbar to burst-to-lite)
   bp_bedrock_lce_cmd_header_s [num_lce_p-1:0] lce_cmd_header_li;
   logic [num_lce_p-1:0] lce_cmd_header_v_li, lce_cmd_header_ready_and_lo, lce_cmd_has_data_li;
-  logic [num_lce_p-1:0][dword_width_gp-1:0] lce_cmd_data_li;
+  logic [num_lce_p-1:0][bedrock_data_width_p-1:0] lce_cmd_data_li;
   logic [num_lce_p-1:0] lce_cmd_data_v_li, lce_cmd_data_ready_and_lo, lce_cmd_last_li;
   // LCE-CCE command interface (from burst-to-lite to LCE) - BedRock Lite
   bp_bedrock_lce_cmd_header_s [num_lce_p-1:0] lce_cmd_in_header_li;
@@ -191,21 +192,21 @@ module testbench
   // LCE-CCE command out interface (from lite-to-burst to xbar)
   bp_bedrock_lce_cmd_header_s [num_lce_p-1:0] lce_cmd_out_header;
   logic [num_lce_p-1:0] lce_cmd_out_header_v, lce_cmd_out_header_ready_and, lce_cmd_out_has_data;
-  logic [num_lce_p-1:0][dword_width_gp-1:0] lce_cmd_out_data;
+  logic [num_lce_p-1:0][bedrock_data_width_p-1:0] lce_cmd_out_data;
   logic [num_lce_p-1:0] lce_cmd_out_data_v, lce_cmd_out_data_ready_and, lce_cmd_out_last;
   logic [num_lce_p-1:0][lg_num_lce_lp-1:0] lce_cmd_out_dst;
 
   // LCE-CCE command interface (from CCE to xbar)
   bp_bedrock_lce_cmd_header_s cce_lce_cmd_header_lo;
   logic cce_lce_cmd_header_v_lo, cce_lce_cmd_header_ready_and_li, cce_lce_cmd_has_data_lo;
-  logic [dword_width_gp-1:0] cce_lce_cmd_data_lo;
+  logic [bedrock_data_width_p-1:0] cce_lce_cmd_data_lo;
   logic cce_lce_cmd_data_v_lo, cce_lce_cmd_data_ready_and_li, cce_lce_cmd_last_lo;
   wire [lg_num_lce_lp-1:0] lce_cmd_dst_lo = cce_lce_cmd_header_lo.payload.dst_id[0+:lg_num_lce_lp];
 
   // Req Crossbar
-  bp_me_xbar_burst
+  bp_me_xbar_burst_buffered
    #(.bp_params_p(bp_params_p)
-     ,.data_width_p(dword_width_gp)
+     ,.data_width_p(bedrock_data_width_p)
      ,.payload_width_p(lce_req_payload_width_lp)
      ,.num_source_p(num_lce_p)
      ,.num_sink_p(num_cce_p)
@@ -216,11 +217,11 @@ module testbench
 
      ,.msg_header_i(lce_req_header)
      ,.msg_header_v_i(lce_req_header_v)
-     ,.msg_header_yumi_o(lce_req_header_ready_and)
+     ,.msg_header_ready_and_o(lce_req_header_ready_and)
      ,.msg_has_data_i(lce_req_has_data)
      ,.msg_data_i(lce_req_data)
      ,.msg_data_v_i(lce_req_data_v)
-     ,.msg_data_yumi_o(lce_req_data_ready_and)
+     ,.msg_data_ready_and_o(lce_req_data_ready_and)
      ,.msg_last_i(lce_req_last)
      ,.msg_dst_i(lce_req_dst)
 
@@ -235,9 +236,9 @@ module testbench
      );
 
   // Resp Crossbar
-  bp_me_xbar_burst
+  bp_me_xbar_burst_buffered
    #(.bp_params_p(bp_params_p)
-     ,.data_width_p(dword_width_gp)
+     ,.data_width_p(bedrock_data_width_p)
      ,.payload_width_p(lce_resp_payload_width_lp)
      ,.num_source_p(num_lce_p)
      ,.num_sink_p(num_cce_p)
@@ -248,11 +249,11 @@ module testbench
 
      ,.msg_header_i(lce_resp_header)
      ,.msg_header_v_i(lce_resp_header_v)
-     ,.msg_header_yumi_o(lce_resp_header_ready_and)
+     ,.msg_header_ready_and_o(lce_resp_header_ready_and)
      ,.msg_has_data_i(lce_resp_has_data)
      ,.msg_data_i(lce_resp_data)
      ,.msg_data_v_i(lce_resp_data_v)
-     ,.msg_data_yumi_o(lce_resp_data_ready_and)
+     ,.msg_data_ready_and_o(lce_resp_data_ready_and)
      ,.msg_last_i(lce_resp_last)
      ,.msg_dst_i(lce_resp_dst)
 
@@ -268,9 +269,9 @@ module testbench
 
   // Cmd Crossbar
   // from CCE and LCE cmd out to LCE cmd in
-  bp_me_xbar_burst
+  bp_me_xbar_burst_buffered
    #(.bp_params_p(bp_params_p)
-     ,.data_width_p(dword_width_gp)
+     ,.data_width_p(bedrock_data_width_p)
      ,.payload_width_p(lce_cmd_payload_width_lp)
      ,.num_source_p(num_cce_p+num_lce_p)
      ,.num_sink_p(num_lce_p)
@@ -281,11 +282,11 @@ module testbench
 
      ,.msg_header_i({cce_lce_cmd_header_lo, lce_cmd_out_header})
      ,.msg_header_v_i({cce_lce_cmd_header_v_lo, lce_cmd_out_header_v})
-     ,.msg_header_yumi_o({cce_lce_cmd_header_ready_and_li, lce_cmd_out_header_ready_and})
+     ,.msg_header_ready_and_o({cce_lce_cmd_header_ready_and_li, lce_cmd_out_header_ready_and})
      ,.msg_has_data_i({cce_lce_cmd_has_data_lo, lce_cmd_out_has_data})
      ,.msg_data_i({cce_lce_cmd_data_lo, lce_cmd_out_data})
      ,.msg_data_v_i({cce_lce_cmd_data_v_lo, lce_cmd_out_data_v})
-     ,.msg_data_yumi_o({cce_lce_cmd_data_ready_and_li, lce_cmd_out_data_ready_and})
+     ,.msg_data_ready_and_o({cce_lce_cmd_data_ready_and_li, lce_cmd_out_data_ready_and})
      ,.msg_last_i({cce_lce_cmd_last_lo, lce_cmd_out_last})
      ,.msg_dst_i({lce_cmd_dst_lo, lce_cmd_out_dst})
 
@@ -402,7 +403,7 @@ module testbench
     bp_me_lite_to_burst
      #(.bp_params_p(bp_params_p)
        ,.in_data_width_p(cce_block_width_p)
-       ,.out_data_width_p(dword_width_gp)
+       ,.out_data_width_p(bedrock_data_width_p)
        ,.payload_width_p(lce_req_payload_width_lp)
        ,.payload_mask_p(lce_req_payload_mask_gp)
        )
@@ -446,7 +447,7 @@ module testbench
     bp_me_lite_to_burst
      #(.bp_params_p(bp_params_p)
        ,.in_data_width_p(cce_block_width_p)
-       ,.out_data_width_p(dword_width_gp)
+       ,.out_data_width_p(bedrock_data_width_p)
        ,.payload_width_p(lce_resp_payload_width_lp)
        ,.payload_mask_p(lce_resp_payload_mask_gp)
        )
@@ -473,7 +474,7 @@ module testbench
     // LCE Command In (from xbar to LCE)
     bp_me_burst_to_lite
      #(.bp_params_p(bp_params_p)
-       ,.in_data_width_p(dword_width_gp)
+       ,.in_data_width_p(bedrock_data_width_p)
        ,.out_data_width_p(cce_block_width_p)
        ,.payload_width_p(lce_cmd_payload_width_lp)
        ,.payload_mask_p(lce_cmd_payload_mask_gp)
@@ -518,7 +519,7 @@ module testbench
     bp_me_lite_to_burst
      #(.bp_params_p(bp_params_p)
        ,.in_data_width_p(cce_block_width_p)
-       ,.out_data_width_p(dword_width_gp)
+       ,.out_data_width_p(bedrock_data_width_p)
        ,.payload_width_p(lce_cmd_payload_width_lp)
        ,.payload_mask_p(lce_cmd_payload_mask_gp)
        )
@@ -548,6 +549,7 @@ module testbench
   // CCE
   wrapper
   #(.bp_params_p(bp_params_p)
+    ,.bedrock_data_width_p(bedrock_data_width_p)
     ,.cce_trace_p(cce_trace_p)
    )
   wrapper
@@ -608,10 +610,10 @@ module testbench
 
   // Memory Command Buffer
   bp_bedrock_mem_header_s mem_cmd_lo;
-  logic [dword_width_gp-1:0] mem_cmd_data_lo;
+  logic [bedrock_data_width_p-1:0] mem_cmd_data_lo;
   logic mem_cmd_v_lo, mem_cmd_ready_and_li, mem_cmd_yumi_li, mem_cmd_last_lo;
   bsg_fifo_1r1w_small
-  #(.width_p($bits(bp_bedrock_mem_header_s)+dword_width_gp+1)
+  #(.width_p($bits(bp_bedrock_mem_header_s)+bedrock_data_width_p+1)
     ,.els_p(mem_buffer_els_lp)
     )
   mem_cmd_stream_buffer
@@ -630,10 +632,10 @@ module testbench
 
   // Memory Response Buffer
   bp_bedrock_mem_header_s mem_resp_li;
-  logic [dword_width_gp-1:0] mem_resp_data_li;
+  logic [bedrock_data_width_p-1:0] mem_resp_data_li;
   logic mem_resp_v_li, mem_resp_ready_and_lo, mem_resp_last_li, mem_resp_yumi_lo;
   bsg_fifo_1r1w_small
-  #(.width_p($bits(bp_bedrock_mem_header_s)+dword_width_gp+1)
+  #(.width_p($bits(bp_bedrock_mem_header_s)+bedrock_data_width_p+1)
     ,.els_p(mem_buffer_els_lp)
     )
   mem_resp_stream_buffer
@@ -748,7 +750,9 @@ module testbench
 
   bind bp_cce_wrapper
     bp_me_nonsynth_cce_tracer
-      #(.bp_params_p(bp_params_p))
+      #(.bp_params_p(bp_params_p)
+        ,.bedrock_data_width_p(bedrock_data_width_p)
+        )
       cce_tracer
        (.clk_i(clk_i & (testbench.cce_trace_p == 1))
         ,.reset_i(reset_i)

--- a/bp_me/test/tb/bp_cce/testbench.sv
+++ b/bp_me/test/tb/bp_cce/testbench.sv
@@ -204,7 +204,7 @@ module testbench
   wire [lg_num_lce_lp-1:0] lce_cmd_dst_lo = cce_lce_cmd_header_lo.payload.dst_id[0+:lg_num_lce_lp];
 
   // Req Crossbar
-  bp_me_xbar_burst_buffered
+  bp_me_xbar_burst
    #(.bp_params_p(bp_params_p)
      ,.data_width_p(bedrock_data_width_p)
      ,.payload_width_p(lce_req_payload_width_lp)
@@ -217,11 +217,11 @@ module testbench
 
      ,.msg_header_i(lce_req_header)
      ,.msg_header_v_i(lce_req_header_v)
-     ,.msg_header_ready_and_o(lce_req_header_ready_and)
+     ,.msg_header_yumi_o(lce_req_header_ready_and)
      ,.msg_has_data_i(lce_req_has_data)
      ,.msg_data_i(lce_req_data)
      ,.msg_data_v_i(lce_req_data_v)
-     ,.msg_data_ready_and_o(lce_req_data_ready_and)
+     ,.msg_data_yumi_o(lce_req_data_ready_and)
      ,.msg_last_i(lce_req_last)
      ,.msg_dst_i(lce_req_dst)
 
@@ -236,7 +236,7 @@ module testbench
      );
 
   // Resp Crossbar
-  bp_me_xbar_burst_buffered
+  bp_me_xbar_burst
    #(.bp_params_p(bp_params_p)
      ,.data_width_p(bedrock_data_width_p)
      ,.payload_width_p(lce_resp_payload_width_lp)
@@ -249,11 +249,11 @@ module testbench
 
      ,.msg_header_i(lce_resp_header)
      ,.msg_header_v_i(lce_resp_header_v)
-     ,.msg_header_ready_and_o(lce_resp_header_ready_and)
+     ,.msg_header_yumi_o(lce_resp_header_ready_and)
      ,.msg_has_data_i(lce_resp_has_data)
      ,.msg_data_i(lce_resp_data)
      ,.msg_data_v_i(lce_resp_data_v)
-     ,.msg_data_ready_and_o(lce_resp_data_ready_and)
+     ,.msg_data_yumi_o(lce_resp_data_ready_and)
      ,.msg_last_i(lce_resp_last)
      ,.msg_dst_i(lce_resp_dst)
 
@@ -269,7 +269,7 @@ module testbench
 
   // Cmd Crossbar
   // from CCE and LCE cmd out to LCE cmd in
-  bp_me_xbar_burst_buffered
+  bp_me_xbar_burst
    #(.bp_params_p(bp_params_p)
      ,.data_width_p(bedrock_data_width_p)
      ,.payload_width_p(lce_cmd_payload_width_lp)
@@ -282,11 +282,11 @@ module testbench
 
      ,.msg_header_i({cce_lce_cmd_header_lo, lce_cmd_out_header})
      ,.msg_header_v_i({cce_lce_cmd_header_v_lo, lce_cmd_out_header_v})
-     ,.msg_header_ready_and_o({cce_lce_cmd_header_ready_and_li, lce_cmd_out_header_ready_and})
+     ,.msg_header_yumi_o({cce_lce_cmd_header_ready_and_li, lce_cmd_out_header_ready_and})
      ,.msg_has_data_i({cce_lce_cmd_has_data_lo, lce_cmd_out_has_data})
      ,.msg_data_i({cce_lce_cmd_data_lo, lce_cmd_out_data})
      ,.msg_data_v_i({cce_lce_cmd_data_v_lo, lce_cmd_out_data_v})
-     ,.msg_data_ready_and_o({cce_lce_cmd_data_ready_and_li, lce_cmd_out_data_ready_and})
+     ,.msg_data_yumi_o({cce_lce_cmd_data_ready_and_li, lce_cmd_out_data_ready_and})
      ,.msg_last_i({cce_lce_cmd_last_lo, lce_cmd_out_last})
      ,.msg_dst_i({lce_cmd_dst_lo, lce_cmd_out_dst})
 

--- a/bp_me/test/tb/bp_cce/wrapper.sv
+++ b/bp_me/test/tb/bp_cce/wrapper.sv
@@ -12,6 +12,7 @@ module wrapper
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = BP_CFG_FLOWVAR
    `declare_bp_proc_params(bp_params_p)
+   , parameter bedrock_data_width_p = dword_width_gp
 
    // interface widths
    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
@@ -37,7 +38,7 @@ module wrapper
    , input                                          lce_req_header_v_i
    , output logic                                   lce_req_header_ready_and_o
    , input                                          lce_req_has_data_i
-   , input [dword_width_gp-1:0]                     lce_req_data_i
+   , input [bedrock_data_width_p-1:0]               lce_req_data_i
    , input                                          lce_req_data_v_i
    , output logic                                   lce_req_data_ready_and_o
    , input                                          lce_req_last_i
@@ -46,7 +47,7 @@ module wrapper
    , input                                          lce_resp_header_v_i
    , output logic                                   lce_resp_header_ready_and_o
    , input                                          lce_resp_has_data_i
-   , input [dword_width_gp-1:0]                     lce_resp_data_i
+   , input [bedrock_data_width_p-1:0]               lce_resp_data_i
    , input                                          lce_resp_data_v_i
    , output logic                                   lce_resp_data_ready_and_o
    , input                                          lce_resp_last_i
@@ -55,7 +56,7 @@ module wrapper
    , output logic                                   lce_cmd_header_v_o
    , input                                          lce_cmd_header_ready_and_i
    , output logic                                   lce_cmd_has_data_o
-   , output logic [dword_width_gp-1:0]              lce_cmd_data_o
+   , output logic [bedrock_data_width_p-1:0]        lce_cmd_data_o
    , output logic                                   lce_cmd_data_v_o
    , input                                          lce_cmd_data_ready_and_i
    , output logic                                   lce_cmd_last_o
@@ -63,20 +64,22 @@ module wrapper
    // CCE-MEM Interface
    // BedRock Burst protocol: ready&valid
    , input [mem_header_width_lp-1:0]                mem_resp_header_i
-   , input [dword_width_gp-1:0]                     mem_resp_data_i
+   , input [bedrock_data_width_p-1:0]               mem_resp_data_i
    , input                                          mem_resp_v_i
    , output logic                                   mem_resp_ready_and_o
    , input                                          mem_resp_last_i
 
    , output logic [mem_header_width_lp-1:0]         mem_cmd_header_o
-   , output logic [dword_width_gp-1:0]              mem_cmd_data_o
+   , output logic [bedrock_data_width_p-1:0]        mem_cmd_data_o
    , output logic                                   mem_cmd_v_o
    , input                                          mem_cmd_ready_and_i
    , output logic                                   mem_cmd_last_o
   );
 
   bp_cce_wrapper
-   #(.bp_params_p(bp_params_p))
+   #(.bp_params_p(bp_params_p)
+     ,.bedrock_data_width_p(bedrock_data_width_p)
+     )
    dut
     (.*);
 

--- a/bp_top/src/v/bp_l2e_tile.sv
+++ b/bp_top/src/v/bp_l2e_tile.sv
@@ -228,7 +228,7 @@ module bp_l2e_tile
   // CCE-side CCE-Mem network connections
   bp_bedrock_mem_header_s mem_cmd_header_lo;
   logic [dword_width_gp-1:0] mem_cmd_data_lo;
-  logic mem_cmd_v_lo, mem_cmd_last_lo, mem_cmd_yumi_li;
+  logic mem_cmd_v_lo, mem_cmd_last_lo, mem_cmd_ready_and_li;
   bp_bedrock_mem_header_s mem_resp_header_li;
   logic [dword_width_gp-1:0] mem_resp_data_li;
   logic mem_resp_v_li, mem_resp_ready_and_lo, mem_resp_last_li;
@@ -320,7 +320,7 @@ module bp_l2e_tile
   // All CCE-Mem network responses go to the CCE on this tile (id = 0 in xbar)
   wire [2:0] dev_resp_dst_lo = '0;
 
-  bp_me_xbar_stream
+  bp_me_xbar_stream_buffered
    #(.bp_params_p(bp_params_p)
      ,.data_width_p(dword_width_gp)
      ,.payload_width_p(mem_payload_width_lp)
@@ -334,7 +334,7 @@ module bp_l2e_tile
      ,.msg_header_i(mem_cmd_header_lo)
      ,.msg_data_i(mem_cmd_data_lo)
      ,.msg_v_i(mem_cmd_v_lo)
-     ,.msg_yumi_o(mem_cmd_yumi_li)
+     ,.msg_ready_and_o(mem_cmd_ready_and_li)
      ,.msg_last_i(mem_cmd_last_lo)
      ,.msg_dst_i(mem_cmd_dst_lo)
 
@@ -345,7 +345,7 @@ module bp_l2e_tile
      ,.msg_last_o(dev_cmd_last_li)
      );
 
-  bp_me_xbar_stream
+  bp_me_xbar_stream_buffered
    #(.bp_params_p(bp_params_p)
      ,.data_width_p(dword_width_gp)
      ,.payload_width_p(mem_payload_width_lp)
@@ -359,7 +359,7 @@ module bp_l2e_tile
      ,.msg_header_i(dev_resp_header_lo)
      ,.msg_data_i(dev_resp_data_lo)
      ,.msg_v_i(dev_resp_v_lo)
-     ,.msg_yumi_o(dev_resp_ready_and_li)
+     ,.msg_ready_and_o(dev_resp_ready_and_li)
      ,.msg_last_i(dev_resp_last_lo)
      ,.msg_dst_i(dev_resp_dst_lo)
 
@@ -427,7 +427,7 @@ module bp_l2e_tile
      ,.mem_cmd_header_o(mem_cmd_header_lo)
      ,.mem_cmd_data_o(mem_cmd_data_lo)
      ,.mem_cmd_v_o(mem_cmd_v_lo)
-     ,.mem_cmd_ready_and_i(mem_cmd_yumi_li)
+     ,.mem_cmd_ready_and_i(mem_cmd_ready_and_li)
      ,.mem_cmd_last_o(mem_cmd_last_lo)
      );
 

--- a/bp_top/src/v/bp_l2e_tile.sv
+++ b/bp_top/src/v/bp_l2e_tile.sv
@@ -372,7 +372,9 @@ module bp_l2e_tile
 
   // CCE: Cache Coherence Engine
   bp_cce_wrapper
-   #(.bp_params_p(bp_params_p))
+   #(.bp_params_p(bp_params_p)
+     ,.bedrock_data_width_p(dword_width_gp)
+     )
    cce
     (.clk_i(clk_i)
      ,.reset_i(reset_r)

--- a/bp_top/src/v/bp_tile.sv
+++ b/bp_top/src/v/bp_tile.sv
@@ -622,7 +622,9 @@ module bp_tile
 
   // CCE: Cache Coherence Engine
   bp_cce_wrapper
-   #(.bp_params_p(bp_params_p))
+   #(.bp_params_p(bp_params_p)
+     ,.bedrock_data_width_p(dword_width_gp)
+     )
    cce
     (.clk_i(clk_i)
      ,.reset_i(reset_r)

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -564,7 +564,9 @@ module testbench
         begin
           bind bp_cce_wrapper
             bp_me_nonsynth_cce_tracer
-             #(.bp_params_p(bp_params_p))
+             #(.bp_params_p(bp_params_p)
+               ,.bedrock_data_width_p(bedrock_data_width_p)
+               )
              cce_tracer
               (.clk_i(clk_i & testbench.cce_trace_en_lo)
               ,.reset_i(reset_i)


### PR DESCRIPTION
This PR adds a new param `bedrock_data_width` to the CCEs that controls the width of the LCE-CCE and CCE-MEM interface data widths. The data width of the LCE-CCE and CCE-MEM interface is required to be the same to eliminate unnecessary gearboxing inside the CCE. The physical networks carrying the messages can use an independently selected channel width, but are responsible for required gearboxing.
