### PR TITLE
Enabling L1 atomics for BP unicore

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - be_dev_feature_enablel1
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - be_dev_feature_enablel1
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/bp_be/src/include/bp_be_dcache_pkgdef.svh
+++ b/bp_be/src/include/bp_be_dcache_pkgdef.svh
@@ -29,7 +29,7 @@
     logic                         half_op;
     logic                         byte_op;
     logic                         fencei_op;
-    logic                         l2_op;
+    logic                         uncached_op;
     logic                         lr_op;
     logic                         sc_op;
     logic                         ptw_op;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -271,11 +271,13 @@ module bp_be_pipe_mem
       ,.dcache_pkt_i(dcache_pkt)
       ,.v_i(dcache_pkt_v)
       ,.ready_o(dcache_ready_lo)
+      ,.poison_req_i(flush_i)
 
       ,.ptag_i(dcache_ptag)
       ,.ptag_v_i(dcache_ptag_v)
       ,.ptag_uncached_i(dcache_ptag_uncached)
       ,.ptag_dram_i(dcache_ptag_dram)
+      ,.poison_tl_i(flush_i)
 
       ,.early_hit_v_o(dcache_early_hit_v)
       ,.early_miss_v_o(dcache_early_miss_v)
@@ -288,8 +290,6 @@ module bp_be_pipe_mem
       ,.late_data_o(dcache_late_data)
       ,.late_v_o(dcache_late_v)
       ,.late_yumi_i(dcache_late_yumi)
-
-      ,.flush_i(flush_i)
 
       // D$-LCE Interface
       ,.cache_req_o(cache_req_cast_o)

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache_decoder.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache_decoder.sv
@@ -57,7 +57,7 @@ module bp_be_dcache_decoder
 
     decode_cast_o.amo_op = (decode_cast_o.amo_subop != e_dcache_subop_none);
 
-    decode_cast_o.l2_op =
+    decode_cast_o.uncached_op =
       ((lr_sc_p == e_l2) && (decode_cast_o.lr_op || decode_cast_o.sc_op))
       || ((amo_swap_p == e_l2) && decode_cast_o.amo_subop inside {e_dcache_subop_amoswap})
       || ((amo_fetch_arithmetic_p == e_l2) && decode_cast_o.amo_subop inside

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache_wbuf.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache_wbuf.sv
@@ -25,10 +25,10 @@ module bp_be_dcache_wbuf
 
    , input [wbuf_entry_width_lp-1:0]        wbuf_entry_i
    , input                                  v_i
-   , output logic                           ready_and_o
 
    , output logic [wbuf_entry_width_lp-1:0] wbuf_entry_o
    , output logic                           v_o
+   , output logic                           force_o
    , input                                  yumi_i
 
    , input [paddr_width_p-1:0]              load_addr_i
@@ -56,7 +56,7 @@ module bp_be_dcache_wbuf
     if (reset_i)
       num_els_r <= '0;
     else
-      num_els_r <= num_els_r + (ready_and_o & v_i) - yumi_i;
+      num_els_r <= num_els_r + v_i - yumi_i;
 
   logic el0_valid, el1_valid;
   logic el0_enable, el1_enable;
@@ -93,6 +93,8 @@ module bp_be_dcache_wbuf
       end
     endcase
   end
+
+  assign force_o = v_i & (num_els_r == 2'd2);
 
   // wbuf queue
   //
@@ -180,8 +182,6 @@ module bp_be_dcache_wbuf
      ,.sel_i(bypass_mask_r)
      ,.data_o(data_merged_o)
      );
-
-  assign ready_and_o = num_els_r < 2'd2;
 
   //synopsys translate_off
   always_ff @(negedge clk_i) begin

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -238,7 +238,8 @@ module wrapper
        ,.ptag_uncached_i(rolly_uncached_r[i])
        ,.ptag_dram_i(1'b1)
 
-       ,.flush_i('0)
+       ,.poison_req_i('0)
+       ,.poison_tl_i('0)
 
        ,.cache_req_v_o(cache_req_v_lo[i])
        ,.cache_req_o(cache_req_lo[i])

--- a/bp_common/src/include/bp_common_aviary_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_pkgdef.svh
@@ -464,18 +464,6 @@
                         ,bp_unicore_cfg_p
                         );
 
-  localparam bp_proc_param_s bp_unicore_l1_atomic_override_p =
-    '{lr_sc                 : e_l1
-      ,amo_swap             : e_l1
-      ,amo_fetch_logic      : e_l1
-      ,amo_fetch_arithmetic : e_l1
-      ,default : "inv"
-      };
-  `bp_aviary_derive_cfg(bp_unicore_l1_atomic_cfg_p
-                        ,bp_unicore_l1_atomic_override_p
-                        ,bp_unicore_cfg_p
-                        );
-
   localparam bp_proc_param_s bp_unicore_l2_atomic_override_p =
     '{lr_sc                 : e_l1
       ,amo_swap             : e_l2
@@ -505,10 +493,6 @@
       ,l1_coherent   : 1
       ,dcache_fill_width : 512
       ,icache_fill_width : 512
-      ,lr_sc                : e_l1
-      ,amo_swap             : e_none
-      ,amo_fetch_logic      : e_none
-      ,amo_fetch_arithmetic : e_none
       ,default : "inv"
       };
   `bp_aviary_derive_cfg(bp_multicore_1_cfg_p
@@ -1125,7 +1109,6 @@
     ,bp_unicore_paddr_large_cfg_p
     ,bp_unicore_writethrough_cfg_p
     ,bp_unicore_l2_atomic_cfg_p
-    ,bp_unicore_l1_atomic_cfg_p
     ,bp_unicore_l1_wide_cfg_p
     ,bp_unicore_l1_hetero_cfg_p
     ,bp_unicore_l1_tiny_cfg_p
@@ -1146,63 +1129,62 @@
   typedef enum bit [lg_max_cfgs-1:0]
   {
     // Various testing config
-    e_bp_test_multicore_8x1_cce_ucode_cfg           = 56
-    ,e_bp_test_multicore_8x1_cfg                    = 55
-    ,e_bp_test_multicore_4x1_cce_ucode_cfg          = 54
-    ,e_bp_test_multicore_4x1_cfg                    = 53
-    ,e_bp_test_multicore_2x1_cce_ucode_cfg          = 52
-    ,e_bp_test_multicore_2x1_cfg                    = 51
-    ,e_bp_test_multicore_half_cce_ucode_cfg         = 50
-    ,e_bp_test_multicore_half_cfg                   = 49
-    ,e_bp_test_unicore_half_cfg                     = 48
+    e_bp_test_multicore_8x1_cce_ucode_cfg           = 55
+    ,e_bp_test_multicore_8x1_cfg                    = 54
+    ,e_bp_test_multicore_4x1_cce_ucode_cfg          = 53
+    ,e_bp_test_multicore_4x1_cfg                    = 52
+    ,e_bp_test_multicore_2x1_cce_ucode_cfg          = 51
+    ,e_bp_test_multicore_2x1_cfg                    = 50
+    ,e_bp_test_multicore_half_cce_ucode_cfg         = 49
+    ,e_bp_test_multicore_half_cfg                   = 48
+    ,e_bp_test_unicore_half_cfg                     = 47
 
-    // L2 extension configurations
-    ,e_bp_multicore_4_l2e_cfg                       = 47
-    ,e_bp_multicore_2_l2e_cfg                       = 46
-    ,e_bp_multicore_1_l2e_cfg                       = 45
+    // L2 extension configuration
+    ,e_bp_multicore_4_l2e_cfg                       = 46
+    ,e_bp_multicore_2_l2e_cfg                       = 45
+    ,e_bp_multicore_1_l2e_cfg                       = 44
 
     // Accelerator configurations
-    ,e_bp_multicore_4_acc_vdp_cfg                   = 44
-    ,e_bp_multicore_4_acc_loopback_cfg              = 43
-    ,e_bp_multicore_1_acc_vdp_cfg                   = 42
-    ,e_bp_multicore_1_acc_loopback_cfg              = 41
+    ,e_bp_multicore_4_acc_vdp_cfg                   = 43
+    ,e_bp_multicore_4_acc_loopback_cfg              = 42
+    ,e_bp_multicore_1_acc_vdp_cfg                   = 41
+    ,e_bp_multicore_1_acc_loopback_cfg              = 40
 
     // Ucode configurations
-    ,e_bp_multicore_16_cce_ucode_cfg                = 40
-    ,e_bp_multicore_12_cce_ucode_cfg                = 39
-    ,e_bp_multicore_8_cce_ucode_cfg                 = 38
-    ,e_bp_multicore_6_cce_ucode_cfg                 = 37
-    ,e_bp_multicore_4_cce_ucode_cfg                 = 36
-    ,e_bp_multicore_3_cce_ucode_cfg                 = 35
-    ,e_bp_multicore_2_cce_ucode_cfg                 = 34
-    ,e_bp_multicore_1_cce_ucode_paddr_small_cfg     = 33
-    ,e_bp_multicore_1_cce_ucode_paddr_large_cfg     = 32
-    ,e_bp_multicore_1_cce_ucode_bootrom_cfg         = 31
-    ,e_bp_multicore_1_cce_ucode_cfg                 = 30
+    ,e_bp_multicore_16_cce_ucode_cfg                = 39
+    ,e_bp_multicore_12_cce_ucode_cfg                = 38
+    ,e_bp_multicore_8_cce_ucode_cfg                 = 37
+    ,e_bp_multicore_6_cce_ucode_cfg                 = 36
+    ,e_bp_multicore_4_cce_ucode_cfg                 = 35
+    ,e_bp_multicore_3_cce_ucode_cfg                 = 34
+    ,e_bp_multicore_2_cce_ucode_cfg                 = 33
+    ,e_bp_multicore_1_cce_ucode_paddr_small_cfg     = 32
+    ,e_bp_multicore_1_cce_ucode_paddr_large_cfg     = 31
+    ,e_bp_multicore_1_cce_ucode_bootrom_cfg         = 30
+    ,e_bp_multicore_1_cce_ucode_cfg                 = 29
 
     // Multicore configurations
-    ,e_bp_multicore_16_cfg                          = 29
-    ,e_bp_multicore_12_cfg                          = 28
-    ,e_bp_multicore_8_cfg                           = 27
-    ,e_bp_multicore_6_cfg                           = 26
-    ,e_bp_multicore_4_cfg                           = 25
-    ,e_bp_multicore_3_cfg                           = 24
-    ,e_bp_multicore_2_cfg                           = 23
-    ,e_bp_multicore_1_paddr_small_cfg               = 22
-    ,e_bp_multicore_1_paddr_large_cfg               = 21
-    ,e_bp_multicore_1_l1_small_cfg                  = 20
-    ,e_bp_multicore_1_l1_medium_cfg                 = 19
-    ,e_bp_multicore_1_no_l2_cfg                     = 18
-    ,e_bp_multicore_1_bootrom_cfg                   = 17
-    ,e_bp_multicore_1_cfg                           = 16
+    ,e_bp_multicore_16_cfg                          = 28
+    ,e_bp_multicore_12_cfg                          = 27
+    ,e_bp_multicore_8_cfg                           = 26
+    ,e_bp_multicore_6_cfg                           = 25
+    ,e_bp_multicore_4_cfg                           = 24
+    ,e_bp_multicore_3_cfg                           = 23
+    ,e_bp_multicore_2_cfg                           = 22
+    ,e_bp_multicore_1_paddr_small_cfg               = 21
+    ,e_bp_multicore_1_paddr_large_cfg               = 20
+    ,e_bp_multicore_1_l1_small_cfg                  = 19
+    ,e_bp_multicore_1_l1_medium_cfg                 = 18
+    ,e_bp_multicore_1_no_l2_cfg                     = 17
+    ,e_bp_multicore_1_bootrom_cfg                   = 16
+    ,e_bp_multicore_1_cfg                           = 15
 
     // Unicore configurations
-    ,e_bp_unicore_tinyparrot_cfg                    = 15
-    ,e_bp_unicore_paddr_small_cfg                   = 14
-    ,e_bp_unicore_paddr_large_cfg                   = 13
-    ,e_bp_unicore_writethrough_cfg                  = 12
-    ,e_bp_unicore_l2_atomic_cfg                     = 11
-    ,e_bp_unicore_l1_atomic_cfg                     = 10
+    ,e_bp_unicore_tinyparrot_cfg                    = 14
+    ,e_bp_unicore_paddr_small_cfg                   = 13
+    ,e_bp_unicore_paddr_large_cfg                   = 12
+    ,e_bp_unicore_writethrough_cfg                  = 11
+    ,e_bp_unicore_l2_atomic_cfg                     = 10
     ,e_bp_unicore_l1_wide_cfg                       = 9
     ,e_bp_unicore_l1_hetero_cfg                     = 8
     ,e_bp_unicore_l1_tiny_cfg                       = 7

--- a/bp_common/src/include/bp_common_aviary_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_pkgdef.svh
@@ -242,9 +242,9 @@
       ,dtlb_els_1g : 0
 
       ,lr_sc                : e_l1
-      ,amo_swap             : e_none
-      ,amo_fetch_logic      : e_none
-      ,amo_fetch_arithmetic : e_none
+      ,amo_swap             : e_l1
+      ,amo_fetch_logic      : e_l1
+      ,amo_fetch_arithmetic : e_l1
 
       ,l1_writethrough      : 0
       ,l1_coherent          : 0
@@ -355,7 +355,12 @@
       ,dcache_block_width : 64
       ,dcache_fill_width  : 64
 
-      ,l2_en              : 0
+      ,lr_sc                : e_l1
+      ,amo_swap             : e_none
+      ,amo_fetch_logic      : e_none
+      ,amo_fetch_arithmetic : e_none
+
+      ,l2_en : 0
 
       ,default : "inv"
       };
@@ -500,6 +505,10 @@
       ,l1_coherent   : 1
       ,dcache_fill_width : 512
       ,icache_fill_width : 512
+      ,lr_sc                : e_l1
+      ,amo_swap             : e_none
+      ,amo_fetch_logic      : e_none
+      ,amo_fetch_arithmetic : e_none
       ,default : "inv"
       };
   `bp_aviary_derive_cfg(bp_multicore_1_cfg_p

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -133,7 +133,8 @@ module bp_cacc_vdp
      ,.ptag_uncached_i(dcache_uncached)
      ,.ptag_dram_i(dcache_dram)
 
-     ,.flush_i(1'b0)
+     ,.poison_req_i(1'b0)
+     ,.poison_tl_i(1'b0)
 
      // D$-LCE Interface
      ,.cache_req_complete_i(cache_req_complete_lo)

--- a/bp_top/test/common/bp_nonsynth_cosim.sv
+++ b/bp_top/test/common/bp_nonsynth_cosim.sv
@@ -46,8 +46,7 @@ module bp_nonsynth_cosim
     , input [rv64_reg_addr_width_gp-1:0]      frd_addr_i
     , input [dpath_width_gp-1:0]              frd_data_i
 
-    , input                                   cache_req_v_i
-    , input                                   cache_req_ready_i
+    , input                                   cache_req_yumi_i
     , input                                   cache_req_complete_i
     , input                                   cache_req_nonblocking_i
 
@@ -92,7 +91,7 @@ module bp_nonsynth_cosim
 
   logic cache_req_complete_r, cache_req_v_r;
   // We filter out for ready so that the request only tracks once
-  wire cache_req_v_li = cache_req_v_i & cache_req_ready_i & ~cache_req_nonblocking_i;
+  wire cache_req_v_li = cache_req_yumi_i & ~cache_req_nonblocking_i;
   bsg_dff_chain
    #(.width_p(2), .num_stages_p(2))
    cache_req_reg

--- a/bp_top/test/common/bp_nonsynth_if_verif.sv
+++ b/bp_top/test/common/bp_nonsynth_if_verif.sv
@@ -52,39 +52,39 @@ module bp_nonsynth_if_verif
       $display("bp_bedrock_cce_mem_header_s       bits: struct %d width %d", $bits(bp_bedrock_cce_mem_header_s), cce_mem_header_width_lp);
 
       if (!(num_cce_p inside {1,2,3,4,6,7,8,12,14,15,16,24,28,30,31,32})) begin
-        $fatal("Error: unsupported number of CCE's");
+        $error("Error: unsupported number of CCE's");
       end
 
     end
 
   if (ic_y_dim_p != 1 && multicore_p == 1)
-    $fatal("Error: Must have exactly 1 row of I/O routers for multicore");
+    $error("Error: Must have exactly 1 row of I/O routers for multicore");
   if (mc_y_dim_p > 2)
-    $fatal("Error: Multi-row L2 expansion nodes not yet supported");
+    $error("Error: Multi-row L2 expansion nodes not yet supported");
   if (sac_x_dim_p > 1)
-    $fatal("Error: Must have <= 1 column of streaming accelerators");
+    $error("Error: Must have <= 1 column of streaming accelerators");
   if (cac_x_dim_p > 1)
-    $fatal("Error: Must have <= 1 column of coherent accelerators");
+    $error("Error: Must have <= 1 column of coherent accelerators");
   if (multicore_p == 1 && !((dcache_block_width_p == icache_block_width_p) && (dcache_block_width_p ==  acache_block_width_p)))
-    $fatal("Error: We don't currently support different block widths for multicore configurations");
+    $error("Error: We don't currently support different block widths for multicore configurations");
   if ((cce_block_width_p == 256) && (dcache_assoc_p == 8 || icache_assoc_p == 8))
-    $fatal("Error: We can't maintain 64-bit dwords with a 256-bit cache block size and 8-way cache associativity");
+    $error("Error: We can't maintain 64-bit dwords with a 256-bit cache block size and 8-way cache associativity");
   if ((cce_block_width_p == 128) && (dcache_assoc_p == 4 || dcache_assoc_p == 8 || icache_assoc_p == 4 || icache_assoc_p == 8))
-    $fatal("Error: We can't maintain 64-bit dwords with a 128-bit cache block size and 4-way or 8-way cache associativity");
+    $error("Error: We can't maintain 64-bit dwords with a 128-bit cache block size and 4-way or 8-way cache associativity");
   if ((l1_writethrough_p == 1) && (l1_coherent_p == 1))
-    $fatal("Error: Writethrough with coherent_l1 is unsupported");
+    $error("Error: Writethrough with coherent_l1 is unsupported");
   if ((icache_fill_width_p > icache_block_width_p) || (dcache_fill_width_p > dcache_block_width_p))
-    $fatal("Error: Cache fill width should be less or equal to L1 cache block width");
+    $error("Error: Cache fill width should be less or equal to L1 cache block width");
   if ((icache_fill_width_p % (icache_block_width_p/icache_assoc_p) != 0) || (dcache_fill_width_p % (dcache_block_width_p / dcache_assoc_p) != 0))
-    $fatal("Error: Cache fill width should be a multiple of cache bank width");
+    $error("Error: Cache fill width should be a multiple of cache bank width");
   if (icache_fill_width_p != dcache_fill_width_p)
-    $fatal("Error: L1-Cache fill width should be the same");
+    $error("Error: L1-Cache fill width should be the same");
   if ((multicore_p == 0) && ((icache_fill_width_p != l2_data_width_p) || (dcache_fill_width_p != l2_data_width_p)))
-    $fatal("Error: unicore requires L2-Cache data width same as L1-Cache fill width");
+    $error("Error: unicore requires L2-Cache data width same as L1-Cache fill width");
   if ((multicore_p == 1) && (l2_data_width_p != dword_width_gp))
-    $fatal("Error: multicore requires L2 data width same as dword width");
+    $error("Error: multicore requires L2 data width same as dword width");
   if (l2_data_width_p < l2_fill_width_p)
-    $fatal("Error: L2 fill width must be at least as large as L2 data width");
+    $error("Error: L2 fill width must be at least as large as L2 data width");
 
   if (l2_block_width_p != 512)
     $error("L2 block width must be 512");
@@ -103,19 +103,22 @@ module bp_nonsynth_if_verif
   if (caddr_width_p >= daddr_width_p)
     $warning("Warning: caddr must <= daddr");
   if (daddr_width_p >= paddr_width_p)
-    $fatal("Error: caddr cannot exceed paddr_width_p-1");
+    $error("Error: caddr cannot exceed paddr_width_p-1");
 
   if (branch_metadata_fwd_width_p != $bits(bp_fe_branch_metadata_fwd_s))
-    $fatal("Branch metadata width: %d != width of branch metadata struct: %d", branch_metadata_fwd_width_p, $bits(bp_fe_branch_metadata_fwd_s));
+    $error("Branch metadata width: %d != width of branch metadata struct: %d", branch_metadata_fwd_width_p, $bits(bp_fe_branch_metadata_fwd_s));
 
-  if ((multicore_p == 1) && ((amo_swap_p != e_none) || (amo_fetch_logic_p != e_none) || (amo_fetch_arithmetic_p != e_none)))
-    $fatal("Error: L2 atomics are not currently supported in bp_multicore");
+  if ((multicore_p == 1) && ((amo_swap_p == e_l2) || (amo_fetch_logic_p == e_l2) || (amo_fetch_arithmetic_p == e_l2)))
+    $error("Error: L2 atomics are not currently supported in bp_multicore");
+
+  if (lr_sc_p == e_none)
+    $error("Warning: Atomics cannot be emulated without LR/SC. Those instructions will fail");
 
   if (mem_noc_flit_width_p % l2_fill_width_p != 0)
-    $fatal("Memory NoC flit width must match l2 fill width");
+    $error("Memory NoC flit width must match l2 fill width");
 
   if (multicore_p == 0 && num_core_p != 1)
-    $fatal("Unicore only supports a single core configuration in the tethered testbench");
+    $error("Unicore only supports a single core configuration in the tethered testbench");
 
 endmodule
 

--- a/bp_top/test/tb/bp_tethered/Makefile.cfgs
+++ b/bp_top/test/tb/bp_tethered/Makefile.cfgs
@@ -27,14 +27,11 @@ else
 	export NCPUS ?= $(_NCPUS)
 endif
 
-e_bp_unicore_l2_atomic_cfg_amoen       := 1
-e_bp_unicore_l1_atomic_cfg_amoen       := 1
-
-e_bp_default_cfg_amoen                 := 0
+e_bp_unicore_tinyparrot_cfg_amoen      := 0
 
 _AMOEN :=$($(CFG)_amoen)
 ifeq ($(_AMOEN),)
-	export AMOEN ?= 0
+	export AMOEN ?= 1
 else
 	export AMOEN ?= $(_AMOEN)
 endif

--- a/bp_top/test/tb/bp_tethered/Makefile.cfgs
+++ b/bp_top/test/tb/bp_tethered/Makefile.cfgs
@@ -27,8 +27,7 @@ else
 	export NCPUS ?= $(_NCPUS)
 endif
 
-e_bp_unicore_tinyparrot_cfg_amoen      := 0
-$(CFG)_amoen ?= $(if $(findstring multicore,$(CFG)),0,1)
+e_bp_unicore_tinyparrot_cfg_amoen := 0
 
 _AMOEN :=$($(CFG)_amoen)
 ifeq ($(_AMOEN),)

--- a/bp_top/test/tb/bp_tethered/Makefile.cfgs
+++ b/bp_top/test/tb/bp_tethered/Makefile.cfgs
@@ -28,6 +28,7 @@ else
 endif
 
 e_bp_unicore_tinyparrot_cfg_amoen      := 0
+$(CFG)_amoen ?= $(if $(findstring multicore,$(CFG)),0,1)
 
 _AMOEN :=$($(CFG)_amoen)
 ifeq ($(_AMOEN),)

--- a/bp_top/test/tb/bp_tethered/Makefile.testlist
+++ b/bp_top/test/tb/bp_tethered/Makefile.testlist
@@ -7,6 +7,8 @@
 #  amo_interrupt
 #  These tests are expected to fail
 #  unhandled_trap
+#  These tests dont work on all configs
+#  aviary_rom
 MISC_TESTS := \
   hello_world           \
   instr_coherence       \
@@ -23,7 +25,6 @@ MISC_TESTS := \
   mstatus_fs            \
   wfi                   \
   divide_hazard         \
-  aviary_rom            \
   readonly              \
   epc                   \
   virtual               \

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -387,8 +387,7 @@ module testbench
            ,.frd_addr_i(scheduler.fwb_pkt_cast_i.rd_addr)
            ,.frd_data_i(scheduler.fwb_pkt_cast_i.rd_data)
 
-           ,.cache_req_v_i(calculator.pipe_mem.dcache.cache_req_v_o)
-           ,.cache_req_ready_i(calculator.pipe_mem.dcache.is_ready)
+           ,.cache_req_yumi_i(calculator.pipe_mem.dcache.cache_req_yumi_i)
            ,.cache_req_complete_i(calculator.pipe_mem.dcache.cache_req_complete_i)
            ,.cache_req_nonblocking_i(calculator.pipe_mem.dcache.nonblocking_req)
 

--- a/ci/single_core_atomics.sh
+++ b/ci/single_core_atomics.sh
@@ -23,7 +23,7 @@ N=${2:-1}
 # Bash array to iterate over for configurations
 cfgs=(\
     "e_bp_unicore_cfg"
-    "e_bp_unicore_l1_atomic_cfg"
+    "e_bp_unicore_tinyparrot_cfg"
     "e_bp_unicore_l2_atomic_cfg"
     )
 


### PR DESCRIPTION
## Summary
This PR enables L1 atomics for bp unicore. The L1 atomics were optional, but they are fairly low overhead and it is easier to integrate into vanilla RISC-V software so it makes a sensible default.

## Issue Fixed
No issue

## Area
bp_be_dcache

## Additional Changes Required (if any)
https://github.com/black-parrot-sdk/bp-tests/pull/25

## Analysis
The major issue with L1 atomics is pressure on the 1rw rams in the dcache. Atomics both read and write the RAMs, so they don't fall into the normal paradigm of wbuf == dcache pipeline depth. One option is stalling wbuf entries until they are able to write back, but this complicates control logic. Instead, we detect an extra hazard condition when wbuf must write back or the request in TL will drop. This is absorbed by the normal replay mechanism.

## Verification
- [ ] Normal atomic regression
- [ ] Running linux 
