### PR TITLE
Fix to axil client

### DIFF
--- a/bp_me/src/v/network/bp_me_axil_client.sv
+++ b/bp_me/src/v/network/bp_me_axil_client.sv
@@ -30,7 +30,7 @@ module bp_me_axil_client
    , input [cce_mem_header_width_lp-1:0]        io_resp_header_i
    , input [axil_data_width_p-1:0]              io_resp_data_i
    , input                                      io_resp_v_i
-   , output logic                               io_resp_ready_and_o
+   , output logic                               io_resp_yumi_o
 
    //====================== AXI-4 LITE =========================
    // WRITE ADDRESS CHANNEL SIGNALS
@@ -71,21 +71,31 @@ module bp_me_axil_client
   `bp_cast_i(bp_bedrock_cce_mem_header_s, io_resp_header);
 
   // Declaring all possible states
-  enum {e_wait, e_read_resp, e_write_resp} state_n, state_r;
+  enum {e_ready, e_send_read, e_send_write} state_n, state_r;
+  wire is_ready = (state_r == e_ready);
+  wire is_send_read = (state_r == e_send_read);
+  wire is_send_write = (state_r == e_send_write);
 
+  // AW buffer
+  logic [axil_addr_width_p-1:0] s_axil_awaddr_r;
+  bsg_dff_en
+   #(.width_p(axil_addr_width_p))
+   awaddr_reg
+    (.clk_i(clk_i)
+     ,.en_i(s_axil_awready_o & s_axil_awvalid_i)
+     ,.data_i(s_axil_awaddr_i)
+     ,.data_o(s_axil_awaddr_r)
+     );
+
+  // Command Logic
   always_comb
     begin
       state_n = state_r;
 
       // BP side
-      io_cmd_header_cast_o = '0;
-      io_cmd_data_o        = '0;
-
-      // set default header size
-      io_cmd_header_cast_o.size = (axil_data_width_p == 32) ? e_bedrock_msg_size_4 : e_bedrock_msg_size_8;
-
-      io_cmd_v_o           = '0;
-      io_resp_ready_and_o  = '0;
+      io_cmd_header_cast_o      = '0;
+      io_cmd_data_o             = s_axil_wdata_i;
+      io_cmd_v_o                = '0;
 
       // WRITE ADDRESS CHANNEL SIGNALS
       s_axil_awready_o = '0;
@@ -95,15 +105,6 @@ module bp_me_axil_client
 
       // READ ADDRESS CHANNEL SIGNALS
       s_axil_arready_o = '0;
-
-      // READ DATA CHANNEL SIGNALS
-      s_axil_rdata_o   = '0;
-      s_axil_rresp_o   = e_axi_resp_okay;
-      s_axil_rvalid_o  = '0;
-
-      // WRITE RESPONSE CHANNEL SIGNALS
-      s_axil_bresp_o   = e_axi_resp_okay;
-      s_axil_bvalid_o  = '0;
 
       case (s_axil_wstrb_i)
         (axil_data_width_p>>3)'('h1)  : io_cmd_header_cast_o.size = e_bedrock_msg_size_1;
@@ -118,63 +119,71 @@ module bp_me_axil_client
       endcase
 
       unique casez (state_r)
-        e_wait:
+        // Can send writes immediately if both aw/w are available, else read/write with 1 cycle delay
+        e_ready:
           begin
-            // TODO: This assumes that we can either get a read/write, but not both.
-            //   Generally this is a good assumption, but is non-compliant with AXI
-            s_axil_arready_o = 1'b1;
-            s_axil_awready_o = 1'b1;
-            s_axil_wready_o  = 1'b1;
+            s_axil_awready_o = io_cmd_ready_and_i;
+            s_axil_wready_o = io_cmd_ready_and_i;
 
-            if (s_axil_arready_o & s_axil_arvalid_i)
-              begin
-                io_cmd_header_cast_o.addr           = s_axil_araddr_i;
-                io_cmd_header_cast_o.msg_type       = e_bedrock_mem_uc_rd;
-                io_cmd_header_cast_o.payload.lce_id = lce_id_i;
-                io_cmd_header_cast_o.payload.did    = did_i;
-                io_cmd_v_o                          = s_axil_arvalid_i;
+            io_cmd_header_cast_o.addr                = s_axil_awaddr_i;
+            io_cmd_header_cast_o.msg_type            = e_bedrock_mem_uc_wr;
+            io_cmd_header_cast_o.payload.lce_id      = lce_id_i;
+            io_cmd_header_cast_o.payload.did         = did_i;
+            io_cmd_v_o                               = (s_axil_awvalid_i & s_axil_wvalid_i);
 
-                state_n = (io_cmd_ready_and_i & io_cmd_v_o) ? e_read_resp : e_wait;
-              end
-
-            else if (s_axil_awready_o & s_axil_awvalid_i & s_axil_wready_o & s_axil_wvalid_i)
-              begin
-                io_cmd_header_cast_o.addr                = s_axil_awaddr_i;
-                io_cmd_header_cast_o.msg_type            = e_bedrock_mem_uc_wr;
-                io_cmd_header_cast_o.payload.lce_id      = lce_id_i;
-                io_cmd_header_cast_o.payload.did         = did_i;
-                io_cmd_data_o                            = s_axil_wdata_i;
-                io_cmd_v_o                               = (s_axil_awvalid_i & s_axil_wvalid_i);
-
-                state_n = (io_cmd_ready_and_i & io_cmd_v_o) ? e_write_resp : e_wait;
-              end
+            // Send          
+            state_n = (s_axil_awvalid_i & ~s_axil_wvalid_i)
+                      ? e_send_write
+                      : s_axil_arvalid_i
+                        ? e_send_read
+                        : e_ready;
           end
 
-        e_write_resp:
+        e_send_read:
           begin
-            s_axil_bvalid_o     = io_resp_v_i;
-            io_resp_ready_and_o = s_axil_bready_i;
+            s_axil_arready_o = io_cmd_ready_and_i;
 
-            state_n = (io_resp_ready_and_o & io_resp_v_i) ? e_wait : state_r;
+            io_cmd_header_cast_o.addr                = s_axil_araddr_i;
+            io_cmd_header_cast_o.msg_type            = e_bedrock_mem_uc_rd;
+            io_cmd_header_cast_o.payload.lce_id      = lce_id_i;
+            io_cmd_header_cast_o.payload.did         = did_i;
+            io_cmd_v_o                               = s_axil_arvalid_i;
+
+            state_n = (io_cmd_ready_and_i & io_cmd_v_o) ? e_ready : e_send_read;
           end
 
-        e_read_resp:
+        e_send_write:
           begin
-            s_axil_rdata_o      = io_resp_data_i;
-            s_axil_rvalid_o     = io_resp_v_i;
-            io_resp_ready_and_o = s_axil_rready_i;
+            io_cmd_header_cast_o.addr                = s_axil_awaddr_r;
+            io_cmd_header_cast_o.msg_type            = e_bedrock_mem_uc_wr;
+            io_cmd_header_cast_o.payload.lce_id      = lce_id_i;
+            io_cmd_header_cast_o.payload.did         = did_i;
+            io_cmd_v_o                               = 1'b1;
 
-            state_n = (io_resp_ready_and_o & io_resp_v_i) ? e_wait : state_r;
+            state_n = (io_cmd_ready_and_i & io_cmd_v_o) ? e_ready : e_send_write;
           end
 
         default: state_n = state_r;
       endcase
     end
 
+  // Resp logic, redirect responses based on type
+  always_comb
+    begin
+      s_axil_rresp_o  = e_axi_resp_okay;
+      s_axil_rdata_o  = io_resp_data_i;
+      s_axil_rvalid_o = io_resp_v_i & io_resp_header_cast_i.msg_type inside {e_bedrock_mem_uc_rd, e_bedrock_mem_rd};
+
+      s_axil_bresp_o  = e_axi_resp_okay;
+      s_axil_bvalid_o = io_resp_v_i & io_resp_header_cast_i.msg_type inside {e_bedrock_mem_uc_wr, e_bedrock_mem_wr};
+
+      io_resp_yumi_o  = (s_axil_rvalid_o & s_axil_rready_i) | (s_axil_bvalid_o & s_axil_bready_i);
+    end
+
   // synopsys sync_set_reset "reset_i"
   always_ff @(posedge clk_i)
     if (reset_i)
-      state_r <= e_wait;
+      state_r <= e_ready;
     else
       state_r <= state_n;
 

--- a/bp_me/src/v/network/bp_me_axil_client.sv
+++ b/bp_me/src/v/network/bp_me_axil_client.sv
@@ -154,11 +154,13 @@ module bp_me_axil_client
 
         e_send_write:
           begin
+            s_axil_wready_o = io_cmd_ready_and_i;
+           
             io_cmd_header_cast_o.addr                = s_axil_awaddr_r;
             io_cmd_header_cast_o.msg_type            = e_bedrock_mem_uc_wr;
             io_cmd_header_cast_o.payload.lce_id      = lce_id_i;
             io_cmd_header_cast_o.payload.did         = did_i;
-            io_cmd_v_o                               = 1'b1;
+            io_cmd_v_o                               = s_axil_wvalid_i;
 
             state_n = (io_cmd_ready_and_i & io_cmd_v_o) ? e_ready : e_send_write;
           end

--- a/bp_top/src/v/bp_axi_top.sv
+++ b/bp_top/src/v/bp_axi_top.sv
@@ -139,7 +139,7 @@ module bp_axi_top
   logic [l2_banks_p-1:0] dma_data_v_li, dma_data_ready_and_lo;
 
   if (multicore_p == 0)
-    begin : w
+    begin : u
       // note: bp_unicore has L2 cache; (bp_unicore_lite does not, but does not have dma_* interface
       // and would need mem_cmd/mem_resp-to-axi converter to be written.)
       bp_unicore
@@ -193,7 +193,7 @@ module bp_axi_top
         );
     end
   else
-    begin : w
+    begin : m
       `declare_bsg_ready_and_link_sif_s(io_noc_flit_width_p, bp_io_noc_ral_link_s);
       `declare_bsg_ready_and_link_sif_s(mem_noc_flit_width_p, bp_mem_noc_ral_link_s);
       bp_io_noc_ral_link_s proc_cmd_link_li, proc_cmd_link_lo;

--- a/bp_top/src/v/bp_axi_top.sv
+++ b/bp_top/src/v/bp_axi_top.sv
@@ -200,7 +200,7 @@ module bp_axi_top
       bp_io_noc_ral_link_s proc_resp_link_li, proc_resp_link_lo;
       bp_io_noc_ral_link_s stub_cmd_link_li, stub_resp_link_li;
       bp_io_noc_ral_link_s stub_cmd_link_lo, stub_resp_link_lo;
-      bp_mem_noc_ral_link_s [mc_x_dim_p-1:0] dram_cmd_link_lo, dram_resp_link_li;
+      bp_mem_noc_ral_link_s dram_cmd_link_lo, dram_resp_link_li;
 
       assign stub_cmd_link_li  = '0;
       assign stub_resp_link_li = '0;

--- a/bp_top/src/v/bp_axi_top.sv
+++ b/bp_top/src/v/bp_axi_top.sv
@@ -128,7 +128,7 @@ module bp_axi_top
   logic io_cmd_v_li, io_cmd_ready_and_lo, io_resp_v_lo, io_resp_yumi_li;
   bp_bedrock_uce_mem_header_s io_cmd_header_lo, io_resp_header_li;
   logic [uce_fill_width_p-1:0] io_cmd_data_lo, io_resp_data_li;
-  logic io_cmd_v_lo, io_cmd_ready_and_li, io_resp_v_li, io_resp_ready_and_lo;
+  logic io_cmd_v_lo, io_cmd_yumi_li, io_resp_v_li, io_resp_ready_and_lo;
 
   `declare_bsg_cache_dma_pkt_s(daddr_width_p);
   bsg_cache_dma_pkt_s [l2_banks_p-1:0] dma_pkt_lo;
@@ -157,7 +157,7 @@ module bp_axi_top
         ,.io_cmd_header_o(io_cmd_header_lo)
         ,.io_cmd_data_o(io_cmd_data_lo)
         ,.io_cmd_v_o(io_cmd_v_lo)
-        ,.io_cmd_ready_and_i(io_cmd_ready_and_li)
+        ,.io_cmd_ready_and_i(io_cmd_yumi_li)
         ,.io_cmd_last_o()
 
         ,.io_resp_header_i(io_resp_header_li)
@@ -306,7 +306,7 @@ module bp_axi_top
          ,.mem_cmd_header_o(io_cmd_header_lo)
          ,.mem_cmd_data_o(io_cmd_data_lo)
          ,.mem_cmd_v_o(io_cmd_v_lo)
-         ,.mem_cmd_yumi_i(io_cmd_ready_and_li & io_cmd_v_lo)
+         ,.mem_cmd_yumi_i(io_cmd_yumi_li)
          ,.mem_cmd_last_o()
 
          ,.mem_resp_header_i(io_resp_header_li)
@@ -391,7 +391,7 @@ module bp_axi_top
      ,.io_cmd_header_i(io_cmd_header_lo)
      ,.io_cmd_data_i(io_cmd_data_lo)
      ,.io_cmd_v_i(io_cmd_v_lo)
-     ,.io_cmd_ready_and_o(io_cmd_ready_and_li)
+     ,.io_cmd_yumi_o(io_cmd_yumi_li)
 
      ,.io_resp_header_o(io_resp_header_li)
      ,.io_resp_data_o(io_resp_data_li)

--- a/bp_top/src/v/bp_axi_top.sv
+++ b/bp_top/src/v/bp_axi_top.sv
@@ -125,7 +125,7 @@ module bp_axi_top
   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, uce);
   bp_bedrock_uce_mem_header_s io_cmd_header_li, io_resp_header_lo;
   logic [uce_fill_width_p-1:0] io_cmd_data_li, io_resp_data_lo;
-  logic io_cmd_v_li, io_cmd_ready_and_lo, io_resp_v_lo, io_resp_ready_and_li;
+  logic io_cmd_v_li, io_cmd_ready_and_lo, io_resp_v_lo, io_resp_yumi_li;
   bp_bedrock_uce_mem_header_s io_cmd_header_lo, io_resp_header_li;
   logic [uce_fill_width_p-1:0] io_cmd_data_lo, io_resp_data_li;
   logic io_cmd_v_lo, io_cmd_ready_and_li, io_resp_v_li, io_resp_ready_and_lo;
@@ -176,7 +176,7 @@ module bp_axi_top
         ,.io_resp_header_o(io_resp_header_lo)
         ,.io_resp_data_o(io_resp_data_lo)
         ,.io_resp_v_o(io_resp_v_lo)
-        ,.io_resp_ready_and_i(io_resp_ready_and_li)
+        ,.io_resp_ready_and_i(io_resp_yumi_li)
         ,.io_resp_last_o()
 
         ,.dma_pkt_o(dma_pkt_lo)
@@ -281,7 +281,7 @@ module bp_axi_top
          ,.mem_resp_header_o(io_resp_header_lo)
          ,.mem_resp_data_o(io_resp_data_lo)
          ,.mem_resp_v_o(io_resp_v_lo)
-         ,.mem_resp_yumi_i(io_resp_ready_and_li & io_resp_v_lo)
+         ,.mem_resp_yumi_i(io_resp_yumi_li)
          ,.mem_resp_last_o()
 
 
@@ -369,7 +369,7 @@ module bp_axi_top
      ,.io_resp_header_i(io_resp_header_lo)
      ,.io_resp_data_i(io_resp_data_lo)
      ,.io_resp_v_i(io_resp_v_lo)
-     ,.io_resp_ready_and_o(io_resp_ready_and_li)
+     ,.io_resp_yumi_o(io_resp_yumi_li)
 
      ,.lce_id_i(lce_id_width_p'('b10))
      ,.did_i(did_width_p'('1))


### PR DESCRIPTION
This PR fixes the axi lite client for #1013. Writes are able to proceed at 100% throughput, but reads now take an additional cycle. Reads are much less common in our current AXI systems, but future enhancements could pipeline this as well by adding registers for the araddr and additional state