### PR TITLE
Fix fflags hazards

### DIFF
--- a/bp_be/src/include/bp_be_defines.svh
+++ b/bp_be/src/include/bp_be_defines.svh
@@ -20,7 +20,7 @@
                                                                                                    \
     typedef struct packed                                                                          \
     {                                                                                              \
-      logic                                    csr_w_v;                                            \
+      logic                                    csr_v;                                              \
       logic                                    mem_v;                                              \
       logic                                    fence_v;                                            \
       logic                                    long_v;                                             \
@@ -56,7 +56,7 @@
     {                                                                                              \
       logic                              instr_v;                                                  \
       logic                              mem_v;                                                    \
-      logic                              csr_w_v;                                                  \
+      logic                              csr_v;                                                    \
       logic                              fflags_w_v;                                               \
       logic                              ctl_iwb_v;                                                \
       logic                              aux_iwb_v;                                                \
@@ -81,7 +81,7 @@
       logic                                    fence_v;                                            \
       logic                                    mem_v;                                              \
       logic                                    long_v;                                             \
-      logic                                    csr_w_v;                                            \
+      logic                                    csr_v;                                              \
       logic                                    irs1_v;                                             \
       logic                                    frs1_v;                                             \
       logic [rv64_reg_addr_width_gp-1:0]       rs1_addr;                                           \

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -43,7 +43,8 @@ module bp_be_calculator_top
   // Calculator - Checker interface
   , input [dispatch_pkt_width_lp-1:0]               dispatch_pkt_i
 
-  , output logic                                    long_ready_o
+  , output logic                                    idiv_ready_o
+  , output logic                                    fdiv_ready_o
   , output logic                                    mem_ready_o
   , output logic                                    ptw_busy_o
   , output logic [decode_info_width_lp-1:0]         decode_info_o
@@ -373,7 +374,8 @@ module bp_be_calculator_top
 
      ,.reservation_i(reservation_r)
      ,.flush_i(commit_pkt_cast_o.npc_w_v)
-     ,.ready_o(long_ready_o)
+     ,.iready_o(idiv_ready_o)
+     ,.fready_o(fdiv_ready_o)
      ,.frm_dyn_i(frm_dyn_lo)
 
      ,.iwb_pkt_o(long_iwb_pkt)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
@@ -15,7 +15,8 @@ module bp_be_pipe_long
    , input                              reset_i
 
    , input [dispatch_pkt_width_lp-1:0]  reservation_i
-   , output logic                       ready_o
+   , output logic                       iready_o
+   , output logic                       fready_o
    , input rv64_frm_e                   frm_dyn_i
 
    , input                              flush_i
@@ -182,7 +183,7 @@ module bp_be_pipe_long
    round_dp
     (.control(control_li)
      ,.invalidExc(invalid_exc)
-     ,.infiniteExc('0)
+     ,.infiniteExc(infinite_exc)
      ,.in_isNaN(is_nan)
      ,.in_isInf(is_inf)
      ,.in_isZero(is_zero)
@@ -205,7 +206,7 @@ module bp_be_pipe_long
    round_sp
     (.control(control_li)
      ,.invalidExc(invalid_exc)
-     ,.infiniteExc('0)
+     ,.infiniteExc(infinite_exc)
      ,.in_isNaN(is_nan)
      ,.in_isInf(is_inf)
      ,.in_isZero(is_zero)
@@ -246,7 +247,8 @@ module bp_be_pipe_long
       rd_data_lo = remainder_lo;
 
   // Actually a busy signal
-  assign ready_o = fdiv_ready_lo & idiv_ready_and_lo & ~rd_w_v_r & ~v_li;
+  assign iready_o = idiv_ready_and_lo & ~rd_w_v_r & ~v_li;
+  assign fready_o = fdiv_ready_lo & ~rd_w_v_r & ~v_li;
 
   assign iwb_pkt.ird_w_v    = rd_w_v_r;
   assign iwb_pkt.frd_w_v    = 1'b0;

--- a/bp_be/src/v/bp_be_checker/bp_be_issue_queue.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_issue_queue.sv
@@ -153,8 +153,7 @@ module bp_be_issue_queue
       issue_pkt_li = '0;
 
       // Pre-decode
-      issue_pkt_li.csr_w_v = (instr inside {`RV64_CSRRW, `RV64_CSRRWI})
-        || (instr.opcode inside {`RV64_SYSTEM_OP} && (instr.rs1_addr != '0));
+      issue_pkt_li.csr_v = instr.opcode inside {`RV64_SYSTEM_OP};
       issue_pkt_li.mem_v = instr.opcode inside {`RV64_FLOAD_OP, `RV64_FSTORE_OP
                                                 ,`RV64_LOAD_OP, `RV64_STORE_OP
                                                 ,`RV64_AMO_OP, `RV64_SYSTEM_OP

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -176,7 +176,7 @@ module bp_be_scheduler
       isd_status_cast_o.pc       = fe_queue_lo.msg.fetch.pc;
       isd_status_cast_o.branch_metadata_fwd = fe_queue_lo.msg.fetch.branch_metadata_fwd;
       isd_status_cast_o.fence_v  = fe_queue_v_lo & issue_pkt.fence_v;
-      isd_status_cast_o.csr_w_v  = fe_queue_v_lo & issue_pkt.csr_w_v;
+      isd_status_cast_o.csr_v    = fe_queue_v_lo & issue_pkt.csr_v;
       isd_status_cast_o.mem_v    = fe_queue_v_lo & issue_pkt.mem_v;
       isd_status_cast_o.long_v   = fe_queue_v_lo & issue_pkt.long_v;
       isd_status_cast_o.irs1_v   = fe_queue_v_lo & issue_pkt.irs1_v;

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -94,7 +94,7 @@ module bp_be_top
   logic waiting_for_irq_lo;
 
   logic cmd_full_n_lo, cmd_full_r_lo, cmd_empty_lo;
-  logic mem_ready_lo, long_ready_lo, ptw_busy_lo;
+  logic mem_ready_lo, idiv_ready_lo, fdiv_ready_lo, ptw_busy_lo;
 
   bp_be_director
    #(.bp_params_p(bp_params_p))
@@ -135,7 +135,8 @@ module bp_be_top
      ,.credits_full_i(cache_req_credits_full_i)
      ,.credits_empty_i(cache_req_credits_empty_i)
      ,.mem_ready_i(mem_ready_lo)
-     ,.long_ready_i(long_ready_lo)
+     ,.fdiv_ready_i(fdiv_ready_lo)
+     ,.idiv_ready_i(idiv_ready_lo)
      ,.ptw_busy_i(ptw_busy_lo)
      ,.irq_pending_i(irq_pending_lo)
 
@@ -185,7 +186,8 @@ module bp_be_top
 
      ,.decode_info_o(decode_info_lo)
      ,.mem_ready_o(mem_ready_lo)
-     ,.long_ready_o(long_ready_lo)
+     ,.idiv_ready_o(idiv_ready_lo)
+     ,.fdiv_ready_o(fdiv_ready_lo)
      ,.ptw_busy_o(ptw_busy_lo)
 
      ,.br_pkt_o(br_pkt)

--- a/bp_common/src/include/bp_common_aviary_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_pkgdef.svh
@@ -1139,7 +1139,7 @@
     ,e_bp_test_multicore_half_cfg                   = 48
     ,e_bp_test_unicore_half_cfg                     = 47
 
-    // L2 extension configuration
+    // L2 extension configurations
     ,e_bp_multicore_4_l2e_cfg                       = 46
     ,e_bp_multicore_2_l2e_cfg                       = 45
     ,e_bp_multicore_1_l2e_cfg                       = 44


### PR DESCRIPTION
## Summary
This PR prevents FFLAGs instructions from proceeding while there are instructions pending that will write FCSR (fdiv, fqsrt). It also connects an erroneously disconnected infinite exception signal.

## Issue Fixed
no issue raised

## Area
bp_be_pipe_long, bp_be_detector

## Reasoning (outdated, confusing, verbose, etc.)
Bug discovered by random verification

## Additional Changes Required (if any)
none

## Analysis
Potential performance regression if fflags are frequently checked. Not expected to cause issues

## Verification
https://github.com/black-parrot-sdk/bp-tests/pull/24

