### PR TITLE
Misaligned Memory Access Detection

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - be_dev_feature_misaligned
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - be_dev_feature_misaligned
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/bp_be/src/include/bp_be_dcache_defines.svh
+++ b/bp_be/src/include/bp_be_dcache_defines.svh
@@ -2,14 +2,26 @@
 `ifndef BP_BE_DCACHE_DEFINES_SVH
 `define BP_BE_DCACHE_DEFINES_SVH
 
+  `define declare_bp_be_dcache_pkt_s(vaddr_width_mp) \
+    typedef struct packed                           \
+    {                                               \
+      logic [reg_addr_width_gp-1:0]    rd_addr;     \
+      bp_be_dcache_fu_op_e             opcode;      \
+      logic [vaddr_width_mp-1:0]       vaddr;       \
+      logic [dpath_width_gp-1:0]       data;        \
+    }  bp_be_dcache_pkt_s;                          \
+
   `define declare_bp_be_dcache_wbuf_entry_s(paddr_width_mp, ways_mp) \
-    typedef struct packed                                        \
-    {                                                            \
-      logic [paddr_width_mp-1:0]           paddr;                \
-      logic [dword_width_gp-1:0]           data;                 \
-      logic [(dword_width_gp>>3)-1:0]      mask;                 \
-      logic [`BSG_SAFE_CLOG2(ways_mp)-1:0] way_id;               \
+    typedef struct packed                           \
+    {                                               \
+      logic [paddr_width_mp-1:0]           paddr;   \
+      logic [dword_width_gp-1:0]           data;    \
+      logic [(dword_width_gp>>3)-1:0]      mask;    \
+      logic [`BSG_SAFE_CLOG2(ways_mp)-1:0] way_id;  \
     } bp_be_dcache_wbuf_entry_s
+
+  `define bp_be_dcache_pkt_width(vaddr_width_mp) \
+    (dpath_width_gp+vaddr_width_mp+$bits(bp_be_dcache_fu_op_e)+reg_addr_width_gp)
 
   `define bp_be_dcache_wbuf_entry_width(paddr_width_mp, ways_mp) \
     (paddr_width_mp+dword_width_gp+(dword_width_gp>>3)+`BSG_SAFE_CLOG2(ways_mp))

--- a/bp_be/src/include/bp_be_dcache_pkgdef.svh
+++ b/bp_be/src/include/bp_be_dcache_pkgdef.svh
@@ -38,13 +38,5 @@
     logic [reg_addr_width_gp-1:0] rd_addr;
   }  bp_be_dcache_decode_s;
 
-  typedef struct packed
-  {
-    logic [reg_addr_width_gp-1:0]    rd_addr;
-    bp_be_dcache_fu_op_e             opcode;
-    logic [page_offset_width_gp-1:0] page_offset;
-    logic [dpath_width_gp-1:0]       data;
-  }  bp_be_dcache_pkt_s;
-
 `endif
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -150,7 +150,8 @@ module bp_be_pipe_mem
   logic [dpath_width_gp-1:0] dcache_early_data, dcache_final_data, dcache_late_data;
   logic [reg_addr_width_gp-1:0] dcache_late_rd_addr;
   logic [ptag_width_p-1:0]  dcache_ptag;
-  logic                     dcache_early_miss_v, dcache_early_hit_v, dcache_final_v, dcache_pkt_v;
+  logic                     dcache_pkt_v;
+  logic                     dcache_early_miss_v, dcache_early_fencei, dcache_early_hit_v, dcache_final_v;
   logic                     dcache_late_float, dcache_late_v, dcache_late_yumi;
   logic                     dcache_ptag_v;
   logic                     dcache_ptag_uncached;
@@ -162,10 +163,6 @@ module bp_be_pipe_mem
   logic load_misaligned_v, store_misaligned_v;
 
   /* Control signals */
-  logic is_req_mem2, is_req_mem3;
-  logic is_fencei_mem2, is_fencei_mem3;
-  logic is_store_mem2, is_store_mem3;
-
   wire is_store  = (decode.pipe_mem_early_v | decode.pipe_mem_final_v) & decode.dcache_w_v;
   wire is_load   = (decode.pipe_mem_early_v | decode.pipe_mem_final_v) & decode.dcache_r_v;
   wire is_fencei = (decode.pipe_mem_early_v | decode.pipe_mem_final_v) & decode.fu_op inside {e_dcache_op_fencei};
@@ -210,13 +207,18 @@ module bp_be_pipe_mem
 
      ,.r_v_o(dtlb_v_lo)
      ,.r_ptag_o(dtlb_ptag_lo)
-     ,.r_miss_o(dtlb_miss_v)
+     ,.r_instr_miss_o()
+     ,.r_load_miss_o(tlb_load_miss_v_o)
+     ,.r_store_miss_o(tlb_store_miss_v_o)
      ,.r_uncached_o(dcache_ptag_uncached)
      ,.r_nonidem_o(/* All D$ misses are non-speculative */)
      ,.r_dram_o(dcache_ptag_dram)
      ,.r_instr_access_fault_o()
      ,.r_load_access_fault_o(load_access_fault_v)
      ,.r_store_access_fault_o(store_access_fault_v)
+     ,.r_instr_misaligned_o()
+     ,.r_load_misaligned_o(load_misaligned_v)
+     ,.r_store_misaligned_o(store_misaligned_v)
      ,.r_instr_page_fault_o()
      ,.r_load_page_fault_o(load_page_fault_v)
      ,.r_store_page_fault_o(store_page_fault_v)
@@ -281,6 +283,7 @@ module bp_be_pipe_mem
 
       ,.early_hit_v_o(dcache_early_hit_v)
       ,.early_miss_v_o(dcache_early_miss_v)
+      ,.early_fencei_o(dcache_early_fencei)
       ,.early_data_o(dcache_early_data)
       ,.final_data_o(dcache_final_data)
       ,.final_v_o(dcache_final_v)
@@ -318,28 +321,6 @@ module bp_be_pipe_mem
       ,.stat_mem_pkt_yumi_o(stat_mem_pkt_yumi_o)
       );
 
-  bsg_dff_reset
-   #(.width_p(3))
-   mem2_reg
-    (.clk_i(~clk_i)
-     ,.reset_i(reset_i)
-     ,.data_i({is_req, is_store, is_fencei})
-     ,.data_o({is_req_mem2, is_store_mem2, is_fencei_mem2})
-     );
-
-  bsg_dff_reset
-   #(.width_p(3))
-   mem3_reg
-    (.clk_i(~clk_i)
-     ,.reset_i(reset_i)
-     ,.data_i({is_req_mem2, is_store_mem2, is_fencei_mem2})
-     ,.data_o({is_req_mem3, is_store_mem3, is_fencei_mem3})
-     );
-
-  // Check instruction accesses
-  assign load_misaligned_v = 1'b0; // TODO: detect
-  assign store_misaligned_v = 1'b0; // TODO: detect
-
   // D-Cache connections
   always_comb
     if (ptw_busy)
@@ -360,12 +341,10 @@ module bp_be_pipe_mem
         dcache_ptag_v          = dtlb_v_lo;
       end
 
-  assign tlb_store_miss_v_o     = is_store_mem2 & dtlb_miss_v;
-  assign tlb_load_miss_v_o      = ~is_store_mem2 & dtlb_miss_v;
-  assign cache_miss_v_o         = is_req_mem3 & dcache_early_miss_v;
-  assign cache_fail_v_o         = is_req_mem3 & ~dcache_early_hit_v & ~dcache_early_miss_v;
-  assign fencei_clean_v_o       = is_fencei_mem3 & dcache_early_hit_v;
-  assign fencei_dirty_v_o       = is_fencei_mem3 & ~dcache_early_hit_v;
+  assign cache_fail_v_o         = early_v_o & ~dcache_early_hit_v  & ~dcache_early_miss_v;
+  assign cache_miss_v_o         = early_v_o & ~dcache_early_fencei &  dcache_early_miss_v;
+  assign fencei_clean_v_o       = early_v_o &  dcache_early_fencei &  dcache_early_hit_v;
+  assign fencei_dirty_v_o       = early_v_o &  dcache_early_fencei & ~dcache_early_hit_v;
 
   assign store_page_fault_v_o   = store_page_fault_v;
   assign load_page_fault_v_o    = load_page_fault_v;

--- a/bp_be/src/v/bp_be_calculator/bp_be_ptw.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_ptw.sv
@@ -12,7 +12,7 @@ module bp_be_ptw
    , parameter `BSG_INV_PARAM(pte_size_in_bytes_p)
    , parameter `BSG_INV_PARAM(page_idx_width_p)
 
-   , localparam dcache_pkt_width_lp   = $bits(bp_be_dcache_pkt_s)
+   , localparam dcache_pkt_width_lp   = `bp_be_dcache_pkt_width(vaddr_width_p)
    , localparam ptw_miss_pkt_width_lp = `bp_be_ptw_miss_pkt_width(vaddr_width_p)
    , localparam ptw_fill_pkt_width_lp = `bp_be_ptw_fill_pkt_width(vaddr_width_p, paddr_width_p)
    )
@@ -43,6 +43,7 @@ module bp_be_ptw
   );
 
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
+  `declare_bp_be_dcache_pkt_s(vaddr_width_p);
   `bp_cast_o(bp_be_dcache_pkt_s, dcache_pkt);
 
   enum logic [2:0] {e_idle, e_send_load, e_send_tag, e_wait_load, e_recv_load, e_writeback} state_n, state_r;
@@ -94,7 +95,7 @@ module bp_be_ptw
   localparam lg_pte_size_in_bytes_lp = `BSG_SAFE_CLOG2(pte_size_in_bytes_p);
   assign dcache_v_o                    = (state_r == e_send_load);
   assign dcache_pkt_cast_o.opcode      = e_dcache_op_ptw_ld;
-  assign dcache_pkt_cast_o.page_offset = {partial_vpn[level_cntr], (lg_pte_size_in_bytes_lp)'(0)};
+  assign dcache_pkt_cast_o.vaddr       = vaddr_width_p'({partial_vpn[level_cntr], (lg_pte_size_in_bytes_lp)'(0)});
   assign dcache_pkt_cast_o.data        = '0;
   assign dcache_pkt_cast_o.rd_addr     = '0;
 

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -118,7 +118,6 @@ module bp_be_dcache
    , localparam cfg_bus_width_lp    = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam dcache_pkt_width_lp = `bp_be_dcache_pkt_width(vaddr_width_p)
    )
-<<<<<<< HEAD
   (input                                             clk_i
    , input                                           reset_i
 
@@ -145,6 +144,7 @@ module bp_be_dcache
    , output logic [dpath_width_gp-1:0]               early_data_o
    , output logic                                    early_miss_v_o
    , output logic                                    early_hit_v_o
+   , output logic                                    early_fencei_o
 
    // Cycle 3: "Data Mux"
    // Data comes out this cycle for operations which require additional

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -116,7 +116,7 @@ module bp_be_dcache
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, dcache)
 
    , localparam cfg_bus_width_lp    = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
-   , localparam dcache_pkt_width_lp = $bits(bp_be_dcache_pkt_s)
+   , localparam dcache_pkt_width_lp = `bp_be_dcache_pkt_width(vaddr_width_p)
    )
 <<<<<<< HEAD
   (input                                             clk_i
@@ -262,6 +262,7 @@ module bp_be_dcache
   /////////////////////////////////////////////////////////////////////////////
   // Decode Stage
   /////////////////////////////////////////////////////////////////////////////
+  `declare_bp_be_dcache_pkt_s(vaddr_width_p);
   `bp_cast_i(bp_be_dcache_pkt_s, dcache_pkt);
 
   bp_be_dcache_decode_s decode_lo;
@@ -272,9 +273,10 @@ module bp_be_dcache
      ,.decode_o(decode_lo)
      );
 
-  wire [page_offset_width_gp-1:0]  page_offset = dcache_pkt_cast_i.page_offset;
+  wire [page_offset_width_gp-1:0]  page_offset = dcache_pkt_cast_i.vaddr[0+:page_offset_width_gp];
   wire [sindex_width_lp-1:0]       vaddr_index = page_offset[block_offset_width_lp+:sindex_width_lp];
   wire [bindex_width_lp-1:0]       vaddr_bank  = page_offset[byte_offset_width_lp+:bindex_width_lp];
+  wire [vtag_width_p-1:0]          vaddr_tag   = dcache_pkt_cast_i.vaddr[vaddr_width_p-1-:vtag_width_p];
 
   ///////////////////////////
   // Tag Mem Storage

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -118,6 +118,7 @@ module bp_be_dcache
    , localparam cfg_bus_width_lp    = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam dcache_pkt_width_lp = $bits(bp_be_dcache_pkt_s)
    )
+<<<<<<< HEAD
   (input                                             clk_i
    , input                                           reset_i
 
@@ -627,6 +628,8 @@ module bp_be_dcache
       // Cached load / store
        | (cached_op_tv_r & ~any_miss_tv)
        );
+  // fence.i
+  assign early_fencei_o = decode_tv_r.fencei_op;
 
   assign early_miss_v_o = v_tv_r & cache_req_yumi_i & ~early_hit_v_o;
 

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache_decoder.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache_decoder.sv
@@ -10,13 +10,14 @@ module bp_be_dcache_decoder
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
 
-   , localparam dcache_pkt_width_lp = $bits(bp_be_dcache_pkt_s)
+   , localparam dcache_pkt_width_lp = `bp_be_dcache_pkt_width(vaddr_width_p)
    , localparam dcache_pipeline_struct_width_lp = $bits(bp_be_dcache_decode_s)
    )
   (input [dcache_pkt_width_lp-1:0]                      pkt_i
    , output logic [dcache_pipeline_struct_width_lp-1:0] decode_o
    );
 
+  `declare_bp_be_dcache_pkt_s(vaddr_width_p);
   bp_be_dcache_pkt_s dcache_pkt;
   assign dcache_pkt = pkt_i;
 
@@ -82,15 +83,15 @@ module bp_be_dcache_decoder
 
     // Size decoding
     unique case (dcache_pkt.opcode)
+      e_dcache_op_lb, e_dcache_op_lbu, e_dcache_op_sb: decode_cast_o.byte_op   = 1'b1;
+      e_dcache_op_lh, e_dcache_op_lhu, e_dcache_op_sh: decode_cast_o.half_op   = 1'b1;
       e_dcache_op_amoswapw, e_dcache_op_amoaddw, e_dcache_op_amoxorw
       ,e_dcache_op_amoandw, e_dcache_op_amoorw, e_dcache_op_amominw
       ,e_dcache_op_amomaxw, e_dcache_op_amominuw, e_dcache_op_amomaxuw
       ,e_dcache_op_lw, e_dcache_op_lwu, e_dcache_op_sw
       ,e_dcache_op_flw, e_dcache_op_fsw
       ,e_dcache_op_lrw, e_dcache_op_scw:               decode_cast_o.word_op   = 1'b1;
-      e_dcache_op_lh, e_dcache_op_lhu, e_dcache_op_sh: decode_cast_o.half_op   = 1'b1;
-      e_dcache_op_lb, e_dcache_op_lbu, e_dcache_op_sb: decode_cast_o.byte_op   = 1'b1;
-      default:                                         decode_cast_o.double_op = 1'b1;
+      default: decode_cast_o.double_op = 1'b1;
     endcase
 
     // The destination register of the cache request

--- a/bp_be/test/common/bp_be_nonsynth_dcache_tracer.sv
+++ b/bp_be/test/common/bp_be_nonsynth_dcache_tracer.sv
@@ -17,7 +17,7 @@ module bp_be_nonsynth_dcache_tracer
    // Calculated parameters
    , localparam mhartid_width_lp = `BSG_SAFE_CLOG2(num_core_p)
    , localparam bank_width_lp = block_width_p / assoc_p
-   , localparam dcache_pkt_width_lp = $bits(bp_be_dcache_pkt_s)
+   , localparam dcache_pkt_width_lp = `bp_be_dcache_pkt_width(vaddr_width_p)
    , localparam wbuf_entry_width_lp = `bp_be_dcache_wbuf_entry_width(paddr_width_p, assoc_p)
    )
   (  input                                                clk_i
@@ -90,31 +90,18 @@ module bp_be_nonsynth_dcache_tracer
    );
 
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache);
-  bp_be_dcache_pkt_s dcache_pkt_cast_i;
-  assign dcache_pkt_cast_i = dcache_pkt_i;
-
-  bp_cache_req_s cache_req_cast_o;
-  bp_cache_req_metadata_s cache_req_metadata_cast_o;
-  assign cache_req_cast_o = cache_req_o;
-  assign cache_req_metadata_cast_o = cache_req_metadata_o;
-
-  bp_cache_data_mem_pkt_s data_mem_pkt_cast_i;
-  bp_cache_tag_mem_pkt_s tag_mem_pkt_cast_i;
-  bp_cache_stat_mem_pkt_s stat_mem_pkt_cast_i;
-  assign data_mem_pkt_cast_i = data_mem_pkt_i;
-  assign tag_mem_pkt_cast_i = tag_mem_pkt_i;
-  assign stat_mem_pkt_cast_i = stat_mem_pkt_i;
-
-  logic [assoc_p-1:0][bank_width_lp-1:0] data_mem_cast_o;
-  bp_cache_tag_info_s tag_mem_info_cast_o;
-  bp_cache_tag_info_s stat_mem_info_cast_o;
-  assign data_mem_cast_o = data_mem_o;
-  assign tag_mem_info_cast_o = tag_mem_o;
-  assign stat_mem_info_cast_o = stat_mem_o;
-
+  `declare_bp_be_dcache_pkt_s(vaddr_width_p);
+  `bp_cast_i(bp_be_dcache_pkt_s, dcache_pkt);
+  `bp_cast_o(bp_cache_req_s, cache_req);
+  `bp_cast_o(bp_cache_req_metadata_s, cache_req_metadata);
+  `bp_cast_i(bp_cache_data_mem_pkt_s, data_mem_pkt);
+  `bp_cast_i(bp_cache_tag_mem_pkt_s, tag_mem_pkt);
+  `bp_cast_i(bp_cache_stat_mem_pkt_s, stat_mem_pkt);
+  `bp_cast_o(logic [assoc_p-1:0][bank_width_lp-1:0], data_mem);
+  `bp_cast_o(bp_cache_tag_info_s, tag_mem_info);
+  `bp_cast_o(bp_cache_stat_info_s, stat_mem_info);
   `declare_bp_be_dcache_wbuf_entry_s(paddr_width_p, assoc_p);
-  bp_be_dcache_wbuf_entry_s wbuf_entry_out_cast;
-  assign wbuf_entry_out_cast = wbuf_entry_out;
+  `bp_cast_o(bp_be_dcache_wbuf_entry_s, wbuf_entry);
 
   integer info_file, eng_file, mem_file, acc_file;
   string info_file_name, eng_file_name, mem_file_name, acc_file_name;
@@ -163,7 +150,7 @@ module bp_be_nonsynth_dcache_tracer
       if (final_v_o & decode_dm_r.load_op)
         $fwrite(acc_file, "%12t | final load: %x\n", $time, final_data_o);
       if (wbuf_yumi_li)
-        $fwrite(acc_file, "%12t | wbuf: %p\n", $time, wbuf_entry_out_cast);
+        $fwrite(acc_file, "%12t | wbuf: %p\n", $time, wbuf_entry_cast_o);
 
       if (cache_req_yumi_i)
         $fwrite(eng_file, "%12t | cache_req: %p\n", $time, cache_req_cast_o);

--- a/bp_be/test/common/bp_be_nonsynth_dcache_tracer.sv
+++ b/bp_be/test/common/bp_be_nonsynth_dcache_tracer.sv
@@ -91,17 +91,31 @@ module bp_be_nonsynth_dcache_tracer
 
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache);
   `declare_bp_be_dcache_pkt_s(vaddr_width_p);
-  `bp_cast_i(bp_be_dcache_pkt_s, dcache_pkt);
-  `bp_cast_o(bp_cache_req_s, cache_req);
-  `bp_cast_o(bp_cache_req_metadata_s, cache_req_metadata);
-  `bp_cast_i(bp_cache_data_mem_pkt_s, data_mem_pkt);
-  `bp_cast_i(bp_cache_tag_mem_pkt_s, tag_mem_pkt);
-  `bp_cast_i(bp_cache_stat_mem_pkt_s, stat_mem_pkt);
-  `bp_cast_o(logic [assoc_p-1:0][bank_width_lp-1:0], data_mem);
-  `bp_cast_o(bp_cache_tag_info_s, tag_mem_info);
-  `bp_cast_o(bp_cache_stat_info_s, stat_mem_info);
+  bp_be_dcache_pkt_s dcache_pkt_cast_i;
+  assign dcache_pkt_cast_i = dcache_pkt_i;
+
+  bp_cache_req_s cache_req_cast_o;
+  bp_cache_req_metadata_s cache_req_metadata_cast_o;
+  assign cache_req_cast_o = cache_req_o;
+  assign cache_req_metadata_cast_o = cache_req_metadata_o;
+
+  bp_cache_data_mem_pkt_s data_mem_pkt_cast_i;
+  bp_cache_tag_mem_pkt_s tag_mem_pkt_cast_i;
+  bp_cache_stat_mem_pkt_s stat_mem_pkt_cast_i;
+  assign data_mem_pkt_cast_i = data_mem_pkt_i;
+  assign tag_mem_pkt_cast_i = tag_mem_pkt_i;
+  assign stat_mem_pkt_cast_i = stat_mem_pkt_i;
+
+  logic [assoc_p-1:0][bank_width_lp-1:0] data_mem_cast_o;
+  bp_cache_tag_info_s tag_mem_info_cast_o;
+  bp_cache_tag_info_s stat_mem_info_cast_o;
+  assign data_mem_cast_o = data_mem_o;
+  assign tag_mem_info_cast_o = tag_mem_o;
+  assign stat_mem_info_cast_o = stat_mem_o;
+
   `declare_bp_be_dcache_wbuf_entry_s(paddr_width_p, assoc_p);
-  `bp_cast_o(bp_be_dcache_wbuf_entry_s, wbuf_entry);
+  bp_be_dcache_wbuf_entry_s wbuf_entry_out_cast;
+  assign wbuf_entry_out_cast = wbuf_entry_out;
 
   integer info_file, eng_file, mem_file, acc_file;
   string info_file_name, eng_file_name, mem_file_name, acc_file_name;
@@ -150,7 +164,7 @@ module bp_be_nonsynth_dcache_tracer
       if (final_v_o & decode_dm_r.load_op)
         $fwrite(acc_file, "%12t | final load: %x\n", $time, final_data_o);
       if (wbuf_yumi_li)
-        $fwrite(acc_file, "%12t | wbuf: %p\n", $time, wbuf_entry_cast_o);
+        $fwrite(acc_file, "%12t | wbuf: %p\n", $time, wbuf_entry_out_cast);
 
       if (cache_req_yumi_i)
         $fwrite(eng_file, "%12t | cache_req: %p\n", $time, cache_req_cast_o);

--- a/bp_be/test/tb/bp_be_dcache/testbench.sv
+++ b/bp_be/test/tb/bp_be_dcache/testbench.sv
@@ -33,7 +33,7 @@ module testbench
 
    // Derived parameters
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
-   , localparam dcache_pkt_width_lp = $bits(bp_be_dcache_pkt_s)
+   , localparam dcache_pkt_width_lp = `bp_be_dcache_pkt_width(vaddr_width_p)
    , localparam trace_replay_data_width_lp = ptag_width_p + dcache_pkt_width_lp + 1 // The 1 extra bit is for uncached accesses
    , localparam trace_rom_addr_width_lp = 8
 

--- a/bp_be/test/tb/bp_be_dcache/trace_gen.py
+++ b/bp_be/test/tb/bp_be_dcache/trace_gen.py
@@ -7,13 +7,13 @@ import numpy as np
 class TraceGen:
 
   # constructor
-  def __init__(self, ptag_width_p, page_offset_width_p, opcode_width_p, data_width_p, rd_addr_width_p):
+  def __init__(self, ptag_width_p, vaddr_width_p, opcode_width_p, data_width_p, rd_addr_width_p):
     self.ptag_width_p = ptag_width_p
-    self.page_offset_width_p = page_offset_width_p
+    self.vaddr_width_p = vaddr_width_p
     self.opcode_width_p = opcode_width_p
     # TODO: Update formatting operators to use data width
     self.data_width_p = data_width_p
-    self.packet_len = ptag_width_p + page_offset_width_p + opcode_width_p + rd_addr_width_p + data_width_p + 1 # A bit is added to denote cached/uncached accesses
+    self.packet_len = ptag_width_p + vaddr_width_p + opcode_width_p + rd_addr_width_p + data_width_p + 1 # A bit is added to denote cached/uncached accesses
 
   # print header
   def print_header(self):
@@ -24,8 +24,8 @@ class TraceGen:
   # send load
   # signed: sign extend or not
   # size: load size in bytes
-  # page_offset: dcache pkt page offset
-  def send_load(self, signed, size, page_offset, ptag, uncached):
+  # vaddr: dcache pkt page offset
+  def send_load(self, signed, size, vaddr, ptag, uncached):
     packet = "0001_"
     
     if(uncached):
@@ -57,15 +57,15 @@ class TraceGen:
         else:
           raise ValueError("unexpected size for unsigned load.")
 
-    packet += format(page_offset, "0"+str(self.page_offset_width_p)+"b") + "_"
+    packet += format(vaddr, "0"+str(self.vaddr_width_p)+"b") + "_"
     packet += format(0, "066b") + "\n" 
     return packet
 
   # send store
   # signed: sign extend or not
   # size: store size in bytes
-  # page_offset: dcache pkt page offset
-  def send_store(self, size, page_offset, ptag, uncached, data):
+  # vaddr: dcache pkt page offset
+  def send_store(self, size, vaddr, ptag, uncached, data):
     packet = "0001_"
 
     if(uncached):
@@ -86,7 +86,7 @@ class TraceGen:
     else:
       raise ValueError("unexpected size for store.")
     
-    packet += format(page_offset, "0" + str(self.page_offset_width_p) + "b") + "_"
+    packet += format(vaddr, "0" + str(self.vaddr_width_p) + "b") + "_"
     packet += format(data, "066b") + "\n"
     return packet
 
@@ -95,7 +95,7 @@ class TraceGen:
   def recv_data(self, data):
     packet = "0010_"
     bin_data = np.binary_repr(data, 64)
-    packet += "0" + "0"*(self.ptag_width_p) + "_" + "0"*(self.opcode_width_p) + "_" + "0"*(self.page_offset_width_p) + "_" + "00" + bin_data + "\n"
+    packet += "0" + "0"*(self.ptag_width_p) + "_" + "0"*(self.opcode_width_p) + "_" + "0"*(self.vaddr_width_p) + "_" + "00" + bin_data + "\n"
     return packet
 
   # wait for a number of cycles

--- a/bp_be/test/tb/bp_be_dcache/trace_script.py
+++ b/bp_be/test/tb/bp_be_dcache/trace_script.py
@@ -5,7 +5,7 @@ from trace_gen import TraceGen
 
 def main():
 
-  tracer = TraceGen(28, 12, 6, 66, 5)
+  tracer = TraceGen(28, 39, 6, 66, 5)
   filepath = sys.argv[1]
 
   # Store/Load double word test

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -31,7 +31,7 @@ module wrapper
 
    , localparam wg_per_cce_lp = (lce_sets_p / num_cce_p)
 
-   , localparam dcache_pkt_width_lp=$bits(bp_be_dcache_pkt_s)
+   , localparam dcache_pkt_width_lp = `bp_be_dcache_pkt_width(vaddr_width_p)
 
    , localparam lce_cce_req_packet_width_lp = `bsg_wormhole_concentrator_packet_width(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_req_msg_width_lp)
    , localparam lce_cce_req_packet_hdr_width_lp = (lce_cce_req_packet_width_lp-cce_block_width_p)
@@ -64,699 +64,700 @@ module wrapper
    , input                                             mem_resp_last_i
    );
 
-   `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
-   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+  `declare_bp_be_dcache_pkt_s(vaddr_width_p);
 
-   // Cache to Rolly FIFO signals
-   logic [num_caches_p-1:0] dcache_ready_lo;
-   logic [num_caches_p-1:0] rollback_li;
-   logic [num_caches_p-1:0] rolly_uncached_lo;
-   logic [num_caches_p-1:0] rolly_v_lo, rolly_yumi_li;
-   bp_be_dcache_pkt_s [num_caches_p-1:0] rolly_dcache_pkt_lo;
-   logic [num_caches_p-1:0][ptag_width_p-1:0] rolly_ptag_lo;
+  // Cache to Rolly FIFO signals
+  logic [num_caches_p-1:0] dcache_ready_lo;
+  logic [num_caches_p-1:0] rollback_li;
+  logic [num_caches_p-1:0] rolly_uncached_lo;
+  logic [num_caches_p-1:0] rolly_v_lo, rolly_yumi_li;
+  bp_be_dcache_pkt_s [num_caches_p-1:0] rolly_dcache_pkt_lo;
+  logic [num_caches_p-1:0][ptag_width_p-1:0] rolly_ptag_lo;
 
-   // D$ - LCE Interface signals
-   // Miss, Management Interfaces
-   logic [num_caches_p-1:0] cache_req_v_lo, cache_req_metadata_v_lo;
-   logic [num_caches_p-1:0] cache_req_yumi_lo, cache_req_busy_lo;
-   logic [num_caches_p-1:0] cache_req_complete_lo, cache_req_critical_tag_lo, cache_req_critical_data_lo;
-   logic [num_caches_p-1:0][dcache_req_width_lp-1:0] cache_req_lo;
-   logic [num_caches_p-1:0][dcache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
+  // D$ - LCE Interface signals
+  // Miss, Management Interfaces
+  logic [num_caches_p-1:0] cache_req_v_lo, cache_req_metadata_v_lo;
+  logic [num_caches_p-1:0] cache_req_yumi_lo, cache_req_busy_lo;
+  logic [num_caches_p-1:0] cache_req_complete_lo, cache_req_critical_tag_lo, cache_req_critical_data_lo;
+  logic [num_caches_p-1:0][dcache_req_width_lp-1:0] cache_req_lo;
+  logic [num_caches_p-1:0][dcache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
 
-   // Fill Interface
-   logic [num_caches_p-1:0] data_mem_pkt_v_lo, tag_mem_pkt_v_lo, stat_mem_pkt_v_lo;
-   logic [num_caches_p-1:0] data_mem_pkt_yumi_lo, tag_mem_pkt_yumi_lo, stat_mem_pkt_yumi_lo;
-   logic [num_caches_p-1:0][dcache_data_mem_pkt_width_lp-1:0] data_mem_pkt_lo;
-   logic [num_caches_p-1:0][dcache_tag_mem_pkt_width_lp-1:0] tag_mem_pkt_lo;
-   logic [num_caches_p-1:0][dcache_stat_mem_pkt_width_lp-1:0] stat_mem_pkt_lo;
-   logic [num_caches_p-1:0][block_width_p-1:0] data_mem_lo;
-   logic [num_caches_p-1:0][dcache_tag_info_width_lp-1:0] tag_mem_lo;
-   logic [num_caches_p-1:0][dcache_stat_info_width_lp-1:0] stat_mem_lo;
+  // Fill Interface
+  logic [num_caches_p-1:0] data_mem_pkt_v_lo, tag_mem_pkt_v_lo, stat_mem_pkt_v_lo;
+  logic [num_caches_p-1:0] data_mem_pkt_yumi_lo, tag_mem_pkt_yumi_lo, stat_mem_pkt_yumi_lo;
+  logic [num_caches_p-1:0][dcache_data_mem_pkt_width_lp-1:0] data_mem_pkt_lo;
+  logic [num_caches_p-1:0][dcache_tag_mem_pkt_width_lp-1:0] tag_mem_pkt_lo;
+  logic [num_caches_p-1:0][dcache_stat_mem_pkt_width_lp-1:0] stat_mem_pkt_lo;
+  logic [num_caches_p-1:0][block_width_p-1:0] data_mem_lo;
+  logic [num_caches_p-1:0][dcache_tag_info_width_lp-1:0] tag_mem_lo;
+  logic [num_caches_p-1:0][dcache_stat_info_width_lp-1:0] stat_mem_lo;
 
-   // Credits
-   logic [num_caches_p-1:0] cache_req_credits_full_lo, cache_req_credits_empty_lo;
+  // Credits
+  logic [num_caches_p-1:0] cache_req_credits_full_lo, cache_req_credits_empty_lo;
 
-   logic [num_caches_p-1:0][ptag_width_p-1:0] rolly_ptag_r;
-   logic [num_caches_p-1:0] rolly_uncached_r;
-   logic [num_caches_p-1:0] is_store, is_store_rr, dcache_v_rr;
+  logic [num_caches_p-1:0][ptag_width_p-1:0] rolly_ptag_r;
+  logic [num_caches_p-1:0] rolly_uncached_r;
+  logic [num_caches_p-1:0] is_store, is_store_rr, dcache_v_rr;
 
-   logic [num_caches_p-1:0][dpath_width_gp-1:0] early_data_lo;
-   logic [num_caches_p-1:0] early_v_lo;
-   logic [num_caches_p-1:0][dpath_width_gp-1:0] final_data_lo;
-   logic [num_caches_p-1:0] final_v_lo;
-   logic [num_caches_p-1:0][dpath_width_gp-1:0] late_data_lo;
-   logic [num_caches_p-1:0] late_v_lo;
+  logic [num_caches_p-1:0][dpath_width_gp-1:0] early_data_lo;
+  logic [num_caches_p-1:0] early_v_lo;
+  logic [num_caches_p-1:0][dpath_width_gp-1:0] final_data_lo;
+  logic [num_caches_p-1:0] final_v_lo;
+  logic [num_caches_p-1:0][dpath_width_gp-1:0] late_data_lo;
+  logic [num_caches_p-1:0] late_v_lo;
 
-   // LCE-CCE connections - to/from LCE
-   bp_bedrock_lce_req_header_s [num_caches_p-1:0] lce_req_header_lo;
-   logic [num_caches_p-1:0][cce_block_width_p-1:0] lce_req_data_lo;
-   logic [num_caches_p-1:0] lce_req_ready_and_li, lce_req_v_lo;
-   bp_bedrock_lce_cmd_header_s [num_caches_p-1:0] lce_cmd_header_li;
-   logic [num_caches_p-1:0][cce_block_width_p-1:0] lce_cmd_data_li;
-   logic [num_caches_p-1:0] lce_cmd_v_li, lce_cmd_yumi_lo;
-   bp_bedrock_lce_resp_header_s [num_caches_p-1:0] lce_resp_header_lo;
-   logic [num_caches_p-1:0][cce_block_width_p-1:0] lce_resp_data_lo;
-   logic [num_caches_p-1:0] lce_resp_v_lo, lce_resp_ready_and_li;
-   bp_bedrock_lce_cmd_header_s [num_caches_p-1:0] lce_cmd_header_lo;
-   logic [num_caches_p-1:0][cce_block_width_p-1:0] lce_cmd_data_lo;
-   logic [num_caches_p-1:0] lce_cmd_v_lo, lce_cmd_ready_and_li;
+  // LCE-CCE connections - to/from LCE
+  bp_bedrock_lce_req_header_s [num_caches_p-1:0] lce_req_header_lo;
+  logic [num_caches_p-1:0][cce_block_width_p-1:0] lce_req_data_lo;
+  logic [num_caches_p-1:0] lce_req_ready_and_li, lce_req_v_lo;
+  bp_bedrock_lce_cmd_header_s [num_caches_p-1:0] lce_cmd_header_li;
+  logic [num_caches_p-1:0][cce_block_width_p-1:0] lce_cmd_data_li;
+  logic [num_caches_p-1:0] lce_cmd_v_li, lce_cmd_yumi_lo;
+  bp_bedrock_lce_resp_header_s [num_caches_p-1:0] lce_resp_header_lo;
+  logic [num_caches_p-1:0][cce_block_width_p-1:0] lce_resp_data_lo;
+  logic [num_caches_p-1:0] lce_resp_v_lo, lce_resp_ready_and_li;
+  bp_bedrock_lce_cmd_header_s [num_caches_p-1:0] lce_cmd_header_lo;
+  logic [num_caches_p-1:0][cce_block_width_p-1:0] lce_cmd_data_lo;
+  logic [num_caches_p-1:0] lce_cmd_v_lo, lce_cmd_ready_and_li;
 
-   // LCE-CCE connections - BedRock Lite - to/from converters
-   bp_bedrock_lce_req_header_s cce_lce_req_header_li;
-   logic [cce_block_width_p-1:0] cce_lce_req_data_li;
-   logic cce_lce_req_v_li, cce_lce_req_yumi_lo;
-   bp_bedrock_lce_cmd_header_s cce_lce_cmd_header_lo;
-   logic [cce_block_width_p-1:0] cce_lce_cmd_data_lo;
-   logic cce_lce_cmd_v_lo, cce_lce_cmd_ready_and_li;
-   bp_bedrock_lce_resp_header_s cce_lce_resp_header_li;
-   logic [cce_block_width_p-1:0] cce_lce_resp_data_li;
-   logic cce_lce_resp_v_li, cce_lce_resp_yumi_lo;
+  // LCE-CCE connections - BedRock Lite - to/from converters
+  bp_bedrock_lce_req_header_s cce_lce_req_header_li;
+  logic [cce_block_width_p-1:0] cce_lce_req_data_li;
+  logic cce_lce_req_v_li, cce_lce_req_yumi_lo;
+  bp_bedrock_lce_cmd_header_s cce_lce_cmd_header_lo;
+  logic [cce_block_width_p-1:0] cce_lce_cmd_data_lo;
+  logic cce_lce_cmd_v_lo, cce_lce_cmd_ready_and_li;
+  bp_bedrock_lce_resp_header_s cce_lce_resp_header_li;
+  logic [cce_block_width_p-1:0] cce_lce_resp_data_li;
+  logic cce_lce_resp_v_li, cce_lce_resp_yumi_lo;
 
-   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
-   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
+  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
-   `declare_bp_lce_req_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_bedrock_lce_req_header_s, cce_block_width_p);
-   `declare_bp_lce_cmd_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_bedrock_lce_cmd_header_s, cce_block_width_p);
-   `declare_bp_lce_resp_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_bedrock_lce_resp_header_s, cce_block_width_p);
-   `declare_bsg_ready_and_link_sif_s($bits(bp_lce_req_wormhole_packet_s), coh_req_ready_and_link_s);
-   `declare_bsg_ready_and_link_sif_s($bits(bp_lce_cmd_wormhole_packet_s), coh_cmd_ready_and_link_s);
-   `declare_bsg_ready_and_link_sif_s($bits(bp_lce_resp_wormhole_packet_s), coh_resp_ready_and_link_s);
+  `declare_bp_lce_req_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_bedrock_lce_req_header_s, cce_block_width_p);
+  `declare_bp_lce_cmd_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_bedrock_lce_cmd_header_s, cce_block_width_p);
+  `declare_bp_lce_resp_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_bedrock_lce_resp_header_s, cce_block_width_p);
+  `declare_bsg_ready_and_link_sif_s($bits(bp_lce_req_wormhole_packet_s), coh_req_ready_and_link_s);
+  `declare_bsg_ready_and_link_sif_s($bits(bp_lce_cmd_wormhole_packet_s), coh_cmd_ready_and_link_s);
+  `declare_bsg_ready_and_link_sif_s($bits(bp_lce_resp_wormhole_packet_s), coh_resp_ready_and_link_s);
 
-   coh_req_ready_and_link_s [num_caches_p-1:0]  lce_req_link_li, lce_req_link_lo;
-   coh_cmd_ready_and_link_s [num_caches_p-1:0]  lce_cmd_link_li, lce_cmd_link_lo;
-   coh_resp_ready_and_link_s [num_caches_p-1:0] lce_resp_link_li, lce_resp_link_lo;
+  coh_req_ready_and_link_s [num_caches_p-1:0]  lce_req_link_li, lce_req_link_lo;
+  coh_cmd_ready_and_link_s [num_caches_p-1:0]  lce_cmd_link_li, lce_cmd_link_lo;
+  coh_resp_ready_and_link_s [num_caches_p-1:0] lce_resp_link_li, lce_resp_link_lo;
 
-   coh_req_ready_and_link_s cce_lce_req_link_li, cce_lce_req_link_lo;
-   coh_cmd_ready_and_link_s cce_lce_cmd_link_li, cce_lce_cmd_link_lo;
-   coh_resp_ready_and_link_s cce_lce_resp_link_li, cce_lce_resp_link_lo;
+  coh_req_ready_and_link_s cce_lce_req_link_li, cce_lce_req_link_lo;
+  coh_cmd_ready_and_link_s cce_lce_cmd_link_li, cce_lce_cmd_link_lo;
+  coh_resp_ready_and_link_s cce_lce_resp_link_li, cce_lce_resp_link_lo;
 
-   logic [num_caches_p-1:0] fifo_lce_cmd_ready_lo;
-   bp_lce_req_wormhole_packet_s [num_caches_p-1:0] lce_req_packet_lo;
-   bp_lce_cmd_wormhole_packet_s [num_caches_p-1:0] lce_cmd_packet_lo, lce_cmd_packet_li, fifo_lce_cmd_data_lo;
-   bp_lce_resp_wormhole_packet_s [num_caches_p-1:0] lce_resp_packet_lo;
+  logic [num_caches_p-1:0] fifo_lce_cmd_ready_lo;
+  bp_lce_req_wormhole_packet_s [num_caches_p-1:0] lce_req_packet_lo;
+  bp_lce_cmd_wormhole_packet_s [num_caches_p-1:0] lce_cmd_packet_lo, lce_cmd_packet_li, fifo_lce_cmd_data_lo;
+  bp_lce_resp_wormhole_packet_s [num_caches_p-1:0] lce_resp_packet_lo;
 
-   for (genvar i = 0; i < num_caches_p; i++)
-     begin : cache
-       bsg_fifo_1r1w_rolly
-       #(.width_p(dcache_pkt_width_lp+ptag_width_p+1)
-        ,.els_p(8))
-        rolly
-        (.clk_i(clk_i)
-        ,.reset_i(reset_i)
-
-        ,.roll_v_i(rollback_li[i])
-        ,.clr_v_i(1'b0)
-        ,.deq_v_i(dcache_v_rr[i])
-
-        ,.data_i({uncached_i[i], ptag_i[i], dcache_pkt_i[i]})
-        ,.v_i(v_i[i])
-        ,.ready_o(ready_o[i])
-
-        ,.data_o({rolly_uncached_lo[i], rolly_ptag_lo[i], rolly_dcache_pkt_lo[i]})
-        ,.v_o(rolly_v_lo[i])
-        ,.yumi_i(rolly_yumi_li[i])
-        );
-       assign rolly_yumi_li[i] = rolly_v_lo[i] & dcache_ready_lo[i];
-
-       bsg_dff_reset
-        #(.width_p(1+ptag_width_p)
-         ,.reset_val_p(0)
-        )
-        ptag_dff
-        (.clk_i(clk_i)
-        ,.reset_i(reset_i)
-
-        ,.data_i({rolly_uncached_lo[i], rolly_ptag_lo[i]})
-        ,.data_o({rolly_uncached_r[i], rolly_ptag_r[i]})
-        );
-
-       assign is_store[i] = rolly_dcache_pkt_lo[i].opcode inside {e_dcache_op_sb, e_dcache_op_sh, e_dcache_op_sw, e_dcache_op_sd};
-
-       bsg_dff_chain
-        #(.width_p(2)
-         ,.num_stages_p(2)
-        )
-        dcache_v_reg
-        (.clk_i(clk_i)
-        ,.data_i({is_store[i], rolly_yumi_li[i]})
-        ,.data_o({is_store_rr[i], dcache_v_rr[i]})
-        );
-
-       assign rollback_li[i] = dcache_v_rr[i] & ~v_o[i];
-
-       bp_be_dcache
-       #(.bp_params_p(bp_params_p)
-         ,.writethrough_p(wt_p)
-         ,.sets_p(sets_p)
-         ,.assoc_p(assoc_p)
-         ,.block_width_p(block_width_p)
-         ,.fill_width_p(fill_width_p)
-         )
-       dcache
+  for (genvar i = 0; i < num_caches_p; i++)
+    begin : cache
+      bsg_fifo_1r1w_rolly
+      #(.width_p(dcache_pkt_width_lp+ptag_width_p+1)
+       ,.els_p(8))
+       rolly
        (.clk_i(clk_i)
        ,.reset_i(reset_i)
 
-       ,.cfg_bus_i(cfg_bus_i)
+       ,.roll_v_i(rollback_li[i])
+       ,.clr_v_i(1'b0)
+       ,.deq_v_i(dcache_v_rr[i])
 
-       ,.dcache_pkt_i(rolly_dcache_pkt_lo[i])
-       ,.v_i(rolly_yumi_li[i])
-       ,.ready_o(dcache_ready_lo[i])
+       ,.data_i({uncached_i[i], ptag_i[i], dcache_pkt_i[i]})
+       ,.v_i(v_i[i])
+       ,.ready_o(ready_o[i])
 
-       ,.early_data_o(early_data_lo[i])
-       ,.early_hit_v_o(early_v_lo[i])
-       ,.early_miss_v_o()
-       ,.final_data_o(final_data_lo[i])
-       ,.final_v_o(final_v_lo[i])
-       ,.late_rd_addr_o()
-       ,.late_float_o()
-       ,.late_data_o(late_data_lo[i])
-       ,.late_v_o(late_v_lo[i])
-       ,.late_yumi_i(late_v_lo[i])
+       ,.data_o({rolly_uncached_lo[i], rolly_ptag_lo[i], rolly_dcache_pkt_lo[i]})
+       ,.v_o(rolly_v_lo[i])
+       ,.yumi_i(rolly_yumi_li[i])
+       );
+      assign rolly_yumi_li[i] = rolly_v_lo[i] & dcache_ready_lo[i];
 
-       ,.ptag_v_i(1'b1)
-       ,.ptag_i(rolly_ptag_r[i])
-       ,.ptag_uncached_i(rolly_uncached_r[i])
-       ,.ptag_dram_i(1'b1)
+      bsg_dff_reset
+       #(.width_p(1+ptag_width_p)
+        ,.reset_val_p(0)
+       )
+       ptag_dff
+       (.clk_i(clk_i)
+       ,.reset_i(reset_i)
 
-       ,.poison_req_i('0)
-       ,.poison_tl_i('0)
-
-       ,.cache_req_v_o(cache_req_v_lo[i])
-       ,.cache_req_o(cache_req_lo[i])
-       ,.cache_req_metadata_o(cache_req_metadata_lo[i])
-       ,.cache_req_metadata_v_o(cache_req_metadata_v_lo[i])
-       ,.cache_req_yumi_i(cache_req_yumi_lo[i])
-       ,.cache_req_busy_i(cache_req_busy_lo[i])
-       ,.cache_req_complete_i(cache_req_complete_lo[i])
-       ,.cache_req_critical_tag_i(cache_req_critical_tag_lo[i])
-       ,.cache_req_critical_data_i(cache_req_critical_data_lo[i])
-       ,.cache_req_credits_full_i(cache_req_credits_full_lo[i])
-       ,.cache_req_credits_empty_i(cache_req_credits_empty_lo[i])
-
-       ,.data_mem_pkt_v_i(data_mem_pkt_v_lo[i])
-       ,.data_mem_pkt_i(data_mem_pkt_lo[i])
-       ,.data_mem_o(data_mem_lo[i])
-       ,.data_mem_pkt_yumi_o(data_mem_pkt_yumi_lo[i])
-
-       ,.tag_mem_pkt_v_i(tag_mem_pkt_v_lo[i])
-       ,.tag_mem_pkt_i(tag_mem_pkt_lo[i])
-       ,.tag_mem_o(tag_mem_lo[i])
-       ,.tag_mem_pkt_yumi_o(tag_mem_pkt_yumi_lo[i])
-
-       ,.stat_mem_pkt_v_i(stat_mem_pkt_v_lo[i])
-       ,.stat_mem_pkt_i(stat_mem_pkt_lo[i])
-       ,.stat_mem_o(stat_mem_lo[i])
-       ,.stat_mem_pkt_yumi_o(stat_mem_pkt_yumi_lo[i])
+       ,.data_i({rolly_uncached_lo[i], rolly_ptag_lo[i]})
+       ,.data_o({rolly_uncached_r[i], rolly_ptag_r[i]})
        );
 
-       // Stores "return" 0 to the trace replay module
-       assign data_o[i] = late_v_lo[i] ? late_data_lo : is_store_rr[i] ? '0 : final_data_lo[i];
-       assign v_o[i] = late_v_lo[i] | final_v_lo[i];
+      assign is_store[i] = rolly_dcache_pkt_lo[i].opcode inside {e_dcache_op_sb, e_dcache_op_sh, e_dcache_op_sw, e_dcache_op_sd};
 
-       if (uce_p == 0)
-         begin : lce
-           bp_lce
-            #(.bp_params_p(bp_params_p)
-              ,.assoc_p(assoc_p)
-              ,.sets_p(sets_p)
-              ,.block_width_p(block_width_p)
-              ,.fill_width_p(fill_width_p)
-              ,.timeout_max_limit_p(4)
-              ,.credits_p(coh_noc_max_credits_p)
-              ,.req_invert_clk_p(1)
-              ,.data_mem_invert_clk_p(1)
-              ,.tag_mem_invert_clk_p(1)
-              )
-            dcache_lce
-             (.clk_i(clk_i)
-              ,.reset_i(reset_i)
+      bsg_dff_chain
+       #(.width_p(2)
+        ,.num_stages_p(2)
+       )
+       dcache_v_reg
+       (.clk_i(clk_i)
+       ,.data_i({is_store[i], rolly_yumi_li[i]})
+       ,.data_o({is_store_rr[i], dcache_v_rr[i]})
+       );
 
-              ,.lce_id_i(lce_id_width_p'(i))
-              ,.lce_mode_i(cfg_bus_cast_i.dcache_mode)
+      assign rollback_li[i] = dcache_v_rr[i] & ~v_o[i];
 
-              ,.cache_req_i(cache_req_lo[i])
-              ,.cache_req_v_i(cache_req_v_lo[i])
-              ,.cache_req_yumi_o(cache_req_yumi_lo[i])
-              ,.cache_req_busy_o(cache_req_busy_lo[i])
-              ,.cache_req_metadata_i(cache_req_metadata_lo[i])
-              ,.cache_req_metadata_v_i(cache_req_metadata_v_lo[i])
-              ,.cache_req_critical_tag_o(cache_req_critical_tag_lo[i])
-              ,.cache_req_critical_data_o(cache_req_critical_data_lo[i])
-              ,.cache_req_complete_o(cache_req_complete_lo[i])
-              ,.cache_req_credits_full_o(cache_req_credits_full_lo[i])
-              ,.cache_req_credits_empty_o(cache_req_credits_empty_lo[i])
+      bp_be_dcache
+      #(.bp_params_p(bp_params_p)
+        ,.writethrough_p(wt_p)
+        ,.sets_p(sets_p)
+        ,.assoc_p(assoc_p)
+        ,.block_width_p(block_width_p)
+        ,.fill_width_p(fill_width_p)
+        )
+      dcache
+      (.clk_i(clk_i)
+      ,.reset_i(reset_i)
 
-              ,.data_mem_pkt_v_o(data_mem_pkt_v_lo[i])
-              ,.data_mem_pkt_o(data_mem_pkt_lo[i])
-              ,.data_mem_i(data_mem_lo[i])
-              ,.data_mem_pkt_yumi_i(data_mem_pkt_yumi_lo[i])
+      ,.cfg_bus_i(cfg_bus_i)
 
-              ,.tag_mem_pkt_v_o(tag_mem_pkt_v_lo[i])
-              ,.tag_mem_pkt_o(tag_mem_pkt_lo[i])
-              ,.tag_mem_i(tag_mem_lo[i])
-              ,.tag_mem_pkt_yumi_i(tag_mem_pkt_yumi_lo[i])
+      ,.dcache_pkt_i(rolly_dcache_pkt_lo[i])
+      ,.v_i(rolly_yumi_li[i])
+      ,.ready_o(dcache_ready_lo[i])
 
-              ,.stat_mem_pkt_v_o(stat_mem_pkt_v_lo[i])
-              ,.stat_mem_pkt_o(stat_mem_pkt_lo[i])
-              ,.stat_mem_i(stat_mem_lo[i])
-              ,.stat_mem_pkt_yumi_i(stat_mem_pkt_yumi_lo[i])
+      ,.early_data_o(early_data_lo[i])
+      ,.early_hit_v_o(early_v_lo[i])
+      ,.early_miss_v_o()
+      ,.early_fencei_o()
+      ,.final_data_o(final_data_lo[i])
+      ,.final_v_o(final_v_lo[i])
+      ,.late_rd_addr_o()
+      ,.late_float_o()
+      ,.late_data_o(late_data_lo[i])
+      ,.late_v_o(late_v_lo[i])
+      ,.late_yumi_i(late_v_lo[i])
 
-              ,.lce_req_header_o(lce_req_header_lo[i])
-              ,.lce_req_data_o(lce_req_data_lo[i])
-              ,.lce_req_v_o(lce_req_v_lo[i])
-              ,.lce_req_ready_then_i(lce_req_ready_and_li[i])
+      ,.ptag_v_i(1'b1)
+      ,.ptag_i(rolly_ptag_r[i])
+      ,.ptag_uncached_i(rolly_uncached_r[i])
+      ,.ptag_dram_i(1'b1)
 
-              ,.lce_resp_header_o(lce_resp_header_lo[i])
-              ,.lce_resp_data_o(lce_resp_data_lo[i])
-              ,.lce_resp_v_o(lce_resp_v_lo[i])
-              ,.lce_resp_ready_then_i(lce_resp_ready_and_li[i])
+      ,.flush_i('0)
 
-              ,.lce_cmd_header_i(lce_cmd_header_li[i])
-              ,.lce_cmd_data_i(lce_cmd_data_li[i])
-              ,.lce_cmd_v_i(lce_cmd_v_li[i])
-              ,.lce_cmd_yumi_o(lce_cmd_yumi_lo[i])
+      ,.cache_req_v_o(cache_req_v_lo[i])
+      ,.cache_req_o(cache_req_lo[i])
+      ,.cache_req_metadata_o(cache_req_metadata_lo[i])
+      ,.cache_req_metadata_v_o(cache_req_metadata_v_lo[i])
+      ,.cache_req_yumi_i(cache_req_yumi_lo[i])
+      ,.cache_req_busy_i(cache_req_busy_lo[i])
+      ,.cache_req_complete_i(cache_req_complete_lo[i])
+      ,.cache_req_critical_tag_i(cache_req_critical_tag_lo[i])
+      ,.cache_req_critical_data_i(cache_req_critical_data_lo[i])
+      ,.cache_req_credits_full_i(cache_req_credits_full_lo[i])
+      ,.cache_req_credits_empty_i(cache_req_credits_empty_lo[i])
 
-              ,.lce_cmd_header_o(lce_cmd_header_lo[i])
-              ,.lce_cmd_data_o(lce_cmd_data_lo[i])
-              ,.lce_cmd_v_o(lce_cmd_v_lo[i])
-              ,.lce_cmd_ready_then_i(lce_cmd_ready_and_li[i])
-              );
+      ,.data_mem_pkt_v_i(data_mem_pkt_v_lo[i])
+      ,.data_mem_pkt_i(data_mem_pkt_lo[i])
+      ,.data_mem_o(data_mem_lo[i])
+      ,.data_mem_pkt_yumi_o(data_mem_pkt_yumi_lo[i])
 
-           // Request out
-           assign lce_req_packet_lo[i].header.msg_hdr = lce_req_header_lo[i];
-           assign lce_req_packet_lo[i].header.rtr_hdr.cid = '0;
-           assign lce_req_packet_lo[i].header.rtr_hdr.cord = '0;
-           assign lce_req_packet_lo[i].header.rtr_hdr.len = coh_noc_len_width_p'(0);
-           assign lce_req_packet_lo[i].data = lce_req_data_lo[i];
+      ,.tag_mem_pkt_v_i(tag_mem_pkt_v_lo[i])
+      ,.tag_mem_pkt_i(tag_mem_pkt_lo[i])
+      ,.tag_mem_o(tag_mem_lo[i])
+      ,.tag_mem_pkt_yumi_o(tag_mem_pkt_yumi_lo[i])
 
-           // Conversion from request packet to link format
-           assign lce_req_link_lo[i].data = lce_req_packet_lo[i];
-           assign lce_req_link_lo[i].v = lce_req_v_lo[i];
-           assign lce_req_link_lo[i].ready_and_rev = 1'b0;
-           assign lce_req_ready_and_li[i] = lce_req_link_li[i].ready_and_rev;
+      ,.stat_mem_pkt_v_i(stat_mem_pkt_v_lo[i])
+      ,.stat_mem_pkt_i(stat_mem_pkt_lo[i])
+      ,.stat_mem_o(stat_mem_lo[i])
+      ,.stat_mem_pkt_yumi_o(stat_mem_pkt_yumi_lo[i])
+      );
 
-           // Command out
-           assign lce_cmd_packet_lo[i].header.msg_hdr = lce_cmd_header_lo[i];
-           assign lce_cmd_packet_lo[i].header.rtr_hdr.cid = lce_cmd_header_lo[i].payload.dst_id;
-           assign lce_cmd_packet_lo[i].header.rtr_hdr.cord = '0;
-           assign lce_cmd_packet_lo[i].header.rtr_hdr.len = coh_noc_len_width_p'(0);
-           assign lce_cmd_packet_lo[i].data = lce_cmd_data_lo[i];
+      // Stores "return" 0 to the trace replay module
+      assign data_o[i] = late_v_lo[i] ? late_data_lo : is_store_rr[i] ? '0 : final_data_lo[i];
+      assign v_o[i] = late_v_lo[i] | final_v_lo[i];
 
-           // Conversion from command link to command in
-           assign lce_cmd_link_lo[i].ready_and_rev = fifo_lce_cmd_ready_lo[i];
-           assign lce_cmd_packet_li[i] = fifo_lce_cmd_data_lo[i];
-           assign lce_cmd_header_li[i] = lce_cmd_packet_li[i].header.msg_hdr;
-           assign lce_cmd_data_li[i] = lce_cmd_packet_li[i].data;
-
-           // Conversion from command packet to link format
-           assign lce_cmd_link_lo[i].data = lce_cmd_packet_lo[i];
-           assign lce_cmd_link_lo[i].v = lce_cmd_v_lo[i];
-           assign lce_cmd_ready_and_li[i] = lce_cmd_link_li[i].ready_and_rev;
-
-           // LCE cmd demanding -> demanding conversion
-           bsg_two_fifo
-            #(.width_p($bits(bp_lce_cmd_wormhole_packet_s)))
-            cmd_fifo
-             (.clk_i(clk_i)
-              ,.reset_i(reset_i)
-
-              ,.data_i(lce_cmd_link_li[i].data)
-              ,.v_i(lce_cmd_link_li[i].v)
-              ,.ready_o(fifo_lce_cmd_ready_lo[i])
-
-              ,.data_o(fifo_lce_cmd_data_lo[i])
-              ,.v_o(lce_cmd_v_li[i])
-              ,.yumi_i(lce_cmd_yumi_lo[i])
-              );
-
-           // Response out
-           assign lce_resp_packet_lo[i].header.msg_hdr = lce_resp_header_lo[i];
-           assign lce_resp_packet_lo[i].header.rtr_hdr.cid = '0;
-           assign lce_resp_packet_lo[i].header.rtr_hdr.cord = '0;
-           assign lce_resp_packet_lo[i].header.rtr_hdr.len = coh_noc_len_width_p'(0);
-           assign lce_resp_packet_lo[i].data = lce_resp_data_lo[i];
-
-           // Conversion from response packet to link format
-           assign lce_resp_link_lo[i].data = lce_resp_packet_lo[i];
-           assign lce_resp_link_lo[i].v = lce_resp_v_lo[i];
-           assign lce_resp_link_lo[i].ready_and_rev = 1'b0;
-           assign lce_resp_ready_and_li[i] = lce_resp_link_li[i].ready_and_rev;
-         end
-       else if (uce_p == 1)
-         begin : uce
-          bp_uce
+      if (uce_p == 0)
+        begin : lce
+          bp_lce
            #(.bp_params_p(bp_params_p)
-             ,.uce_mem_data_width_p(l2_fill_width_p)
              ,.assoc_p(assoc_p)
              ,.sets_p(sets_p)
              ,.block_width_p(block_width_p)
              ,.fill_width_p(fill_width_p)
+             ,.timeout_max_limit_p(4)
+             ,.credits_p(coh_noc_max_credits_p)
              ,.req_invert_clk_p(1)
              ,.data_mem_invert_clk_p(1)
              ,.tag_mem_invert_clk_p(1)
-             ,.stat_mem_invert_clk_p(1)
              )
-           dcache_uce
+           dcache_lce
             (.clk_i(clk_i)
              ,.reset_i(reset_i)
 
-             ,.lce_id_i('0)
+             ,.lce_id_i(lce_id_width_p'(i))
+             ,.lce_mode_i(cfg_bus_cast_i.dcache_mode)
 
-             ,.cache_req_i(cache_req_lo)
-             ,.cache_req_v_i(cache_req_v_lo)
-             ,.cache_req_yumi_o(cache_req_yumi_lo)
-             ,.cache_req_busy_o(cache_req_busy_lo)
-             ,.cache_req_metadata_i(cache_req_metadata_lo)
-             ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
-             ,.cache_req_critical_tag_o(cache_req_critical_tag_lo)
-             ,.cache_req_critical_data_o(cache_req_critical_data_lo)
-             ,.cache_req_complete_o(cache_req_complete_lo)
-             ,.cache_req_credits_full_o(cache_req_credits_full_lo)
-             ,.cache_req_credits_empty_o(cache_req_credits_empty_lo)
+             ,.cache_req_i(cache_req_lo[i])
+             ,.cache_req_v_i(cache_req_v_lo[i])
+             ,.cache_req_yumi_o(cache_req_yumi_lo[i])
+             ,.cache_req_busy_o(cache_req_busy_lo[i])
+             ,.cache_req_metadata_i(cache_req_metadata_lo[i])
+             ,.cache_req_metadata_v_i(cache_req_metadata_v_lo[i])
+             ,.cache_req_critical_tag_o(cache_req_critical_tag_lo[i])
+             ,.cache_req_critical_data_o(cache_req_critical_data_lo[i])
+             ,.cache_req_complete_o(cache_req_complete_lo[i])
+             ,.cache_req_credits_full_o(cache_req_credits_full_lo[i])
+             ,.cache_req_credits_empty_o(cache_req_credits_empty_lo[i])
 
-             ,.tag_mem_pkt_o(tag_mem_pkt_lo)
-             ,.tag_mem_pkt_v_o(tag_mem_pkt_v_lo)
-             ,.tag_mem_pkt_yumi_i(tag_mem_pkt_yumi_lo)
-             ,.tag_mem_i(tag_mem_lo)
+             ,.data_mem_pkt_v_o(data_mem_pkt_v_lo[i])
+             ,.data_mem_pkt_o(data_mem_pkt_lo[i])
+             ,.data_mem_i(data_mem_lo[i])
+             ,.data_mem_pkt_yumi_i(data_mem_pkt_yumi_lo[i])
 
-             ,.data_mem_pkt_o(data_mem_pkt_lo)
-             ,.data_mem_pkt_v_o(data_mem_pkt_v_lo)
-             ,.data_mem_pkt_yumi_i(data_mem_pkt_yumi_lo)
-             ,.data_mem_i(data_mem_lo)
+             ,.tag_mem_pkt_v_o(tag_mem_pkt_v_lo[i])
+             ,.tag_mem_pkt_o(tag_mem_pkt_lo[i])
+             ,.tag_mem_i(tag_mem_lo[i])
+             ,.tag_mem_pkt_yumi_i(tag_mem_pkt_yumi_lo[i])
 
-             ,.stat_mem_pkt_o(stat_mem_pkt_lo)
-             ,.stat_mem_pkt_v_o(stat_mem_pkt_v_lo)
-             ,.stat_mem_pkt_yumi_i(stat_mem_pkt_yumi_lo)
-             ,.stat_mem_i(stat_mem_lo)
+             ,.stat_mem_pkt_v_o(stat_mem_pkt_v_lo[i])
+             ,.stat_mem_pkt_o(stat_mem_pkt_lo[i])
+             ,.stat_mem_i(stat_mem_lo[i])
+             ,.stat_mem_pkt_yumi_i(stat_mem_pkt_yumi_lo[i])
 
-             ,.mem_cmd_header_o(mem_cmd_header_o)
-             ,.mem_cmd_data_o(mem_cmd_data_o)
-             ,.mem_cmd_v_o(mem_cmd_v_o)
-             ,.mem_cmd_ready_and_i(mem_cmd_ready_and_i)
-             ,.mem_cmd_last_o(mem_cmd_last_o)
+             ,.lce_req_header_o(lce_req_header_lo[i])
+             ,.lce_req_data_o(lce_req_data_lo[i])
+             ,.lce_req_v_o(lce_req_v_lo[i])
+             ,.lce_req_ready_then_i(lce_req_ready_and_li[i])
 
-             ,.mem_resp_header_i(mem_resp_header_i)
-             ,.mem_resp_data_i(mem_resp_data_i)
-             ,.mem_resp_v_i(mem_resp_v_i)
-             ,.mem_resp_ready_and_o(mem_resp_ready_and_o)
-             ,.mem_resp_last_i(mem_resp_last_i)
+             ,.lce_resp_header_o(lce_resp_header_lo[i])
+             ,.lce_resp_data_o(lce_resp_data_lo[i])
+             ,.lce_resp_v_o(lce_resp_v_lo[i])
+             ,.lce_resp_ready_then_i(lce_resp_ready_and_li[i])
+
+             ,.lce_cmd_header_i(lce_cmd_header_li[i])
+             ,.lce_cmd_data_i(lce_cmd_data_li[i])
+             ,.lce_cmd_v_i(lce_cmd_v_li[i])
+             ,.lce_cmd_yumi_o(lce_cmd_yumi_lo[i])
+
+             ,.lce_cmd_header_o(lce_cmd_header_lo[i])
+             ,.lce_cmd_data_o(lce_cmd_data_lo[i])
+             ,.lce_cmd_v_o(lce_cmd_v_lo[i])
+             ,.lce_cmd_ready_then_i(lce_cmd_ready_and_li[i])
              );
+
+          // Request out
+          assign lce_req_packet_lo[i].header.msg_hdr = lce_req_header_lo[i];
+          assign lce_req_packet_lo[i].header.rtr_hdr.cid = '0;
+          assign lce_req_packet_lo[i].header.rtr_hdr.cord = '0;
+          assign lce_req_packet_lo[i].header.rtr_hdr.len = coh_noc_len_width_p'(0);
+          assign lce_req_packet_lo[i].data = lce_req_data_lo[i];
+
+          // Conversion from request packet to link format
+          assign lce_req_link_lo[i].data = lce_req_packet_lo[i];
+          assign lce_req_link_lo[i].v = lce_req_v_lo[i];
+          assign lce_req_link_lo[i].ready_and_rev = 1'b0;
+          assign lce_req_ready_and_li[i] = lce_req_link_li[i].ready_and_rev;
+
+          // Command out
+          assign lce_cmd_packet_lo[i].header.msg_hdr = lce_cmd_header_lo[i];
+          assign lce_cmd_packet_lo[i].header.rtr_hdr.cid = lce_cmd_header_lo[i].payload.dst_id;
+          assign lce_cmd_packet_lo[i].header.rtr_hdr.cord = '0;
+          assign lce_cmd_packet_lo[i].header.rtr_hdr.len = coh_noc_len_width_p'(0);
+          assign lce_cmd_packet_lo[i].data = lce_cmd_data_lo[i];
+
+          // Conversion from command link to command in
+          assign lce_cmd_link_lo[i].ready_and_rev = fifo_lce_cmd_ready_lo[i];
+          assign lce_cmd_packet_li[i] = fifo_lce_cmd_data_lo[i];
+          assign lce_cmd_header_li[i] = lce_cmd_packet_li[i].header.msg_hdr;
+          assign lce_cmd_data_li[i] = lce_cmd_packet_li[i].data;
+
+          // Conversion from command packet to link format
+          assign lce_cmd_link_lo[i].data = lce_cmd_packet_lo[i];
+          assign lce_cmd_link_lo[i].v = lce_cmd_v_lo[i];
+          assign lce_cmd_ready_and_li[i] = lce_cmd_link_li[i].ready_and_rev;
+
+          // LCE cmd demanding -> demanding conversion
+          bsg_two_fifo
+           #(.width_p($bits(bp_lce_cmd_wormhole_packet_s)))
+           cmd_fifo
+            (.clk_i(clk_i)
+             ,.reset_i(reset_i)
+
+             ,.data_i(lce_cmd_link_li[i].data)
+             ,.v_i(lce_cmd_link_li[i].v)
+             ,.ready_o(fifo_lce_cmd_ready_lo[i])
+
+             ,.data_o(fifo_lce_cmd_data_lo[i])
+             ,.v_o(lce_cmd_v_li[i])
+             ,.yumi_i(lce_cmd_yumi_lo[i])
+             );
+
+          // Response out
+          assign lce_resp_packet_lo[i].header.msg_hdr = lce_resp_header_lo[i];
+          assign lce_resp_packet_lo[i].header.rtr_hdr.cid = '0;
+          assign lce_resp_packet_lo[i].header.rtr_hdr.cord = '0;
+          assign lce_resp_packet_lo[i].header.rtr_hdr.len = coh_noc_len_width_p'(0);
+          assign lce_resp_packet_lo[i].data = lce_resp_data_lo[i];
+
+          // Conversion from response packet to link format
+          assign lce_resp_link_lo[i].data = lce_resp_packet_lo[i];
+          assign lce_resp_link_lo[i].v = lce_resp_v_lo[i];
+          assign lce_resp_link_lo[i].ready_and_rev = 1'b0;
+          assign lce_resp_ready_and_li[i] = lce_resp_link_li[i].ready_and_rev;
         end
-     end
+      else if (uce_p == 1)
+        begin : uce
+         bp_uce
+          #(.bp_params_p(bp_params_p)
+            ,.uce_mem_data_width_p(l2_fill_width_p)
+            ,.assoc_p(assoc_p)
+            ,.sets_p(sets_p)
+            ,.block_width_p(block_width_p)
+            ,.fill_width_p(fill_width_p)
+            ,.req_invert_clk_p(1)
+            ,.data_mem_invert_clk_p(1)
+            ,.tag_mem_invert_clk_p(1)
+            ,.stat_mem_invert_clk_p(1)
+            )
+          dcache_uce
+           (.clk_i(clk_i)
+            ,.reset_i(reset_i)
 
-   if (uce_p == 0)
-     begin : concentrator
-       coh_req_ready_and_link_s req_concentrated_link_li, req_concentrated_link_lo, req_concentrated_link_r;
-       coh_cmd_ready_and_link_s cmd_concentrated_link_li, cmd_concentrated_link_lo, cmd_concentrated_link_r;
-       coh_resp_ready_and_link_s resp_concentrated_link_li, resp_concentrated_link_lo, resp_concentrated_link_r;
+            ,.lce_id_i('0)
 
-       // CCE-LCE connections - BedRock Burst - to/from CCE
-       logic cce_lce_req_header_v, cce_lce_req_header_ready_and;
-       logic cce_lce_req_data_v, cce_lce_req_data_ready_and;
-       logic cce_lce_req_has_data, cce_lce_req_last;
-       logic cce_lce_resp_header_v, cce_lce_resp_header_ready_and;
-       logic cce_lce_resp_data_v, cce_lce_resp_data_ready_and;
-       logic cce_lce_resp_has_data, cce_lce_resp_last;
-       logic cce_lce_cmd_header_v, cce_lce_cmd_header_ready_and;
-       logic cce_lce_cmd_data_v, cce_lce_cmd_data_ready_and;
-       logic cce_lce_cmd_has_data, cce_lce_cmd_last;
-       bp_bedrock_lce_req_header_s cce_lce_req_header;
-       bp_bedrock_lce_resp_header_s cce_lce_resp_header;
-       bp_bedrock_lce_cmd_header_s cce_lce_cmd_header;
-       logic [dword_width_gp-1:0] cce_lce_req_data, cce_lce_resp_data, cce_lce_cmd_data;
+            ,.cache_req_i(cache_req_lo)
+            ,.cache_req_v_i(cache_req_v_lo)
+            ,.cache_req_yumi_o(cache_req_yumi_lo)
+            ,.cache_req_busy_o(cache_req_busy_lo)
+            ,.cache_req_metadata_i(cache_req_metadata_lo)
+            ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
+            ,.cache_req_critical_tag_o(cache_req_critical_tag_lo)
+            ,.cache_req_critical_data_o(cache_req_critical_data_lo)
+            ,.cache_req_complete_o(cache_req_complete_lo)
+            ,.cache_req_credits_full_o(cache_req_credits_full_lo)
+            ,.cache_req_credits_empty_o(cache_req_credits_empty_lo)
 
-       // Request adapter to convert the link format to the CCE request input
-       // format
-       bp_lce_req_wormhole_packet_s cce_lce_req_packet_li;
-       bsg_wormhole_router_adapter_out
-        #(.max_payload_width_p($bits(bp_lce_req_wormhole_packet_s)-coh_noc_cord_width_p-coh_noc_len_width_p)
-          ,.len_width_p(coh_noc_len_width_p)
-          ,.cord_width_p(coh_noc_cord_width_p)
-          ,.flit_width_p($bits(bp_lce_req_wormhole_packet_s))
-          )
-        cce_req_adapter_out
-         (.clk_i(clk_i)
-          ,.reset_i(reset_i)
+            ,.tag_mem_pkt_o(tag_mem_pkt_lo)
+            ,.tag_mem_pkt_v_o(tag_mem_pkt_v_lo)
+            ,.tag_mem_pkt_yumi_i(tag_mem_pkt_yumi_lo)
+            ,.tag_mem_i(tag_mem_lo)
 
-          ,.link_i(req_concentrated_link_li)
-          ,.link_o(cce_lce_req_link_lo)
+            ,.data_mem_pkt_o(data_mem_pkt_lo)
+            ,.data_mem_pkt_v_o(data_mem_pkt_v_lo)
+            ,.data_mem_pkt_yumi_i(data_mem_pkt_yumi_lo)
+            ,.data_mem_i(data_mem_lo)
 
-          ,.packet_o(cce_lce_req_packet_li)
-          ,.v_o(cce_lce_req_v_li)
-          ,.yumi_i(cce_lce_req_yumi_lo)
-          );
+            ,.stat_mem_pkt_o(stat_mem_pkt_lo)
+            ,.stat_mem_pkt_v_o(stat_mem_pkt_v_lo)
+            ,.stat_mem_pkt_yumi_i(stat_mem_pkt_yumi_lo)
+            ,.stat_mem_i(stat_mem_lo)
 
-       assign cce_lce_req_header_li = cce_lce_req_packet_li.header.msg_hdr;
-       assign cce_lce_req_data_li = cce_lce_req_packet_li.data;
+            ,.mem_cmd_header_o(mem_cmd_header_o)
+            ,.mem_cmd_data_o(mem_cmd_data_o)
+            ,.mem_cmd_v_o(mem_cmd_v_o)
+            ,.mem_cmd_ready_and_i(mem_cmd_ready_and_i)
+            ,.mem_cmd_last_o(mem_cmd_last_o)
 
-       // LCE Request
-       logic cce_lce_req_ready_and_lo;
-       assign cce_lce_req_yumi_lo = cce_lce_req_v_li & cce_lce_req_ready_and_lo;
-       bp_me_lite_to_burst
-        #(.bp_params_p(bp_params_p)
-          ,.in_data_width_p(cce_block_width_p)
-          ,.out_data_width_p(dword_width_gp)
-          ,.payload_width_p(lce_req_payload_width_lp)
-          ,.payload_mask_p(lce_req_payload_mask_gp)
-          )
-        lce_req_lite2burst
-         (.clk_i(clk_i)
-          ,.reset_i(reset_i)
+            ,.mem_resp_header_i(mem_resp_header_i)
+            ,.mem_resp_data_i(mem_resp_data_i)
+            ,.mem_resp_v_i(mem_resp_v_i)
+            ,.mem_resp_ready_and_o(mem_resp_ready_and_o)
+            ,.mem_resp_last_i(mem_resp_last_i)
+            );
+       end
+    end
 
-          ,.in_msg_header_i(cce_lce_req_header_li)
-          ,.in_msg_data_i(cce_lce_req_data_li)
-          ,.in_msg_v_i(cce_lce_req_v_li)
-          ,.in_msg_ready_and_o(cce_lce_req_ready_and_lo)
+  if (uce_p == 0)
+    begin : concentrator
+      coh_req_ready_and_link_s req_concentrated_link_li, req_concentrated_link_lo, req_concentrated_link_r;
+      coh_cmd_ready_and_link_s cmd_concentrated_link_li, cmd_concentrated_link_lo, cmd_concentrated_link_r;
+      coh_resp_ready_and_link_s resp_concentrated_link_li, resp_concentrated_link_lo, resp_concentrated_link_r;
 
-          ,.out_msg_header_o(cce_lce_req_header)
-          ,.out_msg_header_v_o(cce_lce_req_header_v)
-          ,.out_msg_header_ready_and_i(cce_lce_req_header_ready_and)
-          ,.out_msg_has_data_o(cce_lce_req_has_data)
+      // CCE-LCE connections - BedRock Burst - to/from CCE
+      logic cce_lce_req_header_v, cce_lce_req_header_ready_and;
+      logic cce_lce_req_data_v, cce_lce_req_data_ready_and;
+      logic cce_lce_req_has_data, cce_lce_req_last;
+      logic cce_lce_resp_header_v, cce_lce_resp_header_ready_and;
+      logic cce_lce_resp_data_v, cce_lce_resp_data_ready_and;
+      logic cce_lce_resp_has_data, cce_lce_resp_last;
+      logic cce_lce_cmd_header_v, cce_lce_cmd_header_ready_and;
+      logic cce_lce_cmd_data_v, cce_lce_cmd_data_ready_and;
+      logic cce_lce_cmd_has_data, cce_lce_cmd_last;
+      bp_bedrock_lce_req_header_s cce_lce_req_header;
+      bp_bedrock_lce_resp_header_s cce_lce_resp_header;
+      bp_bedrock_lce_cmd_header_s cce_lce_cmd_header;
+      logic [dword_width_gp-1:0] cce_lce_req_data, cce_lce_resp_data, cce_lce_cmd_data;
 
-          ,.out_msg_data_o(cce_lce_req_data)
-          ,.out_msg_data_v_o(cce_lce_req_data_v)
-          ,.out_msg_data_ready_and_i(cce_lce_req_data_ready_and)
-          ,.out_msg_last_o(cce_lce_req_last)
-          );
+      // Request adapter to convert the link format to the CCE request input
+      // format
+      bp_lce_req_wormhole_packet_s cce_lce_req_packet_li;
+      bsg_wormhole_router_adapter_out
+       #(.max_payload_width_p($bits(bp_lce_req_wormhole_packet_s)-coh_noc_cord_width_p-coh_noc_len_width_p)
+         ,.len_width_p(coh_noc_len_width_p)
+         ,.cord_width_p(coh_noc_cord_width_p)
+         ,.flit_width_p($bits(bp_lce_req_wormhole_packet_s))
+         )
+       cce_req_adapter_out
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
 
-       // LCE Command
-       bp_me_burst_to_lite
-        #(.bp_params_p(bp_params_p)
-          ,.in_data_width_p(dword_width_gp)
-          ,.out_data_width_p(cce_block_width_p)
-          ,.payload_width_p(lce_cmd_payload_width_lp)
-          ,.payload_mask_p(lce_cmd_payload_mask_gp)
-          )
-        lce_cmd_burst2lite
-         (.clk_i(clk_i)
-          ,.reset_i(reset_i)
+         ,.link_i(req_concentrated_link_li)
+         ,.link_o(cce_lce_req_link_lo)
 
-          ,.in_msg_header_i(cce_lce_cmd_header)
-          ,.in_msg_header_v_i(cce_lce_cmd_header_v)
-          ,.in_msg_header_ready_and_o(cce_lce_cmd_header_ready_and)
-          ,.in_msg_has_data_i(cce_lce_cmd_has_data)
+         ,.packet_o(cce_lce_req_packet_li)
+         ,.v_o(cce_lce_req_v_li)
+         ,.yumi_i(cce_lce_req_yumi_lo)
+         );
 
-          ,.in_msg_data_i(cce_lce_cmd_data)
-          ,.in_msg_data_v_i(cce_lce_cmd_data_v)
-          ,.in_msg_data_ready_and_o(cce_lce_cmd_data_ready_and)
-          ,.in_msg_last_i(cce_lce_cmd_last)
+      assign cce_lce_req_header_li = cce_lce_req_packet_li.header.msg_hdr;
+      assign cce_lce_req_data_li = cce_lce_req_packet_li.data;
 
-          ,.out_msg_header_o(cce_lce_cmd_header_lo)
-          ,.out_msg_data_o(cce_lce_cmd_data_lo)
-          ,.out_msg_v_o(cce_lce_cmd_v_lo)
-          ,.out_msg_ready_and_i(cce_lce_cmd_ready_and_li)
-          );
+      // LCE Request
+      logic cce_lce_req_ready_and_lo;
+      assign cce_lce_req_yumi_lo = cce_lce_req_v_li & cce_lce_req_ready_and_lo;
+      bp_me_lite_to_burst
+       #(.bp_params_p(bp_params_p)
+         ,.in_data_width_p(cce_block_width_p)
+         ,.out_data_width_p(dword_width_gp)
+         ,.payload_width_p(lce_req_payload_width_lp)
+         ,.payload_mask_p(lce_req_payload_mask_gp)
+         )
+       lce_req_lite2burst
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+
+         ,.in_msg_header_i(cce_lce_req_header_li)
+         ,.in_msg_data_i(cce_lce_req_data_li)
+         ,.in_msg_v_i(cce_lce_req_v_li)
+         ,.in_msg_ready_and_o(cce_lce_req_ready_and_lo)
+
+         ,.out_msg_header_o(cce_lce_req_header)
+         ,.out_msg_header_v_o(cce_lce_req_header_v)
+         ,.out_msg_header_ready_and_i(cce_lce_req_header_ready_and)
+         ,.out_msg_has_data_o(cce_lce_req_has_data)
+
+         ,.out_msg_data_o(cce_lce_req_data)
+         ,.out_msg_data_v_o(cce_lce_req_data_v)
+         ,.out_msg_data_ready_and_i(cce_lce_req_data_ready_and)
+         ,.out_msg_last_o(cce_lce_req_last)
+         );
+
+      // LCE Command
+      bp_me_burst_to_lite
+       #(.bp_params_p(bp_params_p)
+         ,.in_data_width_p(dword_width_gp)
+         ,.out_data_width_p(cce_block_width_p)
+         ,.payload_width_p(lce_cmd_payload_width_lp)
+         ,.payload_mask_p(lce_cmd_payload_mask_gp)
+         )
+       lce_cmd_burst2lite
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+
+         ,.in_msg_header_i(cce_lce_cmd_header)
+         ,.in_msg_header_v_i(cce_lce_cmd_header_v)
+         ,.in_msg_header_ready_and_o(cce_lce_cmd_header_ready_and)
+         ,.in_msg_has_data_i(cce_lce_cmd_has_data)
+
+         ,.in_msg_data_i(cce_lce_cmd_data)
+         ,.in_msg_data_v_i(cce_lce_cmd_data_v)
+         ,.in_msg_data_ready_and_o(cce_lce_cmd_data_ready_and)
+         ,.in_msg_last_i(cce_lce_cmd_last)
+
+         ,.out_msg_header_o(cce_lce_cmd_header_lo)
+         ,.out_msg_data_o(cce_lce_cmd_data_lo)
+         ,.out_msg_v_o(cce_lce_cmd_v_lo)
+         ,.out_msg_ready_and_i(cce_lce_cmd_ready_and_li)
+         );
 
 
-       bp_lce_cmd_wormhole_packet_s cce_lce_cmd_packet_lo;
-       assign cce_lce_cmd_packet_lo.header.msg_hdr = cce_lce_cmd_header_lo;
-       assign cce_lce_cmd_packet_lo.header.rtr_hdr.cid = cce_lce_cmd_header_lo.payload.dst_id;
-       assign cce_lce_cmd_packet_lo.header.rtr_hdr.cord = '0;
-       assign cce_lce_cmd_packet_lo.header.rtr_hdr.len = coh_noc_len_width_p'(0);
-       assign cce_lce_cmd_packet_lo.data = cce_lce_cmd_data_lo;
+      bp_lce_cmd_wormhole_packet_s cce_lce_cmd_packet_lo;
+      assign cce_lce_cmd_packet_lo.header.msg_hdr = cce_lce_cmd_header_lo;
+      assign cce_lce_cmd_packet_lo.header.rtr_hdr.cid = cce_lce_cmd_header_lo.payload.dst_id;
+      assign cce_lce_cmd_packet_lo.header.rtr_hdr.cord = '0;
+      assign cce_lce_cmd_packet_lo.header.rtr_hdr.len = coh_noc_len_width_p'(0);
+      assign cce_lce_cmd_packet_lo.data = cce_lce_cmd_data_lo;
 
-       assign cce_lce_cmd_link_lo.data = cce_lce_cmd_packet_lo;
-       assign cce_lce_cmd_link_lo.v = cce_lce_cmd_v_lo;
-       assign cce_lce_cmd_link_lo.ready_and_rev = '0;
-       assign cce_lce_cmd_ready_and_li = cce_lce_cmd_link_li.ready_and_rev;
+      assign cce_lce_cmd_link_lo.data = cce_lce_cmd_packet_lo;
+      assign cce_lce_cmd_link_lo.v = cce_lce_cmd_v_lo;
+      assign cce_lce_cmd_link_lo.ready_and_rev = '0;
+      assign cce_lce_cmd_ready_and_li = cce_lce_cmd_link_li.ready_and_rev;
 
-       // Response adapter to convert from the link format to the CCE
-       // response input  format
-       bp_lce_resp_wormhole_packet_s cce_lce_resp_packet_li;
-       bsg_wormhole_router_adapter_out
-        #(.max_payload_width_p($bits(bp_lce_resp_wormhole_packet_s)-coh_noc_cord_width_p-coh_noc_len_width_p)
-          ,.len_width_p(coh_noc_len_width_p)
-          ,.cord_width_p(coh_noc_cord_width_p)
-          ,.flit_width_p($bits(bp_lce_resp_wormhole_packet_s))
-          )
-        cce_resp_adapter_out
-         (.clk_i(clk_i)
-          ,.reset_i(reset_i)
+      // Response adapter to convert from the link format to the CCE
+      // response input  format
+      bp_lce_resp_wormhole_packet_s cce_lce_resp_packet_li;
+      bsg_wormhole_router_adapter_out
+       #(.max_payload_width_p($bits(bp_lce_resp_wormhole_packet_s)-coh_noc_cord_width_p-coh_noc_len_width_p)
+         ,.len_width_p(coh_noc_len_width_p)
+         ,.cord_width_p(coh_noc_cord_width_p)
+         ,.flit_width_p($bits(bp_lce_resp_wormhole_packet_s))
+         )
+       cce_resp_adapter_out
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
 
-          ,.link_i(resp_concentrated_link_li)
-          ,.link_o(cce_lce_resp_link_lo)
+         ,.link_i(resp_concentrated_link_li)
+         ,.link_o(cce_lce_resp_link_lo)
 
-          ,.packet_o(cce_lce_resp_packet_li)
-          ,.v_o(cce_lce_resp_v_li)
-          ,.yumi_i(cce_lce_resp_yumi_lo)
-          );
-       assign cce_lce_resp_header_li = cce_lce_resp_packet_li.header.msg_hdr;
-       assign cce_lce_resp_data_li = cce_lce_resp_packet_li.data;
+         ,.packet_o(cce_lce_resp_packet_li)
+         ,.v_o(cce_lce_resp_v_li)
+         ,.yumi_i(cce_lce_resp_yumi_lo)
+         );
+      assign cce_lce_resp_header_li = cce_lce_resp_packet_li.header.msg_hdr;
+      assign cce_lce_resp_data_li = cce_lce_resp_packet_li.data;
 
-       // LCE Response
-       logic cce_lce_resp_ready_and_lo;
-       assign cce_lce_resp_yumi_lo = cce_lce_resp_v_li & cce_lce_resp_ready_and_lo;
-       bp_me_lite_to_burst
-        #(.bp_params_p(bp_params_p)
-          ,.in_data_width_p(cce_block_width_p)
-          ,.out_data_width_p(dword_width_gp)
-          ,.payload_width_p(lce_resp_payload_width_lp)
-          ,.payload_mask_p(lce_resp_payload_mask_gp)
-          )
-        lce_resp_lite2burst
-         (.clk_i(clk_i)
-          ,.reset_i(reset_i)
+      // LCE Response
+      logic cce_lce_resp_ready_and_lo;
+      assign cce_lce_resp_yumi_lo = cce_lce_resp_v_li & cce_lce_resp_ready_and_lo;
+      bp_me_lite_to_burst
+       #(.bp_params_p(bp_params_p)
+         ,.in_data_width_p(cce_block_width_p)
+         ,.out_data_width_p(dword_width_gp)
+         ,.payload_width_p(lce_resp_payload_width_lp)
+         ,.payload_mask_p(lce_resp_payload_mask_gp)
+         )
+       lce_resp_lite2burst
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
 
-          ,.in_msg_header_i(cce_lce_resp_header_li)
-          ,.in_msg_data_i(cce_lce_resp_data_li)
-          ,.in_msg_v_i(cce_lce_resp_v_li)
-          ,.in_msg_ready_and_o(cce_lce_resp_ready_and_lo)
+         ,.in_msg_header_i(cce_lce_resp_header_li)
+         ,.in_msg_data_i(cce_lce_resp_data_li)
+         ,.in_msg_v_i(cce_lce_resp_v_li)
+         ,.in_msg_ready_and_o(cce_lce_resp_ready_and_lo)
 
-          ,.out_msg_header_o(cce_lce_resp_header)
-          ,.out_msg_header_v_o(cce_lce_resp_header_v)
-          ,.out_msg_header_ready_and_i(cce_lce_resp_header_ready_and)
-          ,.out_msg_has_data_o(cce_lce_resp_has_data)
+         ,.out_msg_header_o(cce_lce_resp_header)
+         ,.out_msg_header_v_o(cce_lce_resp_header_v)
+         ,.out_msg_header_ready_and_i(cce_lce_resp_header_ready_and)
+         ,.out_msg_has_data_o(cce_lce_resp_has_data)
 
-          ,.out_msg_data_o(cce_lce_resp_data)
-          ,.out_msg_data_v_o(cce_lce_resp_data_v)
-          ,.out_msg_data_ready_and_i(cce_lce_resp_data_ready_and)
-          ,.out_msg_last_o(cce_lce_resp_last)
-          );
+         ,.out_msg_data_o(cce_lce_resp_data)
+         ,.out_msg_data_v_o(cce_lce_resp_data_v)
+         ,.out_msg_data_ready_and_i(cce_lce_resp_data_ready_and)
+         ,.out_msg_last_o(cce_lce_resp_last)
+         );
 
-       assign req_concentrated_link_li = '{data          : req_concentrated_link_lo.data
-                                           ,v            : req_concentrated_link_lo.v
-                                           ,ready_and_rev: cce_lce_req_link_lo.ready_and_rev
-                                           };
+      assign req_concentrated_link_li = '{data          : req_concentrated_link_lo.data
+                                          ,v            : req_concentrated_link_lo.v
+                                          ,ready_and_rev: cce_lce_req_link_lo.ready_and_rev
+                                          };
 
-       // We use concentrators just for the 1 -> N arbitration capabilities,
-       // rather than serialization
+      // We use concentrators just for the 1 -> N arbitration capabilities,
+      // rather than serialization
 
-       // Request concentrator
-       bsg_wormhole_concentrator_in
-        #(.flit_width_p($bits(bp_lce_req_wormhole_packet_s))
-          ,.len_width_p(coh_noc_len_width_p)
-          ,.cid_width_p(coh_noc_cid_width_p)
-          ,.num_in_p(num_caches_p)
-          ,.cord_width_p(coh_noc_cord_width_p)
-          )
-        req_concentrator
-         (.clk_i(clk_i)
-          ,.reset_i(reset_i)
+      // Request concentrator
+      bsg_wormhole_concentrator_in
+       #(.flit_width_p($bits(bp_lce_req_wormhole_packet_s))
+         ,.len_width_p(coh_noc_len_width_p)
+         ,.cid_width_p(coh_noc_cid_width_p)
+         ,.num_in_p(num_caches_p)
+         ,.cord_width_p(coh_noc_cord_width_p)
+         )
+       req_concentrator
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
 
-          ,.links_i(lce_req_link_lo)
-          ,.links_o(lce_req_link_li)
+         ,.links_i(lce_req_link_lo)
+         ,.links_o(lce_req_link_li)
 
-          ,.concentrated_link_i(req_concentrated_link_li)
-          ,.concentrated_link_o(req_concentrated_link_lo)
-          );
+         ,.concentrated_link_i(req_concentrated_link_li)
+         ,.concentrated_link_o(req_concentrated_link_lo)
+         );
 
-       assign cmd_concentrated_link_li = cmd_concentrated_link_lo;
-       // Command concentrator
-       bsg_wormhole_concentrator
-        #(.flit_width_p($bits(bp_lce_cmd_wormhole_packet_s))
-          ,.len_width_p(coh_noc_len_width_p)
-          ,.cid_width_p(coh_noc_cid_width_p)
-          ,.num_in_p(num_caches_p+1)
-          ,.cord_width_p(coh_noc_cord_width_p)
-          )
-        cmd_concentrator
-         (.clk_i(clk_i)
-          ,.reset_i(reset_i)
+      assign cmd_concentrated_link_li = cmd_concentrated_link_lo;
+      // Command concentrator
+      bsg_wormhole_concentrator
+       #(.flit_width_p($bits(bp_lce_cmd_wormhole_packet_s))
+         ,.len_width_p(coh_noc_len_width_p)
+         ,.cid_width_p(coh_noc_cid_width_p)
+         ,.num_in_p(num_caches_p+1)
+         ,.cord_width_p(coh_noc_cord_width_p)
+         )
+       cmd_concentrator
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
 
-          ,.links_i({cce_lce_cmd_link_lo, lce_cmd_link_lo})
-          ,.links_o({cce_lce_cmd_link_li, lce_cmd_link_li})
+         ,.links_i({cce_lce_cmd_link_lo, lce_cmd_link_lo})
+         ,.links_o({cce_lce_cmd_link_li, lce_cmd_link_li})
 
-          ,.concentrated_link_i(cmd_concentrated_link_li)
-          ,.concentrated_link_o(cmd_concentrated_link_lo)
-          );
+         ,.concentrated_link_i(cmd_concentrated_link_li)
+         ,.concentrated_link_o(cmd_concentrated_link_lo)
+         );
 
-       assign resp_concentrated_link_li = '{data          : resp_concentrated_link_lo.data
-                                            ,v            : resp_concentrated_link_lo.v
-                                            ,ready_and_rev: cce_lce_resp_link_lo.ready_and_rev
-                                           };
+      assign resp_concentrated_link_li = '{data          : resp_concentrated_link_lo.data
+                                           ,v            : resp_concentrated_link_lo.v
+                                           ,ready_and_rev: cce_lce_resp_link_lo.ready_and_rev
+                                          };
 
-       // Response concentrator
-       bsg_wormhole_concentrator_in
-        #(.flit_width_p($bits(bp_lce_resp_wormhole_packet_s))
-          ,.len_width_p(coh_noc_len_width_p)
-          ,.cid_width_p(coh_noc_cid_width_p)
-          ,.num_in_p(num_caches_p)
-          ,.cord_width_p(coh_noc_cord_width_p)
-          )
-        resp_concentrator
-         (.clk_i(clk_i)
-          ,.reset_i(reset_i)
+      // Response concentrator
+      bsg_wormhole_concentrator_in
+       #(.flit_width_p($bits(bp_lce_resp_wormhole_packet_s))
+         ,.len_width_p(coh_noc_len_width_p)
+         ,.cid_width_p(coh_noc_cid_width_p)
+         ,.num_in_p(num_caches_p)
+         ,.cord_width_p(coh_noc_cord_width_p)
+         )
+       resp_concentrator
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
 
-          ,.links_i(lce_resp_link_lo)
-          ,.links_o(lce_resp_link_li)
+         ,.links_i(lce_resp_link_lo)
+         ,.links_o(lce_resp_link_li)
 
-          ,.concentrated_link_i(resp_concentrated_link_li)
-          ,.concentrated_link_o(resp_concentrated_link_lo)
-          );
+         ,.concentrated_link_i(resp_concentrated_link_li)
+         ,.concentrated_link_o(resp_concentrated_link_lo)
+         );
 
-       bp_cce_fsm
-        #(.bp_params_p(bp_params_p))
-        cce
-         (.clk_i(clk_i)
-          ,.reset_i(reset_i)
+      bp_cce_fsm
+       #(.bp_params_p(bp_params_p))
+       cce
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
 
-          ,.cfg_bus_i(cfg_bus_i)
+         ,.cfg_bus_i(cfg_bus_i)
 
-          // LCE-CCE Interface
-          // BedRock Burst protocol: ready&valid
-          ,.lce_req_header_i(cce_lce_req_header)
-          ,.lce_req_header_v_i(cce_lce_req_header_v)
-          ,.lce_req_header_ready_and_o(cce_lce_req_header_ready_and)
-          ,.lce_req_has_data_i(cce_lce_req_has_data)
-          ,.lce_req_data_i(cce_lce_req_data)
-          ,.lce_req_data_v_i(cce_lce_req_data_v)
-          ,.lce_req_data_ready_and_o(cce_lce_req_data_ready_and)
-          ,.lce_req_last_i(cce_lce_req_last)
+         // LCE-CCE Interface
+         // BedRock Burst protocol: ready&valid
+         ,.lce_req_header_i(cce_lce_req_header)
+         ,.lce_req_header_v_i(cce_lce_req_header_v)
+         ,.lce_req_header_ready_and_o(cce_lce_req_header_ready_and)
+         ,.lce_req_has_data_i(cce_lce_req_has_data)
+         ,.lce_req_data_i(cce_lce_req_data)
+         ,.lce_req_data_v_i(cce_lce_req_data_v)
+         ,.lce_req_data_ready_and_o(cce_lce_req_data_ready_and)
+         ,.lce_req_last_i(cce_lce_req_last)
 
-          ,.lce_resp_header_i(cce_lce_resp_header)
-          ,.lce_resp_header_v_i(cce_lce_resp_header_v)
-          ,.lce_resp_header_ready_and_o(cce_lce_resp_header_ready_and)
-          ,.lce_resp_has_data_i(cce_lce_resp_has_data)
-          ,.lce_resp_data_i(cce_lce_resp_data)
-          ,.lce_resp_data_v_i(cce_lce_resp_data_v)
-          ,.lce_resp_data_ready_and_o(cce_lce_resp_data_ready_and)
-          ,.lce_resp_last_i(cce_lce_resp_last)
+         ,.lce_resp_header_i(cce_lce_resp_header)
+         ,.lce_resp_header_v_i(cce_lce_resp_header_v)
+         ,.lce_resp_header_ready_and_o(cce_lce_resp_header_ready_and)
+         ,.lce_resp_has_data_i(cce_lce_resp_has_data)
+         ,.lce_resp_data_i(cce_lce_resp_data)
+         ,.lce_resp_data_v_i(cce_lce_resp_data_v)
+         ,.lce_resp_data_ready_and_o(cce_lce_resp_data_ready_and)
+         ,.lce_resp_last_i(cce_lce_resp_last)
 
-          ,.lce_cmd_header_o(cce_lce_cmd_header)
-          ,.lce_cmd_header_v_o(cce_lce_cmd_header_v)
-          ,.lce_cmd_header_ready_and_i(cce_lce_cmd_header_ready_and)
-          ,.lce_cmd_has_data_o(cce_lce_cmd_has_data)
-          ,.lce_cmd_data_o(cce_lce_cmd_data)
-          ,.lce_cmd_data_v_o(cce_lce_cmd_data_v)
-          ,.lce_cmd_data_ready_and_i(cce_lce_cmd_data_ready_and)
-          ,.lce_cmd_last_o(cce_lce_cmd_last)
+         ,.lce_cmd_header_o(cce_lce_cmd_header)
+         ,.lce_cmd_header_v_o(cce_lce_cmd_header_v)
+         ,.lce_cmd_header_ready_and_i(cce_lce_cmd_header_ready_and)
+         ,.lce_cmd_has_data_o(cce_lce_cmd_has_data)
+         ,.lce_cmd_data_o(cce_lce_cmd_data)
+         ,.lce_cmd_data_v_o(cce_lce_cmd_data_v)
+         ,.lce_cmd_data_ready_and_i(cce_lce_cmd_data_ready_and)
+         ,.lce_cmd_last_o(cce_lce_cmd_last)
 
-          // CCE-MEM Interface
-          // BedRock Stream protocol: ready&valid
-          // TODO: match data widths with top-level
-          ,.mem_resp_header_i(mem_resp_header_i)
-          ,.mem_resp_data_i(mem_resp_data_i)
-          ,.mem_resp_v_i(mem_resp_v_i)
-          ,.mem_resp_ready_and_o(mem_resp_ready_and_o)
-          ,.mem_resp_last_i(mem_resp_last_i)
+         // CCE-MEM Interface
+         // BedRock Stream protocol: ready&valid
+         // TODO: match data widths with top-level
+         ,.mem_resp_header_i(mem_resp_header_i)
+         ,.mem_resp_data_i(mem_resp_data_i)
+         ,.mem_resp_v_i(mem_resp_v_i)
+         ,.mem_resp_ready_and_o(mem_resp_ready_and_o)
+         ,.mem_resp_last_i(mem_resp_last_i)
 
-          ,.mem_cmd_header_o(mem_cmd_header_o)
-          ,.mem_cmd_data_o(mem_cmd_data_o)
-          ,.mem_cmd_v_o(mem_cmd_v_o)
-          ,.mem_cmd_ready_and_i(mem_cmd_ready_and_i)
-          ,.mem_cmd_last_o(mem_cmd_last_o)
-          );
-     end
+         ,.mem_cmd_header_o(mem_cmd_header_o)
+         ,.mem_cmd_data_o(mem_cmd_data_o)
+         ,.mem_cmd_v_o(mem_cmd_v_o)
+         ,.mem_cmd_ready_and_i(mem_cmd_ready_and_i)
+         ,.mem_cmd_last_o(mem_cmd_last_o)
+         );
+    end
 
 endmodule
 

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -64,700 +64,701 @@ module wrapper
    , input                                             mem_resp_last_i
    );
 
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
-  `declare_bp_be_dcache_pkt_s(vaddr_width_p);
-
-  // Cache to Rolly FIFO signals
-  logic [num_caches_p-1:0] dcache_ready_lo;
-  logic [num_caches_p-1:0] rollback_li;
-  logic [num_caches_p-1:0] rolly_uncached_lo;
-  logic [num_caches_p-1:0] rolly_v_lo, rolly_yumi_li;
-  bp_be_dcache_pkt_s [num_caches_p-1:0] rolly_dcache_pkt_lo;
-  logic [num_caches_p-1:0][ptag_width_p-1:0] rolly_ptag_lo;
-
-  // D$ - LCE Interface signals
-  // Miss, Management Interfaces
-  logic [num_caches_p-1:0] cache_req_v_lo, cache_req_metadata_v_lo;
-  logic [num_caches_p-1:0] cache_req_yumi_lo, cache_req_busy_lo;
-  logic [num_caches_p-1:0] cache_req_complete_lo, cache_req_critical_tag_lo, cache_req_critical_data_lo;
-  logic [num_caches_p-1:0][dcache_req_width_lp-1:0] cache_req_lo;
-  logic [num_caches_p-1:0][dcache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
-
-  // Fill Interface
-  logic [num_caches_p-1:0] data_mem_pkt_v_lo, tag_mem_pkt_v_lo, stat_mem_pkt_v_lo;
-  logic [num_caches_p-1:0] data_mem_pkt_yumi_lo, tag_mem_pkt_yumi_lo, stat_mem_pkt_yumi_lo;
-  logic [num_caches_p-1:0][dcache_data_mem_pkt_width_lp-1:0] data_mem_pkt_lo;
-  logic [num_caches_p-1:0][dcache_tag_mem_pkt_width_lp-1:0] tag_mem_pkt_lo;
-  logic [num_caches_p-1:0][dcache_stat_mem_pkt_width_lp-1:0] stat_mem_pkt_lo;
-  logic [num_caches_p-1:0][block_width_p-1:0] data_mem_lo;
-  logic [num_caches_p-1:0][dcache_tag_info_width_lp-1:0] tag_mem_lo;
-  logic [num_caches_p-1:0][dcache_stat_info_width_lp-1:0] stat_mem_lo;
-
-  // Credits
-  logic [num_caches_p-1:0] cache_req_credits_full_lo, cache_req_credits_empty_lo;
-
-  logic [num_caches_p-1:0][ptag_width_p-1:0] rolly_ptag_r;
-  logic [num_caches_p-1:0] rolly_uncached_r;
-  logic [num_caches_p-1:0] is_store, is_store_rr, dcache_v_rr;
-
-  logic [num_caches_p-1:0][dpath_width_gp-1:0] early_data_lo;
-  logic [num_caches_p-1:0] early_v_lo;
-  logic [num_caches_p-1:0][dpath_width_gp-1:0] final_data_lo;
-  logic [num_caches_p-1:0] final_v_lo;
-  logic [num_caches_p-1:0][dpath_width_gp-1:0] late_data_lo;
-  logic [num_caches_p-1:0] late_v_lo;
-
-  // LCE-CCE connections - to/from LCE
-  bp_bedrock_lce_req_header_s [num_caches_p-1:0] lce_req_header_lo;
-  logic [num_caches_p-1:0][cce_block_width_p-1:0] lce_req_data_lo;
-  logic [num_caches_p-1:0] lce_req_ready_and_li, lce_req_v_lo;
-  bp_bedrock_lce_cmd_header_s [num_caches_p-1:0] lce_cmd_header_li;
-  logic [num_caches_p-1:0][cce_block_width_p-1:0] lce_cmd_data_li;
-  logic [num_caches_p-1:0] lce_cmd_v_li, lce_cmd_yumi_lo;
-  bp_bedrock_lce_resp_header_s [num_caches_p-1:0] lce_resp_header_lo;
-  logic [num_caches_p-1:0][cce_block_width_p-1:0] lce_resp_data_lo;
-  logic [num_caches_p-1:0] lce_resp_v_lo, lce_resp_ready_and_li;
-  bp_bedrock_lce_cmd_header_s [num_caches_p-1:0] lce_cmd_header_lo;
-  logic [num_caches_p-1:0][cce_block_width_p-1:0] lce_cmd_data_lo;
-  logic [num_caches_p-1:0] lce_cmd_v_lo, lce_cmd_ready_and_li;
-
-  // LCE-CCE connections - BedRock Lite - to/from converters
-  bp_bedrock_lce_req_header_s cce_lce_req_header_li;
-  logic [cce_block_width_p-1:0] cce_lce_req_data_li;
-  logic cce_lce_req_v_li, cce_lce_req_yumi_lo;
-  bp_bedrock_lce_cmd_header_s cce_lce_cmd_header_lo;
-  logic [cce_block_width_p-1:0] cce_lce_cmd_data_lo;
-  logic cce_lce_cmd_v_lo, cce_lce_cmd_ready_and_li;
-  bp_bedrock_lce_resp_header_s cce_lce_resp_header_li;
-  logic [cce_block_width_p-1:0] cce_lce_resp_data_li;
-  logic cce_lce_resp_v_li, cce_lce_resp_yumi_lo;
-
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
-  `bp_cast_i(bp_cfg_bus_s, cfg_bus);
-
-  `declare_bp_lce_req_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_bedrock_lce_req_header_s, cce_block_width_p);
-  `declare_bp_lce_cmd_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_bedrock_lce_cmd_header_s, cce_block_width_p);
-  `declare_bp_lce_resp_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_bedrock_lce_resp_header_s, cce_block_width_p);
-  `declare_bsg_ready_and_link_sif_s($bits(bp_lce_req_wormhole_packet_s), coh_req_ready_and_link_s);
-  `declare_bsg_ready_and_link_sif_s($bits(bp_lce_cmd_wormhole_packet_s), coh_cmd_ready_and_link_s);
-  `declare_bsg_ready_and_link_sif_s($bits(bp_lce_resp_wormhole_packet_s), coh_resp_ready_and_link_s);
-
-  coh_req_ready_and_link_s [num_caches_p-1:0]  lce_req_link_li, lce_req_link_lo;
-  coh_cmd_ready_and_link_s [num_caches_p-1:0]  lce_cmd_link_li, lce_cmd_link_lo;
-  coh_resp_ready_and_link_s [num_caches_p-1:0] lce_resp_link_li, lce_resp_link_lo;
-
-  coh_req_ready_and_link_s cce_lce_req_link_li, cce_lce_req_link_lo;
-  coh_cmd_ready_and_link_s cce_lce_cmd_link_li, cce_lce_cmd_link_lo;
-  coh_resp_ready_and_link_s cce_lce_resp_link_li, cce_lce_resp_link_lo;
-
-  logic [num_caches_p-1:0] fifo_lce_cmd_ready_lo;
-  bp_lce_req_wormhole_packet_s [num_caches_p-1:0] lce_req_packet_lo;
-  bp_lce_cmd_wormhole_packet_s [num_caches_p-1:0] lce_cmd_packet_lo, lce_cmd_packet_li, fifo_lce_cmd_data_lo;
-  bp_lce_resp_wormhole_packet_s [num_caches_p-1:0] lce_resp_packet_lo;
-
-  for (genvar i = 0; i < num_caches_p; i++)
-    begin : cache
-      bsg_fifo_1r1w_rolly
-      #(.width_p(dcache_pkt_width_lp+ptag_width_p+1)
-       ,.els_p(8))
-       rolly
-       (.clk_i(clk_i)
-       ,.reset_i(reset_i)
-
-       ,.roll_v_i(rollback_li[i])
-       ,.clr_v_i(1'b0)
-       ,.deq_v_i(dcache_v_rr[i])
-
-       ,.data_i({uncached_i[i], ptag_i[i], dcache_pkt_i[i]})
-       ,.v_i(v_i[i])
-       ,.ready_o(ready_o[i])
-
-       ,.data_o({rolly_uncached_lo[i], rolly_ptag_lo[i], rolly_dcache_pkt_lo[i]})
-       ,.v_o(rolly_v_lo[i])
-       ,.yumi_i(rolly_yumi_li[i])
-       );
-      assign rolly_yumi_li[i] = rolly_v_lo[i] & dcache_ready_lo[i];
-
-      bsg_dff_reset
-       #(.width_p(1+ptag_width_p)
-        ,.reset_val_p(0)
-       )
-       ptag_dff
-       (.clk_i(clk_i)
-       ,.reset_i(reset_i)
-
-       ,.data_i({rolly_uncached_lo[i], rolly_ptag_lo[i]})
-       ,.data_o({rolly_uncached_r[i], rolly_ptag_r[i]})
-       );
-
-      assign is_store[i] = rolly_dcache_pkt_lo[i].opcode inside {e_dcache_op_sb, e_dcache_op_sh, e_dcache_op_sw, e_dcache_op_sd};
-
-      bsg_dff_chain
-       #(.width_p(2)
-        ,.num_stages_p(2)
-       )
-       dcache_v_reg
-       (.clk_i(clk_i)
-       ,.data_i({is_store[i], rolly_yumi_li[i]})
-       ,.data_o({is_store_rr[i], dcache_v_rr[i]})
-       );
-
-      assign rollback_li[i] = dcache_v_rr[i] & ~v_o[i];
-
-      bp_be_dcache
-      #(.bp_params_p(bp_params_p)
-        ,.writethrough_p(wt_p)
-        ,.sets_p(sets_p)
-        ,.assoc_p(assoc_p)
-        ,.block_width_p(block_width_p)
-        ,.fill_width_p(fill_width_p)
+   `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
+   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+   `declare_bp_be_dcache_pkt_s(vaddr_width_p);
+ 
+   // Cache to Rolly FIFO signals
+   logic [num_caches_p-1:0] dcache_ready_lo;
+   logic [num_caches_p-1:0] rollback_li;
+   logic [num_caches_p-1:0] rolly_uncached_lo;
+   logic [num_caches_p-1:0] rolly_v_lo, rolly_yumi_li;
+   bp_be_dcache_pkt_s [num_caches_p-1:0] rolly_dcache_pkt_lo;
+   logic [num_caches_p-1:0][ptag_width_p-1:0] rolly_ptag_lo;
+ 
+   // D$ - LCE Interface signals
+   // Miss, Management Interfaces
+   logic [num_caches_p-1:0] cache_req_v_lo, cache_req_metadata_v_lo;
+   logic [num_caches_p-1:0] cache_req_yumi_lo, cache_req_busy_lo;
+   logic [num_caches_p-1:0] cache_req_complete_lo, cache_req_critical_tag_lo, cache_req_critical_data_lo;
+   logic [num_caches_p-1:0][dcache_req_width_lp-1:0] cache_req_lo;
+   logic [num_caches_p-1:0][dcache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
+ 
+   // Fill Interface
+   logic [num_caches_p-1:0] data_mem_pkt_v_lo, tag_mem_pkt_v_lo, stat_mem_pkt_v_lo;
+   logic [num_caches_p-1:0] data_mem_pkt_yumi_lo, tag_mem_pkt_yumi_lo, stat_mem_pkt_yumi_lo;
+   logic [num_caches_p-1:0][dcache_data_mem_pkt_width_lp-1:0] data_mem_pkt_lo;
+   logic [num_caches_p-1:0][dcache_tag_mem_pkt_width_lp-1:0] tag_mem_pkt_lo;
+   logic [num_caches_p-1:0][dcache_stat_mem_pkt_width_lp-1:0] stat_mem_pkt_lo;
+   logic [num_caches_p-1:0][block_width_p-1:0] data_mem_lo;
+   logic [num_caches_p-1:0][dcache_tag_info_width_lp-1:0] tag_mem_lo;
+   logic [num_caches_p-1:0][dcache_stat_info_width_lp-1:0] stat_mem_lo;
+ 
+   // Credits
+   logic [num_caches_p-1:0] cache_req_credits_full_lo, cache_req_credits_empty_lo;
+ 
+   logic [num_caches_p-1:0][ptag_width_p-1:0] rolly_ptag_r;
+   logic [num_caches_p-1:0] rolly_uncached_r;
+   logic [num_caches_p-1:0] is_store, is_store_rr, dcache_v_rr;
+ 
+   logic [num_caches_p-1:0][dpath_width_gp-1:0] early_data_lo;
+   logic [num_caches_p-1:0] early_v_lo;
+   logic [num_caches_p-1:0][dpath_width_gp-1:0] final_data_lo;
+   logic [num_caches_p-1:0] final_v_lo;
+   logic [num_caches_p-1:0][dpath_width_gp-1:0] late_data_lo;
+   logic [num_caches_p-1:0] late_v_lo;
+ 
+   // LCE-CCE connections - to/from LCE
+   bp_bedrock_lce_req_header_s [num_caches_p-1:0] lce_req_header_lo;
+   logic [num_caches_p-1:0][cce_block_width_p-1:0] lce_req_data_lo;
+   logic [num_caches_p-1:0] lce_req_ready_and_li, lce_req_v_lo;
+   bp_bedrock_lce_cmd_header_s [num_caches_p-1:0] lce_cmd_header_li;
+   logic [num_caches_p-1:0][cce_block_width_p-1:0] lce_cmd_data_li;
+   logic [num_caches_p-1:0] lce_cmd_v_li, lce_cmd_yumi_lo;
+   bp_bedrock_lce_resp_header_s [num_caches_p-1:0] lce_resp_header_lo;
+   logic [num_caches_p-1:0][cce_block_width_p-1:0] lce_resp_data_lo;
+   logic [num_caches_p-1:0] lce_resp_v_lo, lce_resp_ready_and_li;
+   bp_bedrock_lce_cmd_header_s [num_caches_p-1:0] lce_cmd_header_lo;
+   logic [num_caches_p-1:0][cce_block_width_p-1:0] lce_cmd_data_lo;
+   logic [num_caches_p-1:0] lce_cmd_v_lo, lce_cmd_ready_and_li;
+ 
+   // LCE-CCE connections - BedRock Lite - to/from converters
+   bp_bedrock_lce_req_header_s cce_lce_req_header_li;
+   logic [cce_block_width_p-1:0] cce_lce_req_data_li;
+   logic cce_lce_req_v_li, cce_lce_req_yumi_lo;
+   bp_bedrock_lce_cmd_header_s cce_lce_cmd_header_lo;
+   logic [cce_block_width_p-1:0] cce_lce_cmd_data_lo;
+   logic cce_lce_cmd_v_lo, cce_lce_cmd_ready_and_li;
+   bp_bedrock_lce_resp_header_s cce_lce_resp_header_li;
+   logic [cce_block_width_p-1:0] cce_lce_resp_data_li;
+   logic cce_lce_resp_v_li, cce_lce_resp_yumi_lo;
+ 
+   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
+ 
+   `declare_bp_lce_req_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_bedrock_lce_req_header_s, cce_block_width_p);
+   `declare_bp_lce_cmd_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_bedrock_lce_cmd_header_s, cce_block_width_p);
+   `declare_bp_lce_resp_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_bedrock_lce_resp_header_s, cce_block_width_p);
+   `declare_bsg_ready_and_link_sif_s($bits(bp_lce_req_wormhole_packet_s), coh_req_ready_and_link_s);
+   `declare_bsg_ready_and_link_sif_s($bits(bp_lce_cmd_wormhole_packet_s), coh_cmd_ready_and_link_s);
+   `declare_bsg_ready_and_link_sif_s($bits(bp_lce_resp_wormhole_packet_s), coh_resp_ready_and_link_s);
+ 
+   coh_req_ready_and_link_s [num_caches_p-1:0]  lce_req_link_li, lce_req_link_lo;
+   coh_cmd_ready_and_link_s [num_caches_p-1:0]  lce_cmd_link_li, lce_cmd_link_lo;
+   coh_resp_ready_and_link_s [num_caches_p-1:0] lce_resp_link_li, lce_resp_link_lo;
+ 
+   coh_req_ready_and_link_s cce_lce_req_link_li, cce_lce_req_link_lo;
+   coh_cmd_ready_and_link_s cce_lce_cmd_link_li, cce_lce_cmd_link_lo;
+   coh_resp_ready_and_link_s cce_lce_resp_link_li, cce_lce_resp_link_lo;
+ 
+   logic [num_caches_p-1:0] fifo_lce_cmd_ready_lo;
+   bp_lce_req_wormhole_packet_s [num_caches_p-1:0] lce_req_packet_lo;
+   bp_lce_cmd_wormhole_packet_s [num_caches_p-1:0] lce_cmd_packet_lo, lce_cmd_packet_li, fifo_lce_cmd_data_lo;
+   bp_lce_resp_wormhole_packet_s [num_caches_p-1:0] lce_resp_packet_lo;
+ 
+   for (genvar i = 0; i < num_caches_p; i++)
+     begin : cache
+       bsg_fifo_1r1w_rolly
+       #(.width_p(dcache_pkt_width_lp+ptag_width_p+1)
+        ,.els_p(8))
+        rolly
+        (.clk_i(clk_i)
+        ,.reset_i(reset_i)
+ 
+        ,.roll_v_i(rollback_li[i])
+        ,.clr_v_i(1'b0)
+        ,.deq_v_i(dcache_v_rr[i])
+ 
+        ,.data_i({uncached_i[i], ptag_i[i], dcache_pkt_i[i]})
+        ,.v_i(v_i[i])
+        ,.ready_o(ready_o[i])
+ 
+        ,.data_o({rolly_uncached_lo[i], rolly_ptag_lo[i], rolly_dcache_pkt_lo[i]})
+        ,.v_o(rolly_v_lo[i])
+        ,.yumi_i(rolly_yumi_li[i])
+        );
+       assign rolly_yumi_li[i] = rolly_v_lo[i] & dcache_ready_lo[i];
+ 
+       bsg_dff_reset
+        #(.width_p(1+ptag_width_p)
+         ,.reset_val_p(0)
         )
-      dcache
-      (.clk_i(clk_i)
-      ,.reset_i(reset_i)
-
-      ,.cfg_bus_i(cfg_bus_i)
-
-      ,.dcache_pkt_i(rolly_dcache_pkt_lo[i])
-      ,.v_i(rolly_yumi_li[i])
-      ,.ready_o(dcache_ready_lo[i])
-
-      ,.early_data_o(early_data_lo[i])
-      ,.early_hit_v_o(early_v_lo[i])
-      ,.early_miss_v_o()
-      ,.early_fencei_o()
-      ,.final_data_o(final_data_lo[i])
-      ,.final_v_o(final_v_lo[i])
-      ,.late_rd_addr_o()
-      ,.late_float_o()
-      ,.late_data_o(late_data_lo[i])
-      ,.late_v_o(late_v_lo[i])
-      ,.late_yumi_i(late_v_lo[i])
-
-      ,.ptag_v_i(1'b1)
-      ,.ptag_i(rolly_ptag_r[i])
-      ,.ptag_uncached_i(rolly_uncached_r[i])
-      ,.ptag_dram_i(1'b1)
-
-      ,.flush_i('0)
-
-      ,.cache_req_v_o(cache_req_v_lo[i])
-      ,.cache_req_o(cache_req_lo[i])
-      ,.cache_req_metadata_o(cache_req_metadata_lo[i])
-      ,.cache_req_metadata_v_o(cache_req_metadata_v_lo[i])
-      ,.cache_req_yumi_i(cache_req_yumi_lo[i])
-      ,.cache_req_busy_i(cache_req_busy_lo[i])
-      ,.cache_req_complete_i(cache_req_complete_lo[i])
-      ,.cache_req_critical_tag_i(cache_req_critical_tag_lo[i])
-      ,.cache_req_critical_data_i(cache_req_critical_data_lo[i])
-      ,.cache_req_credits_full_i(cache_req_credits_full_lo[i])
-      ,.cache_req_credits_empty_i(cache_req_credits_empty_lo[i])
-
-      ,.data_mem_pkt_v_i(data_mem_pkt_v_lo[i])
-      ,.data_mem_pkt_i(data_mem_pkt_lo[i])
-      ,.data_mem_o(data_mem_lo[i])
-      ,.data_mem_pkt_yumi_o(data_mem_pkt_yumi_lo[i])
-
-      ,.tag_mem_pkt_v_i(tag_mem_pkt_v_lo[i])
-      ,.tag_mem_pkt_i(tag_mem_pkt_lo[i])
-      ,.tag_mem_o(tag_mem_lo[i])
-      ,.tag_mem_pkt_yumi_o(tag_mem_pkt_yumi_lo[i])
-
-      ,.stat_mem_pkt_v_i(stat_mem_pkt_v_lo[i])
-      ,.stat_mem_pkt_i(stat_mem_pkt_lo[i])
-      ,.stat_mem_o(stat_mem_lo[i])
-      ,.stat_mem_pkt_yumi_o(stat_mem_pkt_yumi_lo[i])
-      );
-
-      // Stores "return" 0 to the trace replay module
-      assign data_o[i] = late_v_lo[i] ? late_data_lo : is_store_rr[i] ? '0 : final_data_lo[i];
-      assign v_o[i] = late_v_lo[i] | final_v_lo[i];
-
-      if (uce_p == 0)
-        begin : lce
-          bp_lce
+        ptag_dff
+        (.clk_i(clk_i)
+        ,.reset_i(reset_i)
+ 
+        ,.data_i({rolly_uncached_lo[i], rolly_ptag_lo[i]})
+        ,.data_o({rolly_uncached_r[i], rolly_ptag_r[i]})
+        );
+ 
+       assign is_store[i] = rolly_dcache_pkt_lo[i].opcode inside {e_dcache_op_sb, e_dcache_op_sh, e_dcache_op_sw, e_dcache_op_sd};
+ 
+       bsg_dff_chain
+        #(.width_p(2)
+         ,.num_stages_p(2)
+        )
+        dcache_v_reg
+        (.clk_i(clk_i)
+        ,.data_i({is_store[i], rolly_yumi_li[i]})
+        ,.data_o({is_store_rr[i], dcache_v_rr[i]})
+        );
+ 
+       assign rollback_li[i] = dcache_v_rr[i] & ~v_o[i];
+ 
+       bp_be_dcache
+       #(.bp_params_p(bp_params_p)
+         ,.writethrough_p(wt_p)
+         ,.sets_p(sets_p)
+         ,.assoc_p(assoc_p)
+         ,.block_width_p(block_width_p)
+         ,.fill_width_p(fill_width_p)
+         )
+       dcache
+       (.clk_i(clk_i)
+       ,.reset_i(reset_i)
+ 
+       ,.cfg_bus_i(cfg_bus_i)
+ 
+       ,.dcache_pkt_i(rolly_dcache_pkt_lo[i])
+       ,.v_i(rolly_yumi_li[i])
+       ,.ready_o(dcache_ready_lo[i])
+ 
+       ,.early_data_o(early_data_lo[i])
+       ,.early_hit_v_o(early_v_lo[i])
+       ,.early_miss_v_o()
+       ,.early_fencei_o()
+       ,.final_data_o(final_data_lo[i])
+       ,.final_v_o(final_v_lo[i])
+       ,.late_rd_addr_o()
+       ,.late_float_o()
+       ,.late_data_o(late_data_lo[i])
+       ,.late_v_o(late_v_lo[i])
+       ,.late_yumi_i(late_v_lo[i])
+ 
+       ,.ptag_v_i(1'b1)
+       ,.ptag_i(rolly_ptag_r[i])
+       ,.ptag_uncached_i(rolly_uncached_r[i])
+       ,.ptag_dram_i(1'b1)
+ 
+       ,.poison_req_i('0)
+       ,.poison_tl_i('0)
+ 
+       ,.cache_req_v_o(cache_req_v_lo[i])
+       ,.cache_req_o(cache_req_lo[i])
+       ,.cache_req_metadata_o(cache_req_metadata_lo[i])
+       ,.cache_req_metadata_v_o(cache_req_metadata_v_lo[i])
+       ,.cache_req_yumi_i(cache_req_yumi_lo[i])
+       ,.cache_req_busy_i(cache_req_busy_lo[i])
+       ,.cache_req_complete_i(cache_req_complete_lo[i])
+       ,.cache_req_critical_tag_i(cache_req_critical_tag_lo[i])
+       ,.cache_req_critical_data_i(cache_req_critical_data_lo[i])
+       ,.cache_req_credits_full_i(cache_req_credits_full_lo[i])
+       ,.cache_req_credits_empty_i(cache_req_credits_empty_lo[i])
+ 
+       ,.data_mem_pkt_v_i(data_mem_pkt_v_lo[i])
+       ,.data_mem_pkt_i(data_mem_pkt_lo[i])
+       ,.data_mem_o(data_mem_lo[i])
+       ,.data_mem_pkt_yumi_o(data_mem_pkt_yumi_lo[i])
+ 
+       ,.tag_mem_pkt_v_i(tag_mem_pkt_v_lo[i])
+       ,.tag_mem_pkt_i(tag_mem_pkt_lo[i])
+       ,.tag_mem_o(tag_mem_lo[i])
+       ,.tag_mem_pkt_yumi_o(tag_mem_pkt_yumi_lo[i])
+ 
+       ,.stat_mem_pkt_v_i(stat_mem_pkt_v_lo[i])
+       ,.stat_mem_pkt_i(stat_mem_pkt_lo[i])
+       ,.stat_mem_o(stat_mem_lo[i])
+       ,.stat_mem_pkt_yumi_o(stat_mem_pkt_yumi_lo[i])
+       );
+ 
+       // Stores "return" 0 to the trace replay module
+       assign data_o[i] = late_v_lo[i] ? late_data_lo : is_store_rr[i] ? '0 : final_data_lo[i];
+       assign v_o[i] = late_v_lo[i] | final_v_lo[i];
+ 
+       if (uce_p == 0)
+         begin : lce
+           bp_lce
+            #(.bp_params_p(bp_params_p)
+              ,.assoc_p(assoc_p)
+              ,.sets_p(sets_p)
+              ,.block_width_p(block_width_p)
+              ,.fill_width_p(fill_width_p)
+              ,.timeout_max_limit_p(4)
+              ,.credits_p(coh_noc_max_credits_p)
+              ,.req_invert_clk_p(1)
+              ,.data_mem_invert_clk_p(1)
+              ,.tag_mem_invert_clk_p(1)
+              )
+            dcache_lce
+             (.clk_i(clk_i)
+              ,.reset_i(reset_i)
+ 
+              ,.lce_id_i(lce_id_width_p'(i))
+              ,.lce_mode_i(cfg_bus_cast_i.dcache_mode)
+ 
+              ,.cache_req_i(cache_req_lo[i])
+              ,.cache_req_v_i(cache_req_v_lo[i])
+              ,.cache_req_yumi_o(cache_req_yumi_lo[i])
+              ,.cache_req_busy_o(cache_req_busy_lo[i])
+              ,.cache_req_metadata_i(cache_req_metadata_lo[i])
+              ,.cache_req_metadata_v_i(cache_req_metadata_v_lo[i])
+              ,.cache_req_critical_tag_o(cache_req_critical_tag_lo[i])
+              ,.cache_req_critical_data_o(cache_req_critical_data_lo[i])
+              ,.cache_req_complete_o(cache_req_complete_lo[i])
+              ,.cache_req_credits_full_o(cache_req_credits_full_lo[i])
+              ,.cache_req_credits_empty_o(cache_req_credits_empty_lo[i])
+ 
+              ,.data_mem_pkt_v_o(data_mem_pkt_v_lo[i])
+              ,.data_mem_pkt_o(data_mem_pkt_lo[i])
+              ,.data_mem_i(data_mem_lo[i])
+              ,.data_mem_pkt_yumi_i(data_mem_pkt_yumi_lo[i])
+ 
+              ,.tag_mem_pkt_v_o(tag_mem_pkt_v_lo[i])
+              ,.tag_mem_pkt_o(tag_mem_pkt_lo[i])
+              ,.tag_mem_i(tag_mem_lo[i])
+              ,.tag_mem_pkt_yumi_i(tag_mem_pkt_yumi_lo[i])
+ 
+              ,.stat_mem_pkt_v_o(stat_mem_pkt_v_lo[i])
+              ,.stat_mem_pkt_o(stat_mem_pkt_lo[i])
+              ,.stat_mem_i(stat_mem_lo[i])
+              ,.stat_mem_pkt_yumi_i(stat_mem_pkt_yumi_lo[i])
+ 
+              ,.lce_req_header_o(lce_req_header_lo[i])
+              ,.lce_req_data_o(lce_req_data_lo[i])
+              ,.lce_req_v_o(lce_req_v_lo[i])
+              ,.lce_req_ready_then_i(lce_req_ready_and_li[i])
+ 
+              ,.lce_resp_header_o(lce_resp_header_lo[i])
+              ,.lce_resp_data_o(lce_resp_data_lo[i])
+              ,.lce_resp_v_o(lce_resp_v_lo[i])
+              ,.lce_resp_ready_then_i(lce_resp_ready_and_li[i])
+ 
+              ,.lce_cmd_header_i(lce_cmd_header_li[i])
+              ,.lce_cmd_data_i(lce_cmd_data_li[i])
+              ,.lce_cmd_v_i(lce_cmd_v_li[i])
+              ,.lce_cmd_yumi_o(lce_cmd_yumi_lo[i])
+ 
+              ,.lce_cmd_header_o(lce_cmd_header_lo[i])
+              ,.lce_cmd_data_o(lce_cmd_data_lo[i])
+              ,.lce_cmd_v_o(lce_cmd_v_lo[i])
+              ,.lce_cmd_ready_then_i(lce_cmd_ready_and_li[i])
+              );
+ 
+           // Request out
+           assign lce_req_packet_lo[i].header.msg_hdr = lce_req_header_lo[i];
+           assign lce_req_packet_lo[i].header.rtr_hdr.cid = '0;
+           assign lce_req_packet_lo[i].header.rtr_hdr.cord = '0;
+           assign lce_req_packet_lo[i].header.rtr_hdr.len = coh_noc_len_width_p'(0);
+           assign lce_req_packet_lo[i].data = lce_req_data_lo[i];
+ 
+           // Conversion from request packet to link format
+           assign lce_req_link_lo[i].data = lce_req_packet_lo[i];
+           assign lce_req_link_lo[i].v = lce_req_v_lo[i];
+           assign lce_req_link_lo[i].ready_and_rev = 1'b0;
+           assign lce_req_ready_and_li[i] = lce_req_link_li[i].ready_and_rev;
+ 
+           // Command out
+           assign lce_cmd_packet_lo[i].header.msg_hdr = lce_cmd_header_lo[i];
+           assign lce_cmd_packet_lo[i].header.rtr_hdr.cid = lce_cmd_header_lo[i].payload.dst_id;
+           assign lce_cmd_packet_lo[i].header.rtr_hdr.cord = '0;
+           assign lce_cmd_packet_lo[i].header.rtr_hdr.len = coh_noc_len_width_p'(0);
+           assign lce_cmd_packet_lo[i].data = lce_cmd_data_lo[i];
+ 
+           // Conversion from command link to command in
+           assign lce_cmd_link_lo[i].ready_and_rev = fifo_lce_cmd_ready_lo[i];
+           assign lce_cmd_packet_li[i] = fifo_lce_cmd_data_lo[i];
+           assign lce_cmd_header_li[i] = lce_cmd_packet_li[i].header.msg_hdr;
+           assign lce_cmd_data_li[i] = lce_cmd_packet_li[i].data;
+ 
+           // Conversion from command packet to link format
+           assign lce_cmd_link_lo[i].data = lce_cmd_packet_lo[i];
+           assign lce_cmd_link_lo[i].v = lce_cmd_v_lo[i];
+           assign lce_cmd_ready_and_li[i] = lce_cmd_link_li[i].ready_and_rev;
+ 
+           // LCE cmd demanding -> demanding conversion
+           bsg_two_fifo
+            #(.width_p($bits(bp_lce_cmd_wormhole_packet_s)))
+            cmd_fifo
+             (.clk_i(clk_i)
+              ,.reset_i(reset_i)
+ 
+              ,.data_i(lce_cmd_link_li[i].data)
+              ,.v_i(lce_cmd_link_li[i].v)
+              ,.ready_o(fifo_lce_cmd_ready_lo[i])
+ 
+              ,.data_o(fifo_lce_cmd_data_lo[i])
+              ,.v_o(lce_cmd_v_li[i])
+              ,.yumi_i(lce_cmd_yumi_lo[i])
+              );
+ 
+           // Response out
+           assign lce_resp_packet_lo[i].header.msg_hdr = lce_resp_header_lo[i];
+           assign lce_resp_packet_lo[i].header.rtr_hdr.cid = '0;
+           assign lce_resp_packet_lo[i].header.rtr_hdr.cord = '0;
+           assign lce_resp_packet_lo[i].header.rtr_hdr.len = coh_noc_len_width_p'(0);
+           assign lce_resp_packet_lo[i].data = lce_resp_data_lo[i];
+ 
+           // Conversion from response packet to link format
+           assign lce_resp_link_lo[i].data = lce_resp_packet_lo[i];
+           assign lce_resp_link_lo[i].v = lce_resp_v_lo[i];
+           assign lce_resp_link_lo[i].ready_and_rev = 1'b0;
+           assign lce_resp_ready_and_li[i] = lce_resp_link_li[i].ready_and_rev;
+         end
+       else if (uce_p == 1)
+         begin : uce
+          bp_uce
            #(.bp_params_p(bp_params_p)
+             ,.uce_mem_data_width_p(l2_fill_width_p)
              ,.assoc_p(assoc_p)
              ,.sets_p(sets_p)
              ,.block_width_p(block_width_p)
              ,.fill_width_p(fill_width_p)
-             ,.timeout_max_limit_p(4)
-             ,.credits_p(coh_noc_max_credits_p)
              ,.req_invert_clk_p(1)
              ,.data_mem_invert_clk_p(1)
              ,.tag_mem_invert_clk_p(1)
+             ,.stat_mem_invert_clk_p(1)
              )
-           dcache_lce
+           dcache_uce
             (.clk_i(clk_i)
              ,.reset_i(reset_i)
-
-             ,.lce_id_i(lce_id_width_p'(i))
-             ,.lce_mode_i(cfg_bus_cast_i.dcache_mode)
-
-             ,.cache_req_i(cache_req_lo[i])
-             ,.cache_req_v_i(cache_req_v_lo[i])
-             ,.cache_req_yumi_o(cache_req_yumi_lo[i])
-             ,.cache_req_busy_o(cache_req_busy_lo[i])
-             ,.cache_req_metadata_i(cache_req_metadata_lo[i])
-             ,.cache_req_metadata_v_i(cache_req_metadata_v_lo[i])
-             ,.cache_req_critical_tag_o(cache_req_critical_tag_lo[i])
-             ,.cache_req_critical_data_o(cache_req_critical_data_lo[i])
-             ,.cache_req_complete_o(cache_req_complete_lo[i])
-             ,.cache_req_credits_full_o(cache_req_credits_full_lo[i])
-             ,.cache_req_credits_empty_o(cache_req_credits_empty_lo[i])
-
-             ,.data_mem_pkt_v_o(data_mem_pkt_v_lo[i])
-             ,.data_mem_pkt_o(data_mem_pkt_lo[i])
-             ,.data_mem_i(data_mem_lo[i])
-             ,.data_mem_pkt_yumi_i(data_mem_pkt_yumi_lo[i])
-
-             ,.tag_mem_pkt_v_o(tag_mem_pkt_v_lo[i])
-             ,.tag_mem_pkt_o(tag_mem_pkt_lo[i])
-             ,.tag_mem_i(tag_mem_lo[i])
-             ,.tag_mem_pkt_yumi_i(tag_mem_pkt_yumi_lo[i])
-
-             ,.stat_mem_pkt_v_o(stat_mem_pkt_v_lo[i])
-             ,.stat_mem_pkt_o(stat_mem_pkt_lo[i])
-             ,.stat_mem_i(stat_mem_lo[i])
-             ,.stat_mem_pkt_yumi_i(stat_mem_pkt_yumi_lo[i])
-
-             ,.lce_req_header_o(lce_req_header_lo[i])
-             ,.lce_req_data_o(lce_req_data_lo[i])
-             ,.lce_req_v_o(lce_req_v_lo[i])
-             ,.lce_req_ready_then_i(lce_req_ready_and_li[i])
-
-             ,.lce_resp_header_o(lce_resp_header_lo[i])
-             ,.lce_resp_data_o(lce_resp_data_lo[i])
-             ,.lce_resp_v_o(lce_resp_v_lo[i])
-             ,.lce_resp_ready_then_i(lce_resp_ready_and_li[i])
-
-             ,.lce_cmd_header_i(lce_cmd_header_li[i])
-             ,.lce_cmd_data_i(lce_cmd_data_li[i])
-             ,.lce_cmd_v_i(lce_cmd_v_li[i])
-             ,.lce_cmd_yumi_o(lce_cmd_yumi_lo[i])
-
-             ,.lce_cmd_header_o(lce_cmd_header_lo[i])
-             ,.lce_cmd_data_o(lce_cmd_data_lo[i])
-             ,.lce_cmd_v_o(lce_cmd_v_lo[i])
-             ,.lce_cmd_ready_then_i(lce_cmd_ready_and_li[i])
+ 
+             ,.lce_id_i('0)
+ 
+             ,.cache_req_i(cache_req_lo)
+             ,.cache_req_v_i(cache_req_v_lo)
+             ,.cache_req_yumi_o(cache_req_yumi_lo)
+             ,.cache_req_busy_o(cache_req_busy_lo)
+             ,.cache_req_metadata_i(cache_req_metadata_lo)
+             ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
+             ,.cache_req_critical_tag_o(cache_req_critical_tag_lo)
+             ,.cache_req_critical_data_o(cache_req_critical_data_lo)
+             ,.cache_req_complete_o(cache_req_complete_lo)
+             ,.cache_req_credits_full_o(cache_req_credits_full_lo)
+             ,.cache_req_credits_empty_o(cache_req_credits_empty_lo)
+ 
+             ,.tag_mem_pkt_o(tag_mem_pkt_lo)
+             ,.tag_mem_pkt_v_o(tag_mem_pkt_v_lo)
+             ,.tag_mem_pkt_yumi_i(tag_mem_pkt_yumi_lo)
+             ,.tag_mem_i(tag_mem_lo)
+ 
+             ,.data_mem_pkt_o(data_mem_pkt_lo)
+             ,.data_mem_pkt_v_o(data_mem_pkt_v_lo)
+             ,.data_mem_pkt_yumi_i(data_mem_pkt_yumi_lo)
+             ,.data_mem_i(data_mem_lo)
+ 
+             ,.stat_mem_pkt_o(stat_mem_pkt_lo)
+             ,.stat_mem_pkt_v_o(stat_mem_pkt_v_lo)
+             ,.stat_mem_pkt_yumi_i(stat_mem_pkt_yumi_lo)
+             ,.stat_mem_i(stat_mem_lo)
+ 
+             ,.mem_cmd_header_o(mem_cmd_header_o)
+             ,.mem_cmd_data_o(mem_cmd_data_o)
+             ,.mem_cmd_v_o(mem_cmd_v_o)
+             ,.mem_cmd_ready_and_i(mem_cmd_ready_and_i)
+             ,.mem_cmd_last_o(mem_cmd_last_o)
+ 
+             ,.mem_resp_header_i(mem_resp_header_i)
+             ,.mem_resp_data_i(mem_resp_data_i)
+             ,.mem_resp_v_i(mem_resp_v_i)
+             ,.mem_resp_ready_and_o(mem_resp_ready_and_o)
+             ,.mem_resp_last_i(mem_resp_last_i)
              );
-
-          // Request out
-          assign lce_req_packet_lo[i].header.msg_hdr = lce_req_header_lo[i];
-          assign lce_req_packet_lo[i].header.rtr_hdr.cid = '0;
-          assign lce_req_packet_lo[i].header.rtr_hdr.cord = '0;
-          assign lce_req_packet_lo[i].header.rtr_hdr.len = coh_noc_len_width_p'(0);
-          assign lce_req_packet_lo[i].data = lce_req_data_lo[i];
-
-          // Conversion from request packet to link format
-          assign lce_req_link_lo[i].data = lce_req_packet_lo[i];
-          assign lce_req_link_lo[i].v = lce_req_v_lo[i];
-          assign lce_req_link_lo[i].ready_and_rev = 1'b0;
-          assign lce_req_ready_and_li[i] = lce_req_link_li[i].ready_and_rev;
-
-          // Command out
-          assign lce_cmd_packet_lo[i].header.msg_hdr = lce_cmd_header_lo[i];
-          assign lce_cmd_packet_lo[i].header.rtr_hdr.cid = lce_cmd_header_lo[i].payload.dst_id;
-          assign lce_cmd_packet_lo[i].header.rtr_hdr.cord = '0;
-          assign lce_cmd_packet_lo[i].header.rtr_hdr.len = coh_noc_len_width_p'(0);
-          assign lce_cmd_packet_lo[i].data = lce_cmd_data_lo[i];
-
-          // Conversion from command link to command in
-          assign lce_cmd_link_lo[i].ready_and_rev = fifo_lce_cmd_ready_lo[i];
-          assign lce_cmd_packet_li[i] = fifo_lce_cmd_data_lo[i];
-          assign lce_cmd_header_li[i] = lce_cmd_packet_li[i].header.msg_hdr;
-          assign lce_cmd_data_li[i] = lce_cmd_packet_li[i].data;
-
-          // Conversion from command packet to link format
-          assign lce_cmd_link_lo[i].data = lce_cmd_packet_lo[i];
-          assign lce_cmd_link_lo[i].v = lce_cmd_v_lo[i];
-          assign lce_cmd_ready_and_li[i] = lce_cmd_link_li[i].ready_and_rev;
-
-          // LCE cmd demanding -> demanding conversion
-          bsg_two_fifo
-           #(.width_p($bits(bp_lce_cmd_wormhole_packet_s)))
-           cmd_fifo
-            (.clk_i(clk_i)
-             ,.reset_i(reset_i)
-
-             ,.data_i(lce_cmd_link_li[i].data)
-             ,.v_i(lce_cmd_link_li[i].v)
-             ,.ready_o(fifo_lce_cmd_ready_lo[i])
-
-             ,.data_o(fifo_lce_cmd_data_lo[i])
-             ,.v_o(lce_cmd_v_li[i])
-             ,.yumi_i(lce_cmd_yumi_lo[i])
-             );
-
-          // Response out
-          assign lce_resp_packet_lo[i].header.msg_hdr = lce_resp_header_lo[i];
-          assign lce_resp_packet_lo[i].header.rtr_hdr.cid = '0;
-          assign lce_resp_packet_lo[i].header.rtr_hdr.cord = '0;
-          assign lce_resp_packet_lo[i].header.rtr_hdr.len = coh_noc_len_width_p'(0);
-          assign lce_resp_packet_lo[i].data = lce_resp_data_lo[i];
-
-          // Conversion from response packet to link format
-          assign lce_resp_link_lo[i].data = lce_resp_packet_lo[i];
-          assign lce_resp_link_lo[i].v = lce_resp_v_lo[i];
-          assign lce_resp_link_lo[i].ready_and_rev = 1'b0;
-          assign lce_resp_ready_and_li[i] = lce_resp_link_li[i].ready_and_rev;
         end
-      else if (uce_p == 1)
-        begin : uce
-         bp_uce
-          #(.bp_params_p(bp_params_p)
-            ,.uce_mem_data_width_p(l2_fill_width_p)
-            ,.assoc_p(assoc_p)
-            ,.sets_p(sets_p)
-            ,.block_width_p(block_width_p)
-            ,.fill_width_p(fill_width_p)
-            ,.req_invert_clk_p(1)
-            ,.data_mem_invert_clk_p(1)
-            ,.tag_mem_invert_clk_p(1)
-            ,.stat_mem_invert_clk_p(1)
-            )
-          dcache_uce
-           (.clk_i(clk_i)
-            ,.reset_i(reset_i)
-
-            ,.lce_id_i('0)
-
-            ,.cache_req_i(cache_req_lo)
-            ,.cache_req_v_i(cache_req_v_lo)
-            ,.cache_req_yumi_o(cache_req_yumi_lo)
-            ,.cache_req_busy_o(cache_req_busy_lo)
-            ,.cache_req_metadata_i(cache_req_metadata_lo)
-            ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
-            ,.cache_req_critical_tag_o(cache_req_critical_tag_lo)
-            ,.cache_req_critical_data_o(cache_req_critical_data_lo)
-            ,.cache_req_complete_o(cache_req_complete_lo)
-            ,.cache_req_credits_full_o(cache_req_credits_full_lo)
-            ,.cache_req_credits_empty_o(cache_req_credits_empty_lo)
-
-            ,.tag_mem_pkt_o(tag_mem_pkt_lo)
-            ,.tag_mem_pkt_v_o(tag_mem_pkt_v_lo)
-            ,.tag_mem_pkt_yumi_i(tag_mem_pkt_yumi_lo)
-            ,.tag_mem_i(tag_mem_lo)
-
-            ,.data_mem_pkt_o(data_mem_pkt_lo)
-            ,.data_mem_pkt_v_o(data_mem_pkt_v_lo)
-            ,.data_mem_pkt_yumi_i(data_mem_pkt_yumi_lo)
-            ,.data_mem_i(data_mem_lo)
-
-            ,.stat_mem_pkt_o(stat_mem_pkt_lo)
-            ,.stat_mem_pkt_v_o(stat_mem_pkt_v_lo)
-            ,.stat_mem_pkt_yumi_i(stat_mem_pkt_yumi_lo)
-            ,.stat_mem_i(stat_mem_lo)
-
-            ,.mem_cmd_header_o(mem_cmd_header_o)
-            ,.mem_cmd_data_o(mem_cmd_data_o)
-            ,.mem_cmd_v_o(mem_cmd_v_o)
-            ,.mem_cmd_ready_and_i(mem_cmd_ready_and_i)
-            ,.mem_cmd_last_o(mem_cmd_last_o)
-
-            ,.mem_resp_header_i(mem_resp_header_i)
-            ,.mem_resp_data_i(mem_resp_data_i)
-            ,.mem_resp_v_i(mem_resp_v_i)
-            ,.mem_resp_ready_and_o(mem_resp_ready_and_o)
-            ,.mem_resp_last_i(mem_resp_last_i)
-            );
-       end
-    end
-
-  if (uce_p == 0)
-    begin : concentrator
-      coh_req_ready_and_link_s req_concentrated_link_li, req_concentrated_link_lo, req_concentrated_link_r;
-      coh_cmd_ready_and_link_s cmd_concentrated_link_li, cmd_concentrated_link_lo, cmd_concentrated_link_r;
-      coh_resp_ready_and_link_s resp_concentrated_link_li, resp_concentrated_link_lo, resp_concentrated_link_r;
-
-      // CCE-LCE connections - BedRock Burst - to/from CCE
-      logic cce_lce_req_header_v, cce_lce_req_header_ready_and;
-      logic cce_lce_req_data_v, cce_lce_req_data_ready_and;
-      logic cce_lce_req_has_data, cce_lce_req_last;
-      logic cce_lce_resp_header_v, cce_lce_resp_header_ready_and;
-      logic cce_lce_resp_data_v, cce_lce_resp_data_ready_and;
-      logic cce_lce_resp_has_data, cce_lce_resp_last;
-      logic cce_lce_cmd_header_v, cce_lce_cmd_header_ready_and;
-      logic cce_lce_cmd_data_v, cce_lce_cmd_data_ready_and;
-      logic cce_lce_cmd_has_data, cce_lce_cmd_last;
-      bp_bedrock_lce_req_header_s cce_lce_req_header;
-      bp_bedrock_lce_resp_header_s cce_lce_resp_header;
-      bp_bedrock_lce_cmd_header_s cce_lce_cmd_header;
-      logic [dword_width_gp-1:0] cce_lce_req_data, cce_lce_resp_data, cce_lce_cmd_data;
-
-      // Request adapter to convert the link format to the CCE request input
-      // format
-      bp_lce_req_wormhole_packet_s cce_lce_req_packet_li;
-      bsg_wormhole_router_adapter_out
-       #(.max_payload_width_p($bits(bp_lce_req_wormhole_packet_s)-coh_noc_cord_width_p-coh_noc_len_width_p)
-         ,.len_width_p(coh_noc_len_width_p)
-         ,.cord_width_p(coh_noc_cord_width_p)
-         ,.flit_width_p($bits(bp_lce_req_wormhole_packet_s))
-         )
-       cce_req_adapter_out
-        (.clk_i(clk_i)
-         ,.reset_i(reset_i)
-
-         ,.link_i(req_concentrated_link_li)
-         ,.link_o(cce_lce_req_link_lo)
-
-         ,.packet_o(cce_lce_req_packet_li)
-         ,.v_o(cce_lce_req_v_li)
-         ,.yumi_i(cce_lce_req_yumi_lo)
-         );
-
-      assign cce_lce_req_header_li = cce_lce_req_packet_li.header.msg_hdr;
-      assign cce_lce_req_data_li = cce_lce_req_packet_li.data;
-
-      // LCE Request
-      logic cce_lce_req_ready_and_lo;
-      assign cce_lce_req_yumi_lo = cce_lce_req_v_li & cce_lce_req_ready_and_lo;
-      bp_me_lite_to_burst
-       #(.bp_params_p(bp_params_p)
-         ,.in_data_width_p(cce_block_width_p)
-         ,.out_data_width_p(dword_width_gp)
-         ,.payload_width_p(lce_req_payload_width_lp)
-         ,.payload_mask_p(lce_req_payload_mask_gp)
-         )
-       lce_req_lite2burst
-        (.clk_i(clk_i)
-         ,.reset_i(reset_i)
-
-         ,.in_msg_header_i(cce_lce_req_header_li)
-         ,.in_msg_data_i(cce_lce_req_data_li)
-         ,.in_msg_v_i(cce_lce_req_v_li)
-         ,.in_msg_ready_and_o(cce_lce_req_ready_and_lo)
-
-         ,.out_msg_header_o(cce_lce_req_header)
-         ,.out_msg_header_v_o(cce_lce_req_header_v)
-         ,.out_msg_header_ready_and_i(cce_lce_req_header_ready_and)
-         ,.out_msg_has_data_o(cce_lce_req_has_data)
-
-         ,.out_msg_data_o(cce_lce_req_data)
-         ,.out_msg_data_v_o(cce_lce_req_data_v)
-         ,.out_msg_data_ready_and_i(cce_lce_req_data_ready_and)
-         ,.out_msg_last_o(cce_lce_req_last)
-         );
-
-      // LCE Command
-      bp_me_burst_to_lite
-       #(.bp_params_p(bp_params_p)
-         ,.in_data_width_p(dword_width_gp)
-         ,.out_data_width_p(cce_block_width_p)
-         ,.payload_width_p(lce_cmd_payload_width_lp)
-         ,.payload_mask_p(lce_cmd_payload_mask_gp)
-         )
-       lce_cmd_burst2lite
-        (.clk_i(clk_i)
-         ,.reset_i(reset_i)
-
-         ,.in_msg_header_i(cce_lce_cmd_header)
-         ,.in_msg_header_v_i(cce_lce_cmd_header_v)
-         ,.in_msg_header_ready_and_o(cce_lce_cmd_header_ready_and)
-         ,.in_msg_has_data_i(cce_lce_cmd_has_data)
-
-         ,.in_msg_data_i(cce_lce_cmd_data)
-         ,.in_msg_data_v_i(cce_lce_cmd_data_v)
-         ,.in_msg_data_ready_and_o(cce_lce_cmd_data_ready_and)
-         ,.in_msg_last_i(cce_lce_cmd_last)
-
-         ,.out_msg_header_o(cce_lce_cmd_header_lo)
-         ,.out_msg_data_o(cce_lce_cmd_data_lo)
-         ,.out_msg_v_o(cce_lce_cmd_v_lo)
-         ,.out_msg_ready_and_i(cce_lce_cmd_ready_and_li)
-         );
-
-
-      bp_lce_cmd_wormhole_packet_s cce_lce_cmd_packet_lo;
-      assign cce_lce_cmd_packet_lo.header.msg_hdr = cce_lce_cmd_header_lo;
-      assign cce_lce_cmd_packet_lo.header.rtr_hdr.cid = cce_lce_cmd_header_lo.payload.dst_id;
-      assign cce_lce_cmd_packet_lo.header.rtr_hdr.cord = '0;
-      assign cce_lce_cmd_packet_lo.header.rtr_hdr.len = coh_noc_len_width_p'(0);
-      assign cce_lce_cmd_packet_lo.data = cce_lce_cmd_data_lo;
-
-      assign cce_lce_cmd_link_lo.data = cce_lce_cmd_packet_lo;
-      assign cce_lce_cmd_link_lo.v = cce_lce_cmd_v_lo;
-      assign cce_lce_cmd_link_lo.ready_and_rev = '0;
-      assign cce_lce_cmd_ready_and_li = cce_lce_cmd_link_li.ready_and_rev;
-
-      // Response adapter to convert from the link format to the CCE
-      // response input  format
-      bp_lce_resp_wormhole_packet_s cce_lce_resp_packet_li;
-      bsg_wormhole_router_adapter_out
-       #(.max_payload_width_p($bits(bp_lce_resp_wormhole_packet_s)-coh_noc_cord_width_p-coh_noc_len_width_p)
-         ,.len_width_p(coh_noc_len_width_p)
-         ,.cord_width_p(coh_noc_cord_width_p)
-         ,.flit_width_p($bits(bp_lce_resp_wormhole_packet_s))
-         )
-       cce_resp_adapter_out
-        (.clk_i(clk_i)
-         ,.reset_i(reset_i)
-
-         ,.link_i(resp_concentrated_link_li)
-         ,.link_o(cce_lce_resp_link_lo)
-
-         ,.packet_o(cce_lce_resp_packet_li)
-         ,.v_o(cce_lce_resp_v_li)
-         ,.yumi_i(cce_lce_resp_yumi_lo)
-         );
-      assign cce_lce_resp_header_li = cce_lce_resp_packet_li.header.msg_hdr;
-      assign cce_lce_resp_data_li = cce_lce_resp_packet_li.data;
-
-      // LCE Response
-      logic cce_lce_resp_ready_and_lo;
-      assign cce_lce_resp_yumi_lo = cce_lce_resp_v_li & cce_lce_resp_ready_and_lo;
-      bp_me_lite_to_burst
-       #(.bp_params_p(bp_params_p)
-         ,.in_data_width_p(cce_block_width_p)
-         ,.out_data_width_p(dword_width_gp)
-         ,.payload_width_p(lce_resp_payload_width_lp)
-         ,.payload_mask_p(lce_resp_payload_mask_gp)
-         )
-       lce_resp_lite2burst
-        (.clk_i(clk_i)
-         ,.reset_i(reset_i)
-
-         ,.in_msg_header_i(cce_lce_resp_header_li)
-         ,.in_msg_data_i(cce_lce_resp_data_li)
-         ,.in_msg_v_i(cce_lce_resp_v_li)
-         ,.in_msg_ready_and_o(cce_lce_resp_ready_and_lo)
-
-         ,.out_msg_header_o(cce_lce_resp_header)
-         ,.out_msg_header_v_o(cce_lce_resp_header_v)
-         ,.out_msg_header_ready_and_i(cce_lce_resp_header_ready_and)
-         ,.out_msg_has_data_o(cce_lce_resp_has_data)
-
-         ,.out_msg_data_o(cce_lce_resp_data)
-         ,.out_msg_data_v_o(cce_lce_resp_data_v)
-         ,.out_msg_data_ready_and_i(cce_lce_resp_data_ready_and)
-         ,.out_msg_last_o(cce_lce_resp_last)
-         );
-
-      assign req_concentrated_link_li = '{data          : req_concentrated_link_lo.data
-                                          ,v            : req_concentrated_link_lo.v
-                                          ,ready_and_rev: cce_lce_req_link_lo.ready_and_rev
-                                          };
-
-      // We use concentrators just for the 1 -> N arbitration capabilities,
-      // rather than serialization
-
-      // Request concentrator
-      bsg_wormhole_concentrator_in
-       #(.flit_width_p($bits(bp_lce_req_wormhole_packet_s))
-         ,.len_width_p(coh_noc_len_width_p)
-         ,.cid_width_p(coh_noc_cid_width_p)
-         ,.num_in_p(num_caches_p)
-         ,.cord_width_p(coh_noc_cord_width_p)
-         )
-       req_concentrator
-        (.clk_i(clk_i)
-         ,.reset_i(reset_i)
-
-         ,.links_i(lce_req_link_lo)
-         ,.links_o(lce_req_link_li)
-
-         ,.concentrated_link_i(req_concentrated_link_li)
-         ,.concentrated_link_o(req_concentrated_link_lo)
-         );
-
-      assign cmd_concentrated_link_li = cmd_concentrated_link_lo;
-      // Command concentrator
-      bsg_wormhole_concentrator
-       #(.flit_width_p($bits(bp_lce_cmd_wormhole_packet_s))
-         ,.len_width_p(coh_noc_len_width_p)
-         ,.cid_width_p(coh_noc_cid_width_p)
-         ,.num_in_p(num_caches_p+1)
-         ,.cord_width_p(coh_noc_cord_width_p)
-         )
-       cmd_concentrator
-        (.clk_i(clk_i)
-         ,.reset_i(reset_i)
-
-         ,.links_i({cce_lce_cmd_link_lo, lce_cmd_link_lo})
-         ,.links_o({cce_lce_cmd_link_li, lce_cmd_link_li})
-
-         ,.concentrated_link_i(cmd_concentrated_link_li)
-         ,.concentrated_link_o(cmd_concentrated_link_lo)
-         );
-
-      assign resp_concentrated_link_li = '{data          : resp_concentrated_link_lo.data
-                                           ,v            : resp_concentrated_link_lo.v
-                                           ,ready_and_rev: cce_lce_resp_link_lo.ready_and_rev
-                                          };
-
-      // Response concentrator
-      bsg_wormhole_concentrator_in
-       #(.flit_width_p($bits(bp_lce_resp_wormhole_packet_s))
-         ,.len_width_p(coh_noc_len_width_p)
-         ,.cid_width_p(coh_noc_cid_width_p)
-         ,.num_in_p(num_caches_p)
-         ,.cord_width_p(coh_noc_cord_width_p)
-         )
-       resp_concentrator
-        (.clk_i(clk_i)
-         ,.reset_i(reset_i)
-
-         ,.links_i(lce_resp_link_lo)
-         ,.links_o(lce_resp_link_li)
-
-         ,.concentrated_link_i(resp_concentrated_link_li)
-         ,.concentrated_link_o(resp_concentrated_link_lo)
-         );
-
-      bp_cce_fsm
-       #(.bp_params_p(bp_params_p))
-       cce
-        (.clk_i(clk_i)
-         ,.reset_i(reset_i)
-
-         ,.cfg_bus_i(cfg_bus_i)
-
-         // LCE-CCE Interface
-         // BedRock Burst protocol: ready&valid
-         ,.lce_req_header_i(cce_lce_req_header)
-         ,.lce_req_header_v_i(cce_lce_req_header_v)
-         ,.lce_req_header_ready_and_o(cce_lce_req_header_ready_and)
-         ,.lce_req_has_data_i(cce_lce_req_has_data)
-         ,.lce_req_data_i(cce_lce_req_data)
-         ,.lce_req_data_v_i(cce_lce_req_data_v)
-         ,.lce_req_data_ready_and_o(cce_lce_req_data_ready_and)
-         ,.lce_req_last_i(cce_lce_req_last)
-
-         ,.lce_resp_header_i(cce_lce_resp_header)
-         ,.lce_resp_header_v_i(cce_lce_resp_header_v)
-         ,.lce_resp_header_ready_and_o(cce_lce_resp_header_ready_and)
-         ,.lce_resp_has_data_i(cce_lce_resp_has_data)
-         ,.lce_resp_data_i(cce_lce_resp_data)
-         ,.lce_resp_data_v_i(cce_lce_resp_data_v)
-         ,.lce_resp_data_ready_and_o(cce_lce_resp_data_ready_and)
-         ,.lce_resp_last_i(cce_lce_resp_last)
-
-         ,.lce_cmd_header_o(cce_lce_cmd_header)
-         ,.lce_cmd_header_v_o(cce_lce_cmd_header_v)
-         ,.lce_cmd_header_ready_and_i(cce_lce_cmd_header_ready_and)
-         ,.lce_cmd_has_data_o(cce_lce_cmd_has_data)
-         ,.lce_cmd_data_o(cce_lce_cmd_data)
-         ,.lce_cmd_data_v_o(cce_lce_cmd_data_v)
-         ,.lce_cmd_data_ready_and_i(cce_lce_cmd_data_ready_and)
-         ,.lce_cmd_last_o(cce_lce_cmd_last)
-
-         // CCE-MEM Interface
-         // BedRock Stream protocol: ready&valid
-         // TODO: match data widths with top-level
-         ,.mem_resp_header_i(mem_resp_header_i)
-         ,.mem_resp_data_i(mem_resp_data_i)
-         ,.mem_resp_v_i(mem_resp_v_i)
-         ,.mem_resp_ready_and_o(mem_resp_ready_and_o)
-         ,.mem_resp_last_i(mem_resp_last_i)
-
-         ,.mem_cmd_header_o(mem_cmd_header_o)
-         ,.mem_cmd_data_o(mem_cmd_data_o)
-         ,.mem_cmd_v_o(mem_cmd_v_o)
-         ,.mem_cmd_ready_and_i(mem_cmd_ready_and_i)
-         ,.mem_cmd_last_o(mem_cmd_last_o)
-         );
-    end
+     end
+ 
+   if (uce_p == 0)
+     begin : concentrator
+       coh_req_ready_and_link_s req_concentrated_link_li, req_concentrated_link_lo, req_concentrated_link_r;
+       coh_cmd_ready_and_link_s cmd_concentrated_link_li, cmd_concentrated_link_lo, cmd_concentrated_link_r;
+       coh_resp_ready_and_link_s resp_concentrated_link_li, resp_concentrated_link_lo, resp_concentrated_link_r;
+ 
+       // CCE-LCE connections - BedRock Burst - to/from CCE
+       logic cce_lce_req_header_v, cce_lce_req_header_ready_and;
+       logic cce_lce_req_data_v, cce_lce_req_data_ready_and;
+       logic cce_lce_req_has_data, cce_lce_req_last;
+       logic cce_lce_resp_header_v, cce_lce_resp_header_ready_and;
+       logic cce_lce_resp_data_v, cce_lce_resp_data_ready_and;
+       logic cce_lce_resp_has_data, cce_lce_resp_last;
+       logic cce_lce_cmd_header_v, cce_lce_cmd_header_ready_and;
+       logic cce_lce_cmd_data_v, cce_lce_cmd_data_ready_and;
+       logic cce_lce_cmd_has_data, cce_lce_cmd_last;
+       bp_bedrock_lce_req_header_s cce_lce_req_header;
+       bp_bedrock_lce_resp_header_s cce_lce_resp_header;
+       bp_bedrock_lce_cmd_header_s cce_lce_cmd_header;
+       logic [dword_width_gp-1:0] cce_lce_req_data, cce_lce_resp_data, cce_lce_cmd_data;
+ 
+       // Request adapter to convert the link format to the CCE request input
+       // format
+       bp_lce_req_wormhole_packet_s cce_lce_req_packet_li;
+       bsg_wormhole_router_adapter_out
+        #(.max_payload_width_p($bits(bp_lce_req_wormhole_packet_s)-coh_noc_cord_width_p-coh_noc_len_width_p)
+          ,.len_width_p(coh_noc_len_width_p)
+          ,.cord_width_p(coh_noc_cord_width_p)
+          ,.flit_width_p($bits(bp_lce_req_wormhole_packet_s))
+          )
+        cce_req_adapter_out
+         (.clk_i(clk_i)
+          ,.reset_i(reset_i)
+ 
+          ,.link_i(req_concentrated_link_li)
+          ,.link_o(cce_lce_req_link_lo)
+ 
+          ,.packet_o(cce_lce_req_packet_li)
+          ,.v_o(cce_lce_req_v_li)
+          ,.yumi_i(cce_lce_req_yumi_lo)
+          );
+ 
+       assign cce_lce_req_header_li = cce_lce_req_packet_li.header.msg_hdr;
+       assign cce_lce_req_data_li = cce_lce_req_packet_li.data;
+ 
+       // LCE Request
+       logic cce_lce_req_ready_and_lo;
+       assign cce_lce_req_yumi_lo = cce_lce_req_v_li & cce_lce_req_ready_and_lo;
+       bp_me_lite_to_burst
+        #(.bp_params_p(bp_params_p)
+          ,.in_data_width_p(cce_block_width_p)
+          ,.out_data_width_p(dword_width_gp)
+          ,.payload_width_p(lce_req_payload_width_lp)
+          ,.payload_mask_p(lce_req_payload_mask_gp)
+          )
+        lce_req_lite2burst
+         (.clk_i(clk_i)
+          ,.reset_i(reset_i)
+ 
+          ,.in_msg_header_i(cce_lce_req_header_li)
+          ,.in_msg_data_i(cce_lce_req_data_li)
+          ,.in_msg_v_i(cce_lce_req_v_li)
+          ,.in_msg_ready_and_o(cce_lce_req_ready_and_lo)
+ 
+          ,.out_msg_header_o(cce_lce_req_header)
+          ,.out_msg_header_v_o(cce_lce_req_header_v)
+          ,.out_msg_header_ready_and_i(cce_lce_req_header_ready_and)
+          ,.out_msg_has_data_o(cce_lce_req_has_data)
+ 
+          ,.out_msg_data_o(cce_lce_req_data)
+          ,.out_msg_data_v_o(cce_lce_req_data_v)
+          ,.out_msg_data_ready_and_i(cce_lce_req_data_ready_and)
+          ,.out_msg_last_o(cce_lce_req_last)
+          );
+ 
+       // LCE Command
+       bp_me_burst_to_lite
+        #(.bp_params_p(bp_params_p)
+          ,.in_data_width_p(dword_width_gp)
+          ,.out_data_width_p(cce_block_width_p)
+          ,.payload_width_p(lce_cmd_payload_width_lp)
+          ,.payload_mask_p(lce_cmd_payload_mask_gp)
+          )
+        lce_cmd_burst2lite
+         (.clk_i(clk_i)
+          ,.reset_i(reset_i)
+ 
+          ,.in_msg_header_i(cce_lce_cmd_header)
+          ,.in_msg_header_v_i(cce_lce_cmd_header_v)
+          ,.in_msg_header_ready_and_o(cce_lce_cmd_header_ready_and)
+          ,.in_msg_has_data_i(cce_lce_cmd_has_data)
+ 
+          ,.in_msg_data_i(cce_lce_cmd_data)
+          ,.in_msg_data_v_i(cce_lce_cmd_data_v)
+          ,.in_msg_data_ready_and_o(cce_lce_cmd_data_ready_and)
+          ,.in_msg_last_i(cce_lce_cmd_last)
+ 
+          ,.out_msg_header_o(cce_lce_cmd_header_lo)
+          ,.out_msg_data_o(cce_lce_cmd_data_lo)
+          ,.out_msg_v_o(cce_lce_cmd_v_lo)
+          ,.out_msg_ready_and_i(cce_lce_cmd_ready_and_li)
+          );
+ 
+ 
+       bp_lce_cmd_wormhole_packet_s cce_lce_cmd_packet_lo;
+       assign cce_lce_cmd_packet_lo.header.msg_hdr = cce_lce_cmd_header_lo;
+       assign cce_lce_cmd_packet_lo.header.rtr_hdr.cid = cce_lce_cmd_header_lo.payload.dst_id;
+       assign cce_lce_cmd_packet_lo.header.rtr_hdr.cord = '0;
+       assign cce_lce_cmd_packet_lo.header.rtr_hdr.len = coh_noc_len_width_p'(0);
+       assign cce_lce_cmd_packet_lo.data = cce_lce_cmd_data_lo;
+ 
+       assign cce_lce_cmd_link_lo.data = cce_lce_cmd_packet_lo;
+       assign cce_lce_cmd_link_lo.v = cce_lce_cmd_v_lo;
+       assign cce_lce_cmd_link_lo.ready_and_rev = '0;
+       assign cce_lce_cmd_ready_and_li = cce_lce_cmd_link_li.ready_and_rev;
+ 
+       // Response adapter to convert from the link format to the CCE
+       // response input  format
+       bp_lce_resp_wormhole_packet_s cce_lce_resp_packet_li;
+       bsg_wormhole_router_adapter_out
+        #(.max_payload_width_p($bits(bp_lce_resp_wormhole_packet_s)-coh_noc_cord_width_p-coh_noc_len_width_p)
+          ,.len_width_p(coh_noc_len_width_p)
+          ,.cord_width_p(coh_noc_cord_width_p)
+          ,.flit_width_p($bits(bp_lce_resp_wormhole_packet_s))
+          )
+        cce_resp_adapter_out
+         (.clk_i(clk_i)
+          ,.reset_i(reset_i)
+ 
+          ,.link_i(resp_concentrated_link_li)
+          ,.link_o(cce_lce_resp_link_lo)
+ 
+          ,.packet_o(cce_lce_resp_packet_li)
+          ,.v_o(cce_lce_resp_v_li)
+          ,.yumi_i(cce_lce_resp_yumi_lo)
+          );
+       assign cce_lce_resp_header_li = cce_lce_resp_packet_li.header.msg_hdr;
+       assign cce_lce_resp_data_li = cce_lce_resp_packet_li.data;
+ 
+       // LCE Response
+       logic cce_lce_resp_ready_and_lo;
+       assign cce_lce_resp_yumi_lo = cce_lce_resp_v_li & cce_lce_resp_ready_and_lo;
+       bp_me_lite_to_burst
+        #(.bp_params_p(bp_params_p)
+          ,.in_data_width_p(cce_block_width_p)
+          ,.out_data_width_p(dword_width_gp)
+          ,.payload_width_p(lce_resp_payload_width_lp)
+          ,.payload_mask_p(lce_resp_payload_mask_gp)
+          )
+        lce_resp_lite2burst
+         (.clk_i(clk_i)
+          ,.reset_i(reset_i)
+ 
+          ,.in_msg_header_i(cce_lce_resp_header_li)
+          ,.in_msg_data_i(cce_lce_resp_data_li)
+          ,.in_msg_v_i(cce_lce_resp_v_li)
+          ,.in_msg_ready_and_o(cce_lce_resp_ready_and_lo)
+ 
+          ,.out_msg_header_o(cce_lce_resp_header)
+          ,.out_msg_header_v_o(cce_lce_resp_header_v)
+          ,.out_msg_header_ready_and_i(cce_lce_resp_header_ready_and)
+          ,.out_msg_has_data_o(cce_lce_resp_has_data)
+ 
+          ,.out_msg_data_o(cce_lce_resp_data)
+          ,.out_msg_data_v_o(cce_lce_resp_data_v)
+          ,.out_msg_data_ready_and_i(cce_lce_resp_data_ready_and)
+          ,.out_msg_last_o(cce_lce_resp_last)
+          );
+ 
+       assign req_concentrated_link_li = '{data          : req_concentrated_link_lo.data
+                                           ,v            : req_concentrated_link_lo.v
+                                           ,ready_and_rev: cce_lce_req_link_lo.ready_and_rev
+                                           };
+ 
+       // We use concentrators just for the 1 -> N arbitration capabilities,
+       // rather than serialization
+ 
+       // Request concentrator
+       bsg_wormhole_concentrator_in
+        #(.flit_width_p($bits(bp_lce_req_wormhole_packet_s))
+          ,.len_width_p(coh_noc_len_width_p)
+          ,.cid_width_p(coh_noc_cid_width_p)
+          ,.num_in_p(num_caches_p)
+          ,.cord_width_p(coh_noc_cord_width_p)
+          )
+        req_concentrator
+         (.clk_i(clk_i)
+          ,.reset_i(reset_i)
+ 
+          ,.links_i(lce_req_link_lo)
+          ,.links_o(lce_req_link_li)
+ 
+          ,.concentrated_link_i(req_concentrated_link_li)
+          ,.concentrated_link_o(req_concentrated_link_lo)
+          );
+ 
+       assign cmd_concentrated_link_li = cmd_concentrated_link_lo;
+       // Command concentrator
+       bsg_wormhole_concentrator
+        #(.flit_width_p($bits(bp_lce_cmd_wormhole_packet_s))
+          ,.len_width_p(coh_noc_len_width_p)
+          ,.cid_width_p(coh_noc_cid_width_p)
+          ,.num_in_p(num_caches_p+1)
+          ,.cord_width_p(coh_noc_cord_width_p)
+          )
+        cmd_concentrator
+         (.clk_i(clk_i)
+          ,.reset_i(reset_i)
+ 
+          ,.links_i({cce_lce_cmd_link_lo, lce_cmd_link_lo})
+          ,.links_o({cce_lce_cmd_link_li, lce_cmd_link_li})
+ 
+          ,.concentrated_link_i(cmd_concentrated_link_li)
+          ,.concentrated_link_o(cmd_concentrated_link_lo)
+          );
+ 
+       assign resp_concentrated_link_li = '{data          : resp_concentrated_link_lo.data
+                                            ,v            : resp_concentrated_link_lo.v
+                                            ,ready_and_rev: cce_lce_resp_link_lo.ready_and_rev
+                                           };
+ 
+       // Response concentrator
+       bsg_wormhole_concentrator_in
+        #(.flit_width_p($bits(bp_lce_resp_wormhole_packet_s))
+          ,.len_width_p(coh_noc_len_width_p)
+          ,.cid_width_p(coh_noc_cid_width_p)
+          ,.num_in_p(num_caches_p)
+          ,.cord_width_p(coh_noc_cord_width_p)
+          )
+        resp_concentrator
+         (.clk_i(clk_i)
+          ,.reset_i(reset_i)
+ 
+          ,.links_i(lce_resp_link_lo)
+          ,.links_o(lce_resp_link_li)
+ 
+          ,.concentrated_link_i(resp_concentrated_link_li)
+          ,.concentrated_link_o(resp_concentrated_link_lo)
+          );
+ 
+       bp_cce_fsm
+        #(.bp_params_p(bp_params_p))
+        cce
+         (.clk_i(clk_i)
+          ,.reset_i(reset_i)
+ 
+          ,.cfg_bus_i(cfg_bus_i)
+ 
+          // LCE-CCE Interface
+          // BedRock Burst protocol: ready&valid
+          ,.lce_req_header_i(cce_lce_req_header)
+          ,.lce_req_header_v_i(cce_lce_req_header_v)
+          ,.lce_req_header_ready_and_o(cce_lce_req_header_ready_and)
+          ,.lce_req_has_data_i(cce_lce_req_has_data)
+          ,.lce_req_data_i(cce_lce_req_data)
+          ,.lce_req_data_v_i(cce_lce_req_data_v)
+          ,.lce_req_data_ready_and_o(cce_lce_req_data_ready_and)
+          ,.lce_req_last_i(cce_lce_req_last)
+ 
+          ,.lce_resp_header_i(cce_lce_resp_header)
+          ,.lce_resp_header_v_i(cce_lce_resp_header_v)
+          ,.lce_resp_header_ready_and_o(cce_lce_resp_header_ready_and)
+          ,.lce_resp_has_data_i(cce_lce_resp_has_data)
+          ,.lce_resp_data_i(cce_lce_resp_data)
+          ,.lce_resp_data_v_i(cce_lce_resp_data_v)
+          ,.lce_resp_data_ready_and_o(cce_lce_resp_data_ready_and)
+          ,.lce_resp_last_i(cce_lce_resp_last)
+ 
+          ,.lce_cmd_header_o(cce_lce_cmd_header)
+          ,.lce_cmd_header_v_o(cce_lce_cmd_header_v)
+          ,.lce_cmd_header_ready_and_i(cce_lce_cmd_header_ready_and)
+          ,.lce_cmd_has_data_o(cce_lce_cmd_has_data)
+          ,.lce_cmd_data_o(cce_lce_cmd_data)
+          ,.lce_cmd_data_v_o(cce_lce_cmd_data_v)
+          ,.lce_cmd_data_ready_and_i(cce_lce_cmd_data_ready_and)
+          ,.lce_cmd_last_o(cce_lce_cmd_last)
+ 
+          // CCE-MEM Interface
+          // BedRock Stream protocol: ready&valid
+          // TODO: match data widths with top-level
+          ,.mem_resp_header_i(mem_resp_header_i)
+          ,.mem_resp_data_i(mem_resp_data_i)
+          ,.mem_resp_v_i(mem_resp_v_i)
+          ,.mem_resp_ready_and_o(mem_resp_ready_and_o)
+          ,.mem_resp_last_i(mem_resp_last_i)
+ 
+          ,.mem_cmd_header_o(mem_cmd_header_o)
+          ,.mem_cmd_data_o(mem_cmd_data_o)
+          ,.mem_cmd_v_o(mem_cmd_v_o)
+          ,.mem_cmd_ready_and_i(mem_cmd_ready_and_i)
+          ,.mem_cmd_last_o(mem_cmd_last_o)
+          );
+     end
 
 endmodule
 

--- a/bp_common/src/v/bp_mmu.sv
+++ b/bp_common/src/v/bp_mmu.sv
@@ -33,6 +33,7 @@ module bp_mmu
    , input                                            r_load_i
    , input                                            r_store_i
    , input [dword_width_gp-1:0]                       r_eaddr_i
+   , input [1:0]                                      r_size_i
 
    , output logic                                     r_v_o
    , output logic [ptag_width_p-1:0]                  r_ptag_o
@@ -169,6 +170,18 @@ module bp_mmu
   wire store_page_fault_v = trans_en_r & r_store_r & (data_priv_page_fault | data_write_page_fault | eaddr_fault_v);
   wire any_page_fault_v   = |{instr_page_fault_v, load_page_fault_v, store_page_fault_v};
 
+  // This logic only works for 8-byte words max.
+  logic r_misaligned_n, r_misaligned_r;
+  always_comb
+    case (r_size_i)
+      2'b01: r_misaligned_n = |r_eaddr_i[0+:1];
+      2'b10: r_misaligned_n = |r_eaddr_i[0+:2];
+      2'b11: r_misaligned_n = |r_eaddr_i[0+:3];
+      default: r_misaligned_n = '0;
+    endcase
+  always_ff @(posedge clk_i)
+    r_misaligned_r <= r_misaligned_n;
+
   assign r_v_o                   = r_v_r &  tlb_v_lo & ~any_access_fault_v & ~any_page_fault_v;
   assign r_ptag_o                = ptag_lo;
   assign r_instr_miss_o          = r_v_r & ~tlb_v_lo & r_instr_r & ~any_access_fault_v & ~any_page_fault_v;;
@@ -177,9 +190,9 @@ module bp_mmu
   assign r_uncached_o            = r_v_r &  tlb_v_lo & ptag_uncached_lo;
   assign r_nonidem_o             = r_v_r &  tlb_v_lo & ptag_nonidem_lo;
   assign r_dram_o                = r_v_r &  tlb_v_lo & ptag_dram_lo;
-  assign r_instr_misaligned_o    = '0;
-  assign r_load_misaligned_o     = '0;
-  assign r_store_misaligned_o    = '0;
+  assign r_instr_misaligned_o    = r_v_r & r_misaligned_r & r_instr_r;
+  assign r_load_misaligned_o     = r_v_r & r_misaligned_r & r_load_r;
+  assign r_store_misaligned_o    = r_v_r & r_misaligned_r & r_store_r;
   assign r_instr_access_fault_o  = r_v_r & instr_access_fault_v;
   assign r_load_access_fault_o   = r_v_r & load_access_fault_v;
   assign r_store_access_fault_o  = r_v_r & store_access_fault_v;

--- a/bp_common/src/v/bp_mmu.sv
+++ b/bp_common/src/v/bp_mmu.sv
@@ -36,13 +36,18 @@ module bp_mmu
 
    , output logic                                     r_v_o
    , output logic [ptag_width_p-1:0]                  r_ptag_o
-   , output logic                                     r_miss_o
+   , output logic                                     r_instr_miss_o
+   , output logic                                     r_load_miss_o
+   , output logic                                     r_store_miss_o
    , output logic                                     r_uncached_o
    , output logic                                     r_nonidem_o
    , output logic                                     r_dram_o
    , output logic                                     r_instr_access_fault_o
    , output logic                                     r_load_access_fault_o
    , output logic                                     r_store_access_fault_o
+   , output logic                                     r_instr_misaligned_o
+   , output logic                                     r_load_misaligned_o
+   , output logic                                     r_store_misaligned_o
    , output logic                                     r_instr_page_fault_o
    , output logic                                     r_load_page_fault_o
    , output logic                                     r_store_page_fault_o
@@ -166,10 +171,15 @@ module bp_mmu
 
   assign r_v_o                   = r_v_r &  tlb_v_lo & ~any_access_fault_v & ~any_page_fault_v;
   assign r_ptag_o                = ptag_lo;
-  assign r_miss_o                = r_v_r & ~tlb_v_lo & ~any_access_fault_v & ~any_page_fault_v;;
+  assign r_instr_miss_o          = r_v_r & ~tlb_v_lo & r_instr_r & ~any_access_fault_v & ~any_page_fault_v;;
+  assign r_load_miss_o           = r_v_r & ~tlb_v_lo & r_load_r  & ~any_access_fault_v & ~any_page_fault_v;;
+  assign r_store_miss_o          = r_v_r & ~tlb_v_lo & r_store_r & ~any_access_fault_v & ~any_page_fault_v;;
   assign r_uncached_o            = r_v_r &  tlb_v_lo & ptag_uncached_lo;
   assign r_nonidem_o             = r_v_r &  tlb_v_lo & ptag_nonidem_lo;
   assign r_dram_o                = r_v_r &  tlb_v_lo & ptag_dram_lo;
+  assign r_instr_misaligned_o    = '0;
+  assign r_load_misaligned_o     = '0;
+  assign r_store_misaligned_o    = '0;
   assign r_instr_access_fault_o  = r_v_r & instr_access_fault_v;
   assign r_load_access_fault_o   = r_v_r & load_access_fault_v;
   assign r_store_access_fault_o  = r_v_r & store_access_fault_v;

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -210,7 +210,7 @@ module bp_fe_top
   assign attaboy_v_li               = attaboy_v;
   assign attaboy_pc_li              = fe_cmd_cast_i.vaddr;
 
-  logic instr_access_fault_v, instr_page_fault_v;
+  logic instr_misaligned_v, instr_access_fault_v, instr_page_fault_v;
   logic ptag_v_li, ptag_uncached_li, ptag_nonidem_li, ptag_dram_li, ptag_miss_li;
   logic [ptag_width_p-1:0] ptag_li;
 
@@ -249,10 +249,15 @@ module bp_fe_top
 
      ,.r_v_o(ptag_v_li)
      ,.r_ptag_o(ptag_li)
-     ,.r_miss_o(ptag_miss_li)
+     ,.r_instr_miss_o(ptag_miss_li)
+     ,.r_load_miss_o()
+     ,.r_store_miss_o()
      ,.r_uncached_o(ptag_uncached_li)
      ,.r_nonidem_o(ptag_nonidem_li)
      ,.r_dram_o(ptag_dram_li)
+     ,.r_instr_misaligned_o(instr_misaligned_v)
+     ,.r_load_misaligned_o()
+     ,.r_store_misaligned_o()
      ,.r_instr_access_fault_o(instr_access_fault_v)
      ,.r_load_access_fault_o()
      ,.r_store_access_fault_o()
@@ -322,15 +327,15 @@ module bp_fe_top
      ,.stat_mem_o(stat_mem_o)
      );
 
-  logic itlb_miss_r, instr_access_fault_r, instr_page_fault_r;
+  logic itlb_miss_r, instr_misaligned_r, instr_access_fault_r, instr_page_fault_r;
   bsg_dff_reset
-   #(.width_p(3))
+   #(.width_p(4))
    fault_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.data_i({ptag_miss_li, instr_access_fault_v, instr_page_fault_v})
-     ,.data_o({itlb_miss_r, instr_access_fault_r, instr_page_fault_r})
+     ,.data_i({ptag_miss_li, instr_misaligned_v, instr_access_fault_v, instr_page_fault_v})
+     ,.data_o({itlb_miss_r, instr_misaligned_r, instr_access_fault_r, instr_page_fault_r})
      );
 
   logic v_if1_r, v_if2_r;
@@ -348,7 +353,7 @@ module bp_fe_top
 
   wire icache_miss    = v_if2_r & ~icache_data_v_lo;
   wire queue_miss     = v_if2_r & ~fe_queue_ready_i;
-  wire fe_exception_v = v_if2_r & (instr_access_fault_r | instr_page_fault_r | itlb_miss_r | icache_miss_v_lo);
+  wire fe_exception_v = v_if2_r & (instr_misaligned_r | instr_access_fault_r | instr_page_fault_r | itlb_miss_r | icache_miss_v_lo);
   wire fe_instr_v     = v_if2_r & icache_data_v_lo;
   assign fe_queue_v_o = fe_queue_ready_i & (fe_instr_v | fe_exception_v) & ~cmd_nonattaboy_v;
 
@@ -372,11 +377,13 @@ module bp_fe_top
         fe_queue_cast_o.msg.exception.vaddr          = fetch_pc_lo;
         fe_queue_cast_o.msg.exception.exception_code = itlb_miss_r
                                                        ? e_itlb_miss
-                                                       : instr_page_fault_r
-                                                         ? e_instr_page_fault
-                                                         : instr_access_fault_r
-                                                           ? e_instr_access_fault
-                                                           : e_icache_miss;
+                                                       : instr_misaligned_r
+                                                         ? e_instr_misaligned
+                                                           : instr_page_fault_r
+                                                             ? e_instr_page_fault
+                                                             : instr_access_fault_r
+                                                               ? e_instr_access_fault
+                                                                 : e_icache_miss;
       end
     else
       begin

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -219,6 +219,7 @@ module bp_fe_top
   assign w_tlb_entry_li = fe_cmd_cast_i.operands.itlb_fill_response.pte_leaf;
 
   wire [dword_width_gp-1:0] r_eaddr_li = `BSG_SIGN_EXTEND(next_pc_lo, dword_width_gp);
+  wire [1:0] r_size_li = 2'b10;
   bp_mmu
    #(.bp_params_p(bp_params_p)
      ,.tlb_els_4k_p(itlb_els_4k_p)
@@ -246,6 +247,7 @@ module bp_fe_top
      ,.r_load_i('0)
      ,.r_store_i('0)
      ,.r_eaddr_i(r_eaddr_li)
+     ,.r_size_i(r_size_li)
 
      ,.r_v_o(ptag_v_li)
      ,.r_ptag_o(ptag_li)

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -1,5 +1,7 @@
+
 `include "bp_common_defines.svh"
-`include "bp_top_defines.svh"
+`include "bp_be_defines.svh"
+`include "bp_me_defines.svh"
 
 module bp_cacc_vdp
  import bp_common_pkg::*;

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -49,6 +49,7 @@ module bp_cacc_vdp
     , input                                       io_resp_yumi_i
     );
 
+  `declare_bp_be_dcache_pkt_s(vaddr_width_p);
   bp_be_dcache_pkt_s        dcache_pkt;
   logic                     dcache_ready, dcache_v;
   logic [dpath_width_gp-1:0] dcache_data;

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -123,6 +123,7 @@ module bp_cacc_vdp
      ,.early_hit_v_o(dcache_v)
      ,.early_miss_v_o()
      ,.early_data_o(dcache_data)
+     ,.early_fencei_o()
      ,.final_v_o()
      ,.final_data_o()
      ,.late_rd_addr_o()
@@ -395,7 +396,7 @@ module bp_cacc_vdp
         dcache_ptag = {(ptag_width_p-vtag_width_p)'(0), v_addr[vaddr_width_p-1-:vtag_width_p]};
         dcache_pkt.opcode = load ? e_dcache_op_ld : e_dcache_op_sd;
         dcache_pkt.data = load ? '0 : dot_product_res;
-        dcache_pkt.page_offset = v_addr[0+:page_offset_width_gp];
+        dcache_pkt.vaddr = v_addr;
         dcache_pkt.rd_addr = '0; 
         res_status = '0;
         dcache_pkt_v = '1;
@@ -406,7 +407,7 @@ module bp_cacc_vdp
         res_status = '0;
         dcache_ptag = {(ptag_width_p-vtag_width_p)'(0), v_addr[vaddr_width_p-1-:vtag_width_p]};
         dcache_pkt.opcode = load ? e_dcache_op_ld : e_dcache_op_sd;
-        dcache_pkt.page_offset = v_addr[0+:page_offset_width_gp];
+        dcache_pkt.vaddr = v_addr;
         dcache_pkt.rd_addr = '0; 
         dcache_pkt.data = load ? '0 : dot_product_res;
         dcache_pkt_v = '0;
@@ -420,7 +421,7 @@ module bp_cacc_vdp
         dcache_ptag = {(ptag_width_p-vtag_width_p)'(0), v_addr[vaddr_width_p-1-:vtag_width_p]};
         dcache_pkt.opcode = load ? e_dcache_op_ld : e_dcache_op_sd;
         dcache_pkt.data = load ? '0 : dot_product_res;
-        dcache_pkt.page_offset = v_addr[0+:page_offset_width_gp];
+        dcache_pkt.vaddr = v_addr;
         dcache_pkt.rd_addr = '0; 
         dcache_pkt_v = '0;
         done = 0;
@@ -431,7 +432,7 @@ module bp_cacc_vdp
         dcache_ptag = {(ptag_width_p-vtag_width_p)'(0), v_addr[vaddr_width_p-1-:vtag_width_p]};
         dcache_pkt.opcode = load ? e_dcache_op_ld : e_dcache_op_sd;
         dcache_pkt.data = load ? '0 : dot_product_res;
-        dcache_pkt.page_offset = v_addr[0+:page_offset_width_gp];
+        dcache_pkt.vaddr = v_addr;
         dcache_pkt.rd_addr = '0; 
         dcache_pkt_v = '0;
         done = 0;
@@ -442,7 +443,7 @@ module bp_cacc_vdp
         dcache_ptag = {(ptag_width_p-vtag_width_p)'(0), v_addr[vaddr_width_p-1-:vtag_width_p]};
         dcache_pkt.opcode = load ? e_dcache_op_ld : e_dcache_op_sd;
         dcache_pkt.data = load ? '0 : dot_product_res;
-        dcache_pkt.page_offset = v_addr[0+:page_offset_width_gp];
+        dcache_pkt.vaddr = v_addr;
         dcache_pkt.rd_addr = '0; 
         dcache_pkt_v = '0;
         second_operand= 1;
@@ -454,7 +455,7 @@ module bp_cacc_vdp
         dcache_ptag = {(ptag_width_p-vtag_width_p)'(0), v_addr[vaddr_width_p-1-:vtag_width_p]};
         dcache_pkt.opcode = load ? e_dcache_op_ld : e_dcache_op_sd;
         dcache_pkt.data = load ? '0 : dot_product_res;
-        dcache_pkt.page_offset = v_addr[0+:page_offset_width_gp];
+        dcache_pkt.vaddr = v_addr;
         dcache_pkt.rd_addr = '0; 
         dcache_pkt_v = '0;
         second_operand= 1;

--- a/ci/accelerator.sh
+++ b/ci/accelerator.sh
@@ -32,7 +32,8 @@ progs=(
     "streaming_accelerator_vdp"
     "coherent_accelerator_vdp"
     "accelerator_loopback_multicore_4"
-    "accelerator_vdp_multicore_4"
+    "streaming_accelerator_loopback"
+    "coherent_accelerator_vdp"
     )
 
 # The base command to append the configuration to


### PR DESCRIPTION

## Summary
This PR adds misaligned instruction / load / store detection to BP. Upon detection the processor will trap as a normal exception.

## Issue Fixed
#995 

## Area
bp_mmu, bp_be_pipe_mem, bp_fe_top

## Reasoning (outdated, confusing, verbose, etc.)
Trapping on misaligned instructions and load/stores is required for RISC-V compliance.

## Additional Changes Required (if any)

## Analysis
Some minor area overhead for the size decoding logic, but this is necessary for RISC-V compliance. Although performant programs should not use this, some low level code may.

## Verification
https://github.com/black-parrot-sdk/bp-tests/pull/26

