### PR TITLE
Read BTB and BHT even if processing an IF2 override

### DIFF
--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -113,7 +113,7 @@ module bp_fe_pc_gen
   wire is_ret  = fetch_instr_v_i & scan_instr.ret;
 
   // BTB
-  wire btb_r_v_li = next_pc_yumi_i & ~ovr_taken & ~ovr_ret;
+  wire btb_r_v_li = next_pc_yumi_i;
   wire btb_w_v_li = (redirect_br_v_i & redirect_br_taken_i)
     | (redirect_br_v_i & redirect_br_nonbr_i & redirect_br_metadata_fwd.src_btb)
     | (attaboy_v_i & attaboy_taken_i & ~attaboy_br_metadata_fwd.src_btb);
@@ -151,7 +151,7 @@ module bp_fe_pc_gen
      );
 
   // BHT
-  wire bht_r_v_li = next_pc_yumi_i & ~ovr_taken & ~ovr_ret;
+  wire bht_r_v_li = next_pc_yumi_i;
   wire [vaddr_width_p-1:0] bht_r_addr_li = next_pc_o;
   wire [ghist_width_p-1:0] bht_r_ghist_li = pred_if1_n.ghist;
   wire bht_w_v_li =


### PR DESCRIPTION
## Summary

Previously, the predictors would read garbage when the PC was the target of an override. This garbage would be used for the following prediction _and_ for the writeback to the BHT, trashing the row.

## Issue Fixed

No open issue. Mentioned to Dan via Slack.

## Area

bp_fe_pc_gen

## Reasoning (outdated, confusing, verbose, etc.)

The BHT/BTB read happens in IF1. The read prediction data is for a prediction of the next instruction, i.e. the next one to enter IF1. There's no reason we would want to avoid the prediction due to the preceding instruction being originally mispredicted.

I suspect the original intent may have been to save power and skip the read for the invalidated IF1 PC on an override, but if I'm understanding correctly what it's actually doing is using that invalidated PC's entry for the real PC that follows since the BHT uses a bypass reg to latch the old value when it's not reading.

## Additional Changes Required (if any)

None

## Analysis

CoreMark before change:

```
2K performance run parameters for coremark.
CoreMark Size    : 666
Total ticks      : 100
Total time (secs): 100.000000
Iterations/Sec   : 0.050000
Iterations       : 5
Compiler version : GCC9.2.0
Compiler flags   : 
Memory location  : STATIC
seedcrc          : 0xe9f5
[0]crclist       : 0xe714
[0]crcmatrix     : 0x1fd7
[0]crcstate      : 0x8e3a
[0]crcfinal      : 0xf24c
Correct operation validated. See README.md for run and reporting rules.
CoreMark 1.0 : 0.050000 / GCC9.2.0  / STATIC
[CORE0 FSH] PASS
All cores finished! Terminating...
$finish called from file "/mnt/users/ssd1/homes/kaelinl/repos/black-parrot/bp_top/test/common/bp_nonsynth_host.sv", line 181.
[CORE0 STATS]
        clk   :              1880473
        instr :              1531935
        mIPC  :                  814
```

CoreMark after change:

```
2K performance run parameters for coremark.
CoreMark Size    : 666
Total ticks      : 100
Total time (secs): 100.000000
Iterations/Sec   : 0.050000
Iterations       : 5
Compiler version : GCC9.2.0
Compiler flags   : 
Memory location  : STATIC
seedcrc          : 0xe9f5
[0]crclist       : 0xe714
[0]crcmatrix     : 0x1fd7
[0]crcstate      : 0x8e3a
[0]crcfinal      : 0xf24c
Correct operation validated. See README.md for run and reporting rules.
CoreMark 1.0 : 0.050000 / GCC9.2.0  / STATIC
[CORE0 FSH] PASS
All cores finished! Terminating...
$finish called from file "/mnt/users/ssd1/homes/kaelinl/repos/black-parrot/bp_top/test/common/bp_nonsynth_host.sv", line 181.
[CORE0 STATS]
        clk   :              1874424
        instr :              1531935
        mIPC  :                  817
```

This is an 0.3% improvement in cycle count.

I don't have other benchmarks available to me to run, but I'd be happy to do so if desired. CoreMark is likely a rather poor indicator.

## Verification

Cursory examination of the wave indicates that the reads are being forwarded back in the attaboy/redirect as expected. I haven't done any rigorous verification.

Risk of the change is low, as reading when not needed is unlikely to cause a regression. The bypass register latching the old read _does_ introduce some possibility of intentional behavior lost here, but it certainly seems wrong to me.

These changes do not seem to affect the bp-tests `loop_test` program at all (with all the parts enabled at once, i.e. with some branch predictor contamination).

A short test program with dummy jumps that I'm using for other purposes performs worse after this change. I haven't had time to investigate yet. It's only a 10-cycle difference on a 50-cycle function call so it's likely to be an aberration due to poorly trained predictors.

## Additional Context

None
