### PR TITLE
Clean up bedrock macros

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - me_dev_fix_macros
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - me_dev_fix_macros
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/bp_be/test/tb/bp_be_dcache/testbench.sv
+++ b/bp_be/test/tb/bp_be_dcache/testbench.sv
@@ -14,7 +14,7 @@ module testbench
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = BP_CFG_FLOWVAR // Replaced by the flow with a specific bp_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    // Tracing parameters
    , parameter cce_trace_p                 = 0
@@ -42,7 +42,7 @@ module testbench
    )
   (output bit reset_i);
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
 
   // Bit to deal with initial X->0 transition detection
@@ -93,7 +93,7 @@ module testbench
 
   logic mem_cmd_v_lo, mem_resp_v_li;
   logic mem_cmd_ready_and_lo, mem_resp_ready_and_li;
-  bp_bedrock_cce_mem_header_s mem_cmd_header_lo, mem_resp_header_li;
+  bp_bedrock_mem_header_s mem_cmd_header_lo, mem_resp_header_li;
   logic [l2_fill_width_p-1:0] mem_cmd_data_lo, mem_resp_data_li;
 
   logic [num_caches_p-1:0][trace_replay_data_width_lp-1:0] trace_data_lo;

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -18,8 +18,8 @@ module wrapper
    , parameter assoc_p = dcache_assoc_p
    , parameter block_width_p = dcache_block_width_p
    , parameter fill_width_p = dcache_fill_width_p
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, dcache)
 
    , parameter debug_p=0
@@ -33,7 +33,7 @@ module wrapper
 
    , localparam dcache_pkt_width_lp=$bits(bp_be_dcache_pkt_s)
 
-   , localparam lce_cce_req_packet_width_lp = `bsg_wormhole_concentrator_packet_width(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_req_msg_width_lp)
+   , localparam lce_cce_req_packet_width_lp = `bsg_wormhole_concentrator_packet_width(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_req_header_width_lp+cce_block_width_p)
    , localparam lce_cce_req_packet_hdr_width_lp = (lce_cce_req_packet_width_lp-cce_block_width_p)
    )
    ( input                                             clk_i
@@ -51,21 +51,21 @@ module wrapper
    , output logic [num_caches_p-1:0][dword_width_gp-1:0] data_o
    , output logic [num_caches_p-1:0]                     v_o
 
-   , output logic [cce_mem_header_width_lp-1:0]        mem_cmd_header_o
+   , output logic [mem_header_width_lp-1:0]            mem_cmd_header_o
    , output logic [l2_fill_width_p-1:0]                mem_cmd_data_o
    , output logic                                      mem_cmd_v_o
    , input                                             mem_cmd_ready_and_i
    , output logic                                      mem_cmd_last_o
 
-   , input [cce_mem_header_width_lp-1:0]               mem_resp_header_i
+   , input [mem_header_width_lp-1:0]                   mem_resp_header_i
    , input [l2_fill_width_p-1:0]                       mem_resp_data_i
    , input                                             mem_resp_v_i
    , output logic                                      mem_resp_ready_and_o
    , input                                             mem_resp_last_i
    );
 
-   `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
-   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+   `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
 
    // Cache to Rolly FIFO signals
    logic [num_caches_p-1:0] dcache_ready_lo;
@@ -405,7 +405,7 @@ module wrapper
          begin : uce
           bp_uce
            #(.bp_params_p(bp_params_p)
-             ,.uce_mem_data_width_p(l2_fill_width_p)
+             ,.mem_data_width_p(l2_fill_width_p)
              ,.assoc_p(assoc_p)
              ,.sets_p(sets_p)
              ,.block_width_p(block_width_p)

--- a/bp_common/src/include/bp_common_bedrock_if.svh
+++ b/bp_common/src/include/bp_common_bedrock_if.svh
@@ -77,7 +77,7 @@
    * speculative is set if the request was issued speculatively by the CCE
    */
 
-  `define declare_bp_bedrock_lce_payload_s(lce_id_width_mp, cce_id_width_mp, lce_assoc_mp, name_mp) \
+  `define declare_bp_bedrock_lce_payload_s(lce_id_width_mp, cce_id_width_mp, lce_assoc_mp) \
                                                                                        \
     typedef struct packed                                                              \
     {                                                                                  \
@@ -85,7 +85,7 @@
       bp_bedrock_req_non_excl_e                    non_exclusive;                      \
       logic [lce_id_width_mp-1:0]                  src_id;                             \
       logic [cce_id_width_mp-1:0]                  dst_id;                             \
-    } bp_bedrock_``name_mp``_req_payload_s;                                            \
+    } bp_bedrock_lce_req_payload_s;                                                    \
                                                                                        \
     typedef struct packed                                                              \
     {                                                                                  \
@@ -96,15 +96,15 @@
       logic [`BSG_SAFE_CLOG2(lce_assoc_mp)-1:0]    way_id;                             \
       logic [cce_id_width_mp-1:0]                  src_id;                             \
       logic [lce_id_width_mp-1:0]                  dst_id;                             \
-    } bp_bedrock_``name_mp``_cmd_payload_s;                                            \
+    } bp_bedrock_lce_cmd_payload_s;                                                    \
                                                                                        \
     typedef struct packed                                                              \
     {                                                                                  \
       logic [lce_id_width_mp-1:0]                  src_id;                             \
       logic [cce_id_width_mp-1:0]                  dst_id;                             \
-    } bp_bedrock_``name_mp``_resp_payload_s;                                           \
+    } bp_bedrock_lce_resp_payload_s;                                                   \
 
-  `define declare_bp_bedrock_mem_payload_s(did_width_mp, lce_id_width_mp, lce_assoc_mp, name_mp) \
+  `define declare_bp_bedrock_mem_payload_s(did_width_mp, lce_id_width_mp, lce_assoc_mp) \
                                                                                        \
     typedef struct packed                                                              \
     {                                                                                  \
@@ -115,7 +115,7 @@
       logic                                        prefetch;                           \
       logic                                        uncached;                           \
       logic                                        speculative;                        \
-    } bp_bedrock_``name_mp``_mem_payload_s;
+    } bp_bedrock_mem_payload_s;
 
   /*
    * BedRock Payload width macros
@@ -136,13 +136,13 @@
   `define bp_bedrock_mem_payload_width(did_width_mp, lce_id_width_mp, lce_assoc_mp) \
     (3+lce_id_width_mp+did_width_mp+`BSG_SAFE_CLOG2(lce_assoc_mp)+$bits(bp_coh_states_e))
 
-  `define declare_bp_bedrock_lce_payload_widths(lce_id_width_mp, cce_id_width_mp, lce_assoc_mp, name_mp) \
-    , localparam ``name_mp``_req_payload_width_lp = `bp_bedrock_req_payload_width(lce_id_width_mp, cce_id_width_mp, lce_assoc_mp) \
-    , localparam ``name_mp``_cmd_payload_width_lp = `bp_bedrock_cmd_payload_width(lce_id_width_mp, cce_id_width_mp, lce_assoc_mp) \
-    , localparam ``name_mp``_resp_payload_width_lp = `bp_bedrock_resp_payload_width(lce_id_width_mp, cce_id_width_mp)
+  `define declare_bp_bedrock_lce_payload_widths(lce_id_width_mp, cce_id_width_mp, lce_assoc_mp) \
+    , localparam lce_req_payload_width_lp = `bp_bedrock_req_payload_width(lce_id_width_mp, cce_id_width_mp, lce_assoc_mp) \
+    , localparam lce_cmd_payload_width_lp = `bp_bedrock_cmd_payload_width(lce_id_width_mp, cce_id_width_mp, lce_assoc_mp) \
+    , localparam lce_resp_payload_width_lp = `bp_bedrock_resp_payload_width(lce_id_width_mp, cce_id_width_mp)
 
-  `define declare_bp_bedrock_mem_payload_width(did_width_mp, lce_id_width_mp, lce_assoc_mp, name_mp) \
-    , localparam ``name_mp``_mem_payload_width_lp = `bp_bedrock_mem_payload_width(did_width_mp, lce_id_width_mp, lce_assoc_mp)
+  `define declare_bp_bedrock_mem_payload_width(did_width_mp, lce_id_width_mp, lce_assoc_mp) \
+    , localparam mem_payload_width_lp = `bp_bedrock_mem_payload_width(did_width_mp, lce_id_width_mp, lce_assoc_mp)
 
   /*
    * BedRock Message width macros
@@ -154,45 +154,36 @@
   `define bp_bedrock_header_width(addr_width_mp, payload_width_mp) \
     ($bits(bp_bedrock_msg_u)+$bits(bp_bedrock_wr_subop_e)+addr_width_mp+$bits(bp_bedrock_msg_size_e)+payload_width_mp)
 
-  `define bp_bedrock_msg_width(addr_width_mp, payload_width_mp) \
-    (`bp_bedrock_header_width(addr_width_mp, payload_width_mp))
-
   `define declare_bp_bedrock_header_width(addr_width_mp, payload_width_mp, name_mp) \
     , localparam ``name_mp``_header_width_lp = `bp_bedrock_header_width(addr_width_mp, payload_width_mp)
-
-  `define declare_bp_bedrock_msg_width(addr_width_mp, payload_width_mp, name_mp) \
-    , localparam ``name_mp``_msg_width_lp = `bp_bedrock_msg_width(addr_width_mp, payload_width_mp)
 
   /*
    * BedRock Interface Macros
    */
 
-  `define declare_bp_bedrock_lce_if_widths(addr_width_mp, lce_id_width_mp, cce_id_width_mp, lce_assoc_mp, name_mp) \
-    `declare_bp_bedrock_lce_payload_widths(lce_id_width_mp, cce_id_width_mp, lce_assoc_mp, name_mp)                               \
-    `declare_bp_bedrock_header_width(addr_width_mp, ``name_mp``_req_payload_width_lp, ``name_mp``_req)             \
-    `declare_bp_bedrock_header_width(addr_width_mp, ``name_mp``_cmd_payload_width_lp, ``name_mp``_cmd)             \
-    `declare_bp_bedrock_header_width(addr_width_mp, ``name_mp``_resp_payload_width_lp, ``name_mp``_resp)           \
-    `declare_bp_bedrock_msg_width(addr_width_mp, ``name_mp``_req_payload_width_lp, ``name_mp``_req)     \
-    `declare_bp_bedrock_msg_width(addr_width_mp, ``name_mp``_cmd_payload_width_lp, ``name_mp``_cmd)     \
-    `declare_bp_bedrock_msg_width(addr_width_mp, ``name_mp``_resp_payload_width_lp, ``name_mp``_resp)
+  `define declare_bp_bedrock_lce_if_widths(addr_width_mp, lce_id_width_mp, cce_id_width_mp, lce_assoc_mp) \
+    `declare_bp_bedrock_lce_payload_widths(lce_id_width_mp, cce_id_width_mp, lce_assoc_mp)         \
+    `declare_bp_bedrock_header_width(addr_width_mp, lce_req_payload_width_lp, lce_req)             \
+    `declare_bp_bedrock_header_width(addr_width_mp, lce_cmd_payload_width_lp, lce_cmd)             \
+    `declare_bp_bedrock_header_width(addr_width_mp, lce_resp_payload_width_lp, lce_resp)           \
 
-  `define declare_bp_bedrock_lce_if(addr_width_mp, lce_id_width_mp, cce_id_width_mp, lce_assoc_mp, name_mp) \
-    `declare_bp_bedrock_lce_payload_s(lce_id_width_mp, cce_id_width_mp, lce_assoc_mp, name_mp);                            \
-    `declare_bp_bedrock_header_s(addr_width_mp, bp_bedrock_``name_mp``_req_payload_s, ``name_mp``_req); \
-    `declare_bp_bedrock_header_s(addr_width_mp, bp_bedrock_``name_mp``_cmd_payload_s, ``name_mp``_cmd); \
-    `declare_bp_bedrock_header_s(addr_width_mp, bp_bedrock_``name_mp``_resp_payload_s, ``name_mp``_resp);
+  `define declare_bp_bedrock_lce_if(addr_width_mp, lce_id_width_mp, cce_id_width_mp, lce_assoc_mp) \
+    `declare_bp_bedrock_lce_payload_s(lce_id_width_mp, cce_id_width_mp, lce_assoc_mp);  \
+    `declare_bp_bedrock_header_s(addr_width_mp, bp_bedrock_lce_req_payload_s, lce_req); \
+    `declare_bp_bedrock_header_s(addr_width_mp, bp_bedrock_lce_cmd_payload_s, lce_cmd); \
+    `declare_bp_bedrock_header_s(addr_width_mp, bp_bedrock_lce_resp_payload_s, lce_resp);
 
-  `define declare_bp_bedrock_mem_if_widths(addr_width_mp, did_width_mp, lce_id_width_mp, lce_assoc_mp, name_mp)       \
-    `declare_bp_bedrock_mem_payload_width(did_width_mp, lce_id_width_mp, lce_assoc_mp, name_mp)                                      \
-    `declare_bp_bedrock_header_width(addr_width_mp, ``name_mp``_mem_payload_width_lp, ``name_mp``_mem)  \
+  `define declare_bp_bedrock_mem_if_widths(addr_width_mp, did_width_mp, lce_id_width_mp, lce_assoc_mp)       \
+    `declare_bp_bedrock_mem_payload_width(did_width_mp, lce_id_width_mp, lce_assoc_mp)      \
+    `declare_bp_bedrock_header_width(addr_width_mp, mem_payload_width_lp, mem)  \
 
   `define declare_bp_bedrock_if_widths(addr_width_mp, payload_width_mp, name_mp) \
-    , localparam ``name_mp``_msg_payload_width_lp = payload_width_mp                                                   \
+    , localparam ``name_mp``_msg_payload_width_lp = payload_width_mp    \
     `declare_bp_bedrock_header_width(addr_width_mp, ``name_mp``_msg_payload_width_lp, ``name_mp``)                 \
 
-  `define declare_bp_bedrock_mem_if(addr_width_mp, did_width_mp, lce_id_width_mp, lce_assoc_mp, name_mp) \
-    `declare_bp_bedrock_mem_payload_s(did_width_mp, lce_id_width_mp, lce_assoc_mp, name_mp);                            \
-    `declare_bp_bedrock_header_s(addr_width_mp, bp_bedrock_``name_mp``_mem_payload_s, ``name_mp``_mem);
+  `define declare_bp_bedrock_mem_if(addr_width_mp, did_width_mp, lce_id_width_mp, lce_assoc_mp) \
+    `declare_bp_bedrock_mem_payload_s(did_width_mp, lce_id_width_mp, lce_assoc_mp);                            \
+    `declare_bp_bedrock_header_s(addr_width_mp, bp_bedrock_mem_payload_s, mem);
 
   `define declare_bp_bedrock_if(addr_width_mp, payload_width_mp, lce_id_width_mp, lce_assoc_mp, name_mp) \
     `declare_bp_bedrock_header_s(addr_width_mp, logic [payload_width_mp-1:0], ``name_mp``);

--- a/bp_common/src/include/bp_common_bedrock_if.svh
+++ b/bp_common/src/include/bp_common_bedrock_if.svh
@@ -54,7 +54,7 @@
    *   and each endpoint will interpret the field as appropriate
    *
    */
-  // placed here for search: this macro defines types like bp_bedrock_cce_mem_header_s
+  // placed here for search: this macro defines types like bp_bedrock_mem_header_s
   `define declare_bp_bedrock_header_s(addr_width_mp, payload_mp, name_mp) \
     typedef struct packed                                                                   \
     {                                                                                       \
@@ -171,22 +171,22 @@
     `declare_bp_bedrock_lce_payload_s(lce_id_width_mp, cce_id_width_mp, lce_assoc_mp);  \
     `declare_bp_bedrock_header_s(addr_width_mp, bp_bedrock_lce_req_payload_s, lce_req); \
     `declare_bp_bedrock_header_s(addr_width_mp, bp_bedrock_lce_cmd_payload_s, lce_cmd); \
-    `declare_bp_bedrock_header_s(addr_width_mp, bp_bedrock_lce_resp_payload_s, lce_resp);
+    `declare_bp_bedrock_header_s(addr_width_mp, bp_bedrock_lce_resp_payload_s, lce_resp)
 
-  `define declare_bp_bedrock_mem_if_widths(addr_width_mp, did_width_mp, lce_id_width_mp, lce_assoc_mp)       \
-    `declare_bp_bedrock_mem_payload_width(did_width_mp, lce_id_width_mp, lce_assoc_mp)      \
-    `declare_bp_bedrock_header_width(addr_width_mp, mem_payload_width_lp, mem)  \
-
-  `define declare_bp_bedrock_if_widths(addr_width_mp, payload_width_mp, name_mp) \
-    , localparam ``name_mp``_msg_payload_width_lp = payload_width_mp    \
-    `declare_bp_bedrock_header_width(addr_width_mp, ``name_mp``_msg_payload_width_lp, ``name_mp``)                 \
+  `define declare_bp_bedrock_mem_if_widths(addr_width_mp, did_width_mp, lce_id_width_mp, lce_assoc_mp) \
+    `declare_bp_bedrock_mem_payload_width(did_width_mp, lce_id_width_mp, lce_assoc_mp) \
+    `declare_bp_bedrock_header_width(addr_width_mp, mem_payload_width_lp, mem)
 
   `define declare_bp_bedrock_mem_if(addr_width_mp, did_width_mp, lce_id_width_mp, lce_assoc_mp) \
-    `declare_bp_bedrock_mem_payload_s(did_width_mp, lce_id_width_mp, lce_assoc_mp);                            \
-    `declare_bp_bedrock_header_s(addr_width_mp, bp_bedrock_mem_payload_s, mem);
+    `declare_bp_bedrock_mem_payload_s(did_width_mp, lce_id_width_mp, lce_assoc_mp); \
+    `declare_bp_bedrock_header_s(addr_width_mp, bp_bedrock_mem_payload_s, mem)
+
+  `define declare_bp_bedrock_if_widths(addr_width_mp, payload_width_mp, name_mp) \
+    , localparam ``name_mp``_msg_payload_width_lp = payload_width_mp \
+    `declare_bp_bedrock_header_width(addr_width_mp, ``name_mp``_msg_payload_width_lp, ``name_mp``)
 
   `define declare_bp_bedrock_if(addr_width_mp, payload_width_mp, lce_id_width_mp, lce_assoc_mp, name_mp) \
-    `declare_bp_bedrock_header_s(addr_width_mp, logic [payload_width_mp-1:0], ``name_mp``);
+    `declare_bp_bedrock_header_s(addr_width_mp, logic [payload_width_mp-1:0], ``name_mp``)
 
 `endif
 

--- a/bp_fe/test/tb/bp_fe_icache/testbench.sv
+++ b/bp_fe/test/tb/bp_fe_icache/testbench.sv
@@ -8,7 +8,7 @@ module testbench
   import bp_me_pkg::*;
   #(parameter bp_params_e bp_params_p = BP_CFG_FLOWVAR
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    // Tracing parameters
    , parameter cce_trace_p                 = 0
@@ -31,7 +31,7 @@ module testbench
   )
   (output bit reset_i);
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
 
   // Bit to deal with initial X->0 transition detection
@@ -82,7 +82,7 @@ module testbench
 
   logic mem_cmd_v_lo, mem_resp_v_li;
   logic mem_cmd_ready_and_li, mem_resp_ready_and_lo, mem_cmd_last_lo, mem_resp_last_li;
-  bp_bedrock_cce_mem_header_s mem_cmd_header_lo, mem_resp_header_li;
+  bp_bedrock_mem_header_s mem_cmd_header_lo, mem_resp_header_li;
   logic [l2_fill_width_p-1:0] mem_cmd_data_lo, mem_resp_data_li;
 
   logic [trace_replay_data_width_lp-1:0] trace_data_lo;

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -10,8 +10,8 @@ module wrapper
    , parameter assoc_p = icache_assoc_p
    , parameter block_width_p = icache_block_width_p
    , parameter fill_width_p = icache_fill_width_p
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, uce)
+   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, block_width_p, icache_fill_width_p, icache)
 
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
@@ -46,25 +46,25 @@ module wrapper
    , output [instr_width_gp-1:0]             data_o
    , output                                  data_v_o
 
-   , output logic [uce_mem_header_width_lp-1:0]        mem_cmd_header_o
-   , output logic [l2_fill_width_p-1:0]                mem_cmd_data_o
-   , output logic                                      mem_cmd_v_o
-   , input                                             mem_cmd_ready_and_i
-   , output logic                                      mem_cmd_last_o
+   , output logic [mem_header_width_lp-1:0]  mem_cmd_header_o
+   , output logic [l2_fill_width_p-1:0]      mem_cmd_data_o
+   , output logic                            mem_cmd_v_o
+   , input                                   mem_cmd_ready_and_i
+   , output logic                            mem_cmd_last_o
 
-   , input [uce_mem_header_width_lp-1:0]               mem_resp_header_i
-   , input [l2_fill_width_p-1:0]                       mem_resp_data_i
-   , input                                             mem_resp_v_i
-   , output logic                                      mem_resp_ready_and_o
-   , input                                             mem_resp_last_i
+   , input [mem_header_width_lp-1:0]         mem_resp_header_i
+   , input [l2_fill_width_p-1:0]             mem_resp_data_i
+   , input                                   mem_resp_v_i
+   , output logic                            mem_resp_ready_and_o
+   , input                                   mem_resp_last_i
    );
 
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   bp_cfg_bus_s cfg_bus_cast_i;
   assign cfg_bus_cast_i = cfg_bus_i;
 
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
 
   // I$-LCE Interface signals
   // Miss, Management Interfaces
@@ -418,7 +418,7 @@ module wrapper
        );
 
     bsg_two_fifo
-     #(.width_p(lce_cmd_msg_width_lp))
+     #(.width_p(cce_block_width_p+lce_cmd_header_width_lp))
      cmd_fifo
       (.clk_i(clk_i)
        ,.reset_i(reset_i)
@@ -492,7 +492,7 @@ module wrapper
   else begin: UCE
     bp_uce
      #(.bp_params_p(bp_params_p)
-       ,.uce_mem_data_width_p(l2_fill_width_p)
+       ,.mem_data_width_p(l2_fill_width_p)
        ,.assoc_p(icache_assoc_p)
        ,.sets_p(icache_sets_p)
        ,.block_width_p(block_width_p)

--- a/bp_me/src/v/cce/bp_cce.sv
+++ b/bp_me/src/v/cce/bp_cce.sv
@@ -28,8 +28,8 @@ module bp_cce
 
     // Interface Widths
     , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
   )
   (input                                            clk_i
    , input                                          reset_i
@@ -75,13 +75,13 @@ module bp_cce
 
    // CCE-MEM Interface
    // BedRock Stream protocol: ready&valid
-   , input [cce_mem_header_width_lp-1:0]            mem_resp_header_i
+   , input [mem_header_width_lp-1:0]                mem_resp_header_i
    , input [dword_width_gp-1:0]                     mem_resp_data_i
    , input                                          mem_resp_v_i
    , output logic                                   mem_resp_ready_and_o
    , input                                          mem_resp_last_i
 
-   , output logic [cce_mem_header_width_lp-1:0]     mem_cmd_header_o
+   , output logic [mem_header_width_lp-1:0]         mem_cmd_header_o
    , output logic [dword_width_gp-1:0]              mem_cmd_data_o
    , output logic                                   mem_cmd_v_o
    , input                                          mem_cmd_ready_and_i
@@ -108,8 +108,8 @@ module bp_cce
     $fatal(0, "invalid CCE block width");
 
   // LCE-CCE and Mem-CCE Interface
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
 
   // MSHR
   `declare_bp_cce_mshr_s(lce_id_width_p, lce_assoc_p, paddr_width_p);
@@ -237,7 +237,7 @@ module bp_cce
   logic                                      msg_mem_cmd_stall_lo;
 
   // From memory response stream pump to CCE
-  bp_bedrock_cce_mem_header_s mem_resp_base_header_li;
+  bp_bedrock_mem_header_s mem_resp_base_header_li;
   logic mem_resp_v_li, mem_resp_yumi_lo;
   logic mem_resp_stream_new_li, mem_resp_stream_last_li, mem_resp_stream_done_li;
   logic [paddr_width_p-1:0] mem_resp_addr_li;
@@ -246,7 +246,7 @@ module bp_cce
   // From CCE to memory command stream pump
   localparam stream_words_lp = cce_block_width_p / dword_width_gp;
   localparam data_len_width_lp = `BSG_SAFE_CLOG2(stream_words_lp);
-  bp_bedrock_cce_mem_header_s mem_cmd_base_header_lo;
+  bp_bedrock_mem_header_s mem_cmd_base_header_lo;
   logic mem_cmd_v_lo, mem_cmd_ready_and_li;
   logic mem_cmd_stream_new_li, mem_cmd_stream_done_li;
   logic [dword_width_gp-1:0] mem_cmd_data_lo;
@@ -305,7 +305,7 @@ module bp_cce
     #(.bp_params_p(bp_params_p)
       ,.stream_data_width_p(dword_width_gp)
       ,.block_width_p(cce_block_width_p)
-      ,.payload_width_p(cce_mem_payload_width_lp)
+      ,.payload_width_p(mem_payload_width_lp)
       ,.msg_stream_mask_p(mem_resp_payload_mask_gp)
       ,.fsm_stream_mask_p(mem_resp_payload_mask_gp)
       // provide buffer space for two stream messages with data (for coherence protocol)
@@ -336,7 +336,7 @@ module bp_cce
     #(.bp_params_p(bp_params_p)
       ,.stream_data_width_p(dword_width_gp)
       ,.block_width_p(cce_block_width_p)
-      ,.payload_width_p(cce_mem_payload_width_lp)
+      ,.payload_width_p(mem_payload_width_lp)
       ,.msg_stream_mask_p(mem_cmd_payload_mask_gp)
       ,.fsm_stream_mask_p(mem_cmd_payload_mask_gp)
       )

--- a/bp_me/src/v/cce/bp_cce_fsm.sv
+++ b/bp_me/src/v/cce/bp_cce_fsm.sv
@@ -44,8 +44,8 @@ module bp_cce_fsm
     , localparam lg_max_tag_sets_lp        = `BSG_SAFE_CLOG2(max_tag_sets_lp)
 
     // interface widths
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
     , localparam counter_max_lp = 256
     , localparam hash_index_width_lp=$clog2((2**lg_lce_sets_lp+num_cce_p-1)/num_cce_p)
@@ -92,13 +92,13 @@ module bp_cce_fsm
 
    // CCE-MEM Interface
    // BedRock Stream protocol: ready&valid
-   , input [cce_mem_header_width_lp-1:0]            mem_resp_header_i
+   , input [mem_header_width_lp-1:0]                mem_resp_header_i
    , input [dword_width_gp-1:0]                     mem_resp_data_i
    , input                                          mem_resp_v_i
    , output logic                                   mem_resp_ready_and_o
    , input                                          mem_resp_last_i
 
-   , output logic [cce_mem_header_width_lp-1:0]     mem_cmd_header_o
+   , output logic [mem_header_width_lp-1:0]         mem_cmd_header_o
    , output logic [dword_width_gp-1:0]              mem_cmd_data_o
    , output logic                                   mem_cmd_v_o
    , input                                          mem_cmd_ready_and_i
@@ -117,8 +117,8 @@ module bp_cce_fsm
     $fatal(0, "invalid CCE block width");
 
   // Define structure variables for output queues
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
 
   // LCE-CCE Interface structs
   bp_bedrock_lce_req_header_s  lce_req;
@@ -157,7 +157,7 @@ module bp_cce_fsm
       );
 
   // Memory Response Stream Pump
-  bp_bedrock_cce_mem_header_s mem_resp_base_header_li;
+  bp_bedrock_mem_header_s mem_resp_base_header_li;
   logic mem_resp_v_li, mem_resp_yumi_lo;
   logic mem_resp_stream_new_li, mem_resp_stream_last_li, mem_resp_stream_done_li;
   logic [paddr_width_p-1:0] mem_resp_addr_li;
@@ -166,7 +166,7 @@ module bp_cce_fsm
     #(.bp_params_p(bp_params_p)
       ,.stream_data_width_p(dword_width_gp)
       ,.block_width_p(cce_block_width_p)
-      ,.payload_width_p(cce_mem_payload_width_lp)
+      ,.payload_width_p(mem_payload_width_lp)
       ,.msg_stream_mask_p(mem_resp_payload_mask_gp)
       ,.fsm_stream_mask_p(mem_resp_payload_mask_gp)
       // provide buffer space for two stream messages with data (for coherence protocol)
@@ -195,7 +195,7 @@ module bp_cce_fsm
   // Memory Command Stream Pump
   localparam stream_words_lp = cce_block_width_p / dword_width_gp;
   localparam data_len_width_lp = `BSG_SAFE_CLOG2(stream_words_lp);
-  bp_bedrock_cce_mem_header_s mem_cmd_base_header_lo;
+  bp_bedrock_mem_header_s mem_cmd_base_header_lo;
   logic mem_cmd_v_lo, mem_cmd_ready_and_li;
   logic mem_cmd_stream_new_li, mem_cmd_stream_done_li;
   logic [dword_width_gp-1:0] mem_cmd_data_lo;
@@ -204,7 +204,7 @@ module bp_cce_fsm
     #(.bp_params_p(bp_params_p)
       ,.stream_data_width_p(dword_width_gp)
       ,.block_width_p(cce_block_width_p)
-      ,.payload_width_p(cce_mem_payload_width_lp)
+      ,.payload_width_p(mem_payload_width_lp)
       ,.msg_stream_mask_p(mem_cmd_payload_mask_gp)
       ,.fsm_stream_mask_p(mem_cmd_payload_mask_gp)
       )

--- a/bp_me/src/v/cce/bp_cce_msg.sv
+++ b/bp_me/src/v/cce/bp_cce_msg.sv
@@ -32,8 +32,8 @@ module bp_cce_msg
     // Interface Widths
     , localparam mshr_width_lp             = `bp_cce_mshr_width(lce_id_width_p, lce_assoc_p, paddr_width_p)
     , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
     // log2 of dword width bytes
     , localparam lg_dword_width_bytes_lp = `BSG_SAFE_CLOG2(dword_width_gp/8)
@@ -80,7 +80,7 @@ module bp_cce_msg
 
    // CCE-MEM Interface
    // memory response stream pump in
-   , input [cce_mem_header_width_lp-1:0]            mem_resp_header_i
+   , input [mem_header_width_lp-1:0]            mem_resp_header_i
    , input [paddr_width_p-1:0]                      mem_resp_addr_i
    , input [dword_width_gp-1:0]                     mem_resp_data_i
    , input                                          mem_resp_v_i
@@ -90,7 +90,7 @@ module bp_cce_msg
    , input                                          mem_resp_stream_done_i
 
    // memory command stream pump out
-   , output logic [cce_mem_header_width_lp-1:0]     mem_cmd_header_o
+   , output logic [mem_header_width_lp-1:0]     mem_cmd_header_o
    , output logic [dword_width_gp-1:0]              mem_cmd_data_o
    , output logic                                   mem_cmd_v_o
    , input                                          mem_cmd_ready_and_i
@@ -145,8 +145,8 @@ module bp_cce_msg
   );
 
   // LCE-CCE and Mem-CCE Interface
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
 
   // MSHR
   `declare_bp_cce_mshr_s(lce_id_width_p, lce_assoc_p, paddr_width_p);
@@ -171,13 +171,13 @@ module bp_cce_msg
   assign mshr = mshr_i;
 
   // memory command and response message casting
-  bp_bedrock_cce_mem_header_s mem_cmd_base_header_lo;
+  bp_bedrock_mem_header_s mem_cmd_base_header_lo;
   assign mem_cmd_header_o = mem_cmd_base_header_lo;
-  bp_bedrock_cce_mem_header_s mem_resp_base_header_li;
+  bp_bedrock_mem_header_s mem_resp_base_header_li;
   assign mem_resp_base_header_li = mem_resp_header_i;
 
   // memory command header register used to complete pushq mem_cmd
-  bp_bedrock_cce_mem_header_s mem_cmd_base_header_r, mem_cmd_base_header_n;
+  bp_bedrock_mem_header_s mem_cmd_base_header_r, mem_cmd_base_header_n;
 
   // Cache block aligned address mask
   // TODO: should CCE ever align the address?

--- a/bp_me/src/v/cce/bp_cce_msg.sv
+++ b/bp_me/src/v/cce/bp_cce_msg.sv
@@ -80,7 +80,7 @@ module bp_cce_msg
 
    // CCE-MEM Interface
    // memory response stream pump in
-   , input [mem_header_width_lp-1:0]            mem_resp_header_i
+   , input [mem_header_width_lp-1:0]                mem_resp_header_i
    , input [paddr_width_p-1:0]                      mem_resp_addr_i
    , input [dword_width_gp-1:0]                     mem_resp_data_i
    , input                                          mem_resp_v_i
@@ -90,7 +90,7 @@ module bp_cce_msg
    , input                                          mem_resp_stream_done_i
 
    // memory command stream pump out
-   , output logic [mem_header_width_lp-1:0]     mem_cmd_header_o
+   , output logic [mem_header_width_lp-1:0]         mem_cmd_header_o
    , output logic [dword_width_gp-1:0]              mem_cmd_data_o
    , output logic                                   mem_cmd_v_o
    , input                                          mem_cmd_ready_and_i

--- a/bp_me/src/v/cce/bp_cce_reg.sv
+++ b/bp_me/src/v/cce/bp_cce_reg.sv
@@ -23,8 +23,8 @@ module bp_cce_reg
     , localparam mshr_width_lp = `bp_cce_mshr_width(lce_id_width_p, lce_assoc_p, paddr_width_p)
 
     // Interface Widths
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
   )
   (input                                                                   clk_i
@@ -44,7 +44,7 @@ module bp_cce_reg
    , input [lce_req_header_width_lp-1:0]                                   lce_req_header_i
    , input                                                                 lce_req_v_i
    , input [lce_resp_header_width_lp-1:0]                                  lce_resp_header_i
-   , input [cce_mem_header_width_lp-1:0]                                   mem_resp_header_i
+   , input [mem_header_width_lp-1:0]                                       mem_resp_header_i
 
    // For RDP, output state of pending bits from read operation
    , input                                                                 pending_i
@@ -81,12 +81,12 @@ module bp_cce_reg
 
 
   // Interface Structs
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
 
   bp_bedrock_lce_req_header_s  lce_req_hdr;
   bp_bedrock_lce_resp_header_s lce_resp_hdr;
-  bp_bedrock_cce_mem_header_s  mem_resp_hdr;
+  bp_bedrock_mem_header_s      mem_resp_hdr;
 
   assign lce_req_hdr  = lce_req_header_i;
   assign lce_resp_hdr = lce_resp_header_i;

--- a/bp_me/src/v/cce/bp_cce_src_sel.sv
+++ b/bp_me/src/v/cce/bp_cce_src_sel.sv
@@ -30,8 +30,8 @@ module bp_cce_src_sel
 
     , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
 
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
   )
   (// Select signals for src_a and src_b - from decoded instruction
@@ -62,7 +62,7 @@ module bp_cce_src_sel
    , input                                                          lce_req_header_v_i
    , input [lce_req_header_width_lp-1:0]                            lce_req_header_i
    , input [lce_resp_header_width_lp-1:0]                           lce_resp_header_i
-   , input [cce_mem_header_width_lp-1:0]                            mem_resp_header_i
+   , input [mem_header_width_lp-1:0]                                mem_resp_header_i
    // TODO: data inputs are not guarded by valid
    , input [dword_width_gp-1:0]                                     lce_req_data_i
    , input [dword_width_gp-1:0]                                     lce_resp_data_i
@@ -96,13 +96,13 @@ module bp_cce_src_sel
   assign mshr = mshr_i;
 
   // LCE-CCE and Mem-CCE Interface
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
 
   // Message casting
   bp_bedrock_lce_req_header_s  lce_req_header_li;
   bp_bedrock_lce_resp_header_s lce_resp_header_li;
-  bp_bedrock_cce_mem_header_s  mem_resp_header_li;
+  bp_bedrock_mem_header_s  mem_resp_header_li;
 
   assign lce_req_header_li   = lce_req_header_i;
   assign lce_resp_header_li  = lce_resp_header_i;

--- a/bp_me/src/v/cce/bp_cce_wrapper.sv
+++ b/bp_me/src/v/cce/bp_cce_wrapper.sv
@@ -24,8 +24,8 @@ module bp_cce_wrapper
 
     // Interface Widths
     , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
   )
   (input                                            clk_i
    , input                                          reset_i
@@ -71,13 +71,13 @@ module bp_cce_wrapper
 
    // CCE-MEM Interface
    // BedRock Stream protocol: ready&valid
-   , input [cce_mem_header_width_lp-1:0]            mem_resp_header_i
+   , input [mem_header_width_lp-1:0]                mem_resp_header_i
    , input [dword_width_gp-1:0]                     mem_resp_data_i
    , input                                          mem_resp_v_i
    , output logic                                   mem_resp_ready_and_o
    , input                                          mem_resp_last_i
 
-   , output logic [cce_mem_header_width_lp-1:0]     mem_cmd_header_o
+   , output logic [mem_header_width_lp-1:0]         mem_cmd_header_o
    , output logic [dword_width_gp-1:0]              mem_cmd_data_o
    , output logic                                   mem_cmd_v_o
    , input                                          mem_cmd_ready_and_i

--- a/bp_me/src/v/cce/bp_io_cce.sv
+++ b/bp_me/src/v/cce/bp_io_cce.sv
@@ -15,8 +15,8 @@ module bp_io_cce
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
    )
   (input                                        clk_i
    , input                                      reset_i
@@ -34,23 +34,23 @@ module bp_io_cce
    , output logic                               lce_cmd_v_o
    , input                                      lce_cmd_ready_and_i
 
-   , input [cce_mem_header_width_lp-1:0]        io_resp_header_i
+   , input [mem_header_width_lp-1:0]            io_resp_header_i
    , input [cce_block_width_p-1:0]              io_resp_data_i
    , input                                      io_resp_v_i
    , output logic                               io_resp_ready_and_o
 
-   , output logic [cce_mem_header_width_lp-1:0] io_cmd_header_o
+   , output logic [mem_header_width_lp-1:0]     io_cmd_header_o
    , output logic [cce_block_width_p-1:0]       io_cmd_data_o
    , output logic                               io_cmd_v_o
    , input                                      io_cmd_ready_and_i
    );
 
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `bp_cast_i(bp_bedrock_lce_req_header_s, lce_req_header);
   `bp_cast_o(bp_bedrock_lce_cmd_header_s, lce_cmd_header);
-  `bp_cast_o(bp_bedrock_cce_mem_header_s, io_cmd_header);
-  `bp_cast_i(bp_bedrock_cce_mem_header_s, io_resp_header);
+  `bp_cast_o(bp_bedrock_mem_header_s, io_cmd_header);
+  `bp_cast_i(bp_bedrock_mem_header_s, io_resp_header);
 
   assign lce_req_ready_and_o = io_cmd_ready_and_i;
   assign io_cmd_v_o          = lce_req_v_i;

--- a/bp_me/src/v/cce/bp_uce.sv
+++ b/bp_me/src/v/cce/bp_uce.sv
@@ -15,9 +15,9 @@ module bp_uce
   import bp_common_pkg::*;
   import bp_me_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
-    , parameter `BSG_INV_PARAM(uce_mem_data_width_p)
+    , parameter `BSG_INV_PARAM(mem_data_width_p)
     `declare_bp_proc_params(bp_params_p)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, uce)
+    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
     , parameter `BSG_INV_PARAM(assoc_p)
     , parameter `BSG_INV_PARAM(sets_p)
     , parameter `BSG_INV_PARAM(block_width_p)
@@ -64,14 +64,14 @@ module bp_uce
     , input                                          stat_mem_pkt_yumi_i
     , input [cache_stat_info_width_lp-1:0]           stat_mem_i
 
-    , output logic [uce_mem_header_width_lp-1:0]     mem_cmd_header_o
-    , output logic [uce_mem_data_width_p-1:0]        mem_cmd_data_o
+    , output logic [mem_header_width_lp-1:0]         mem_cmd_header_o
+    , output logic [mem_data_width_p-1:0]            mem_cmd_data_o
     , output logic                                   mem_cmd_v_o
     , input                                          mem_cmd_ready_and_i
     , output logic                                   mem_cmd_last_o
 
-    , input [uce_mem_header_width_lp-1:0]            mem_resp_header_i
-    , input [uce_mem_data_width_p-1:0]               mem_resp_data_i
+    , input [mem_header_width_lp-1:0]                mem_resp_header_i
+    , input [mem_data_width_p-1:0]                   mem_resp_data_i
     , input                                          mem_resp_v_i
     , output logic                                   mem_resp_ready_and_o
     , input                                          mem_resp_last_i
@@ -106,7 +106,7 @@ module bp_uce
                                                              ? e_bedrock_msg_size_8
                                                              : e_bedrock_msg_size_64;
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, uce);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache);
 
   `bp_cast_i(bp_cache_req_s, cache_req);
@@ -265,7 +265,7 @@ module bp_uce
      ,.yumi_i(dirty_stat_read)
      );
 
-  bp_bedrock_uce_mem_header_s fsm_cmd_header_lo;
+  bp_bedrock_mem_header_s fsm_cmd_header_lo;
   logic [fill_width_p-1:0] fsm_cmd_data_lo;
   logic fsm_cmd_v_lo, fsm_cmd_ready_and_li;
   logic [fill_cnt_width_lp-1:0] fsm_cmd_cnt;
@@ -274,7 +274,7 @@ module bp_uce
    #(.bp_params_p(bp_params_p)
      ,.stream_data_width_p(fill_width_p)
      ,.block_width_p(block_width_p)
-     ,.payload_width_p(uce_mem_payload_width_lp)
+     ,.payload_width_p(mem_payload_width_lp)
      ,.msg_stream_mask_p(mem_cmd_payload_mask_gp)
      ,.fsm_stream_mask_p(mem_cmd_payload_mask_gp)
      )
@@ -298,7 +298,7 @@ module bp_uce
      ,.fsm_last_o(/* unused */)
      );
 
-  bp_bedrock_uce_mem_header_s fsm_resp_header_li;
+  bp_bedrock_mem_header_s fsm_resp_header_li;
   logic [paddr_width_p-1:0] fsm_resp_addr_li;
   logic [fill_width_p-1:0] fsm_resp_data_li;
   logic fsm_resp_v_li, fsm_resp_yumi_lo;
@@ -307,7 +307,7 @@ module bp_uce
    #(.bp_params_p(bp_params_p)
      ,.stream_data_width_p(fill_width_p)
      ,.block_width_p(block_width_p)
-     ,.payload_width_p(uce_mem_payload_width_lp)
+     ,.payload_width_p(mem_payload_width_lp)
      ,.msg_stream_mask_p(mem_resp_payload_mask_gp)
      ,.fsm_stream_mask_p(mem_resp_payload_mask_gp)
      ,.header_els_p(2)

--- a/bp_me/src/v/dev/bp_me_bedrock_register.sv
+++ b/bp_me/src/v/dev/bp_me_bedrock_register.sv
@@ -14,7 +14,7 @@ module bp_me_bedrock_register
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, xce)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    // The width of the registers. Currently, must all be the same.
    , parameter reg_width_p = dword_width_gp
@@ -38,13 +38,13 @@ module bp_me_bedrock_register
    , input                                          reset_i
 
    // Network-side BP-Stream interface
-   , input [xce_mem_header_width_lp-1:0]            mem_cmd_header_i
+   , input [mem_header_width_lp-1:0]                mem_cmd_header_i
    , input [dword_width_gp-1:0]                     mem_cmd_data_i
    , input                                          mem_cmd_v_i
    , output logic                                   mem_cmd_ready_and_o
    , input                                          mem_cmd_last_i
 
-   , output logic [xce_mem_header_width_lp-1:0]     mem_resp_header_o
+   , output logic [mem_header_width_lp-1:0]         mem_resp_header_o
    , output logic [dword_width_gp-1:0]              mem_resp_data_o
    , output logic                                   mem_resp_v_o
    , input                                          mem_resp_ready_and_i
@@ -66,13 +66,13 @@ module bp_me_bedrock_register
 
   wire unused = &{mem_cmd_last_i};
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, xce);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
 
-  bp_bedrock_xce_mem_header_s mem_cmd_header_li;
+  bp_bedrock_mem_header_s mem_cmd_header_li;
   logic [dword_width_gp-1:0] mem_cmd_data_li;
   logic mem_cmd_v_li, mem_cmd_yumi_li;
   bsg_one_fifo
-   #(.width_p($bits(bp_bedrock_xce_mem_header_s)+dword_width_gp))
+   #(.width_p($bits(bp_bedrock_mem_header_s)+dword_width_gp))
    cmd_fifo
     (.clk_i(clk_i)
      ,.reset_i(reset_i)

--- a/bp_me/src/v/dev/bp_me_cce_to_cache.sv
+++ b/bp_me/src/v/dev/bp_me_cce_to_cache.sv
@@ -23,7 +23,7 @@ module bp_me_cce_to_cache
  import bsg_cache_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    // L2 organization and interface
    , localparam bsg_cache_pkt_width_lp=`bsg_cache_pkt_width(daddr_width_p, l2_data_width_p)
@@ -32,13 +32,13 @@ module bp_me_cce_to_cache
    , input reset_i
 
    // BedRock Stream interface
-   , input  [cce_mem_header_width_lp-1:0]     mem_cmd_header_i
+   , input  [mem_header_width_lp-1:0]     mem_cmd_header_i
    , input  [l2_data_width_p-1:0]             mem_cmd_data_i
    , input                                    mem_cmd_v_i
    , output logic                             mem_cmd_ready_and_o
    , input                                    mem_cmd_last_i
 
-   , output [cce_mem_header_width_lp-1:0]     mem_resp_header_o
+   , output [mem_header_width_lp-1:0]     mem_resp_header_o
    , output [l2_data_width_p-1:0]             mem_resp_data_o
    , output logic                             mem_resp_v_o
    , input                                    mem_resp_ready_and_i
@@ -67,7 +67,7 @@ module bp_me_cce_to_cache
     $fatal(0, "l2 data width must be 64, 128, 256, or 512");
 
   `declare_bsg_cache_pkt_s(daddr_width_p, l2_data_width_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, daddr_width_p);
 
   bsg_cache_pkt_s cache_pkt;
@@ -85,7 +85,7 @@ module bp_me_cce_to_cache
   logic [lg_l2_sets_lp+lg_l2_ways_lp:0] tagst_sent_r, tagst_sent_n;
   logic [lg_l2_sets_lp+lg_l2_ways_lp:0] tagst_received_r, tagst_received_n;
 
-  bp_bedrock_cce_mem_header_s mem_cmd_header_lo;
+  bp_bedrock_mem_header_s mem_cmd_header_lo;
   logic [l2_data_width_p-1:0] mem_cmd_data_lo, mem_resp_data_lo;
   logic mem_cmd_v_lo, mem_cmd_yumi_li;
   logic mem_cmd_new_lo, mem_cmd_done_lo, mem_cmd_last_lo;
@@ -94,7 +94,7 @@ module bp_me_cce_to_cache
    #(.bp_params_p(bp_params_p)
      ,.stream_data_width_p(l2_data_width_p)
      ,.block_width_p(cce_block_width_p)
-     ,.payload_width_p(cce_mem_payload_width_lp)
+     ,.payload_width_p(mem_payload_width_lp)
      ,.msg_stream_mask_p(mem_cmd_payload_mask_gp)
      ,.fsm_stream_mask_p(mem_cmd_payload_mask_gp | mem_resp_payload_mask_gp)
      ,.header_els_p(2)
@@ -217,11 +217,11 @@ module bp_me_cce_to_cache
     ,.data_o(cache_pkt_data_lo)
     );
 
-  bp_bedrock_cce_mem_header_s mem_resp_header_lo;
+  bp_bedrock_mem_header_s mem_resp_header_lo;
   logic mem_resp_v_lo, mem_resp_ready_and_lo;
   logic mem_resp_new_lo, mem_resp_done_lo;
   bsg_fifo_1r1w_small
-   #(.width_p($bits(bp_bedrock_cce_mem_header_s)), .els_p(4))
+   #(.width_p($bits(bp_bedrock_mem_header_s)), .els_p(4))
    stream_fifo
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
@@ -240,7 +240,7 @@ module bp_me_cce_to_cache
    #(.bp_params_p(bp_params_p)
      ,.stream_data_width_p(l2_data_width_p)
      ,.block_width_p(cce_block_width_p)
-     ,.payload_width_p(cce_mem_payload_width_lp)
+     ,.payload_width_p(mem_payload_width_lp)
      ,.msg_stream_mask_p(mem_resp_payload_mask_gp)
      ,.fsm_stream_mask_p(mem_cmd_payload_mask_gp | mem_resp_payload_mask_gp)
      )

--- a/bp_me/src/v/dev/bp_me_cce_to_cache.sv
+++ b/bp_me/src/v/dev/bp_me_cce_to_cache.sv
@@ -32,13 +32,13 @@ module bp_me_cce_to_cache
    , input reset_i
 
    // BedRock Stream interface
-   , input  [mem_header_width_lp-1:0]     mem_cmd_header_i
+   , input  [mem_header_width_lp-1:0]         mem_cmd_header_i
    , input  [l2_data_width_p-1:0]             mem_cmd_data_i
    , input                                    mem_cmd_v_i
    , output logic                             mem_cmd_ready_and_o
    , input                                    mem_cmd_last_i
 
-   , output [mem_header_width_lp-1:0]     mem_resp_header_o
+   , output [mem_header_width_lp-1:0]         mem_resp_header_o
    , output [l2_data_width_p-1:0]             mem_resp_data_o
    , output logic                             mem_resp_v_o
    , input                                    mem_resp_ready_and_i

--- a/bp_me/src/v/dev/bp_me_cfg.sv
+++ b/bp_me/src/v/dev/bp_me_cfg.sv
@@ -7,20 +7,20 @@ module bp_me_cfg
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, xce)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    )
   (input                                            clk_i
    , input                                          reset_i
 
-   , input [xce_mem_header_width_lp-1:0]            mem_cmd_header_i
+   , input [mem_header_width_lp-1:0]                mem_cmd_header_i
    , input [dword_width_gp-1:0]                     mem_cmd_data_i
    , input                                          mem_cmd_v_i
    , output logic                                   mem_cmd_ready_and_o
    , input                                          mem_cmd_last_i
 
-   , output logic [xce_mem_header_width_lp-1:0]     mem_resp_header_o
+   , output logic [mem_header_width_lp-1:0]         mem_resp_header_o
    , output logic [dword_width_gp-1:0]              mem_resp_data_o
    , output logic                                   mem_resp_v_o
    , input                                          mem_resp_ready_and_i
@@ -40,7 +40,7 @@ module bp_me_cfg
    );
 
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, xce);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `bp_cast_o(bp_cfg_bus_s, cfg_bus);
 
   logic cord_r_v_li, did_r_v_li, host_did_r_v_li, hio_mask_r_v_li;

--- a/bp_me/src/v/dev/bp_me_clint_slice.sv
+++ b/bp_me/src/v/dev/bp_me_clint_slice.sv
@@ -9,20 +9,20 @@ module bp_me_clint_slice
  import bsg_wormhole_router_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, xce)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
    )
   (input                                                clk_i
    , input                                              reset_i
 
    , input [core_id_width_p-1:0]                        id_i
 
-   , input [xce_mem_header_width_lp-1:0]                mem_cmd_header_i
+   , input [mem_header_width_lp-1:0]                    mem_cmd_header_i
    , input [dword_width_gp-1:0]                         mem_cmd_data_i
    , input                                              mem_cmd_v_i
    , output logic                                       mem_cmd_ready_and_o
    , input                                              mem_cmd_last_i
 
-   , output logic [xce_mem_header_width_lp-1:0]         mem_resp_header_o
+   , output logic [mem_header_width_lp-1:0]             mem_resp_header_o
    , output logic [dword_width_gp-1:0]                  mem_resp_data_o
    , output logic                                       mem_resp_v_o
    , input                                              mem_resp_ready_and_i
@@ -34,7 +34,7 @@ module bp_me_clint_slice
    , output logic                                       external_irq_o
    );
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, xce);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, caddr_width_p);
 
   logic [dev_addr_width_gp-1:0] addr_lo;

--- a/bp_me/src/v/dev/bp_me_loopback.sv
+++ b/bp_me/src/v/dev/bp_me_loopback.sv
@@ -11,18 +11,18 @@ module bp_me_loopback
   import bp_me_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
     )
    (input                                            clk_i
     , input                                          reset_i
 
-    , input [cce_mem_header_width_lp-1:0]            mem_cmd_header_i
+    , input [mem_header_width_lp-1:0]                mem_cmd_header_i
     , input [dword_width_gp-1:0]                     mem_cmd_data_i
     , input                                          mem_cmd_v_i
     , output logic                                   mem_cmd_ready_and_o
     , input logic                                    mem_cmd_last_i
 
-    , output logic [cce_mem_header_width_lp-1:0]     mem_resp_header_o
+    , output logic [mem_header_width_lp-1:0]         mem_resp_header_o
     , output logic [dword_width_gp-1:0]              mem_resp_data_o
     , output logic                                   mem_resp_v_o
     , input                                          mem_resp_ready_and_i
@@ -32,7 +32,7 @@ module bp_me_loopback
   // Used to decouple to help prevent deadlock
   logic mem_resp_last_lo;
   bsg_one_fifo
-   #(.width_p(1+cce_mem_header_width_lp))
+   #(.width_p(1+mem_header_width_lp))
    loopback_buffer
     (.clk_i(clk_i)
      ,.reset_i(reset_i)

--- a/bp_me/src/v/lce/bp_lce.sv
+++ b/bp_me/src/v/lce/bp_lce.sv
@@ -40,7 +40,7 @@ module bp_lce
     , localparam lg_sets_lp = `BSG_SAFE_CLOG2(sets_p)
     , localparam lg_block_size_in_bytes_lp = `BSG_SAFE_CLOG2(block_size_in_bytes_lp)
 
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
+   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache)
   )
   (

--- a/bp_me/src/v/lce/bp_lce_cmd.sv
+++ b/bp_me/src/v/lce/bp_lce_cmd.sv
@@ -38,7 +38,7 @@ module bp_lce_cmd
     , localparam lg_sets_lp = `BSG_SAFE_CLOG2(sets_p)
     , localparam lg_block_size_in_bytes_lp = `BSG_SAFE_CLOG2(block_size_in_bytes_lp)
 
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
+   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache)
 
     // width for counter used during initiliazation and for sync messages
@@ -123,7 +123,7 @@ module bp_lce_cmd
     , input                                          lce_cmd_ready_then_i
   );
 
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache);
   `bp_cast_i(bp_bedrock_lce_cmd_header_s, lce_cmd_header);
   `bp_cast_o(bp_bedrock_lce_cmd_header_s, lce_cmd_header);

--- a/bp_me/src/v/lce/bp_lce_req.sv
+++ b/bp_me/src/v/lce/bp_lce_req.sv
@@ -39,7 +39,7 @@ module bp_lce_req
     , localparam lg_block_size_in_bytes_lp = `BSG_SAFE_CLOG2(block_size_in_bytes_lp)
     , localparam lg_lce_assoc_lp = `BSG_SAFE_CLOG2(lce_assoc_p)
 
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
+   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache)
 
     , localparam stat_info_width_lp = `bp_cache_stat_info_width(assoc_p)
@@ -104,7 +104,7 @@ module bp_lce_req
   if (metadata_latency_p >= 2)
     $fatal(0,"metadata needs to arrive within one cycle of the request");
 
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache);
   `bp_cast_o(bp_bedrock_lce_req_header_s, lce_req_header);
   `bp_cast_i(bp_cache_req_s, cache_req);

--- a/bp_me/src/v/network/bp_me_cce_to_mem_link_recv.sv
+++ b/bp_me/src/v/network/bp_me_cce_to_mem_link_recv.sv
@@ -15,7 +15,7 @@ module bp_me_cce_to_mem_link_recv
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
   `declare_bp_proc_params(bp_params_p)
-  `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+  `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    , parameter `BSG_INV_PARAM(flit_width_p)
    , parameter `BSG_INV_PARAM(cord_width_p)
@@ -32,13 +32,13 @@ module bp_me_cce_to_mem_link_recv
    , input [cord_width_p-1:0]                           dst_cord_i
    , input [cid_width_p-1:0]                            dst_cid_i
 
-   , output logic [cce_mem_header_width_lp-1:0]         mem_cmd_header_o
+   , output logic [mem_header_width_lp-1:0]             mem_cmd_header_o
    , output logic [cce_block_width_p-1:0]               mem_cmd_data_o
    , output logic                                       mem_cmd_v_o
    , input                                              mem_cmd_yumi_i
    , output logic                                       mem_cmd_last_o
 
-   , input [cce_mem_header_width_lp-1:0]                mem_resp_header_i
+   , input [mem_header_width_lp-1:0]                    mem_resp_header_i
    , input [cce_block_width_p-1:0]                      mem_resp_data_i
    , input                                              mem_resp_v_i
    , output logic                                       mem_resp_ready_and_o
@@ -52,9 +52,9 @@ module bp_me_cce_to_mem_link_recv
   wire unused = &{mem_resp_last_i};
   assign mem_cmd_last_o = mem_cmd_v_o;
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
-  `declare_bp_bedrock_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, bp_bedrock_cce_mem_header_s, mem, cce_block_width_p);
-  localparam payload_width_lp = `bp_bedrock_wormhole_payload_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, $bits(bp_bedrock_cce_mem_header_s), cce_block_width_p);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, bp_bedrock_mem_header_s, mem, cce_block_width_p);
+  localparam payload_width_lp = `bp_bedrock_wormhole_payload_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, $bits(bp_bedrock_mem_header_s), cce_block_width_p);
 
   bp_mem_wormhole_packet_s mem_cmd_packet_lo;
   bp_mem_wormhole_packet_s mem_resp_packet_lo;

--- a/bp_me/src/v/network/bp_me_cce_to_mem_link_send.sv
+++ b/bp_me/src/v/network/bp_me_cce_to_mem_link_send.sv
@@ -15,7 +15,7 @@ module bp_me_cce_to_mem_link_send
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    , parameter `BSG_INV_PARAM(flit_width_p)
    , parameter `BSG_INV_PARAM(cord_width_p)
@@ -32,13 +32,13 @@ module bp_me_cce_to_mem_link_send
    , input [cid_width_p-1:0]                            dst_cid_i
 
    // CCE-MEM Interface
-   , input [cce_mem_header_width_lp-1:0]                mem_cmd_header_i
+   , input [mem_header_width_lp-1:0]                    mem_cmd_header_i
    , input [cce_block_width_p-1:0]                      mem_cmd_data_i
    , input                                              mem_cmd_v_i
    , output logic                                       mem_cmd_ready_and_o
    , input                                              mem_cmd_last_i
 
-   , output logic [cce_mem_header_width_lp-1:0]         mem_resp_header_o
+   , output logic [mem_header_width_lp-1:0]             mem_resp_header_o
    , output logic [cce_block_width_p-1:0]               mem_resp_data_o
    , output                                             mem_resp_v_o
    , input                                              mem_resp_yumi_i
@@ -53,11 +53,11 @@ module bp_me_cce_to_mem_link_send
   assign mem_resp_last_o = mem_resp_v_o;
 
   // CCE-MEM interface packets
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
 
   // CCE-MEM IF to Wormhole routed interface
-  `declare_bp_bedrock_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, bp_bedrock_cce_mem_header_s, mem, cce_block_width_p);
-  localparam payload_width_lp = `bp_bedrock_wormhole_payload_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, $bits(bp_bedrock_cce_mem_header_s), cce_block_width_p);
+  `declare_bp_bedrock_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, bp_bedrock_mem_header_s, mem, cce_block_width_p);
+  localparam payload_width_lp = `bp_bedrock_wormhole_payload_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, $bits(bp_bedrock_mem_header_s), cce_block_width_p);
 
   bp_mem_wormhole_packet_s mem_cmd_packet_li;
   bp_mem_wormhole_header_s mem_cmd_header_li;

--- a/bp_me/src/v/network/bp_me_wormhole_packet_encode_lce_cmd.sv
+++ b/bp_me/src/v/network/bp_me_wormhole_packet_encode_lce_cmd.sv
@@ -20,7 +20,7 @@ module bp_me_wormhole_packet_encode_lce_cmd
   import bp_common_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
+    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
 
     , localparam lce_cmd_wormhole_header_lp = `bp_bedrock_wormhole_header_width(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cmd_header_width_lp)
     )
@@ -28,7 +28,7 @@ module bp_me_wormhole_packet_encode_lce_cmd
     , output [lce_cmd_wormhole_header_lp-1:0] wh_header_o
     );
 
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
   `declare_bp_lce_cmd_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_bedrock_lce_cmd_header_s, cce_block_width_p);
 
   bp_bedrock_lce_cmd_header_s header_cast_i;

--- a/bp_me/src/v/network/bp_me_wormhole_packet_encode_lce_req.sv
+++ b/bp_me/src/v/network/bp_me_wormhole_packet_encode_lce_req.sv
@@ -20,7 +20,7 @@ module bp_me_wormhole_packet_encode_lce_req
   import bp_common_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
+    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
 
     , localparam lce_cce_req_wormhole_header_lp = `bp_bedrock_wormhole_header_width(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_req_header_width_lp)
     )
@@ -28,7 +28,7 @@ module bp_me_wormhole_packet_encode_lce_req
     , output [lce_cce_req_wormhole_header_lp-1:0] wh_header_o
     );
 
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
   `declare_bp_lce_req_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_bedrock_lce_req_header_s, cce_block_width_p);
 
   bp_bedrock_lce_req_header_s header_cast_i;

--- a/bp_me/src/v/network/bp_me_wormhole_packet_encode_lce_resp.sv
+++ b/bp_me/src/v/network/bp_me_wormhole_packet_encode_lce_resp.sv
@@ -20,7 +20,7 @@ module bp_me_wormhole_packet_encode_lce_resp
   import bp_common_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
+    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
 
     , localparam lce_cce_resp_wormhole_header_lp = `bp_bedrock_wormhole_header_width(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_resp_header_width_lp)
     )
@@ -28,7 +28,7 @@ module bp_me_wormhole_packet_encode_lce_resp
     , output [lce_cce_resp_wormhole_header_lp-1:0] wh_header_o
     );
 
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
   `declare_bp_lce_resp_wormhole_packet_s(coh_noc_flit_width_p, coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, bp_bedrock_lce_resp_header_s, cce_block_width_p);
 
   bp_bedrock_lce_resp_header_s header_cast_i;

--- a/bp_me/src/v/network/bp_me_wormhole_packet_encode_mem.sv
+++ b/bp_me/src/v/network/bp_me_wormhole_packet_encode_mem.sv
@@ -17,7 +17,7 @@ module bp_me_wormhole_packet_encode_mem
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    , parameter `BSG_INV_PARAM(flit_width_p)
    , parameter `BSG_INV_PARAM(cord_width_p)
@@ -28,9 +28,9 @@ module bp_me_wormhole_packet_encode_mem
    , parameter payload_mask_p = 0
 
    , localparam mem_wormhole_header_lp =
-       `bp_bedrock_wormhole_header_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, cce_mem_header_width_lp)
+       `bp_bedrock_wormhole_header_width(flit_width_p, cord_width_p, len_width_p, cid_width_p, mem_header_width_lp)
    )
-  (input [cce_mem_header_width_lp-1:0]   mem_header_i
+  (input [mem_header_width_lp-1:0]       mem_header_i
 
    , input [cord_width_p-1:0]            dst_cord_i
    , input [cid_width_p-1:0]             dst_cid_i
@@ -38,10 +38,10 @@ module bp_me_wormhole_packet_encode_mem
    , output [mem_wormhole_header_lp-1:0] wh_header_o
    );
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
-  `declare_bp_bedrock_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, bp_bedrock_cce_mem_header_s, mem, cce_block_width_p);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_wormhole_packet_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, bp_bedrock_mem_header_s, mem, cce_block_width_p);
 
-  bp_bedrock_cce_mem_header_s header_cast_i;
+  bp_bedrock_mem_header_s header_cast_i;
   bp_mem_wormhole_header_s header_cast_o;
 
   assign header_cast_i = mem_header_i;

--- a/bp_me/test/common/bp_cce_mmio_cfg_loader.sv
+++ b/bp_me/test/common/bp_cce_mmio_cfg_loader.sv
@@ -16,7 +16,7 @@ module bp_cce_mmio_cfg_loader
   import bp_me_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
     , parameter `BSG_INV_PARAM(inst_width_p)
     , parameter `BSG_INV_PARAM(inst_ram_addr_width_p)
@@ -37,14 +37,14 @@ module bp_cce_mmio_cfg_loader
 
    // BedRock Stream
    // TODO: convert yumi_i to ready_and_i
-   , output logic [cce_mem_header_width_lp-1:0]      io_cmd_header_o
+   , output logic [mem_header_width_lp-1:0]          io_cmd_header_o
    , output logic [dword_width_gp-1:0]               io_cmd_data_o
    , output logic                                    io_cmd_v_o
    , input                                           io_cmd_yumi_i
    , output logic                                    io_cmd_last_o
 
    // BedRock Stream
-   , input [cce_mem_header_width_lp-1:0]             io_resp_header_i
+   , input [mem_header_width_lp-1:0]                 io_resp_header_i
    , input [dword_width_gp-1:0]                      io_resp_data_i
    , input                                           io_resp_v_i
    , output logic                                    io_resp_ready_and_o
@@ -56,12 +56,12 @@ module bp_cce_mmio_cfg_loader
   wire unused0 = &{io_resp_header_i, io_resp_data_i, io_resp_last_i};
   assign io_resp_ready_and_o = 1'b1;
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, daddr_width_p);
 
-  bp_bedrock_cce_mem_header_s io_cmd_cast_o;
-  bp_bedrock_cce_mem_header_s io_resp_cast_i;
-  bp_bedrock_cce_mem_payload_s io_cmd_payload;
+  bp_bedrock_mem_header_s io_cmd_cast_o;
+  bp_bedrock_mem_header_s io_resp_cast_i;
+  bp_bedrock_mem_payload_s io_cmd_payload;
 
   assign io_cmd_header_o = io_cmd_cast_o;
   assign io_resp_cast_i = io_resp_header_i;

--- a/bp_me/test/common/bp_me_nonsynth_cce_inst_tracer.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cce_inst_tracer.sv
@@ -18,8 +18,8 @@ module bp_me_nonsynth_cce_inst_tracer
 
     , localparam cce_inst_trace_file_p = "cce_inst"
 
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
   )
   (input                        clk_i
    , input                      reset_i

--- a/bp_me/test/common/bp_me_nonsynth_cce_perf.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cce_perf.sv
@@ -16,8 +16,8 @@ module bp_me_nonsynth_cce_perf
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
 
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
     , localparam cnt_max_lp = 64'h0FFF_FFFF_FFFF_FFFF
     , localparam cce_trace_file_p = "cce_perf"
@@ -35,13 +35,13 @@ module bp_me_nonsynth_cce_perf
    , input [lce_resp_header_width_lp-1:0]           lce_resp_header_i
    , input                                          mem_resp_receive_i
    , input                                          mem_resp_squash_i
-   , input [cce_mem_header_width_lp-1:0]            mem_resp_header_i
+   , input [mem_header_width_lp-1:0]                mem_resp_header_i
    , input                                          mem_cmd_send_i
-   , input [cce_mem_header_width_lp-1:0]            mem_cmd_header_i
+   , input [mem_header_width_lp-1:0]                mem_cmd_header_i
   );
 
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   bp_bedrock_lce_req_header_s  lce_req;
 
   integer file;

--- a/bp_me/test/common/bp_me_nonsynth_cce_tracer.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cce_tracer.sv
@@ -27,8 +27,8 @@ module bp_me_nonsynth_cce_tracer
     , localparam lg_num_way_groups_lp      = `BSG_SAFE_CLOG2(num_way_groups_lp)
     , localparam lg_cce_way_groups_lp      = `BSG_SAFE_CLOG2(cce_way_groups_p)
 
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
   )
   (input                                            clk_i
    , input                                          reset_i
@@ -58,13 +58,13 @@ module bp_me_nonsynth_cce_tracer
 
    // CCE-MEM Interface
    // BedRock Stream protocol: ready&valid
-   , input [cce_mem_header_width_lp-1:0]            mem_resp_header_i
+   , input [mem_header_width_lp-1:0]            mem_resp_header_i
    , input [dword_width_gp-1:0]                     mem_resp_data_i
    , input                                          mem_resp_v_i
    , input                                          mem_resp_ready_and_i
    , input                                          mem_resp_last_i
 
-   , input [cce_mem_header_width_lp-1:0]            mem_cmd_header_i
+   , input [mem_header_width_lp-1:0]            mem_cmd_header_i
    , input [dword_width_gp-1:0]                     mem_cmd_data_i
    , input                                          mem_cmd_v_i
    , input                                          mem_cmd_ready_and_i
@@ -74,8 +74,8 @@ module bp_me_nonsynth_cce_tracer
   );
 
   // LCE-CCE and Mem-CCE Interface
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
 
   // LCE-CCE Interface structs
   bp_bedrock_lce_req_header_s  lce_req;
@@ -86,8 +86,8 @@ module bp_me_nonsynth_cce_tracer
   bp_bedrock_lce_resp_payload_s    lce_resp_payload;
 
   // CCE-MEM Interface structs
-  bp_bedrock_cce_mem_header_s  mem_cmd, mem_resp;
-  bp_bedrock_cce_mem_payload_s     mem_cmd_payload, mem_resp_payload;
+  bp_bedrock_mem_header_s  mem_cmd, mem_resp;
+  bp_bedrock_mem_payload_s mem_cmd_payload, mem_resp_payload;
 
   assign lce_req             = lce_req_header_i;
   assign lce_resp            = lce_resp_header_i;

--- a/bp_me/test/common/bp_me_nonsynth_cce_tracer.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cce_tracer.sv
@@ -58,13 +58,13 @@ module bp_me_nonsynth_cce_tracer
 
    // CCE-MEM Interface
    // BedRock Stream protocol: ready&valid
-   , input [mem_header_width_lp-1:0]            mem_resp_header_i
+   , input [mem_header_width_lp-1:0]                mem_resp_header_i
    , input [dword_width_gp-1:0]                     mem_resp_data_i
    , input                                          mem_resp_v_i
    , input                                          mem_resp_ready_and_i
    , input                                          mem_resp_last_i
 
-   , input [mem_header_width_lp-1:0]            mem_cmd_header_i
+   , input [mem_header_width_lp-1:0]                mem_cmd_header_i
    , input [dword_width_gp-1:0]                     mem_cmd_data_i
    , input                                          mem_cmd_v_i
    , input                                          mem_cmd_ready_and_i

--- a/bp_me/test/common/bp_me_nonsynth_dev_tracer.sv
+++ b/bp_me/test/common/bp_me_nonsynth_dev_tracer.sv
@@ -18,7 +18,7 @@ module bp_me_nonsynth_dev_tracer
 
     , parameter trace_file_p = "dev"
 
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, xce)
+    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
   )
   (input                                            clk_i
    , input                                          reset_i
@@ -27,23 +27,23 @@ module bp_me_nonsynth_dev_tracer
 
    // CCE-MEM Interface
    // BedRock Stream protocol: ready&valid
-   , input [xce_mem_header_width_lp-1:0]            mem_cmd_header_i
+   , input [mem_header_width_lp-1:0]                mem_cmd_header_i
    , input [dword_width_gp-1:0]                     mem_cmd_data_i
    , input                                          mem_cmd_v_i
    , input                                          mem_cmd_ready_and_i
    , input                                          mem_cmd_last_i
 
-   , input [xce_mem_header_width_lp-1:0]            mem_resp_header_i
+   , input [mem_header_width_lp-1:0]                mem_resp_header_i
    , input [dword_width_gp-1:0]                     mem_resp_data_i
    , input                                          mem_resp_v_i
    , input                                          mem_resp_ready_and_i
    , input                                          mem_resp_last_i
   );
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, xce);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
 
-  `bp_cast_i(bp_bedrock_xce_mem_header_s, mem_cmd_header);
-  `bp_cast_i(bp_bedrock_xce_mem_header_s, mem_resp_header);
+  `bp_cast_i(bp_bedrock_mem_header_s, mem_cmd_header);
+  `bp_cast_i(bp_bedrock_mem_header_s, mem_resp_header);
 
   integer file;
   string file_name;

--- a/bp_me/test/common/bp_me_nonsynth_lce_tracer.sv
+++ b/bp_me/test/common/bp_me_nonsynth_lce_tracer.sv
@@ -31,7 +31,7 @@ module bp_me_nonsynth_lce_tracer
 
     , localparam lce_req_data_width_lp = dword_width_gp
 
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
+    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
 
     , localparam integer cnt_max_lp = 1<<31
     , localparam cnt_ptr_width_lp = `BSG_SAFE_CLOG2(cnt_max_lp+1)
@@ -68,7 +68,7 @@ module bp_me_nonsynth_lce_tracer
   );
 
   // LCE-CCE interface structs
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
   `bp_cast_i(bp_bedrock_lce_req_header_s, lce_req_header);
   `bp_cast_i(bp_bedrock_lce_cmd_header_s, lce_cmd_header);
   `bp_cast_i(bp_bedrock_lce_resp_header_s, lce_resp_header);

--- a/bp_me/test/common/bp_me_nonsynth_mock_lce.sv
+++ b/bp_me/test/common/bp_me_nonsynth_mock_lce.sv
@@ -46,7 +46,7 @@ module bp_me_nonsynth_mock_lce
     , localparam counter_max_p = 512
     , localparam counter_width_p=`BSG_WIDTH(counter_max_p+1)
 
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
+    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
 
   )
   (
@@ -101,7 +101,7 @@ module bp_me_nonsynth_mock_lce
   wire axe_trace_en = !(axe_trace_p == 0);
 
   // LCE-CCE interface structs
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
 
   // LCE TR Packet struct
   `declare_bp_me_nonsynth_lce_tr_pkt_s(paddr_width_p, dword_width_gp);

--- a/bp_me/test/common/bp_mem_nonsynth_tracer.sv
+++ b/bp_me/test/common/bp_mem_nonsynth_tracer.sv
@@ -11,7 +11,7 @@ module bp_mem_nonsynth_tracer
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    , parameter data_width_p = l2_fill_width_p
    , parameter trace_file_p = "dram.trace"
@@ -20,22 +20,22 @@ module bp_mem_nonsynth_tracer
    , input                                      reset_i
 
    // BP side
-   , input [cce_mem_header_width_lp-1:0]        mem_cmd_header_i
+   , input [mem_header_width_lp-1:0]            mem_cmd_header_i
    , input [data_width_p-1:0]                   mem_cmd_data_i
    , input                                      mem_cmd_v_i
    , input                                      mem_cmd_ready_and_i
    , input                                      mem_cmd_last_i
 
-   , input [cce_mem_header_width_lp-1:0]        mem_resp_header_i
+   , input [mem_header_width_lp-1:0]            mem_resp_header_i
    , input [data_width_p-1:0]                   mem_resp_data_i
    , input                                      mem_resp_v_i
    , input                                      mem_resp_ready_and_i
    , input                                      mem_resp_last_i
    );
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
-  `bp_cast_i(bp_bedrock_cce_mem_header_s, mem_cmd_header);
-  `bp_cast_i(bp_bedrock_cce_mem_header_s, mem_resp_header);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `bp_cast_i(bp_bedrock_mem_header_s, mem_cmd_header);
+  `bp_cast_i(bp_bedrock_mem_header_s, mem_resp_header);
 
   integer file;
   always_ff @(negedge reset_i)

--- a/bp_me/test/common/bp_nonsynth_dram.sv
+++ b/bp_me/test/common/bp_nonsynth_dram.sv
@@ -13,7 +13,7 @@ module bp_nonsynth_dram
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    , parameter num_dma_p = 1
    , parameter preload_mem_p = 0

--- a/bp_me/test/common/bp_nonsynth_mem.sv
+++ b/bp_me/test/common/bp_nonsynth_mem.sv
@@ -13,7 +13,7 @@ module bp_nonsynth_mem
  import bsg_cache_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    , parameter preload_mem_p = 0
    , parameter mem_els_p = 0
@@ -22,13 +22,13 @@ module bp_nonsynth_mem
   (input                                            clk_i
    , input                                          reset_i
 
-   , input [cce_mem_header_width_lp-1:0]            mem_cmd_header_i
+   , input [mem_header_width_lp-1:0]                mem_cmd_header_i
    , input [l2_fill_width_p-1:0]                    mem_cmd_data_i
    , input                                          mem_cmd_v_i
    , output logic                                   mem_cmd_ready_and_o
    , input                                          mem_cmd_last_i
 
-   , output logic [cce_mem_header_width_lp-1:0]     mem_resp_header_o
+   , output logic [mem_header_width_lp-1:0]         mem_resp_header_o
    , output logic [l2_fill_width_p-1:0]             mem_resp_data_o
    , output logic                                   mem_resp_v_o
    , input                                          mem_resp_ready_and_i

--- a/bp_me/test/tb/bp_cce/testbench.sv
+++ b/bp_me/test/tb/bp_cce/testbench.sv
@@ -42,8 +42,8 @@ module testbench
    , localparam trace_replay_data_width_lp=`bp_me_nonsynth_lce_tr_pkt_width(paddr_width_p, dword_width_gp)
    , localparam trace_rom_addr_width_lp = 20
 
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
    )
   (output bit reset_i);
 
@@ -59,8 +59,8 @@ module testbench
   endfunction
 
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `declare_bp_me_nonsynth_lce_tr_pkt_s(paddr_width_p, dword_width_gp);
 
   // Bit to deal with initial X->0 transition detection
@@ -116,7 +116,7 @@ module testbench
   logic [cce_instr_width_gp-1:0] cce_ucode_data_lo;
 
   // CCE Memory Interface - BedRock Stream
-  bp_bedrock_cce_mem_header_s mem_resp_header, mem_cmd_header;
+  bp_bedrock_mem_header_s mem_resp_header, mem_cmd_header;
   logic [dword_width_gp-1:0] mem_cmd_data, mem_resp_data;
   logic mem_resp_v, mem_resp_ready_and;
   logic mem_cmd_v, mem_cmd_ready_and;
@@ -607,11 +607,11 @@ module testbench
   );
 
   // Memory Command Buffer
-  bp_bedrock_cce_mem_header_s mem_cmd_lo;
+  bp_bedrock_mem_header_s mem_cmd_lo;
   logic [dword_width_gp-1:0] mem_cmd_data_lo;
   logic mem_cmd_v_lo, mem_cmd_ready_and_li, mem_cmd_yumi_li, mem_cmd_last_lo;
   bsg_fifo_1r1w_small
-  #(.width_p($bits(bp_bedrock_cce_mem_header_s)+dword_width_gp+1)
+  #(.width_p($bits(bp_bedrock_mem_header_s)+dword_width_gp+1)
     ,.els_p(mem_buffer_els_lp)
     )
   mem_cmd_stream_buffer
@@ -629,11 +629,11 @@ module testbench
   assign mem_cmd_yumi_li = mem_cmd_v_lo & mem_cmd_ready_and_li;
 
   // Memory Response Buffer
-  bp_bedrock_cce_mem_header_s mem_resp_li;
+  bp_bedrock_mem_header_s mem_resp_li;
   logic [dword_width_gp-1:0] mem_resp_data_li;
   logic mem_resp_v_li, mem_resp_ready_and_lo, mem_resp_last_li, mem_resp_yumi_lo;
   bsg_fifo_1r1w_small
-  #(.width_p($bits(bp_bedrock_cce_mem_header_s)+dword_width_gp+1)
+  #(.width_p($bits(bp_bedrock_mem_header_s)+dword_width_gp+1)
     ,.els_p(mem_buffer_els_lp)
     )
   mem_resp_stream_buffer
@@ -888,7 +888,7 @@ module testbench
 
 
   // Config
-  bp_bedrock_cce_mem_header_s cfg_mem_cmd_lo;
+  bp_bedrock_mem_header_s cfg_mem_cmd_lo;
   logic [dword_width_gp-1:0] cfg_mem_cmd_data_lo;
   logic cfg_mem_cmd_v_lo, cfg_mem_cmd_ready_and_li, cfg_mem_cmd_last_lo;
   logic cfg_mem_resp_v_lo;

--- a/bp_me/test/tb/bp_cce/wrapper.sv
+++ b/bp_me/test/tb/bp_cce/wrapper.sv
@@ -14,8 +14,8 @@ module wrapper
    `declare_bp_proc_params(bp_params_p)
 
    // interface widths
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
 
    , parameter cce_trace_p = 0
@@ -62,13 +62,13 @@ module wrapper
 
    // CCE-MEM Interface
    // BedRock Burst protocol: ready&valid
-   , input [cce_mem_header_width_lp-1:0]            mem_resp_header_i
+   , input [mem_header_width_lp-1:0]                mem_resp_header_i
    , input [dword_width_gp-1:0]                     mem_resp_data_i
    , input                                          mem_resp_v_i
    , output logic                                   mem_resp_ready_and_o
    , input                                          mem_resp_last_i
 
-   , output logic [cce_mem_header_width_lp-1:0]     mem_cmd_header_o
+   , output logic [mem_header_width_lp-1:0]         mem_cmd_header_o
    , output logic [dword_width_gp-1:0]              mem_cmd_data_o
    , output logic                                   mem_cmd_v_o
    , input                                          mem_cmd_ready_and_i

--- a/bp_top/src/v/bp_cacc_tile.sv
+++ b/bp_top/src/v/bp_cacc_tile.sv
@@ -16,8 +16,8 @@ module bp_cacc_tile
  import bsg_wormhole_router_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam io_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(io_noc_flit_width_p)
@@ -39,8 +39,8 @@ module bp_cacc_tile
 
    );
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
 
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, bp_coh_ready_and_link_s);
 
@@ -52,10 +52,10 @@ module bp_cacc_tile
   logic [cce_block_width_p-1:0] cce_lce_cmd_data_lo;
   logic cce_lce_cmd_v_lo, cce_lce_cmd_ready_and_li;
 
-  bp_bedrock_cce_mem_header_s cce_io_cmd_header_lo;
+  bp_bedrock_mem_header_s cce_io_cmd_header_lo;
   logic [cce_block_width_p-1:0] cce_io_cmd_data_lo;
   logic cce_io_cmd_v_lo, cce_io_cmd_ready_and_li;
-  bp_bedrock_cce_mem_header_s cce_io_resp_header_li;
+  bp_bedrock_mem_header_s cce_io_resp_header_li;
   logic [cce_block_width_p-1:0] cce_io_resp_data_li;
   logic cce_io_resp_v_li, cce_io_resp_ready_and_lo;
 

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -7,8 +7,8 @@ module bp_cacc_vdp
  import bp_me_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
     `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, acache_sets_p, acache_assoc_p, dword_width_gp, acache_block_width_p, acache_fill_width_p, cache)
 
     , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
@@ -38,12 +38,12 @@ module bp_cacc_vdp
     , output logic                                lce_cmd_v_o
     , input                                       lce_cmd_ready_i
 
-    , input [cce_mem_header_width_lp-1:0]         io_cmd_header_i
+    , input [mem_header_width_lp-1:0]             io_cmd_header_i
     , input [cce_block_width_p-1:0]               io_cmd_data_i
     , input                                       io_cmd_v_i
     , output logic                                io_cmd_ready_o
 
-    , output logic [cce_mem_header_width_lp-1:0]  io_resp_header_o
+    , output logic [mem_header_width_lp-1:0]      io_resp_header_o
     , output logic [cce_block_width_p-1:0]        io_resp_data_o
     , output logic                                io_resp_v_o
     , input                                       io_resp_yumi_i
@@ -231,9 +231,9 @@ module bp_cacc_vdp
      );
 
   // CCE-IO interface is used for uncached requests-read/write memory mapped CSR
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
-  `bp_cast_i(bp_bedrock_cce_mem_header_s, io_cmd_header);
-  `bp_cast_o(bp_bedrock_cce_mem_header_s, io_resp_header);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `bp_cast_i(bp_bedrock_mem_header_s, io_cmd_header);
+  `bp_cast_o(bp_bedrock_mem_header_s, io_resp_header);
 
   assign io_cmd_ready_o = 1'b1;
 
@@ -251,7 +251,7 @@ module bp_cacc_vdp
   logic [63:0] sum_l2 [0:1];
   logic [63:0] dot_product_temp;
 
-  bp_bedrock_cce_mem_payload_s  resp_payload;
+  bp_bedrock_mem_payload_s      resp_payload;
   bp_bedrock_msg_size_e         resp_size;
   bp_bedrock_mem_type_e         resp_msg;
   bp_local_addr_s               local_addr_li;

--- a/bp_top/src/v/bp_core.sv
+++ b/bp_top/src/v/bp_core.sv
@@ -15,7 +15,7 @@ module bp_core
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_core_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
+   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
 

--- a/bp_top/src/v/bp_io_link_to_lce.sv
+++ b/bp_top/src/v/bp_io_link_to_lce.sv
@@ -10,8 +10,8 @@ module bp_io_link_to_lce
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
@@ -21,13 +21,13 @@ module bp_io_link_to_lce
 
    , input [lce_id_width_p-1:0]                     lce_id_i
 
-   , input [cce_mem_header_width_lp-1:0]            io_cmd_header_i
+   , input [mem_header_width_lp-1:0]                io_cmd_header_i
    , input [cce_block_width_p-1:0]                  io_cmd_data_i
    , input                                          io_cmd_v_i
    , input                                          io_cmd_last_i
    , output logic                                   io_cmd_yumi_o
 
-   , output logic [cce_mem_header_width_lp-1:0]     io_resp_header_o
+   , output logic [mem_header_width_lp-1:0]         io_resp_header_o
    , output logic [cce_block_width_p-1:0]           io_resp_data_o
    , output logic                                   io_resp_v_o
    , output logic                                   io_resp_last_o
@@ -46,19 +46,19 @@ module bp_io_link_to_lce
    // No lce_resp acknowledgements for I/O (uncached) accesses
    );
 
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
-  `bp_cast_i(bp_bedrock_cce_mem_header_s, io_cmd_header);
-  `bp_cast_o(bp_bedrock_cce_mem_header_s, io_resp_header);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `bp_cast_i(bp_bedrock_mem_header_s, io_cmd_header);
+  `bp_cast_o(bp_bedrock_mem_header_s, io_resp_header);
   `bp_cast_o(bp_bedrock_lce_req_header_s, lce_req_header);
   `bp_cast_i(bp_bedrock_lce_req_header_s, lce_cmd_header);
 
   // TODO: This implementation only works for burst length == 1, like the
   //   rest of this module
-  bp_bedrock_cce_mem_payload_s io_resp_payload;
+  bp_bedrock_mem_payload_s io_resp_payload;
   logic payload_ready_lo, payload_v_lo;
   bsg_fifo_1r1w_small
-   #(.width_p($bits(bp_bedrock_cce_mem_payload_s)), .els_p(io_noc_max_credits_p))
+   #(.width_p($bits(bp_bedrock_mem_payload_s)), .els_p(io_noc_max_credits_p))
    payload_fifo
     (.clk_i(clk_i)
      ,.reset_i(reset_i)

--- a/bp_top/src/v/bp_io_tile.sv
+++ b/bp_top/src/v/bp_io_tile.sv
@@ -8,8 +8,8 @@ module bp_io_tile
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam io_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(io_noc_flit_width_p)
@@ -34,9 +34,9 @@ module bp_io_tile
    , output [io_noc_ral_link_width_lp-1:0]  io_resp_link_o
    );
 
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
-  `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cmd_msg_width_lp, lce_cmd_packet_s);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bsg_wormhole_concentrator_packet_s(coh_noc_cord_width_p, coh_noc_len_width_p, coh_noc_cid_width_p, lce_cmd_header_width_lp, lce_cmd_packet_s);
   `declare_bp_memory_map(paddr_width_p, daddr_width_p);
 
   bp_bedrock_lce_req_header_s cce_lce_req_header_li, lce_lce_req_header_lo;
@@ -46,10 +46,10 @@ module bp_io_tile
   logic [cce_block_width_p-1:0] cce_lce_cmd_data_lo, lce_lce_cmd_data_li;
   logic cce_lce_cmd_v_lo, cce_lce_cmd_ready_and_li, lce_lce_cmd_v_li, lce_lce_cmd_yumi_lo;
 
-  bp_bedrock_cce_mem_header_s cce_io_cmd_header_lo, lce_io_cmd_header_li;
+  bp_bedrock_mem_header_s cce_io_cmd_header_lo, lce_io_cmd_header_li;
   logic [cce_block_width_p-1:0] cce_io_cmd_data_lo, lce_io_cmd_data_li;
   logic cce_io_cmd_v_lo, cce_io_cmd_ready_and_li, lce_io_cmd_v_li, lce_io_cmd_yumi_lo;
-  bp_bedrock_cce_mem_header_s cce_io_resp_header_li, lce_io_resp_header_lo;
+  bp_bedrock_mem_header_s cce_io_resp_header_li, lce_io_resp_header_lo;
   logic [cce_block_width_p-1:0] cce_io_resp_data_li, lce_io_resp_data_lo;
   logic cce_io_resp_v_li, cce_io_resp_ready_and_lo, lce_io_resp_v_lo, lce_io_resp_ready_and_li;
   logic cce_io_resp_last_li, lce_io_cmd_last_li;

--- a/bp_top/src/v/bp_sacc_loopback.sv
+++ b/bp_top/src/v/bp_sacc_loopback.sv
@@ -7,7 +7,7 @@ module bp_sacc_loopback
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
    , localparam cfg_bus_width_lp= `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    )
   (input                                        clk_i
@@ -15,34 +15,34 @@ module bp_sacc_loopback
 
    , input [lce_id_width_p-1:0]                 lce_id_i
 
-   , input [cce_mem_header_width_lp-1:0]        io_cmd_header_i
+   , input [mem_header_width_lp-1:0]            io_cmd_header_i
    , input [cce_block_width_p-1:0]              io_cmd_data_i
    , input                                      io_cmd_v_i
    , output logic                               io_cmd_ready_o
 
-   , output logic [cce_mem_header_width_lp-1:0] io_resp_header_o
+   , output logic [mem_header_width_lp-1:0]     io_resp_header_o
    , output logic [cce_block_width_p-1:0]       io_resp_data_o
    , output logic                               io_resp_v_o
    , input                                      io_resp_yumi_i
 
-   , output logic [cce_mem_header_width_lp-1:0] io_cmd_header_o
+   , output logic [mem_header_width_lp-1:0]     io_cmd_header_o
    , output logic [cce_block_width_p-1:0]       io_cmd_data_o
    , output logic                               io_cmd_v_o
    , input                                      io_cmd_yumi_i
 
-   , input [cce_mem_header_width_lp-1:0]        io_resp_header_i
+   , input [mem_header_width_lp-1:0]            io_resp_header_i
    , input [cce_block_width_p-1:0]              io_resp_data_i
    , input                                      io_resp_v_i
    , output logic                               io_resp_ready_o
    );
 
   // CCE-IO interface is used for uncached requests-read/write memory mapped CSR
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, daddr_width_p);
-  `bp_cast_o(bp_bedrock_cce_mem_header_s, io_cmd_header);
-  `bp_cast_i(bp_bedrock_cce_mem_header_s, io_resp_header);
-  `bp_cast_i(bp_bedrock_cce_mem_header_s, io_cmd_header);
-  `bp_cast_o(bp_bedrock_cce_mem_header_s, io_resp_header);
+  `bp_cast_o(bp_bedrock_mem_header_s, io_cmd_header);
+  `bp_cast_i(bp_bedrock_mem_header_s, io_resp_header);
+  `bp_cast_i(bp_bedrock_mem_header_s, io_cmd_header);
+  `bp_cast_o(bp_bedrock_mem_header_s, io_resp_header);
 
   assign io_cmd_ready_o = 1'b1;
   assign io_resp_ready_o = 1'b1;
@@ -54,7 +54,7 @@ module bp_sacc_loopback
   logic [vaddr_width_p-1:0] spm_addr;
   logic spm_read_v_li, spm_write_v_li, spm_v_lo, resp_v_lo;
 
-  bp_bedrock_cce_mem_payload_s  resp_payload;
+  bp_bedrock_mem_payload_s  resp_payload;
   bp_bedrock_msg_size_e         resp_size;
   bp_bedrock_mem_type_e         resp_msg;
   bp_local_addr_s           local_addr_li;

--- a/bp_top/src/v/bp_sacc_tile.sv
+++ b/bp_top/src/v/bp_sacc_tile.sv
@@ -17,8 +17,8 @@ module bp_sacc_tile
 
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam io_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(io_noc_flit_width_p)
@@ -37,8 +37,8 @@ module bp_sacc_tile
 
    );
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, bp_coh_ready_and_link_s);
 
   //io-cce-side connections
@@ -48,10 +48,10 @@ module bp_sacc_tile
   bp_bedrock_lce_cmd_header_s cce_lce_cmd_header_lo, lce_lce_cmd_header_li;
   logic [cce_block_width_p-1:0] cce_lce_cmd_data_lo, lce_lce_cmd_data_li;
   logic cce_lce_cmd_v_lo, cce_lce_cmd_ready_and_li, lce_lce_cmd_v_li, lce_lce_cmd_yumi_lo;
-  bp_bedrock_cce_mem_header_s cce_io_cmd_header_lo, lce_io_cmd_header_li;
+  bp_bedrock_mem_header_s cce_io_cmd_header_lo, lce_io_cmd_header_li;
   logic [cce_block_width_p-1:0] cce_io_cmd_data_lo, lce_io_cmd_data_li;
   logic cce_io_cmd_v_lo, cce_io_cmd_ready_and_li, lce_io_cmd_v_li, lce_io_cmd_yumi_lo;
-  bp_bedrock_cce_mem_header_s cce_io_resp_header_li, lce_io_resp_header_lo;
+  bp_bedrock_mem_header_s cce_io_resp_header_li, lce_io_resp_header_lo;
   logic [cce_block_width_p-1:0] cce_io_resp_data_li, lce_io_resp_data_lo;
   logic cce_io_resp_v_li, cce_io_resp_ready_and_lo, lce_io_resp_v_lo, lce_io_resp_ready_and_li;
 

--- a/bp_top/src/v/bp_sacc_vdp.sv
+++ b/bp_top/src/v/bp_sacc_vdp.sv
@@ -7,7 +7,7 @@ module bp_sacc_vdp
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
    , localparam cfg_bus_width_lp= `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    )
   (input                                        clk_i
@@ -15,34 +15,34 @@ module bp_sacc_vdp
 
    , input [lce_id_width_p-1:0]                 lce_id_i
 
-   , input [cce_mem_header_width_lp-1:0]        io_cmd_header_i
+   , input [mem_header_width_lp-1:0]            io_cmd_header_i
    , input [cce_block_width_p-1:0]              io_cmd_data_i
    , input                                      io_cmd_v_i
    , output logic                               io_cmd_ready_o
 
-   , output logic [cce_mem_header_width_lp-1:0] io_resp_header_o
+   , output logic [mem_header_width_lp-1:0]     io_resp_header_o
    , output logic [cce_block_width_p-1:0]       io_resp_data_o
    , output logic                               io_resp_v_o
    , input                                      io_resp_yumi_i
 
-   , output logic [cce_mem_header_width_lp-1:0] io_cmd_header_o
+   , output logic [mem_header_width_lp-1:0]     io_cmd_header_o
    , output logic [cce_block_width_p-1:0]       io_cmd_data_o
    , output logic                               io_cmd_v_o
    , input                                      io_cmd_yumi_i
 
-   , input [cce_mem_header_width_lp-1:0]        io_resp_header_i
+   , input [mem_header_width_lp-1:0]            io_resp_header_i
    , input [cce_block_width_p-1:0]              io_resp_data_i
    , input                                      io_resp_v_i
    , output logic                               io_resp_ready_o
    );
 
   // CCE-IO interface is used for uncached requests-read/write memory mapped CSR
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, daddr_width_p);
-  `bp_cast_o(bp_bedrock_cce_mem_header_s, io_cmd_header);
-  `bp_cast_i(bp_bedrock_cce_mem_header_s, io_resp_header);
-  `bp_cast_i(bp_bedrock_cce_mem_header_s, io_cmd_header);
-  `bp_cast_o(bp_bedrock_cce_mem_header_s, io_resp_header);
+  `bp_cast_o(bp_bedrock_mem_header_s, io_cmd_header);
+  `bp_cast_i(bp_bedrock_mem_header_s, io_resp_header);
+  `bp_cast_i(bp_bedrock_mem_header_s, io_cmd_header);
+  `bp_cast_o(bp_bedrock_mem_header_s, io_resp_header);
 
   assign io_cmd_ready_o = 1'b1;
   assign io_resp_ready_o = 1'b1;
@@ -67,9 +67,9 @@ module bp_sacc_vdp
                             spm_external_read_v_li, spm_external_write_v_li,
                             spm_internal_v_lo, spm_external_v_lo, resp_v_lo;
 
-  bp_bedrock_cce_mem_payload_s  resp_payload;
-  bp_bedrock_msg_size_e         resp_size;
-  bp_bedrock_mem_type_e         resp_msg;
+  bp_bedrock_mem_payload_s  resp_payload;
+  bp_bedrock_msg_size_e     resp_size;
+  bp_bedrock_mem_type_e     resp_msg;
   bp_local_addr_s           local_addr_li;
   bp_global_addr_s          global_addr_li;
 

--- a/bp_top/src/v/bp_tile.sv
+++ b/bp_top/src/v/bp_tile.sv
@@ -21,10 +21,10 @@ module bp_tile
  import bsg_wormhole_router_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
-   , localparam cfg_bus_width_lp        = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
 
    // Wormhole parameters
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
@@ -52,8 +52,8 @@ module bp_tile
    );
 
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, daddr_width_p);
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, bp_coh_ready_and_link_s);
 
@@ -450,19 +450,19 @@ module bp_tile
      );
 
   // CCE-side CCE-Mem network connections
-  bp_bedrock_cce_mem_header_s cce_mem_cmd_header_lo;
-  logic [dword_width_gp-1:0] cce_mem_cmd_data_lo;
-  logic cce_mem_cmd_v_lo, cce_mem_cmd_last_lo, cce_mem_cmd_ready_and_li;
-  bp_bedrock_cce_mem_header_s cce_mem_resp_header_li;
-  logic [dword_width_gp-1:0] cce_mem_resp_data_li;
-  logic cce_mem_resp_v_li, cce_mem_resp_ready_and_lo, cce_mem_resp_last_li;
+  bp_bedrock_mem_header_s mem_cmd_header_lo;
+  logic [dword_width_gp-1:0] mem_cmd_data_lo;
+  logic mem_cmd_v_lo, mem_cmd_last_lo, mem_cmd_ready_and_li;
+  bp_bedrock_mem_header_s mem_resp_header_li;
+  logic [dword_width_gp-1:0] mem_resp_data_li;
+  logic mem_resp_v_li, mem_resp_ready_and_lo, mem_resp_last_li;
 
   // Device-side CCE-Mem network connections
   // dev_cmd[3:0] = {CCE loopback, CLINT, CFG, memory (cache)}
-  bp_bedrock_cce_mem_header_s [3:0] dev_cmd_header_li;
+  bp_bedrock_mem_header_s [3:0] dev_cmd_header_li;
   logic [3:0][dword_width_gp-1:0] dev_cmd_data_li;
   logic [3:0] dev_cmd_v_li, dev_cmd_ready_and_lo, dev_cmd_last_li;
-  bp_bedrock_cce_mem_header_s [3:0] dev_resp_header_lo;
+  bp_bedrock_mem_header_s [3:0] dev_resp_header_lo;
   logic [3:0][dword_width_gp-1:0] dev_resp_data_lo;
   logic [3:0] dev_resp_v_lo, dev_resp_ready_and_li, dev_resp_last_lo;
 
@@ -548,11 +548,11 @@ module bp_tile
      );
 
   // Select destination of CCE-Mem command from CCE
-  logic [`BSG_SAFE_CLOG2(4)-1:0] cce_mem_cmd_dst_lo;
+  logic [`BSG_SAFE_CLOG2(4)-1:0] mem_cmd_dst_lo;
   bp_local_addr_s local_addr;
-  assign local_addr = cce_mem_cmd_header_lo.addr;
+  assign local_addr = mem_cmd_header_lo.addr;
   wire [dev_id_width_gp-1:0] device_cmd_li = local_addr.dev;
-  wire local_cmd_li    = (cce_mem_cmd_header_lo.addr < dram_base_addr_gp);
+  wire local_cmd_li    = (mem_cmd_header_lo.addr < dram_base_addr_gp);
 
   wire is_cfg_cmd      = local_cmd_li & (device_cmd_li == cfg_dev_gp);
   wire is_clint_cmd    = local_cmd_li & (device_cmd_li == clint_dev_gp);
@@ -563,7 +563,7 @@ module bp_tile
    #(.width_p(4), .lo_to_hi_p(1))
    cmd_pe
     (.i({is_loopback_cmd, is_clint_cmd, is_cfg_cmd, is_mem_cmd})
-     ,.addr_o(cce_mem_cmd_dst_lo)
+     ,.addr_o(mem_cmd_dst_lo)
      ,.v_o()
      );
 
@@ -573,7 +573,7 @@ module bp_tile
   bp_me_xbar_stream_buffered
    #(.bp_params_p(bp_params_p)
      ,.data_width_p(dword_width_gp)
-     ,.payload_width_p(cce_mem_payload_width_lp)
+     ,.payload_width_p(mem_payload_width_lp)
      ,.num_source_p(1)
      ,.num_sink_p(4)
      )
@@ -581,12 +581,12 @@ module bp_tile
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.msg_header_i(cce_mem_cmd_header_lo)
-     ,.msg_data_i(cce_mem_cmd_data_lo)
-     ,.msg_v_i(cce_mem_cmd_v_lo)
-     ,.msg_ready_and_o(cce_mem_cmd_ready_and_li)
-     ,.msg_last_i(cce_mem_cmd_last_lo)
-     ,.msg_dst_i(cce_mem_cmd_dst_lo)
+     ,.msg_header_i(mem_cmd_header_lo)
+     ,.msg_data_i(mem_cmd_data_lo)
+     ,.msg_v_i(mem_cmd_v_lo)
+     ,.msg_ready_and_o(mem_cmd_ready_and_li)
+     ,.msg_last_i(mem_cmd_last_lo)
+     ,.msg_dst_i(mem_cmd_dst_lo)
 
      ,.msg_header_o(dev_cmd_header_li)
      ,.msg_data_o(dev_cmd_data_li)
@@ -598,7 +598,7 @@ module bp_tile
   bp_me_xbar_stream_buffered
    #(.bp_params_p(bp_params_p)
      ,.data_width_p(dword_width_gp)
-     ,.payload_width_p(cce_mem_payload_width_lp)
+     ,.payload_width_p(mem_payload_width_lp)
      ,.num_source_p(4)
      ,.num_sink_p(1)
      )
@@ -613,11 +613,11 @@ module bp_tile
      ,.msg_last_i(dev_resp_last_lo)
      ,.msg_dst_i(dev_resp_dst_lo)
 
-     ,.msg_header_o(cce_mem_resp_header_li)
-     ,.msg_data_o(cce_mem_resp_data_li)
-     ,.msg_v_o(cce_mem_resp_v_li)
-     ,.msg_ready_and_i(cce_mem_resp_ready_and_lo)
-     ,.msg_last_o(cce_mem_resp_last_li)
+     ,.msg_header_o(mem_resp_header_li)
+     ,.msg_data_o(mem_resp_data_li)
+     ,.msg_v_o(mem_resp_v_li)
+     ,.msg_ready_and_i(mem_resp_ready_and_lo)
+     ,.msg_last_o(mem_resp_last_li)
      );
 
   // CCE: Cache Coherence Engine
@@ -666,17 +666,17 @@ module bp_tile
 
      // CCE-MEM Interface
      // BedRock Burst protocol: ready&valid
-     ,.mem_resp_header_i(cce_mem_resp_header_li)
-     ,.mem_resp_data_i(cce_mem_resp_data_li)
-     ,.mem_resp_v_i(cce_mem_resp_v_li)
-     ,.mem_resp_ready_and_o(cce_mem_resp_ready_and_lo)
-     ,.mem_resp_last_i(cce_mem_resp_last_li)
+     ,.mem_resp_header_i(mem_resp_header_li)
+     ,.mem_resp_data_i(mem_resp_data_li)
+     ,.mem_resp_v_i(mem_resp_v_li)
+     ,.mem_resp_ready_and_o(mem_resp_ready_and_lo)
+     ,.mem_resp_last_i(mem_resp_last_li)
 
-     ,.mem_cmd_header_o(cce_mem_cmd_header_lo)
-     ,.mem_cmd_data_o(cce_mem_cmd_data_lo)
-     ,.mem_cmd_v_o(cce_mem_cmd_v_lo)
-     ,.mem_cmd_ready_and_i(cce_mem_cmd_ready_and_li)
-     ,.mem_cmd_last_o(cce_mem_cmd_last_lo)
+     ,.mem_cmd_header_o(mem_cmd_header_lo)
+     ,.mem_cmd_data_o(mem_cmd_data_lo)
+     ,.mem_cmd_v_o(mem_cmd_v_lo)
+     ,.mem_cmd_ready_and_i(mem_cmd_ready_and_li)
+     ,.mem_cmd_last_o(mem_cmd_last_lo)
      );
 
   // CCE-Mem network to L2 Cache adapter

--- a/bp_top/src/v/bp_unicore.sv
+++ b/bp_top/src/v/bp_unicore.sv
@@ -33,7 +33,7 @@ module bp_unicore
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
 
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, uce)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    , localparam dma_pkt_width_lp = `bsg_cache_dma_pkt_width(daddr_width_p)
    )
@@ -45,26 +45,26 @@ module bp_unicore
    , input [coh_noc_cord_width_p-1:0]                  my_cord_i
 
    // Outgoing I/O
-   , output logic [uce_mem_header_width_lp-1:0]        io_cmd_header_o
+   , output logic [mem_header_width_lp-1:0]            io_cmd_header_o
    , output logic [uce_fill_width_p-1:0]               io_cmd_data_o
    , output logic                                      io_cmd_v_o
    , input                                             io_cmd_ready_and_i
    , output logic                                      io_cmd_last_o
 
-   , input [uce_mem_header_width_lp-1:0]               io_resp_header_i
+   , input [mem_header_width_lp-1:0]                   io_resp_header_i
    , input [uce_fill_width_p-1:0]                      io_resp_data_i
    , input                                             io_resp_v_i
    , output logic                                      io_resp_ready_and_o
    , input                                             io_resp_last_i
 
    // Incoming I/O
-   , input [uce_mem_header_width_lp-1:0]               io_cmd_header_i
+   , input [mem_header_width_lp-1:0]                   io_cmd_header_i
    , input [uce_fill_width_p-1:0]                      io_cmd_data_i
    , input                                             io_cmd_v_i
    , output logic                                      io_cmd_ready_and_o
    , input                                             io_cmd_last_i
 
-   , output logic [uce_mem_header_width_lp-1:0]        io_resp_header_o
+   , output logic [mem_header_width_lp-1:0]            io_resp_header_o
    , output logic [uce_fill_width_p-1:0]               io_resp_data_o
    , output logic                                      io_resp_v_o
    , input                                             io_resp_ready_and_i
@@ -85,13 +85,12 @@ module bp_unicore
    );
 
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, uce);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
 
-  bp_bedrock_uce_mem_header_s mem_cmd_header_lo;
+  bp_bedrock_mem_header_s mem_cmd_header_lo;
   logic [l2_data_width_p-1:0] mem_cmd_data_lo;
   logic mem_cmd_v_lo, mem_cmd_ready_and_li, mem_cmd_last_lo;
-  bp_bedrock_uce_mem_header_s mem_resp_header_li;
+  bp_bedrock_mem_header_s mem_resp_header_li;
   logic [l2_data_width_p-1:0] mem_resp_data_li;
   logic mem_resp_v_li, mem_resp_ready_and_lo, mem_resp_last_li;
 

--- a/bp_top/src/v/bp_unicore_complex.sv
+++ b/bp_top/src/v/bp_unicore_complex.sv
@@ -12,7 +12,7 @@ module bp_unicore_complex
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, uce)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    , localparam dma_pkt_width_lp = `bsg_cache_dma_pkt_width(daddr_width_p)
    )
@@ -23,26 +23,26 @@ module bp_unicore_complex
    , input [io_noc_did_width_p-1:0]                                 host_did_i
 
    // Outgoing I/O
-   , output logic [num_core_p-1:0][uce_mem_header_width_lp-1:0]     io_cmd_header_o
+   , output logic [num_core_p-1:0][mem_header_width_lp-1:0]         io_cmd_header_o
    , output logic [num_core_p-1:0][uce_fill_width_p-1:0]            io_cmd_data_o
    , output logic [num_core_p-1:0]                                  io_cmd_v_o
    , input [num_core_p-1:0]                                         io_cmd_ready_and_i
    , output logic [num_core_p-1:0]                                  io_cmd_last_o
 
-   , input [num_core_p-1:0][uce_mem_header_width_lp-1:0]            io_resp_header_i
+   , input [num_core_p-1:0][mem_header_width_lp-1:0]                io_resp_header_i
    , input [num_core_p-1:0][uce_fill_width_p-1:0]                   io_resp_data_i
    , input [num_core_p-1:0]                                         io_resp_v_i
    , output logic [num_core_p-1:0]                                  io_resp_ready_and_o
    , input [num_core_p-1:0]                                         io_resp_last_i
 
    // Incoming I/O
-   , input [num_core_p-1:0][uce_mem_header_width_lp-1:0]            io_cmd_header_i
+   , input [num_core_p-1:0][mem_header_width_lp-1:0]                io_cmd_header_i
    , input [num_core_p-1:0][uce_fill_width_p-1:0]                   io_cmd_data_i
    , input [num_core_p-1:0]                                         io_cmd_v_i
    , output logic [num_core_p-1:0]                                  io_cmd_ready_and_o
    , input [num_core_p-1:0]                                         io_cmd_last_i
 
-   , output logic [num_core_p-1:0][uce_mem_header_width_lp-1:0]     io_resp_header_o
+   , output logic [num_core_p-1:0][mem_header_width_lp-1:0]         io_resp_header_o
    , output logic [num_core_p-1:0][uce_fill_width_p-1:0]            io_resp_data_o
    , output logic [num_core_p-1:0]                                  io_resp_v_o
    , input        [num_core_p-1:0]                                  io_resp_ready_and_i

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -11,7 +11,7 @@ module bp_unicore_lite
  import bsg_noc_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, uce)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
    )
   (input                                               clk_i
    , input                                             reset_i
@@ -21,39 +21,39 @@ module bp_unicore_lite
    , input [coh_noc_cord_width_p-1:0]                  my_cord_i
 
    // Outgoing I/O
-   , output logic [uce_mem_header_width_lp-1:0]        io_cmd_header_o
+   , output logic [mem_header_width_lp-1:0]            io_cmd_header_o
    , output logic [uce_fill_width_p-1:0]               io_cmd_data_o
    , output logic                                      io_cmd_v_o
    , input                                             io_cmd_ready_and_i
    , output logic                                      io_cmd_last_o
 
-   , input [uce_mem_header_width_lp-1:0]               io_resp_header_i
+   , input [mem_header_width_lp-1:0]                   io_resp_header_i
    , input [uce_fill_width_p-1:0]                      io_resp_data_i
    , input                                             io_resp_v_i
    , output logic                                      io_resp_ready_and_o
    , input                                             io_resp_last_i
 
    // Incoming I/O
-   , input [uce_mem_header_width_lp-1:0]               io_cmd_header_i
+   , input [mem_header_width_lp-1:0]                   io_cmd_header_i
    , input [uce_fill_width_p-1:0]                      io_cmd_data_i
    , input                                             io_cmd_v_i
    , output logic                                      io_cmd_ready_and_o
    , input                                             io_cmd_last_i
 
-   , output logic [uce_mem_header_width_lp-1:0]        io_resp_header_o
+   , output logic [mem_header_width_lp-1:0]            io_resp_header_o
    , output logic [uce_fill_width_p-1:0]               io_resp_data_o
    , output logic                                      io_resp_v_o
    , input                                             io_resp_ready_and_i
    , output logic                                      io_resp_last_o
 
    // Outgoing BP Stream Mem Bus
-   , output logic [uce_mem_header_width_lp-1:0]        mem_cmd_header_o
+   , output logic [mem_header_width_lp-1:0]            mem_cmd_header_o
    , output logic [uce_fill_width_p-1:0]               mem_cmd_data_o
    , output logic                                      mem_cmd_v_o
    , input                                             mem_cmd_ready_and_i
    , output logic                                      mem_cmd_last_o
 
-   , input [uce_mem_header_width_lp-1:0]               mem_resp_header_i
+   , input [mem_header_width_lp-1:0]                   mem_resp_header_i
    , input [uce_fill_width_p-1:0]                      mem_resp_data_i
    , input                                             mem_resp_v_i
    , output logic                                      mem_resp_ready_and_o
@@ -63,14 +63,14 @@ module bp_unicore_lite
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, uce);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, daddr_width_p);
-  `bp_cast_o(bp_bedrock_uce_mem_header_s, mem_cmd_header);
-  `bp_cast_i(bp_bedrock_uce_mem_header_s, mem_resp_header);
-  `bp_cast_o(bp_bedrock_uce_mem_header_s, io_cmd_header);
-  `bp_cast_i(bp_bedrock_uce_mem_header_s, io_resp_header);
-  `bp_cast_i(bp_bedrock_uce_mem_header_s, io_cmd_header);
-  `bp_cast_o(bp_bedrock_uce_mem_header_s, io_resp_header);
+  `bp_cast_o(bp_bedrock_mem_header_s, mem_cmd_header);
+  `bp_cast_i(bp_bedrock_mem_header_s, mem_resp_header);
+  `bp_cast_o(bp_bedrock_mem_header_s, io_cmd_header);
+  `bp_cast_i(bp_bedrock_mem_header_s, io_resp_header);
+  `bp_cast_i(bp_bedrock_mem_header_s, io_cmd_header);
+  `bp_cast_o(bp_bedrock_mem_header_s, io_resp_header);
 
   bp_icache_req_s icache_req_lo;
   logic icache_req_v_lo, icache_req_yumi_li, icache_req_busy_li;
@@ -113,18 +113,18 @@ module bp_unicore_lite
   logic timer_irq_li, software_irq_li, external_irq_li;
 
   // proc_cmd[2:0] = {IO cmd, BE UCE, FE UCE}
-  bp_bedrock_uce_mem_header_s [2:0] proc_cmd_header_lo;
+  bp_bedrock_mem_header_s [2:0] proc_cmd_header_lo;
   logic [2:0][uce_fill_width_p-1:0] proc_cmd_data_lo;
   logic [2:0] proc_cmd_v_lo, proc_cmd_ready_and_li, proc_cmd_last_lo;
-  bp_bedrock_uce_mem_header_s [2:0] proc_resp_header_li;
+  bp_bedrock_mem_header_s [2:0] proc_resp_header_li;
   logic [2:0][uce_fill_width_p-1:0] proc_resp_data_li;
   logic [2:0] proc_resp_v_li, proc_resp_ready_and_lo, proc_resp_last_li;
 
   // dev_cmd[4:0] = {CCE loopback, Mem cmd, IO cmd, CLINT, CFG}
-  bp_bedrock_uce_mem_header_s [4:0] dev_cmd_header_li;
+  bp_bedrock_mem_header_s [4:0] dev_cmd_header_li;
   logic [4:0][uce_fill_width_p-1:0] dev_cmd_data_li;
   logic [4:0] dev_cmd_v_li, dev_cmd_ready_and_lo, dev_cmd_last_li;
-  bp_bedrock_uce_mem_header_s [4:0] dev_resp_header_lo;
+  bp_bedrock_mem_header_s [4:0] dev_resp_header_lo;
   logic [4:0][uce_fill_width_p-1:0] dev_resp_data_lo;
   logic [4:0] dev_resp_v_lo, dev_resp_ready_and_li, dev_resp_last_lo;
 
@@ -198,7 +198,7 @@ module bp_unicore_lite
   wire [1:0][lce_id_width_p-1:0] lce_id_li = {cfg_bus_lo.dcache_id, cfg_bus_lo.icache_id};
   bp_uce
    #(.bp_params_p(bp_params_p)
-     ,.uce_mem_data_width_p(uce_fill_width_p)
+     ,.mem_data_width_p(uce_fill_width_p)
      ,.assoc_p(dcache_assoc_p)
      ,.sets_p(dcache_sets_p)
      ,.block_width_p(dcache_block_width_p)
@@ -256,7 +256,7 @@ module bp_unicore_lite
 
   bp_uce
    #(.bp_params_p(bp_params_p)
-     ,.uce_mem_data_width_p(uce_fill_width_p)
+     ,.mem_data_width_p(uce_fill_width_p)
      ,.assoc_p(icache_assoc_p)
      ,.sets_p(icache_sets_p)
      ,.block_width_p(icache_block_width_p)
@@ -387,7 +387,7 @@ module bp_unicore_lite
   bp_me_xbar_stream_buffered
    #(.bp_params_p(bp_params_p)
      ,.data_width_p(uce_fill_width_p)
-     ,.payload_width_p(uce_mem_payload_width_lp)
+     ,.payload_width_p(mem_payload_width_lp)
      ,.num_source_p(3)
      ,.num_sink_p(5)
      )
@@ -412,7 +412,7 @@ module bp_unicore_lite
   bp_me_xbar_stream_buffered
    #(.bp_params_p(bp_params_p)
      ,.data_width_p(uce_fill_width_p)
-     ,.payload_width_p(uce_mem_payload_width_lp)
+     ,.payload_width_p(mem_payload_width_lp)
      ,.num_source_p(5)
      ,.num_sink_p(3)
      )

--- a/bp_top/test/common/bp_nonsynth_host.sv
+++ b/bp_top/test/common/bp_nonsynth_host.sv
@@ -10,7 +10,7 @@ module bp_nonsynth_host
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
    , parameter io_data_width_p = dword_width_gp
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, io)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    , parameter icache_trace_p         = 0
    , parameter dcache_trace_p         = 0
@@ -28,13 +28,13 @@ module bp_nonsynth_host
   (input                                            clk_i
    , input                                          reset_i
 
-   , input [io_mem_header_width_lp-1:0]             mem_cmd_header_i
+   , input [mem_header_width_lp-1:0]                mem_cmd_header_i
    , input [dword_width_gp-1:0]                     mem_cmd_data_i
    , input                                          mem_cmd_v_i
    , output logic                                   mem_cmd_ready_and_o
    , input                                          mem_cmd_last_i
 
-   , output logic [io_mem_header_width_lp-1:0]      mem_resp_header_o
+   , output logic [mem_header_width_lp-1:0]         mem_resp_header_o
    , output logic [dword_width_gp-1:0]              mem_resp_data_o
    , output logic                                   mem_resp_v_o
    , input                                          mem_resp_ready_and_i
@@ -114,8 +114,8 @@ module bp_nonsynth_host
   localparam lg_num_core_lp = `BSG_SAFE_CLOG2(num_core_p);
   wire [lg_num_core_lp-1:0] addr_core_enc = addr_lo[byte_offset_width_lp+:lg_num_core_lp];
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, io);
-  bp_bedrock_io_mem_header_s mem_cmd_header_li;
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  bp_bedrock_mem_header_s mem_cmd_header_li;
   assign mem_cmd_header_li = mem_cmd_header_i;
   wire [hio_width_p-1:0] hio_id = mem_cmd_header_li.addr[paddr_width_p-1-:hio_width_p];
   always_comb

--- a/bp_top/test/common/bp_nonsynth_if_verif.sv
+++ b/bp_top/test/common/bp_nonsynth_if_verif.sv
@@ -12,8 +12,8 @@ module bp_nonsynth_if_verif
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_core_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce)
+   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    )
@@ -24,8 +24,8 @@ module bp_nonsynth_if_verif
 
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p, lce);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, cce);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `declare_bp_fe_branch_metadata_fwd_s(btb_tag_width_p, btb_idx_width_p, bht_idx_width_p, ghist_width_p, bht_row_width_p);
 
   initial
@@ -49,7 +49,7 @@ module bp_nonsynth_if_verif
       $display("bp_bedrock_lce_resp_header_s      bits: struct %d width %d", $bits(bp_bedrock_lce_resp_header_s), lce_resp_header_width_lp);
 
       $display("########### CCE-MEM IF ##############");
-      $display("bp_bedrock_cce_mem_header_s       bits: struct %d width %d", $bits(bp_bedrock_cce_mem_header_s), cce_mem_header_width_lp);
+      $display("bp_bedrock_mem_header_s           bits: struct %d width %d", $bits(bp_bedrock_mem_header_s), mem_header_width_lp);
 
       if (!(num_cce_p inside {1,2,3,4,6,7,8,12,14,15,16,24,28,30,31,32})) begin
         $fatal("Error: unsupported number of CCE's");

--- a/bp_top/test/common/bp_nonsynth_nbf_loader.sv
+++ b/bp_top/test/common/bp_nonsynth_nbf_loader.sv
@@ -20,7 +20,7 @@ module bp_nonsynth_nbf_loader
    , parameter io_data_width_p = nbf_data_width_p
    , localparam nbf_width_lp = nbf_opcode_width_p + nbf_addr_width_p + nbf_data_width_p
 
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, io)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
    )
   (input                                            clk_i
    , input                                          reset_i
@@ -28,13 +28,13 @@ module bp_nonsynth_nbf_loader
    , input [lce_id_width_p-1:0]                     lce_id_i
    , input [did_width_p-1:0]                        did_i
 
-   , output logic [io_mem_header_width_lp-1:0]      io_cmd_header_o
+   , output logic [mem_header_width_lp-1:0]         io_cmd_header_o
    , output logic [io_data_width_p-1:0]             io_cmd_data_o
    , output logic                                   io_cmd_v_o
    , input                                          io_cmd_yumi_i
    , output logic                                   io_cmd_last_o
 
-   , input  [io_mem_header_width_lp-1:0]            io_resp_header_i
+   , input  [mem_header_width_lp-1:0]               io_resp_header_i
    , input  [io_data_width_p-1:0]                   io_resp_data_i
    , input                                          io_resp_v_i
    , output logic                                   io_resp_ready_and_o
@@ -103,8 +103,8 @@ module bp_nonsynth_nbf_loader
      ,.data_o(read_data_r)
      );
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, io);
-  bp_bedrock_io_mem_header_s io_cmd, io_resp;
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  bp_bedrock_mem_header_s io_cmd, io_resp;
   assign io_cmd_header_o = io_cmd;
   assign io_resp = io_resp_header_i;
 

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -49,7 +49,7 @@ module testbench
    , parameter no_bind_p                   = 0
 
    , parameter io_data_width_p = multicore_p ? cce_block_width_p : uce_fill_width_p
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, io)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
    )
   (output bit reset_i);
 
@@ -65,7 +65,7 @@ module testbench
     return (`BP_SIM_CLK_PERIOD);
   endfunction
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, io);
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
 
 // Bit to deal with initial X->0 transition detection
   bit clk_i;
@@ -128,18 +128,18 @@ module testbench
      ,.async_reset_o(cosim_reset_i)
      );
 
-  bp_bedrock_io_mem_header_s proc_io_cmd_header_lo;
+  bp_bedrock_mem_header_s proc_io_cmd_header_lo;
   logic [io_data_width_p-1:0] proc_io_cmd_data_lo;
   logic proc_io_cmd_v_lo, proc_io_cmd_ready_and_li, proc_io_cmd_last_lo;
-  bp_bedrock_io_mem_header_s proc_io_resp_header_li;
+  bp_bedrock_mem_header_s proc_io_resp_header_li;
   logic [io_data_width_p-1:0] proc_io_resp_data_li;
   logic proc_io_resp_v_li, proc_io_resp_ready_and_lo;
   logic proc_io_resp_last_li;
 
-  bp_bedrock_io_mem_header_s load_cmd_lo;
+  bp_bedrock_mem_header_s load_cmd_lo;
   logic [io_data_width_p-1:0] load_cmd_data_lo;
   logic load_cmd_v_lo, load_cmd_ready_and_li, load_cmd_last_lo;
-  bp_bedrock_io_mem_header_s load_resp_li;
+  bp_bedrock_mem_header_s load_resp_li;
   logic [io_data_width_p-1:0] load_resp_data_li;
   logic load_resp_v_li, load_resp_ready_and_lo, load_resp_last_li;
 

--- a/bp_top/test/tb/bp_tethered/wrapper.sv
+++ b/bp_top/test/tb/bp_tethered/wrapper.sv
@@ -19,7 +19,7 @@ module wrapper
    `declare_bp_proc_params(bp_params_p)
 
    , parameter io_data_width_p = multicore_p ? cce_block_width_p : uce_fill_width_p
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, io)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    , localparam dma_pkt_width_lp = `bsg_cache_dma_pkt_width(daddr_width_p)
    )
@@ -30,26 +30,26 @@ module wrapper
    , input [did_width_p-1:0]                                host_did_i
 
    // Outgoing I/O
-   , output logic [io_mem_header_width_lp-1:0]              io_cmd_header_o
+   , output logic [mem_header_width_lp-1:0]                 io_cmd_header_o
    , output logic [io_data_width_p-1:0]                     io_cmd_data_o
    , output logic                                           io_cmd_v_o
    , input                                                  io_cmd_ready_and_i
    , output logic                                           io_cmd_last_o
 
-   , input [io_mem_header_width_lp-1:0]                     io_resp_header_i
+   , input [mem_header_width_lp-1:0]                        io_resp_header_i
    , input [io_data_width_p-1:0]                            io_resp_data_i
    , input                                                  io_resp_v_i
    , output logic                                           io_resp_ready_and_o
    , input                                                  io_resp_last_i
 
    // Incoming I/O
-   , input [io_mem_header_width_lp-1:0]                     io_cmd_header_i
+   , input [mem_header_width_lp-1:0]                        io_cmd_header_i
    , input [io_data_width_p-1:0]                            io_cmd_data_i
    , input                                                  io_cmd_v_i
    , output logic                                           io_cmd_ready_and_o
    , input                                                  io_cmd_last_i
 
-   , output logic [io_mem_header_width_lp-1:0]              io_resp_header_o
+   , output logic [mem_header_width_lp-1:0]                 io_resp_header_o
    , output logic [io_data_width_p-1:0]                     io_resp_data_o
    , output logic                                           io_resp_v_o
    , input                                                  io_resp_ready_and_i
@@ -117,12 +117,12 @@ module wrapper
 
       wire [io_noc_cord_width_p-1:0] dst_cord_lo = 1;
 
-      `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, io);
+      `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
       `declare_bsg_ready_and_link_sif_s(io_noc_flit_width_p, bsg_ready_and_link_sif_s);
-      `bp_cast_i(bp_bedrock_io_mem_header_s, io_cmd_header);
-      `bp_cast_o(bp_bedrock_io_mem_header_s, io_resp_header);
-      `bp_cast_o(bp_bedrock_io_mem_header_s, io_cmd_header);
-      `bp_cast_i(bp_bedrock_io_mem_header_s, io_resp_header);
+      `bp_cast_i(bp_bedrock_mem_header_s, io_cmd_header);
+      `bp_cast_o(bp_bedrock_mem_header_s, io_resp_header);
+      `bp_cast_o(bp_bedrock_mem_header_s, io_cmd_header);
+      `bp_cast_i(bp_bedrock_mem_header_s, io_resp_header);
 
       bsg_ready_and_link_sif_s send_cmd_link_lo, send_resp_link_li;
       bsg_ready_and_link_sif_s recv_cmd_link_li, recv_resp_link_lo;


### PR DESCRIPTION
## Summary
This PR cleans up the bedrock macros to not give a prefix to x_mem. Users don't have to supply lce or cce or xce to bedrock macros anymore.

## Issue Fixed
None

## Area
Bedrock macros throughout

## Reasoning (outdated, confusing, verbose, etc.)
This feature was only used to change data_width in the full msg macro so we could differentiate between different width of memory interfaces. With #956, this is no longer necessary. In fact, we want to enforce that all bedrock messages in a system have the exact same format so that there are no bug-prone conversions between them, such as unicore where I/O is assigned directly to memory.

## Additional Changes Required (if any)
FPGA and ASIC wrappers which live outside this repo will need to change. Namely,
- [ ] bsg_fpga
- [ ] zynq-parrot
- [ ] ASIC flow

## Analysis
Clarity improvement, no PPA impact.

## Verification
Standard regression

