### PR TITLE
S-mode external interrupt

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -58,7 +58,8 @@ module bp_be_calculator_top
 
   , input                                           timer_irq_i
   , input                                           software_irq_i
-  , input                                           external_irq_i
+  , input                                           m_external_irq_i
+  , input                                           s_external_irq_i
   , output logic                                    irq_waiting_o
   , output logic                                    irq_pending_o
 
@@ -227,7 +228,8 @@ module bp_be_calculator_top
 
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)
-     ,.external_irq_i(external_irq_i)
+     ,.m_external_irq_i(m_external_irq_i)
+     ,.s_external_irq_i(s_external_irq_i)
      ,.irq_pending_o(irq_pending_o)
      ,.irq_waiting_o(irq_waiting_o)
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -617,7 +617,7 @@ module bp_be_csr
   // However, software read operations return as if it does. bit 9 is supervisor software interrupt
   always_comb
     unique casez (csr_cmd_cast_i.csr_addr)
-      `CSR_ADDR_SIP: csr_data_o = csr_data_lo | ((s_external_irq_i & sip_rmask_li) << 9));
+      `CSR_ADDR_SIP: csr_data_o = csr_data_lo | ((s_external_irq_i & sip_rmask_li) << 9);
       `CSR_ADDR_MIP: csr_data_o = csr_data_lo | (s_external_irq_i << 9);
       default: csr_data_o = csr_data_lo;
     endcase

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -1,5 +1,8 @@
 
 `include "bp_common_defines.svh"
+`include "bp_common_rv64_csr_defines.svh"
+
+
 `include "bp_be_defines.svh"
 
 module bp_be_csr
@@ -37,7 +40,8 @@ module bp_be_csr
    // Interrupts
    , input                                   timer_irq_i
    , input                                   software_irq_i
-   , input                                   external_irq_i
+   , input                                   m_external_irq_i
+   , input                                   s_external_irq_i
    , output logic                            irq_pending_o
    , output logic                            irq_waiting_o
 
@@ -63,7 +67,7 @@ module bp_be_csr
   `bp_cast_o(bp_be_trans_info_s, trans_info);
 
   // The muxed and demuxed CSR outputs
-  logic [dword_width_gp-1:0] csr_data_li, csr_data_lo;
+  logic [dword_width_gp-1:0] csr_data_li, csr_data_lo, effective_csr_data_lo;
   logic exception_v_lo, interrupt_v_lo;
 
   rv64_mstatus_s sstatus_wmask_li, sstatus_rmask_li;
@@ -130,16 +134,35 @@ module bp_be_csr
   `declare_csr(dscratch0);
   `declare_csr(dscratch1);
 
+  logic s_external_irq_r;
+  bsg_dff_reset
+   #(.width_p(1))
+   s_external_irq_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.data_i(s_external_irq_i)
+     ,.data_o(s_external_irq_r)
+     );
+
+  bp_mip_s effective_mip_r;
+  rv64_mip_s effective_mip_lo;
+  always_comb begin
+    effective_mip_r = mip_r;
+    effective_mip_r.seip = (mip_r.seip | s_external_irq_r);
+  end
+  assign effective_mip_lo = `decompress_mip_s(effective_mip_r);
+
+
   wire mgie = (mstatus_r.mie & is_m_mode) | is_s_mode | is_u_mode;
   wire sgie = (mstatus_r.sie & is_s_mode) | is_u_mode;
 
-  wire mti_v = mie_r.mtie & mip_r.mtip;
-  wire msi_v = mie_r.msie & mip_r.msip;
-  wire mei_v = mie_r.meie & mip_r.meip;
+  wire mti_v = mie_r.mtie & effective_mip_r.mtip;
+  wire msi_v = mie_r.msie & effective_mip_r.msip;
+  wire mei_v = mie_r.meie & effective_mip_r.meip;
 
-  wire sti_v = mie_r.stie & mip_r.stip;
-  wire ssi_v = mie_r.ssie & mip_r.ssip;
-  wire sei_v = mie_r.seie & mip_r.seip;
+  wire sti_v = mie_r.stie & effective_mip_r.stip;
+  wire ssi_v = mie_r.ssie & effective_mip_r.ssip;
+  wire sei_v = mie_r.seie & effective_mip_r.seip;
 
   // TODO: interrupt priority is non-compliant with the spec.
   wire [15:0] interrupt_icode_dec_li =
@@ -355,6 +378,7 @@ module bp_be_csr
       csr_illegal_instr_o  = '0;
       csr_csrw_o           = '0;
       csr_data_lo          = '0;
+      effective_csr_data_lo= '0;
 
       if (csr_cmd_v_i)
         begin
@@ -396,7 +420,11 @@ module bp_be_csr
                 {1'b1, `CSR_ADDR_SCAUSE       }: csr_data_lo = scause_lo;
                 {1'b1, `CSR_ADDR_STVAL        }: csr_data_lo = stval_lo;
                 // SIP subset of MIP
-                {1'b1, `CSR_ADDR_SIP          }: csr_data_lo = mip_lo & sip_rmask_li;
+                {1'b1, `CSR_ADDR_SIP          }: begin
+                                                 csr_data_lo = mip_lo & sip_rmask_li;
+                                                 effective_csr_data_lo =
+                                                   effective_mip_lo & sip_rmask_li;
+                                                 end
                 {1'b1, `CSR_ADDR_SATP         }: csr_data_lo = satp_lo;
                 // We havr no vendorid currently
                 {1'b1, `CSR_ADDR_MVENDORID    }: csr_data_lo = '0;
@@ -416,7 +444,10 @@ module bp_be_csr
                 {1'b1, `CSR_ADDR_MIE          }: csr_data_lo = mie_lo;
                 {1'b1, `CSR_ADDR_MTVEC        }: csr_data_lo = mtvec_lo;
                 {1'b1, `CSR_ADDR_MCOUNTEREN   }: csr_data_lo = mcounteren_lo;
-                {1'b1, `CSR_ADDR_MIP          }: csr_data_lo = mip_lo;
+                {1'b1, `CSR_ADDR_MIP          }: begin
+                                                 csr_data_lo = mip_lo;
+                                                 effective_csr_data_lo = effective_mip_lo;
+                                                 end
                 {1'b1, `CSR_ADDR_MSCRATCH     }: csr_data_lo = mscratch_lo;
                 {1'b1, `CSR_ADDR_MEPC         }: csr_data_lo = mepc_lo;
                 {1'b1, `CSR_ADDR_MCAUSE       }: csr_data_lo = mcause_lo;
@@ -595,10 +626,17 @@ module bp_be_csr
           dcsr_li.prv   = priv_mode_r;
         end
 
+
+      casez ({csr_r_v_li, csr_cmd_cast_i.csr_addr})
+        {1'b1, `CSR_ADDR_SIP}: begin end
+        {1'b1, `CSR_ADDR_MIP}: begin end
+        default: effective_csr_data_lo = csr_data_lo;
+      endcase
+
       // Accumulate interrupts
       mip_li.mtip = timer_irq_i;
       mip_li.msip = software_irq_i;
-      mip_li.meip = external_irq_i;
+      mip_li.meip = m_external_irq_i;
 
       // Accumulate FFLAGS
       fcsr_li.fflags |= fflags_acc_i;
@@ -611,7 +649,7 @@ module bp_be_csr
   // Debug Mode masks all interrupts
   assign irq_pending_o = ~is_debug_mode & ((m_interrupt_icode_v_li & mgie) | (s_interrupt_icode_v_li & sgie));
 
-  assign csr_data_o = dword_width_gp'(csr_data_lo);
+  assign csr_data_o = dword_width_gp'(effective_csr_data_lo);
 
   assign commit_pkt_cast_o.npc_w_v          = |{retire_pkt_cast_i.special, retire_pkt_cast_i.exception};
   assign commit_pkt_cast_o.queue_v          = retire_pkt_cast_i.queue_v & ~|retire_pkt_cast_i.exception;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
@@ -53,7 +53,8 @@ module bp_be_pipe_sys
 
    , input                                   timer_irq_i
    , input                                   software_irq_i
-   , input                                   external_irq_i
+   , input                                   m_external_irq_i
+   , input                                   s_external_irq_i
    , output logic                            irq_pending_o
    , output logic                            irq_waiting_o
 
@@ -118,7 +119,8 @@ module bp_be_pipe_sys
 
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)
-     ,.external_irq_i(external_irq_i)
+     ,.m_external_irq_i(m_external_irq_i)
+     ,.s_external_irq_i(s_external_irq_i)
      ,.irq_pending_o(irq_pending_o)
      ,.irq_waiting_o(irq_waiting_o)
 

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -69,7 +69,8 @@ module bp_be_top
 
    , input                                           timer_irq_i
    , input                                           software_irq_i
-   , input                                           external_irq_i
+   , input                                           m_external_irq_i
+   , input                                           s_external_irq_i
    );
 
   // Declare parameterized structures
@@ -225,7 +226,8 @@ module bp_be_top
 
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)
-     ,.external_irq_i(external_irq_i)
+     ,.m_external_irq_i(m_external_irq_i)
+     ,.s_external_irq_i(s_external_irq_i)
      ,.irq_pending_o(irq_pending_lo)
      ,.irq_waiting_o(irq_waiting_lo)
      ,.cmd_full_n_i(cmd_full_n_lo)

--- a/bp_common/src/include/bp_common_clint_pkgdef.svh
+++ b/bp_common/src/include/bp_common_clint_pkgdef.svh
@@ -14,7 +14,8 @@
 
   localparam mtime_reg_addr_gp          = dev_addr_width_gp'('h0_bff8);
   localparam mtime_reg_match_addr_gp    = dev_addr_width_gp'('h0_bff?);
-  localparam plic_reg_addr_gp           = dev_addr_width_gp'('h0_b000);
+  localparam plic_mext_reg_addr_gp      = dev_addr_width_gp'('h0_b000);
+  localparam plic_sext_reg_addr_gp      = dev_addr_width_gp'('h0_a000);
 
 `endif
 

--- a/bp_common/src/include/bp_common_clint_pkgdef.svh
+++ b/bp_common/src/include/bp_common_clint_pkgdef.svh
@@ -14,8 +14,8 @@
 
   localparam mtime_reg_addr_gp          = dev_addr_width_gp'('h0_bff8);
   localparam mtime_reg_match_addr_gp    = dev_addr_width_gp'('h0_bff?);
-  localparam plic_mext_reg_addr_gp      = dev_addr_width_gp'('h0_b000);
-  localparam plic_sext_reg_addr_gp      = dev_addr_width_gp'('h0_a000);
+  localparam plic_reg_match_addr_gp     = dev_addr_width_gp'('h0_b00?);
+
 
 `endif
 

--- a/bp_me/src/v/dev/bp_me_clint_slice.sv
+++ b/bp_me/src/v/dev/bp_me_clint_slice.sv
@@ -29,7 +29,8 @@ module bp_me_clint_slice
    // Local interrupts
    , output logic                                       software_irq_o
    , output logic                                       timer_irq_o
-   , output logic                                       external_irq_o
+   , output logic                                       m_external_irq_o
+   , output logic                                       s_external_irq_o
    );
 
   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p, xce);
@@ -37,19 +38,21 @@ module bp_me_clint_slice
 
   logic [dev_addr_width_gp-1:0] addr_lo;
   logic [dword_width_gp-1:0] data_lo;
-  logic [3:0][dword_width_gp-1:0] data_li;
-  logic plic_w_v_li, mtime_w_v_li, mtimecmp_w_v_li, mipi_w_v_li;
+  logic [4:0][dword_width_gp-1:0] data_li;
+  logic plic_mext_w_v_li, plic_sext_w_v_li;
+  logic mtime_w_v_li, mtimecmp_w_v_li, mipi_w_v_li;
   bp_me_bedrock_register
    #(.bp_params_p(bp_params_p)
-     ,.els_p(4)
+     ,.els_p(5)
      ,.reg_addr_width_p(dev_addr_width_gp)
-     ,.base_addr_p({plic_reg_addr_gp, mtime_reg_addr_gp, mtimecmp_reg_match_addr_gp, mipi_reg_match_addr_gp})
+     ,.base_addr_p({plic_sext_reg_addr_gp,  plic_mext_reg_addr_gp, mtime_reg_addr_gp,
+            mtimecmp_reg_match_addr_gp, mipi_reg_match_addr_gp})
      )
    register
     (.*
      // We ignore reads because these are all asynchronous registers
      ,.r_v_o()
-     ,.w_v_o({plic_w_v_li, mtime_w_v_li, mtimecmp_w_v_li, mipi_w_v_li})
+     ,.w_v_o({plic_sext_w_v_li, plic_mext_w_v_li, mtime_w_v_li, mtimecmp_w_v_li, mipi_w_v_li})
      ,.addr_o(addr_lo)
      ,.size_o()
      ,.data_o(data_lo)
@@ -113,24 +116,39 @@ module bp_me_clint_slice
      );
   assign software_irq_o = mipi_r;
 
-  logic plic_r;
-  wire plic_n = data_lo[0];
+  logic plic_mext_r;
+  logic plic_sext_r;
+  wire plic_mext_n = data_lo[0];
+  wire plic_sext_n = data_lo[0];
   bsg_dff_reset_en
    #(.width_p(1))
-   plic_reg
+   plic_mext_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
-     ,.en_i(plic_w_v_li)
+     ,.en_i(plic_mext_w_v_li)
 
-     ,.data_i(plic_n)
-     ,.data_o(plic_r)
+     ,.data_i(plic_mext_n)
+     ,.data_o(plic_mext_r)
      );
-  assign external_irq_o = plic_r;
+  assign m_external_irq_o = plic_mext_r;
+
+  bsg_dff_reset_en
+   #(.width_p(1))
+   plic_sext_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.en_i(plic_sext_w_v_li)
+
+     ,.data_i(plic_sext_n)
+     ,.data_o(plic_sext_r)
+     );
+  assign s_external_irq_o = plic_sext_r;
 
   assign data_li[0] = mipi_r;
   assign data_li[1] = mtimecmp_r;
   assign data_li[2] = mtime_r;
-  assign data_li[3] = plic_r;
+  assign data_li[3] = plic_mext_r;
+  assign data_li[4] = plic_sext_r;
 
 endmodule
 

--- a/bp_me/src/v/dev/bp_me_clint_slice.sv
+++ b/bp_me/src/v/dev/bp_me_clint_slice.sv
@@ -38,12 +38,12 @@ module bp_me_clint_slice
 
   logic [dev_addr_width_gp-1:0] addr_lo;
   logic [dword_width_gp-1:0] data_lo;
-  logic [4:0][dword_width_gp-1:0] data_li;
+  logic [3:0][dword_width_gp-1:0] data_li;
   logic plic_w_v_li;
   logic mtime_w_v_li, mtimecmp_w_v_li, mipi_w_v_li;
   bp_me_bedrock_register
    #(.bp_params_p(bp_params_p)
-     ,.els_p(5)
+     ,.els_p(4)
      ,.reg_addr_width_p(dev_addr_width_gp)
      ,.base_addr_p({plic_reg_match_addr_gp, mtime_reg_addr_gp,
             mtimecmp_reg_match_addr_gp, mipi_reg_match_addr_gp})
@@ -116,40 +116,39 @@ module bp_me_clint_slice
      );
   assign software_irq_o = mipi_r;
 
-  logic plic_mext_r, plic_sext_r;
-  wire mext_en_li = plic_w_v_li & (addr_lo[2] == 1'b0);
-  wire sext_en_li = plic_w_v_li & (addr_lo[2] == 1'b1);
-  wire plic_mext_n = data_lo[0];
-  wire plic_sext_n = data_lo[0];
-  bsg_dff_reset_en
-   #(.width_p(1))
-   plic_mext_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-     ,.en_i(mext_en_li)
+  // This scheme can be used for N PLIC bits, which may be required in
+  //   a distributed PLIC scheme. However, for now we only support
+  //   M and S mode external interrupts. This code doesn't work for
+  //   only a single PLIC bit.
+  localparam plic_els_lp = 2;
+  localparam lg_plic_els_lp = `BSG_SAFE_CLOG2(plic_els_lp);
+  logic [plic_els_lp-1:0] plic_n, plic_r;
+  wire [lg_plic_els_lp-1:0] plic_addr_li = addr_lo[2+:lg_plic_els_lp];
 
-     ,.data_i(plic_mext_n)
-     ,.data_o(plic_mext_r)
-     );
-  assign m_external_irq_o = plic_mext_r;
+  always_comb
+    begin
+      plic_n = plic_r;
+      plic_n[plic_addr_li] = data_lo[0];
+    end
 
   bsg_dff_reset_en
-   #(.width_p(1))
-   plic_sext_reg
+   #(.width_p(plic_els_lp))
+   plic_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
-     ,.en_i(sext_en_li)
-
-     ,.data_i(plic_sext_n)
-     ,.data_o(plic_sext_r)
+     ,.en_i(plic_w_v_li)
+     ,.data_i(plic_n)
+     ,.data_o(plic_r)
      );
-  assign s_external_irq_o = plic_sext_r;
+  wire plic_lo = plic_r[plic_addr_li];
+
+  assign m_external_irq_o = plic_r[0];
+  assign s_external_irq_o = plic_r[1];
 
   assign data_li[0] = mipi_r;
   assign data_li[1] = mtimecmp_r;
   assign data_li[2] = mtime_r;
-  assign data_li[3] = plic_mext_r;
-  assign data_li[4] = plic_sext_r;
+  assign data_li[3] = plic_lo;
 
 endmodule
 

--- a/bp_top/src/v/bp_core.sv
+++ b/bp_top/src/v/bp_core.sv
@@ -166,7 +166,8 @@ module bp_core
 
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)
-     ,.external_irq_i(external_irq_i)
+     ,.m_external_irq_i(external_irq_i)
+     ,.s_external_irq_i(1'b0) // UNUSED
      );
 
   bp_lce

--- a/bp_top/src/v/bp_core.sv
+++ b/bp_top/src/v/bp_core.sv
@@ -50,7 +50,8 @@ module bp_core
 
   , input                                            timer_irq_i
   , input                                            software_irq_i
-  , input                                            external_irq_i
+  , input                                            m_external_irq_i
+  , input                                            s_external_irq_i
   );
 
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
@@ -166,8 +167,8 @@ module bp_core
 
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)
-     ,.m_external_irq_i(external_irq_i)
-     ,.s_external_irq_i(1'b0) // UNUSED
+     ,.m_external_irq_i(m_external_irq_i)
+     ,.s_external_irq_i(s_external_irq_i)
      );
 
   bp_lce

--- a/bp_top/src/v/bp_core_minimal.sv
+++ b/bp_top/src/v/bp_core_minimal.sv
@@ -77,7 +77,8 @@ module bp_core_minimal
 
    , input                                           timer_irq_i
    , input                                           software_irq_i
-   , input                                           external_irq_i
+   , input                                           m_external_irq_i
+   , input                                           s_external_irq_i
    );
 
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
@@ -179,7 +180,8 @@ module bp_core_minimal
 
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)
-     ,.external_irq_i(external_irq_i)
+     ,.m_external_irq_i(m_external_irq_i)
+     ,.s_external_irq_i(s_external_irq_i)
      );
 
 endmodule

--- a/bp_top/src/v/bp_tile.sv
+++ b/bp_top/src/v/bp_tile.sv
@@ -416,7 +416,7 @@ module bp_tile
      );
 
   // Processor
-  logic timer_irq_li, software_irq_li, external_irq_li;
+  logic timer_irq_li, software_irq_li, m_external_irq_li, s_external_irq_li;
   bp_core
    #(.bp_params_p(bp_params_p))
    core
@@ -447,7 +447,8 @@ module bp_tile
 
      ,.timer_irq_i(timer_irq_li)
      ,.software_irq_i(software_irq_li)
-     ,.external_irq_i(external_irq_li)
+     ,.m_external_irq_i(m_external_irq_li)
+     ,.s_external_irq_i(s_external_irq_li)
      );
 
   // CCE-side CCE-Mem network connections
@@ -524,8 +525,8 @@ module bp_tile
 
      ,.timer_irq_o(timer_irq_li)
      ,.software_irq_o(software_irq_li)
-     ,.m_external_irq_o(external_irq_li)
-     ,.s_external_irq_o(/* UNUSED */)
+     ,.m_external_irq_o(m_external_irq_li)
+     ,.s_external_irq_o(s_external_irq_li)
      );
 
   // CCE-Mem Loopback

--- a/bp_top/src/v/bp_tile.sv
+++ b/bp_top/src/v/bp_tile.sv
@@ -524,7 +524,8 @@ module bp_tile
 
      ,.timer_irq_o(timer_irq_li)
      ,.software_irq_o(software_irq_li)
-     ,.external_irq_o(external_irq_li)
+     ,.m_external_irq_o(external_irq_li)
+     ,.s_external_irq_o(/* UNUSED */)
      );
 
   // CCE-Mem Loopback

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -110,7 +110,7 @@ module bp_unicore_lite
   logic dcache_stat_mem_pkt_v_li, dcache_stat_mem_pkt_yumi_lo;
   bp_dcache_stat_info_s dcache_stat_mem_lo;
 
-  logic timer_irq_li, software_irq_li, external_irq_li;
+  logic timer_irq_li, software_irq_li, m_external_irq_li, s_external_irq_li;
 
   // proc_cmd[2:0] = {IO cmd, BE UCE, FE UCE}
   bp_bedrock_uce_mem_header_s [2:0] proc_cmd_header_lo;
@@ -192,7 +192,8 @@ module bp_unicore_lite
 
      ,.timer_irq_i(timer_irq_li)
      ,.software_irq_i(software_irq_li)
-     ,.external_irq_i(external_irq_li)
+     ,.m_external_irq_i(m_external_irq_li)
+     ,.s_external_irq_i(s_external_irq_li)
      );
 
   wire [1:0][lce_id_width_p-1:0] lce_id_li = {cfg_bus_lo.dcache_id, cfg_bus_lo.icache_id};
@@ -486,7 +487,8 @@ module bp_unicore_lite
 
      ,.timer_irq_o(timer_irq_li)
      ,.software_irq_o(software_irq_li)
-     ,.external_irq_o(external_irq_li)
+     ,.m_external_irq_o(m_external_irq_li)
+     ,.s_external_irq_o(s_external_irq_li)
      );
   assign clint_data_li = dev_cmd_data_li[1];
   assign dev_resp_data_lo[1] = clint_data_lo;


### PR DESCRIPTION
## Summary
This PR brings S-mode external interrupt in BP. 

## Area
Mainly bp_be_csr.

## Verification
1. s_external_interrupt.c from [bp-tests](https://github.com/black-parrot-sdk/bp-tests/pull/29)
2. Have tested it on Zedboard running Ethernet connection in Linux.

## Additional Context
For now I set the S-mode interrupt address to 0x30_a000. Not sure if it really makes sense.
Also, I only considered single-core case, so I didn't do updates for modules like bp_tile, bp_core.