### PR TITLE
Make xbar stream a true crossbar

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - top_dev_fix_lockingxbar
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - top_dev_fix_lockingxbar
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/bp_common/src/v/bsg_crossbar_control_locking_o_by_i.v
+++ b/bp_common/src/v/bsg_crossbar_control_locking_o_by_i.v
@@ -1,0 +1,113 @@
+/**
+ *    bsg_crossbar_control_locking_o_by_i.v
+ *
+ *    This module generates the control signals for bsg_router_crossbar_o_by_i.
+ *    In addition to bsg_crossbar_control_basic_o_by_i.v, it also "locks" the
+ *      outputs so that streams of data will not be interleaved if multiple
+ *      sources attempt to send to the same sink.
+ */
+
+
+`include "bsg_defines.v"
+
+module bsg_crossbar_control_locking_o_by_i
+  #(parameter `BSG_INV_PARAM(i_els_p)
+    , parameter `BSG_INV_PARAM(o_els_p)
+    , parameter lg_o_els_lp=`BSG_SAFE_CLOG2(o_els_p)
+  )
+  (
+    input clk_i
+    , input reset_i
+
+    , input [i_els_p-1:0] valid_i
+    , input [i_els_p-1:0][lg_o_els_lp-1:0] sel_io_i
+    , output [i_els_p-1:0] yumi_o
+
+    // crossbar outputs (ready & valid interface)
+    , input [o_els_p-1:0] unlock_i
+    , input [o_els_p-1:0] ready_and_i
+    , output [o_els_p-1:0] valid_o
+    , output [o_els_p-1:0][i_els_p-1:0] grants_oi_one_hot_o
+  );
+
+  
+  // select logic
+  logic [i_els_p-1:0][o_els_p-1:0] o_select;
+  logic [o_els_p-1:0][i_els_p-1:0] o_select_t;
+
+  for (genvar i = 0; i < i_els_p; i++) begin: dv
+    bsg_decode_with_v #(
+      .num_out_p(o_els_p)
+    ) dv0 (
+      .i(sel_io_i[i])
+      ,.v_i(valid_i[i])
+      ,.o(o_select[i])
+    );
+  end
+
+  bsg_transpose #(
+    .width_p(o_els_p)
+    ,.els_p(i_els_p)
+  ) trans0 (
+    .i(o_select)
+    ,.o(o_select_t)
+  );
+
+
+  // round robin
+  logic [o_els_p-1:0] rr_yumi_li;
+  logic [o_els_p-1:0][i_els_p-1:0] rr_yumi_lo;
+  logic [i_els_p-1:0][o_els_p-1:0] rr_yumi_lo_t;
+  
+  for (genvar i = 0 ; i < o_els_p; i++) begin: rr
+
+    logic [i_els_p-1:0] not_req_mask_r, req_mask_r;
+
+    bsg_dff_reset_en #( .width_p(i_els_p) )
+      req_words_reg
+        ( .clk_i  ( clk_i )
+        , .reset_i( reset_i || unlock_i[i] )
+        , .en_i   ( (&req_mask_r) & (|grants_oi_one_hot_o[i]) )
+        , .data_i ( ~grants_oi_one_hot_o[i] )
+        , .data_o ( not_req_mask_r )
+        );
+
+    assign req_mask_r = ~not_req_mask_r;
+
+    assign valid_o[i] = |o_select_t[i];
+    assign rr_yumi_li[i] = valid_o[i] & ready_and_i[i];
+
+    bsg_arb_round_robin #(
+      .width_p(i_els_p)
+    ) rr0 (
+      .clk_i(clk_i)
+      ,.reset_i(reset_i)
+    
+      ,.reqs_i(o_select_t[i] & req_mask_r)
+      ,.grants_o(grants_oi_one_hot_o[i])
+      ,.yumi_i(rr_yumi_li[i])
+    );
+
+    assign rr_yumi_lo[i] = grants_oi_one_hot_o[i] & {i_els_p{rr_yumi_li[i]}};
+
+  end 
+
+
+  bsg_transpose #(
+    .width_p(i_els_p)
+    ,.els_p(o_els_p)
+  ) trans1 (
+    .i(rr_yumi_lo)
+    ,.o(rr_yumi_lo_t)
+  );
+
+
+  for (genvar i = 0; i < i_els_p; i++) begin
+    assign yumi_o[i] = |rr_yumi_lo_t[i];
+  end
+
+
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_crossbar_control_basic_o_by_i)

--- a/bp_me/src/v/network/bp_me_xbar_stream.sv
+++ b/bp_me/src/v/network/bp_me_xbar_stream.sv
@@ -45,50 +45,43 @@ module bp_me_xbar_stream
 
   `declare_bp_bedrock_if(paddr_width_p, payload_width_p, lce_id_width_p, lce_assoc_p, xbar);
 
-  // msg arbitration logic
-  logic [num_source_p-1:0] msg_grants_lo;
-  wire msg_arb_unlock_li = |{msg_yumi_o & msg_last_i} | reset_i;
-  bsg_locking_arb_fixed
-   #(.inputs_p(num_source_p), .lo_to_hi_p(0))
-   msg_arbiter
+  logic [num_sink_p-1:0] msg_unlock_li;
+  logic [num_sink_p-1:0][num_source_p-1:0] grants_oi_one_hot_lo;
+  bsg_crossbar_control_locking_o_by_i
+   #(.i_els_p(num_source_p), .o_els_p(num_sink_p))
+   cbc
     (.clk_i(clk_i)
-     ,.ready_i(1'b1)
+     ,.reset_i(reset_i)
 
-     ,.unlock_i(msg_arb_unlock_li)
-     ,.reqs_i(msg_v_i)
-     ,.grants_o(msg_grants_lo)
-     );
-  logic [lg_num_source_lp-1:0] msg_grants_sel_li;
-  logic msg_grants_v_li;
-  bsg_encode_one_hot
-   #(.width_p(num_source_p), .lo_to_hi_p(1))
-   msg_sel
-    (.i(msg_grants_lo)
-     ,.addr_o(msg_grants_sel_li)
-     ,.v_o(msg_grants_v_li)
+     ,.valid_i(msg_v_i)
+     ,.sel_io_i(msg_dst_i)
+     ,.yumi_o(msg_yumi_o)
+
+     ,.ready_and_i(msg_ready_and_i)
+     ,.valid_o(msg_v_o)
+     ,.unlock_i(msg_unlock_li)
+     ,.grants_oi_one_hot_o(grants_oi_one_hot_lo)
      );
 
-  bp_bedrock_xbar_header_s header_selected_lo;
-  bsg_mux_one_hot
-   #(.width_p($bits(bp_bedrock_xbar_header_s)), .els_p(num_source_p))
-   header_select
-    (.data_i(msg_header_i)
-     ,.sel_one_hot_i(msg_grants_lo)
-     ,.data_o(header_selected_lo)
+  logic [num_source_p-1:0][xbar_header_width_lp+data_width_p+1-1:0] source_combine;
+  logic [num_sink_p-1:0][xbar_header_width_lp+data_width_p+1-1:0] sink_combine;
+  for (genvar i = 0; i < num_source_p; i++)
+    begin : source_comb
+      assign source_combine[i] = {msg_last_i[i], msg_header_i[i], msg_data_i[i]};
+    end
+  for (genvar i = 0; i < num_sink_p; i++)
+    begin : sink_comb
+      assign {msg_last_o[i], msg_header_o[i], msg_data_o[i]} = sink_combine[i];
+      assign msg_unlock_li[i] = msg_ready_and_i[i] & msg_v_o[i] & msg_last_o[i];
+    end
+
+  bsg_crossbar_o_by_i
+   #(.i_els_p(num_source_p), .o_els_p(num_sink_p), .width_p(1+xbar_header_width_lp+data_width_p))
+   cb
+    (.i(source_combine)
+     ,.sel_oi_one_hot_i(grants_oi_one_hot_lo)
+     ,.o(sink_combine)
      );
-  logic [data_width_p-1:0] msg_data_selected_lo;
-  bsg_mux_one_hot
-   #(.width_p(data_width_p), .els_p(num_source_p))
-   msg_data_select
-    (.data_i(msg_data_i)
-     ,.sel_one_hot_i(msg_grants_lo)
-     ,.data_o(msg_data_selected_lo)
-     );
-  assign msg_header_o = {num_sink_p{header_selected_lo}};
-  assign msg_data_o   = {num_sink_p{msg_data_selected_lo}};
-  assign msg_v_o      = msg_grants_v_li ? (1'b1 << msg_dst_i[msg_grants_sel_li]) : '0;
-  assign msg_yumi_o   = msg_grants_lo & {num_source_p{|{msg_v_o & msg_ready_and_i}}};
-  assign msg_last_o   = msg_v_o & {num_sink_p{msg_last_i[msg_grants_sel_li]}};
 
 endmodule
 

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -105,6 +105,7 @@ $BASEJUMP_STL_DIR/bsg_misc/bsg_counter_set_en.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_counter_up_down.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_counter_up_down_variable.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_crossbar_o_by_i.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_crossbar_control_locking_o_by_i.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_cycle_counter.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_decode.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_decode_with_v.v

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -105,7 +105,6 @@ $BASEJUMP_STL_DIR/bsg_misc/bsg_counter_set_en.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_counter_up_down.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_counter_up_down_variable.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_crossbar_o_by_i.v
-$BASEJUMP_STL_DIR/bsg_misc/bsg_crossbar_control_locking_o_by_i.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_cycle_counter.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_decode.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_decode_with_v.v
@@ -326,5 +325,6 @@ $BP_COMMON_DIR/src/v/bsg_deff_reset.v
 $BP_COMMON_DIR/src/v/bsg_dff_sync_read.v
 $BP_COMMON_DIR/src/v/bsg_wormhole_to_cache_dma_fanout.v
 $BP_COMMON_DIR/src/v/bsg_rom_param.v
+$BP_COMMON_DIR/src/v/bsg_crossbar_control_locking_o_by_i.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dlatch.v
 


### PR DESCRIPTION
## Summary
This PR makes bp_me_xbar_stream into a true crossbar, rather than a glorified round robin arbiter. 

## Area
bp_me_xbar_stream

## Reasoning (outdated, confusing, verbose, etc.)
There is potential for deadlock if there are circular dependencies in the local crossbar. This can happen when an external device is writing to BP, while BP is polling the host. There are many ways to break this cycle, but preventing unnecessary blocking in this crossbar is low cost and provides nice guarantees for BP integrated in external systems

## Additional Changes Required (if any)
Need to modify xbar burst to also have this behavior.

## Analysis
Should have a minimal PPA impact. The data plane of the crossbar is unchanged, it's simply the 

## Verification
- [ ] Run this change through zynq-parrot to verify that https://github.com/black-parrot-hdk/zynq-parrot/issues/16 is fixed

## Additional Context
https://github.com/bespoke-silicon-group/basejump_stl/pull/536

