### PR TITLE
[WIP - DEFERRED] Downclock L2

### DIFF
--- a/bp_common/src/include/bp_common_aviary_defines.svh
+++ b/bp_common/src/include/bp_common_aviary_defines.svh
@@ -95,6 +95,7 @@
         `BSG_MAX(dcache_sets_p, `BSG_MAX(icache_sets_p, num_cacc_p ? acache_sets_p : '0))          \
     , localparam cce_ucode_p                = proc_param_lp.cce_ucode                              \
                                                                                                    \
+    , localparam l2_downclock_p           = proc_param_lp.l2_downclock                             \
     , localparam l2_en_p                  = proc_param_lp.l2_en                                    \
     , localparam l2_banks_p               = proc_param_lp.l2_banks                                 \
     , localparam l2_amo_support_p         = proc_param_lp.l2_amo_support                           \
@@ -243,6 +244,7 @@
           ,`bp_aviary_parameter_override(cce_ucode, override_cfg_mp, default_cfg_mp)               \
           ,`bp_aviary_parameter_override(cce_pc_width, override_cfg_mp, default_cfg_mp)            \
                                                                                                    \
+          ,`bp_aviary_parameter_override(l2_downclock, override_cfg_mp, default_cfg_mp)            \
           ,`bp_aviary_parameter_override(l2_en, override_cfg_mp, default_cfg_mp)                   \
           ,`bp_aviary_parameter_override(l2_banks, override_cfg_mp, default_cfg_mp)                \
           ,`bp_aviary_parameter_override(l2_amo_support, override_cfg_mp, default_cfg_mp)          \

--- a/bp_common/src/include/bp_common_aviary_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_pkgdef.svh
@@ -162,6 +162,8 @@
     // L2 slice parameters (per core)
     // Whether an L2 is present in the system
     integer unsigned l2_en;
+    // How much to downclock the L2
+    integer unsigned l2_downclock;
     // Number of L2 banks present in the slice
     integer unsigned l2_banks;
     // Atomic support in L2
@@ -295,14 +297,15 @@
       ,cce_ucode            : 0
       ,cce_pc_width         : 8
 
+      ,l2_downclock        : 4
       ,l2_en               : 1
       ,l2_banks            : 2
       ,l2_amo_support      : (1 << e_amo_swap)
                              | (1 << e_amo_fetch_logic)
                              | (1 << e_amo_fetch_arithmetic)
       ,l2_data_width       : 64
-      ,l2_sets             : 128
-      ,l2_assoc            : 8
+      ,l2_sets             : 512
+      ,l2_assoc            : 16
       ,l2_block_width      : 512
       ,l2_fill_width       : 64
       ,l2_outstanding_reqs : 6
@@ -1060,6 +1063,7 @@
       ,`bp_aviary_define_override(cce_ucode, BP_CCE_UCODE, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(cce_pc_width, BP_CCE_PC_WIDTH, `BP_CUSTOM_BASE_CFG)
 
+      ,`bp_aviary_define_override(l2_downclock, BP_L2_DOWNCLOCK, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(l2_en, BP_L2_EN, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(l2_banks, BP_L2_BANKS, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(l2_amo_support, BP_L2_AMO_SUPPORT, `BP_CUSTOM_BASE_CFG)

--- a/bp_common/src/include/bp_common_aviary_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_pkgdef.svh
@@ -304,8 +304,8 @@
                              | (1 << e_amo_fetch_logic)
                              | (1 << e_amo_fetch_arithmetic)
       ,l2_data_width       : 64
-      ,l2_sets             : 512
-      ,l2_assoc            : 16
+      ,l2_sets             : 128
+      ,l2_assoc            : 8
       ,l2_block_width      : 512
       ,l2_fill_width       : 64
       ,l2_outstanding_reqs : 6

--- a/bp_common/src/v/bsg_fifo_1r1w_periodic.v
+++ b/bp_common/src/v/bsg_fifo_1r1w_periodic.v
@@ -1,0 +1,55 @@
+
+module bsg_fifo_1r1w_periodic
+ #(parameter `BSG_INV_PARAM(a_period_p)
+   , parameter `BSG_INV_PARAM(b_period_p)
+   , parameter num_hs_p = 1
+   )
+  (input                         a_clk_i
+   , input                       a_reset_i
+   , input [num_hs_p-1:0]        a_v_i
+   , output logic [num_hs_p-1:0] a_ready_and_o
+
+   , input                       b_clk_i
+   , input                       b_reset_i
+   , output logic [num_hs_p-1:0] b_v_o
+   , input [num_hs_p-1:0]        b_ready_and_i
+   );
+
+  localparam fast2slow_lp  = (a_period_p < b_period_p);
+  localparam ratio_lp      = fast2slow_lp ? b_period_p : a_period_p;
+
+  logic [ratio_lp-1:0] cnt_r;
+  if (a_period_p == b_period_p)
+    begin : fi
+      assign cnt_r = 1'b1;
+    end
+  else
+    begin : fi
+      wire fast_clk   = fast2slow_lp ? a_clk_i   : b_clk_i;
+      bsg_counter_clear_up_one_hot
+       #(.max_val_p(ratio_lp-1))
+       counter
+        (.clk_i(fast_clk)
+         ,.reset_i(a_reset_i | b_reset_i)
+
+         ,.clear_i(1'b0)
+         ,.up_i(1'b1)
+         ,.count_r_o(cnt_r)
+         );
+    end
+  wire [num_hs_p-1:0] accept_input = {num_hs_p{cnt_r[ratio_lp-1] & ~a_reset_i & ~b_reset_i}};
+  // VCS 2016.06 incorrectly orders assignments if these were 'assign' statements, so keep them
+  //   in the always_comb...
+  always_comb
+    begin
+      b_v_o         = accept_input & a_v_i;
+      a_ready_and_o = accept_input & b_ready_and_i;
+    end
+
+  if ((a_period_p != 1) && (b_period_p != 1))
+    $error("Only 1:N or N:1 division ratios are currently supported");
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_fifo_1r1w_periodic)
+

--- a/bp_common/src/v/bsg_fifo_1r1w_periodic.v
+++ b/bp_common/src/v/bsg_fifo_1r1w_periodic.v
@@ -41,10 +41,16 @@ module bsg_fifo_1r1w_periodic
   // VCS 2016.06 incorrectly orders assignments if these were 'assign' statements, so keep them
   //   in the always_comb...
   always_comb
-    begin
-      b_v_o         = accept_input & a_v_i;
-      a_ready_and_o = accept_input & b_ready_and_i;
-    end
+    if (fast2slow_lp)
+      begin
+        a_ready_and_o = accept_input & b_ready_and_i;
+        b_v_o         = a_v_i;
+      end
+    else
+      begin
+        a_ready_and_o = b_ready_and_i;
+        b_v_o         = accept_input & a_v_i;
+      end
 
   if ((a_period_p != 1) && (b_period_p != 1))
     $error("Only 1:N or N:1 division ratios are currently supported");

--- a/bp_me/src/v/dev/bp_me_cache_slice.sv
+++ b/bp_me/src/v/dev/bp_me_cache_slice.sv
@@ -61,7 +61,7 @@ module bp_me_cache_slice
   bsg_cache_pkt_s [l2_banks_p-1:0] cache_pkt_li;
   logic [l2_banks_p-1:0] cache_pkt_v_li, cache_pkt_ready_and_lo;
   logic [l2_banks_p-1:0][l2_data_width_p-1:0] cache_data_lo;
-  logic [l2_banks_p-1:0] cache_data_v_lo, cache_data_yumi_li;
+  logic [l2_banks_p-1:0] cache_data_v_lo, cache_data_ready_and_li;
 
   bp_me_cce_to_cache
    #(.bp_params_p(bp_params_p))

--- a/bp_me/src/v/dev/bp_me_cce_to_cache.sv
+++ b/bp_me/src/v/dev/bp_me_cce_to_cache.sv
@@ -414,7 +414,7 @@ module bp_me_cce_to_cache
                 cache_pkt.mask = cache_pkt_mask_lo;
               end
             cache_pkt_v_o[cache_cmd_bank_lo] = stream_fifo_ready_lo & mem_cmd_v_lo;
-            mem_cmd_yumi_li = mem_cmd_v_lo & stream_fifo_ready_lo & cache_pkt_ready_and_i[cache_cmd_bank_lo];
+            mem_cmd_yumi_li = cache_pkt_v_o[cache_cmd_bank_lo] & cache_pkt_ready_and_i[cache_cmd_bank_lo];
 
             mem_resp_v_li = mem_header_v_lo & cache_data_v_i[cache_resp_bank_lo];
             cache_data_yumi_o[cache_resp_bank_lo] = mem_resp_v_li & mem_resp_ready_and_lo;

--- a/bp_me/test/common/bp_nonsynth_dram.sv
+++ b/bp_me/test/common/bp_nonsynth_dram.sv
@@ -187,6 +187,8 @@ module bp_nonsynth_dram
           ,.print_stat_reset_i('0)
           ,.print_stat_v_i('0)
           ,.print_stat_tag_i('0)
+          ,.print_stat_clk_i('0)
+          ,.print_stat_reset_i('0)
           );
 
 

--- a/bp_me/test/common/bp_nonsynth_dram.sv
+++ b/bp_me/test/common/bp_nonsynth_dram.sv
@@ -187,8 +187,6 @@ module bp_nonsynth_dram
           ,.print_stat_reset_i('0)
           ,.print_stat_v_i('0)
           ,.print_stat_tag_i('0)
-          ,.print_stat_clk_i('0)
-          ,.print_stat_reset_i('0)
           );
 
 

--- a/bp_top/src/v/bp_unicore.sv
+++ b/bp_top/src/v/bp_unicore.sv
@@ -94,7 +94,6 @@ module bp_unicore
   bp_bedrock_uce_mem_header_s mem_resp_header_li;
   logic [l2_data_width_p-1:0] mem_resp_data_li;
   logic mem_resp_v_li, mem_resp_ready_and_lo, mem_resp_last_li;
-
   bp_unicore_lite
    #(.bp_params_p(bp_params_p))
    unicore_lite

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -238,12 +238,15 @@ $BP_ME_DIR/src/v/lce/bp_lce_req.sv
 $BP_ME_DIR/src/v/lce/bp_lce_cmd.sv
 # Cache
 $BP_ME_DIR/src/v/dev/bp_me_bedrock_register.sv
+$BP_ME_DIR/src/v/dev/bp_me_cache_slice.sv
 $BP_ME_DIR/src/v/dev/bp_me_cce_to_cache.sv
 $BP_ME_DIR/src/v/dev/bp_me_dram_hash_decode.sv
 $BP_ME_DIR/src/v/dev/bp_me_dram_hash_encode.sv
 $BP_ME_DIR/src/v/dev/bp_me_cache_slice.sv
 $BP_ME_DIR/src/v/dev/bp_me_cfg_slice.sv
 $BP_ME_DIR/src/v/dev/bp_me_clint_slice.sv
+$BP_ME_DIR/src/v/dev/bp_me_dram_hash_decode.sv
+$BP_ME_DIR/src/v/dev/bp_me_dram_hash_encode.sv
 $BP_ME_DIR/src/v/dev/bp_me_loopback.sv
 # CCE
 $BP_ME_DIR/src/v/cce/bp_cce.sv

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -330,5 +330,6 @@ $BP_COMMON_DIR/src/v/bsg_dff_sync_read.v
 $BP_COMMON_DIR/src/v/bsg_wormhole_to_cache_dma_fanout.v
 $BP_COMMON_DIR/src/v/bsg_rom_param.v
 $BP_COMMON_DIR/src/v/bsg_crossbar_control_locking_o_by_i.v
+$BP_COMMON_DIR/src/v/bsg_fifo_1r1w_periodic.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dlatch.v
 

--- a/bp_top/test/common/bp_nonsynth_if_verif.sv
+++ b/bp_top/test/common/bp_nonsynth_if_verif.sv
@@ -126,6 +126,9 @@ module bp_nonsynth_if_verif
   if (mem_noc_flit_width_p % l2_fill_width_p != 0)
     $error("Memory NoC flit width must match l2 fill width");
 
+  if (!`BSG_IS_POW2(l2_downclock_p))
+    $error("L2 downclock ratio must be a power of two");
+
   if (multicore_p == 0 && num_core_p != 1)
     $error("Unicore only supports a single core configuration in the tethered testbench");
 

--- a/bp_top/test/tb/bp_tethered/flist.vcs
+++ b/bp_top/test/tb/bp_tethered/flist.vcs
@@ -59,6 +59,7 @@ $BP_TOP_DIR/test/common/bp_nonsynth_perf.sv
 # bsg_ip_cores files
 +incdir+$BASEJUMP_STL_DIR/bsg_clk_gen
 +incdir+$BASEJUMP_STL_DIR/testing/bsg_dmc/lpddr_verilog_model
++incdir+$BASEJUMP_STL_DIR/bsg_dmc
 $BASEJUMP_STL_DIR/bsg_dmc/bsg_dmc.v
 $BASEJUMP_STL_DIR/bsg_dmc/bsg_dmc_controller.v
 $BASEJUMP_STL_DIR/bsg_dmc/bsg_dmc_phy.v


### PR DESCRIPTION
## Summary
This PR adds the capability to downlock the L2 cache. This is useful in the case that we want a large L2, but don't want to limit the frequency of the core. Of course, the L2 access latency will rise linearly with the downgrade in clock frequency, but overall system performance cares more about L2 hits than L2 latency.

## Area
unicore, tile, L2

## Reasoning (outdated, confusing, verbose, etc.)
We could use async fifos on either end of the cache. However, this incurs a 3 slow cycle penalty on each side, leading to an unnecessary latency hit. Additionally, the extra storage from the async fifos would hurt area gains from a more efficient L2 RAM. Instead, we use a new module, bsg_fifo_1r1w_periodic.sv which modifies the handshakes of ready-valid interfaces to 

## Additional Changes Required (if any)
- [ ] Fix up aviary test for downclock
- [ ] Run through synthesis flow

## Analysis
This change enables nearly arbitrarily sized L2s. Optimal L2 size will change based on a variety of system parameters, but we should pick reasonable defaults.

## Verification
The RTL has been tested for downclock of 1 (none), 2, 4, 8x core frequency. We need to push this through an ASIC flow so that constraints can be determined. Most likely it will simply be a generated clock constraint and disabling some paths.

## Additional Context

