### PR TITLE
Adding RTC

### DIFF
--- a/bp_me/src/v/dev/bp_me_clint_slice.sv
+++ b/bp_me/src/v/dev/bp_me_clint_slice.sv
@@ -57,31 +57,27 @@ module bp_me_clint_slice
      ,.data_i(data_li)
      );
 
-  logic mtime_inc_li;
-  bsg_edge_detect
-   bed
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.sig_i(rt_clk_i)
-     ,.detect_o(mtime_inc_li)
+  logic [dword_width_gp-1:0] mtime_gray_r;
+  bsg_async_ptr_gray
+   #(.lg_size_p(dword_width_gp), .use_async_reset_p(1))
+   mtime_gray
+    (.w_clk_i(rt_clk_i)
+     ,.w_reset_i(reset_i) // async to rtc
+     ,.w_inc_i(1'b1) // TODO: Enable / disable increment?
+     ,.r_clk_i(clk_i)
+     ,.w_ptr_binary_r_o()
+     ,.w_ptr_gray_r_o()
+     ,.w_ptr_gray_r_rsync_o(mtime_gray_r)
      );
+  // Cannot write the RTC. If needed, raise an issue
+  wire unused = mtime_w_v_li;
 
   logic [dword_width_gp-1:0] mtime_r;
-  wire [dword_width_gp-1:0] mtime_n = data_lo;
-  bsg_counter_set_en
-   #(.max_val_p(0) // max_val_p is unused but must be set
-     ,.lg_max_val_lp(dword_width_gp) // Use lg_max_val_lp because of 64-bit parameter restriction
-     ,.reset_val_p(0)
-     )
-   mtime_counter
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.set_i(mtime_w_v_li)
-     ,.en_i(mtime_inc_li)
-     ,.val_i(mtime_n)
-     ,.count_o(mtime_r)
+  bsg_gray_to_binary
+   #(.width_p(dword_width_gp))
+   g2b
+    (.gray_i(mtime_gray_r)
+     ,.binary_o(mtime_r)
      );
 
   logic [dword_width_gp-1:0] mtimecmp_r;

--- a/bp_me/src/v/dev/bp_me_clint_slice.sv
+++ b/bp_me/src/v/dev/bp_me_clint_slice.sv
@@ -12,6 +12,7 @@ module bp_me_clint_slice
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, xce)
    )
   (input                                                clk_i
+   , input                                              rt_clk_i
    , input                                              reset_i
 
    , input [xce_mem_header_width_lp-1:0]                mem_cmd_header_i
@@ -56,18 +57,16 @@ module bp_me_clint_slice
      ,.data_i(data_li)
      );
 
-  // TODO: Should be actual RTC, or at least programmable
-  localparam ds_width_lp = 5;
-  localparam [ds_width_lp-1:0] ds_ratio_li = 8;
   logic mtime_inc_li;
-  bsg_strobe
-   #(.width_p(ds_width_lp))
-   bsg_rtc_strobe
+  bsg_edge_detect
+   bed
     (.clk_i(clk_i)
-     ,.reset_r_i(reset_i)
-     ,.init_val_r_i(ds_ratio_li)
-     ,.strobe_r_o(mtime_inc_li)
+     ,.reset_i(reset_i)
+
+     ,.sig_i(rt_clk_i)
+     ,.detect_o(mtime_inc_li)
      );
+
   logic [dword_width_gp-1:0] mtime_r;
   wire [dword_width_gp-1:0] mtime_n = data_lo;
   bsg_counter_set_en

--- a/bp_top/src/v/bp_core_complex.sv
+++ b/bp_top/src/v/bp_core_complex.sv
@@ -22,6 +22,7 @@ module bp_core_complex
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    )
   (input                                                         core_clk_i
+   , input                                                       core_rt_clk_i
    , input                                                       core_reset_i
 
    , input                                                       coh_clk_i
@@ -89,6 +90,7 @@ module bp_core_complex
            #(.bp_params_p(bp_params_p))
            tile_node
             (.core_clk_i(core_clk_i)
+             ,.core_rt_clk_i(core_rt_clk_i)
              ,.core_reset_i(core_reset_i)
 
              ,.coh_clk_i(coh_clk_i)

--- a/bp_top/src/v/bp_multicore.sv
+++ b/bp_top/src/v/bp_multicore.sv
@@ -23,6 +23,7 @@ module bp_multicore
    , localparam io_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(io_noc_flit_width_p)
    )
   (input                                                    core_clk_i
+   , input                                                  core_rt_clk_i
    , input                                                  core_reset_i
 
    , input                                                  coh_clk_i
@@ -70,6 +71,7 @@ module bp_multicore
    #(.bp_params_p(bp_params_p))
    cc
     (.core_clk_i(core_clk_i)
+     ,.core_rt_clk_i(core_rt_clk_i)
      ,.core_reset_i(core_reset_i)
 
      ,.coh_clk_i(coh_clk_i)

--- a/bp_top/src/v/bp_tile.sv
+++ b/bp_top/src/v/bp_tile.sv
@@ -31,6 +31,7 @@ module bp_tile
    , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
    )
   (input                                                      clk_i
+   , input                                                    rt_clk_i
    , input                                                    reset_i
 
    // Memory side connection
@@ -508,6 +509,7 @@ module bp_tile
    #(.bp_params_p(bp_params_p))
    clint
     (.clk_i(clk_i)
+     ,.rt_clk_i(rt_clk_i)
      ,.reset_i(reset_r)
 
      ,.mem_cmd_header_i(dev_cmd_header_li[2])

--- a/bp_top/src/v/bp_tile_node.sv
+++ b/bp_top/src/v/bp_tile_node.sv
@@ -21,6 +21,7 @@ module bp_tile_node
    , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
    )
   (input                                         core_clk_i
+   , input                                       core_rt_clk_i
    , input                                       core_reset_i
 
    , input                                       coh_clk_i
@@ -67,6 +68,7 @@ module bp_tile_node
    #(.bp_params_p(bp_params_p))
    tile
     (.clk_i(core_clk_i)
+     ,.rt_clk_i(core_rt_clk_i)
      ,.reset_i(core_reset_i)
 
      // Memory side connection

--- a/bp_top/src/v/bp_unicore.sv
+++ b/bp_top/src/v/bp_unicore.sv
@@ -38,6 +38,7 @@ module bp_unicore
    , localparam dma_pkt_width_lp = `bsg_cache_dma_pkt_width(daddr_width_p)
    )
   (input                                                 clk_i
+   , input                                               rt_clk_i
    , input                                               reset_i
 
    , input [io_noc_did_width_p-1:0]                      my_did_i
@@ -99,6 +100,7 @@ module bp_unicore
    #(.bp_params_p(bp_params_p))
    unicore_lite
     (.clk_i(clk_i)
+     ,.rt_clk_i(rt_clk_i)
      ,.reset_i(reset_i)
 
      ,.my_did_i(my_did_i)

--- a/bp_top/src/v/bp_unicore_complex.sv
+++ b/bp_top/src/v/bp_unicore_complex.sv
@@ -18,6 +18,7 @@ module bp_unicore_complex
    )
   (input                                                            clk_i
    , input                                                          reset_i
+   , input                                                          rt_clk_i
 
    , input [io_noc_did_width_p-1:0]                                 my_did_i
    , input [io_noc_did_width_p-1:0]                                 host_did_i
@@ -74,6 +75,7 @@ module bp_unicore_complex
        #(.bp_params_p(bp_params_p))
        dut
         (.clk_i(clk_i)
+         ,.rt_clk_i(rt_clk_i)
          ,.reset_i(reset_i)
 
          ,.my_did_i(my_did_i)

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -14,6 +14,7 @@ module bp_unicore_lite
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, uce)
    )
   (input                                               clk_i
+   , input                                             rt_clk_i
    , input                                             reset_i
 
    , input [io_noc_did_width_p-1:0]                    my_did_i
@@ -470,6 +471,7 @@ module bp_unicore_lite
    #(.bp_params_p(bp_params_p))
    clint
     (.clk_i(clk_i)
+     ,.rt_clk_i(rt_clk_i)
      ,.reset_i(reset_i)
 
      ,.mem_cmd_header_i(dev_cmd_header_li[1])

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -121,6 +121,7 @@ $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_set_clear.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_edge_detect.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_encode_one_hot.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_expand_bitmask.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_gray_to_binary.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_hash_bank.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_hash_bank_reverse.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_idiv_iterative.v

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -150,12 +150,24 @@ module testbench
   logic [num_cce_p-1:0][l2_banks_p-1:0][l2_fill_width_p-1:0] dma_data_li;
   logic [num_cce_p-1:0][l2_banks_p-1:0] dma_data_v_li, dma_data_ready_and_lo;
 
+  logic rt_clk_lo;
+  bsg_counter_clock_downsample
+   #(.width_p(3))
+   ds
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.val_i(3'b111)
+     ,.clk_r_o(rt_clk_lo)
+     );
+
   wire [io_noc_did_width_p-1:0] proc_did_li = 1;
   wire [io_noc_did_width_p-1:0] host_did_li = '1;
   wrapper
    #(.bp_params_p(bp_params_p))
    wrapper
     (.clk_i(clk_i)
+     ,.rt_clk_i(rt_clk_lo)
      ,.reset_i(reset_i)
 
      ,.my_did_i(proc_did_li)

--- a/bp_top/test/tb/bp_tethered/wrapper.sv
+++ b/bp_top/test/tb/bp_tethered/wrapper.sv
@@ -24,6 +24,7 @@ module wrapper
    , localparam dma_pkt_width_lp = `bsg_cache_dma_pkt_width(daddr_width_p)
    )
   (input                                                    clk_i
+   , input                                                  rt_clk_i
    , input                                                  reset_i
 
    , input [did_width_p-1:0]                                my_did_i
@@ -91,6 +92,7 @@ module wrapper
        #(.bp_params_p(bp_params_p))
        dut
         (.core_clk_i(clk_i)
+         ,.core_rt_clk_i(rt_clk_i)
          ,.core_reset_i(reset_i)
 
          ,.coh_clk_i(clk_i)


### PR DESCRIPTION
## Summary
This PR adds a real time clock input to BP. In the testbench here, it is simply a downsampled clock. However, in a real system this could be connected a crystal oscillator etc. ~The increment is handled by a two stage synchronizer with edge detection~. The counter is gray-coded and synchronized before heading to the core clock domain

## Issue Fixed
none

## Area
CLINT

## Reasoning (outdated, confusing, verbose, etc.)
Real systems often require RTC. The riscv platform spec additionally requires a 32 KHz real time clock (which we do not provide, but could).

## Additional Changes Required (if any)
FGPA wrappers need to update to generate the RTC (downsampled version). Any profilers that depend on an exact ratio must be adjusted.
