### PR TITLE
Fixing nanboxing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - dev_fix_nanbox
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - dev_fix_nanbox
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/bp_be/src/v/bp_be_calculator/bp_be_nan_unbox.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_nan_unbox.sv
@@ -9,15 +9,15 @@ module bp_be_nan_unbox
    `declare_bp_proc_params(bp_params_p)
    )
   (input [dpath_width_gp-1:0]          reg_i
-   , input                             ops_i
+   , input                             unbox_i
    , output logic [dpath_width_gp-1:0] reg_o
    );
 
  `bp_cast_i(bp_be_fp_reg_s, reg);
  `bp_cast_o(bp_be_fp_reg_s, reg);
 
-  wire invbox = ops_i & (reg_cast_i.tag == e_fp_full);
-  assign reg_cast_o = invbox ? '{tag: ops_i ? e_rne : e_fp_full, rec: dp_canonical_rec} : reg_i;
+  wire invbox = unbox_i & (reg_cast_i.tag == e_fp_full);
+  assign reg_cast_o = invbox ? '{tag: unbox_i ? e_rne : e_fp_full, rec: dp_canonical_rec} : reg_i;
 
 endmodule
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_nan_unbox.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_nan_unbox.sv
@@ -1,0 +1,23 @@
+
+`include "bp_common_defines.svh"
+`include "bp_be_defines.svh"
+
+module bp_be_nan_unbox
+ import bp_common_pkg::*;
+ import bp_be_pkg::*;
+ #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+   `declare_bp_proc_params(bp_params_p)
+   )
+  (input [dpath_width_gp-1:0]          reg_i
+   , input                             ops_i
+   , output logic [dpath_width_gp-1:0] reg_o
+   );
+
+ `bp_cast_i(bp_be_fp_reg_s, reg);
+ `bp_cast_o(bp_be_fp_reg_s, reg);
+
+  wire invbox = ops_i & (reg_cast_i.tag == e_fp_full);
+  assign reg_cast_o = invbox ? '{tag: ops_i ? e_rne : e_fp_full, rec: dp_canonical_rec} : reg_i;
+
+endmodule
+

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_aux.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_aux.sv
@@ -49,7 +49,7 @@ module bp_be_pipe_aux
     #(.bp_params_p(bp_params_p))
     frs1_unbox
      (.reg_i(reservation.rs1)
-      ,.ops_i(decode.ops_v)
+      ,.unbox_i(decode.ops_v & !(decode.fu_op inside {e_aux_op_fmvi}))
       ,.reg_o(frs1)
       );
 
@@ -57,7 +57,7 @@ module bp_be_pipe_aux
     #(.bp_params_p(bp_params_p))
     frs2_unbox
      (.reg_i(reservation.rs2)
-      ,.ops_i(decode.ops_v)
+      ,.unbox_i(decode.ops_v)
       ,.reg_o(frs2)
       );
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_fma.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_fma.sv
@@ -18,9 +18,9 @@
  *            ...
  *            fma 4 cycles     reservation
  *           /   \                 |
- *        round  imul_out      meta_info
- *          |
- *       fma_out
+ *        round  imul_out      imul meta
+ *          |                      |
+ *       fma_out                fma meta
  *
  */
 `include "bp_common_defines.svh"
@@ -53,24 +53,35 @@ module bp_be_pipe_fma
   bp_be_decode_s decode;
   rv64_instr_s instr;
   bp_be_fp_reg_s frs1, frs2, frs3;
-  logic [dword_width_gp-1:0] rs1, rs2;
-
-  bp_be_fp_reg_s frs1_boxed, frs2_boxed, frs3_boxed;
-  wire frs1_invbox = decode.ops_v & (frs1_boxed.tag == e_fp_full);
-  wire frs2_invbox = decode.ops_v & (frs2_boxed.tag == e_fp_full);
-  wire frs3_invbox = decode.ops_v & (frs3_boxed.tag == e_fp_full);
-  assign frs1_boxed = reservation.rs1;
-  assign frs2_boxed = reservation.rs2;
-  assign frs3_boxed = reservation.imm;
 
   assign reservation = reservation_i;
   assign decode = reservation.decode;
   assign instr = reservation.instr;
-  assign frs1 = frs1_invbox ? '{tag: e_fp_full, rec: dp_canonical_nan} : frs1_boxed;
-  assign frs2 = frs2_invbox ? '{tag: e_fp_full, rec: dp_canonical_nan} : frs2_boxed;
-  assign frs3 = frs3_invbox ? '{tag: e_fp_full, rec: dp_canonical_nan} : frs3_boxed;
-  assign rs1 = decode.opw_v ? (frs1 << word_width_gp) : frs1;
-  assign rs2 = frs2;
+  wire [dword_width_gp-1:0] rs1 = decode.opw_v ? (reservation.rs1 << word_width_gp) : reservation.rs1;
+  wire [dword_width_gp-1:0] rs2 = reservation.rs2;
+  bp_be_nan_unbox
+    #(.bp_params_p(bp_params_p))
+    frs1_unbox
+     (.reg_i(reservation.rs1)
+      ,.ops_i(decode.ops_v)
+      ,.reg_o(frs1)
+      );
+
+  bp_be_nan_unbox
+    #(.bp_params_p(bp_params_p))
+    frs2_unbox
+     (.reg_i(reservation.rs2)
+      ,.ops_i(decode.ops_v)
+      ,.reg_o(frs2)
+      );
+
+  bp_be_nan_unbox
+    #(.bp_params_p(bp_params_p))
+    frs3_unbox
+     (.reg_i(reservation.imm)
+      ,.ops_i(decode.ops_v)
+      ,.reg_o(frs3)
+      );
 
   //
   // Control bits for the FPU
@@ -184,9 +195,6 @@ module bp_be_pipe_fma
   rv64_fflags_s fma_fflags;
   assign fma_result = '{tag: ops_r ? frm_r : e_fp_full, rec: fma_dp_final};
   assign fma_fflags = fma_dp_fflags;
-
-  bp_be_fp_reg_s fma_dp_result;
-  assign fma_dp_result = '{tag: e_fp_full, rec: fma_dp_final};
 
   // TODO: Can combine the registers here if DC doesn't do it automatically
   bsg_dff_chain

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_fma.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_fma.sv
@@ -63,7 +63,7 @@ module bp_be_pipe_fma
     #(.bp_params_p(bp_params_p))
     frs1_unbox
      (.reg_i(reservation.rs1)
-      ,.ops_i(decode.ops_v)
+      ,.unbox_i(decode.ops_v)
       ,.reg_o(frs1)
       );
 
@@ -71,7 +71,7 @@ module bp_be_pipe_fma
     #(.bp_params_p(bp_params_p))
     frs2_unbox
      (.reg_i(reservation.rs2)
-      ,.ops_i(decode.ops_v)
+      ,.unbox_i(decode.ops_v)
       ,.reg_o(frs2)
       );
 
@@ -79,7 +79,7 @@ module bp_be_pipe_fma
     #(.bp_params_p(bp_params_p))
     frs3_unbox
      (.reg_i(reservation.imm)
-      ,.ops_i(decode.ops_v)
+      ,.unbox_i(decode.ops_v)
       ,.reg_o(frs3)
       );
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
@@ -87,7 +87,7 @@ module bp_be_pipe_long
     #(.bp_params_p(bp_params_p))
     frs1_unbox
      (.reg_i(reservation.rs1)
-      ,.ops_i(decode.ops_v)
+      ,.unbox_i(decode.ops_v)
       ,.reg_o(frs1)
       );
 
@@ -95,7 +95,7 @@ module bp_be_pipe_long
     #(.bp_params_p(bp_params_p))
     frs2_unbox
      (.reg_i(reservation.rs2)
-      ,.ops_i(decode.ops_v)
+      ,.unbox_i(decode.ops_v)
       ,.reg_o(frs2)
       );
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
@@ -83,14 +83,21 @@ module bp_be_pipe_long
   wire [word_width_gp-1:0] remainder_w_lo = remainder_lo[0+:word_width_gp];
 
   bp_be_fp_reg_s frs1, frs2;
-  bp_be_fp_reg_s frs1_boxed, frs2_boxed;
-  wire frs1_invbox = decode.ops_v & (frs1_boxed.tag == e_fp_full);
-  wire frs2_invbox = decode.ops_v & (frs2_boxed.tag == e_fp_full);
-  assign frs1_boxed = reservation.rs1;
-  assign frs2_boxed = reservation.rs2;
+  bp_be_nan_unbox
+    #(.bp_params_p(bp_params_p))
+    frs1_unbox
+     (.reg_i(reservation.rs1)
+      ,.ops_i(decode.ops_v)
+      ,.reg_o(frs1)
+      );
 
-  assign frs1 = frs1_invbox ? '{tag: e_fp_full, rec: dp_canonical_nan} : frs1_boxed;
-  assign frs2 = frs2_invbox ? '{tag: e_fp_full, rec: dp_canonical_nan} : frs2_boxed;
+  bp_be_nan_unbox
+    #(.bp_params_p(bp_params_p))
+    frs2_unbox
+     (.reg_i(reservation.rs2)
+      ,.ops_i(decode.ops_v)
+      ,.reg_o(frs2)
+      );
 
   //
   // Control bits for the FPU

--- a/bp_be/syn/flist.vcs
+++ b/bp_be/syn/flist.vcs
@@ -192,6 +192,7 @@ $BP_BE_DIR/src/v/bp_be_top.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_calculator_top.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_csr.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_fp_to_reg.sv
+$BP_BE_DIR/src/v/bp_be_calculator/bp_be_nan_unbox.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_int.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_aux.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_ctl.sv

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -200,6 +200,7 @@ $BP_BE_DIR/src/v/bp_be_top.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_calculator_top.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_csr.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_fp_to_reg.sv
+$BP_BE_DIR/src/v/bp_be_calculator/bp_be_nan_unbox.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_int.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_aux.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_ctl.sv

--- a/bp_top/test/tb/bp_tethered/Makefile.testlist
+++ b/bp_top/test/tb/bp_tethered/Makefile.testlist
@@ -33,6 +33,7 @@ MISC_TESTS := \
   unwinding             \
   vector                \
   map                   \
+  nanboxing             \
 
 MISC_TESTLIST := $(addprefix bp-tests@, $(MISC_TESTS))
 


### PR DESCRIPTION
## Summary
Fixes nanboxing behavior in the FMA and FDIV units. This is (technically?) a regression since #1001 brought in this faulty nanboxing code. However, the nanboxing box existed before this as well.

## Issue Fixed
#971

## Area
FPU

## Reasoning (outdated, confusing, verbose, etc.)
When doing a single precision operation, the operand will be converted into a NaN if the upper 32b of the raw value are not all 1. This is called nan-boxing in RISC-V terminology. We did attempt to nan-box, but we injected the incorrect NaN when unboxing. This caused us to accidentally garbage compute values instead of 

## Additional Changes Required (if any)
- [x] Targeted test for nanboxing (https://github.com/black-parrot-sdk/bp-tests/pull/28)

## Analysis
No PPA impact

## Verification
- [x] Original riscv-tests passing and new regression test

