### PR TITLE
[WIP] Gearboxing modules

### DIFF
--- a/bp_common/src/v/bsg_serial_in_parallel_out_passthrough.v
+++ b/bp_common/src/v/bsg_serial_in_parallel_out_passthrough.v
@@ -1,0 +1,88 @@
+/**
+ *  bsg_serial_in_parallel_out_passthrough.v
+ */
+
+`include "bsg_defines.v"
+
+module bsg_serial_in_parallel_out_passthrough
+ #(parameter `BSG_INV_PARAM(width_p)
+   , parameter `BSG_INV_PARAM(els_p)
+   , parameter hi_to_lo_p = 0
+   )
+  (input                                  clk_i
+  , input                                 reset_i
+
+  , input                                 v_i
+  , output logic                          ready_and_o
+  , input [width_p-1:0]                   data_i
+
+  , output logic [els_p-1:0][width_p-1:0] data_o
+  , output logic                          v_o
+  , input                                 ready_and_i
+  );
+
+  localparam lg_els_lp = `BSG_SAFE_CLOG2(els_p);
+
+  logic [els_p-1:0] count_r;
+
+  assign v_o = v_i & count_r[els_p-1];     // means we received all of the words
+  assign ready_and_o = ~count_r[els_p-1] | ready_and_i; // have space, or we are dequeing; (one gate delay in-to-out)
+
+  wire sending   = v_o & ready_and_i;  // we have all the items, and downstream is ready
+  wire receiving = v_i & ready_and_o;  // data is coming in, and we have space
+
+  // counts one hot, from 0 to width_p
+  // contains one hot pointer to word to write to
+  // simultaneous restart and increment are allowed
+
+  if (els_p == 1)
+    begin : single_word
+      assign count_r = 1'b1;
+    end
+  else
+    begin : multi_word
+      bsg_counter_clear_up_one_hot
+       #(.max_val_p(els_p-1))
+       bcoh
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+         ,.clear_i(sending)
+         ,.up_i(receiving & ~count_r[els_p-1])
+         ,.count_r_o(count_r)
+         );
+    end
+
+  logic [els_p-1:0][width_p-1:0] data_lo;
+
+  for (genvar i = 0; i < els_p-1; i++)
+    begin: rof
+      wire my_turn = v_i & count_r[i];
+      bsg_dff_en #(.width_p(width_p)) dff
+      (.clk_i
+       ,.data_i
+       ,.en_i   (my_turn)
+       ,.data_o (data_lo [i])
+      );
+    end
+  assign data_lo[els_p-1] = data_i;
+
+  // If send hi_to_lo, reverse the output data array
+  if (hi_to_lo_p == 0)
+    begin: lo2hi
+      assign data_o = data_lo;
+    end
+  else
+    begin: hi2lo
+      bsg_array_reverse
+       #(.width_p(width_p), .els_p(els_p))
+       bar
+        (.i(data_lo)
+         ,.o(data_o)
+         );
+    end
+
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_serial_in_parallel_out_passthrough)
+

--- a/bp_me/src/v/cce/bp_uce.sv
+++ b/bp_me/src/v/cce/bp_uce.sv
@@ -15,7 +15,6 @@ module bp_uce
   import bp_common_pkg::*;
   import bp_me_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
-    , parameter `BSG_INV_PARAM(mem_data_width_p)
     `declare_bp_proc_params(bp_params_p)
     `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
     , parameter `BSG_INV_PARAM(assoc_p)
@@ -65,13 +64,13 @@ module bp_uce
     , input [cache_stat_info_width_lp-1:0]           stat_mem_i
 
     , output logic [mem_header_width_lp-1:0]         mem_cmd_header_o
-    , output logic [mem_data_width_p-1:0]            mem_cmd_data_o
+    , output logic [fill_width_p-1:0]                mem_cmd_data_o
     , output logic                                   mem_cmd_v_o
     , input                                          mem_cmd_ready_and_i
     , output logic                                   mem_cmd_last_o
 
     , input [mem_header_width_lp-1:0]                mem_resp_header_i
-    , input [mem_data_width_p-1:0]                   mem_resp_data_i
+    , input [fill_width_p-1:0]                       mem_resp_data_i
     , input                                          mem_resp_v_i
     , output logic                                   mem_resp_ready_and_o
     , input                                          mem_resp_last_i

--- a/bp_me/src/v/network/bp_me_burst_gearbox.sv
+++ b/bp_me/src/v/network/bp_me_burst_gearbox.sv
@@ -1,0 +1,107 @@
+/**
+ *
+ * Name:
+ *   bp_me_burst_gearbox.sv
+ *
+ * Description:
+ *   This module changes the width of a bedrock burst. Ratio must be POT between the two
+ *
+ */
+
+`include "bp_common_defines.svh"
+`include "bp_me_defines.svh"
+
+module bp_me_burst_gearbox
+ import bp_common_pkg::*;
+ import bp_me_pkg::*;
+ #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+   `declare_bp_proc_params(bp_params_p)
+
+   , parameter `BSG_INV_PARAM(in_data_width_p)
+   , parameter `BSG_INV_PARAM(out_data_width_p)
+   , parameter `BSG_INV_PARAM(payload_width_p)
+
+   `declare_bp_bedrock_if_widths(paddr_width_p, payload_width_p, in)
+   `declare_bp_bedrock_if_widths(paddr_width_p, payload_width_p, out)
+   )
+  (input                                     clk_i
+   , input                                   reset_i
+
+   // Input BedRock Burst
+   , input [in_header_width_lp-1:0]          msg_header_i
+   , input                                   msg_header_v_i
+   , output logic                            msg_header_ready_and_o
+   , input                                   msg_has_data_i
+
+   // ready-valid-and
+   , input [in_data_width_p-1:0]             msg_data_i
+   , input                                   msg_data_v_i
+   , output logic                            msg_data_ready_and_o
+   , input                                   msg_last_i
+
+   // Output BedRock Burst
+   , output logic [out_header_width_lp-1:0]  msg_header_o
+   , output logic                            msg_header_v_o
+   , input                                   msg_header_ready_and_i
+   , output logic                            msg_has_data_o
+
+   // ready-valid-and
+   , output logic [out_data_width_p-1:0]     msg_data_o
+   , output logic                            msg_data_v_o
+   , input                                   msg_data_ready_and_i
+   , output logic                            msg_last_o
+   );
+
+  `declare_bp_bedrock_if(paddr_width_p, payload_width_p, lce_id_width_p, lce_assoc_p, in);
+  `declare_bp_bedrock_if(paddr_width_p, payload_width_p, lce_id_width_p, lce_assoc_p, out);
+  `bp_cast_i(bp_bedrock_in_header_s, msg_header);
+  `bp_cast_o(bp_bedrock_out_header_s, msg_header);
+
+  localparam narrow_ratio_lp = in_data_width_p / out_data_width_p;
+  localparam wide_ratio_lp = out_data_width_p / in_data_width_p;
+  if (narrow_ratio_lp >= 1)
+    begin : narrow
+      bsg_parallel_in_serial_out_passthrough
+       #(.width_p(out_data_width_p), .els_p(narrow_ratio_lp))
+       pisop
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+
+         ,.data_i(msg_data_i)
+         ,.v_i(msg_data_v_i)
+         ,.ready_and_o(msg_data_ready_and_o)
+
+         ,.data_o(msg_data_o)
+         ,.v_o(msg_data_v_o)
+         ,.ready_and_i(msg_data_ready_and_i)
+         );
+      assign msg_last_o = msg_last_i & msg_data_v_o;
+    end
+  else
+    begin : wide
+      bsg_serial_in_parallel_out_passthrough
+       #(.width_p(in_data_width_p), .els_p(wide_ratio_lp))
+       sisop
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+
+         ,.data_i(msg_data_i)
+         ,.v_i(msg_data_v_i)
+         ,.ready_and_o(msg_data_ready_and_o)
+
+         ,.data_o(msg_data_o)
+         ,.v_o(msg_data_v_o)
+         ,.ready_and_i(msg_data_ready_and_i)
+         );
+      assign msg_last_o = msg_last_i & msg_data_v_o;
+    end
+
+  assign msg_header_cast_o = msg_header_i;
+  assign msg_header_v_o = msg_header_v_i;
+  assign msg_header_ready_and_o = msg_header_ready_and_i;
+  assign msg_has_data_o = msg_has_data_i;
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bp_me_burst_gearbox)
+

--- a/bp_me/src/v/network/bp_me_stream_gearbox.sv
+++ b/bp_me/src/v/network/bp_me_stream_gearbox.sv
@@ -1,0 +1,173 @@
+/**
+ *
+ * Name:
+ *   bp_me_stream_gearbox.sv
+ *
+ * Description:
+ *   This module changes the width of a bedrock stream. Ratio must be POT between the two.
+ *   TODO: short-circuit if data size < bus size
+ *   TODO: bus_bus_pack
+ *
+ */
+
+`include "bp_common_defines.svh"
+`include "bp_me_defines.svh"
+
+module bp_me_stream_gearbox
+ import bp_common_pkg::*;
+ import bp_me_pkg::*;
+ #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+   `declare_bp_proc_params(bp_params_p)
+
+   , parameter `BSG_INV_PARAM(in_data_width_p)
+   , parameter `BSG_INV_PARAM(out_data_width_p)
+   , parameter `BSG_INV_PARAM(payload_width_p)
+   , parameter `BSG_INV_PARAM(payload_mask_p)
+
+   `declare_bp_bedrock_if_widths(paddr_width_p, payload_width_p, in)
+   `declare_bp_bedrock_if_widths(paddr_width_p, payload_width_p, out)
+   )
+  (input                                            clk_i
+   , input                                          reset_i
+
+   // Input BedRock Stream
+   , input [in_header_width_lp-1:0]                 msg_header_i
+   , input [in_data_width_p-1:0]                    msg_data_i
+   , input                                          msg_v_i
+   , output logic                                   msg_ready_and_o
+   , input                                          msg_last_i
+
+   // Output BedRock Stream
+   , output logic [out_header_width_lp-1:0]         msg_header_o
+   , output logic [out_data_width_p-1:0]            msg_data_o
+   , output logic                                   msg_v_o
+   , input                                          msg_ready_and_i
+   , output logic                                   msg_last_o
+   );
+
+  `declare_bp_bedrock_if(paddr_width_p, payload_width_p, lce_id_width_p, lce_assoc_p, in);
+  `declare_bp_bedrock_if(paddr_width_p, payload_width_p, lce_id_width_p, lce_assoc_p, out);
+  `bp_cast_i(bp_bedrock_in_header_s, msg_header);
+  `bp_cast_o(bp_bedrock_out_header_s, msg_header);
+
+  localparam narrow_ratio_lp = in_data_width_p / out_data_width_p;
+  localparam wide_ratio_lp = out_data_width_p / in_data_width_p;
+
+  // We need to replicate for the case that out_width > in_width and msg_length < out_width
+  // So this is a bit overkill, but should work
+  localparam data_bytes_lp = (out_data_width_p>>3);
+  localparam data_byte_offset_width_lp = `BSG_SAFE_CLOG2(data_bytes_lp);
+  localparam bus_pack_size_width_lp = `BSG_WIDTH(data_byte_offset_width_lp);
+
+  wire has_data =
+    payload_mask_p[msg_header_cast_i.msg_type] && (msg_header_cast_i.size > `BSG_SAFE_CLOG2(data_bytes_lp));
+
+  if (narrow_ratio_lp == 1)
+    begin : passthrough
+      assign msg_header_cast_o = msg_header_i;
+      assign msg_data_o = msg_data_i;
+      assign msg_v_o = msg_v_i;
+      assign msg_last_o = msg_last_i;
+      assign msg_ready_and_o = msg_ready_and_i;
+    end
+  else if (narrow_ratio_lp >= 1)
+    begin : narrow
+      localparam out_words_lp = narrow_ratio_lp;
+      localparam cnt_width_lp = `BSG_SAFE_CLOG2(out_words_lp);
+      localparam offset_width_lp = `BSG_SAFE_CLOG2(out_data_width_p>>3);
+
+      logic msg_data_v_lo;
+      bsg_parallel_in_serial_out_passthrough
+       #(.width_p(out_data_width_p), .els_p(narrow_ratio_lp))
+       pisop
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i | (msg_ready_and_i & msg_v_o & msg_last_o))
+
+         ,.data_i(msg_data_i)
+         ,.v_i(msg_v_i)
+         ,.ready_and_o()
+
+         ,.data_o(msg_data_o)
+         ,.v_o(msg_data_v_lo)
+         ,.ready_and_i(msg_ready_and_i)
+         );
+      assign msg_ready_and_o = msg_ready_and_i & msg_v_o & msg_last_o;
+
+      logic [cnt_width_lp-1:0] cnt;
+      bsg_counter_clear_up
+       #(.max_val_p(out_words_lp-1), .init_val_p('0), .disable_overflow_warning_p(1))
+       counter
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+
+         ,.clear_i(1'b0)
+         ,.up_i(has_data & msg_v_o & msg_ready_and_i)
+         ,.count_o(cnt)
+         );
+      assign msg_v_o = msg_v_i & (~has_data | msg_data_v_lo);
+      assign msg_last_o = msg_last_i & (~has_data | (msg_data_v_lo && cnt == out_words_lp-1));
+
+      wire [cnt_width_lp-1:0] wrap = cnt + msg_header_cast_i.addr[offset_width_lp+:cnt_width_lp];
+      always_comb
+        begin
+          msg_header_cast_o = msg_header_cast_i;
+          msg_header_cast_o.addr = {msg_header_cast_i.addr[paddr_width_p-1:offset_width_lp+cnt_width_lp]
+                                    ,cnt_width_lp'(wrap)
+                                    ,msg_header_cast_i.addr[0+:offset_width_lp]
+                                    };
+        end
+    end
+  else
+    begin : wide
+      localparam in_words_lp = wide_ratio_lp;
+      localparam cnt_width_lp = `BSG_SAFE_CLOG2(in_words_lp);
+      localparam offset_width_lp = `BSG_SAFE_CLOG2(in_data_width_p>>3);
+
+      logic [out_data_width_p-1:0] msg_data_lo;
+      logic msg_data_v_lo;
+      bsg_serial_in_parallel_out_passthrough
+       #(.width_p(in_data_width_p), .els_p(wide_ratio_lp))
+       sisop
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i | (msg_v_o & msg_ready_and_i & msg_last_o))
+
+         ,.data_i(msg_data_i)
+         ,.v_i(msg_v_i)
+         ,.ready_and_o()
+
+         ,.data_o(msg_data_lo)
+         ,.v_o(msg_data_v_lo)
+         ,.ready_and_i(msg_ready_and_i)
+         );
+      assign msg_ready_and_o = msg_ready_and_i;
+
+      wire [bus_pack_size_width_lp-1:0] msg_size_li = ((1 << msg_header_cast_i.size) > data_bytes_lp)
+        ? bus_pack_size_width_lp'(data_byte_offset_width_lp)
+        : msg_header_cast_i.size[0+:bus_pack_size_width_lp];
+      bsg_bus_pack
+       #(.in_width_p(out_data_width_p))
+       out_bus_pack
+        (.data_i(msg_data_lo)
+         ,.sel_i('0)
+         ,.size_i(msg_size_li)
+         ,.data_o(msg_data_o)
+         );
+
+      assign msg_v_o = msg_v_i & (~has_data | msg_data_v_lo);
+      assign msg_last_o = msg_last_i & (~has_data | msg_data_v_lo);
+
+      wire [cnt_width_lp-1:0] wrap = '0;
+      always_comb
+        begin
+          msg_header_cast_o = msg_header_cast_i;
+          msg_header_cast_o.addr = {msg_header_cast_i.addr[paddr_width_p-1:offset_width_lp+cnt_width_lp]
+                                    ,cnt_width_lp'(wrap)
+                                    ,msg_header_cast_i.addr[0+:offset_width_lp]
+                                    };
+        end
+    end
+
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bp_me_stream_gearbox)

--- a/bp_me/src/v/network/bp_me_stream_wraparound.sv
+++ b/bp_me/src/v/network/bp_me_stream_wraparound.sv
@@ -13,11 +13,11 @@
  *
  *   size_i is the zero-based transaction size (e.g., a transaction of 4 stream words has size_i = 3)
  *   - size_i+1 should be a power of two
- *   val_i is the zero-based initial stream word in [0, max_val_p] of the transaction
- *   Both size_i and val_i must be held constant throughout the transaction.
+ *   base_i is first address of the transaction
+ *   Both size_i and base_i must be held constant throughout the transaction.
  *
  *   Two outputs are generated:
- *   1. full_o is a count that wraps around at the end of the full block
+ *   1. cnt_o is a count that wraps around at the end of the full block
  *   2. wrap_o is a count that wraps around at the end of the naturally aligned sub-block with
  *      size size_i targeted by the transaction. wrap_o is typically used directed in the stream
  *      message address.
@@ -28,55 +28,63 @@
 
 module bp_me_stream_wraparound
  #(parameter `BSG_INV_PARAM(max_val_p)
+   , parameter `BSG_INV_PARAM(addr_width_p)
+   , parameter `BSG_INV_PARAM(offset_width_p)
    , localparam width_lp = `BSG_WIDTH(max_val_p)
    )
   (input                                          clk_i
    , input                                        reset_i
 
-   // A new wraparound sequence has started, this is a transparent write
-   , input                                        set_i
    // Increment counter
    , input                                        en_i
    , input [`BSG_SAFE_MINUS(width_lp,1):0]        size_i
-   , input [`BSG_SAFE_MINUS(width_lp,1):0]        val_i
+   , input [addr_width_p-1:0]                     base_i
 
-   // full width count, wraps at end of block
-   , output logic [`BSG_SAFE_MINUS(width_lp,1):0] full_o
-   // wrap-around count, used to construct proper stream beat address
    // wraps within sub-block aligned portion of block targeted by request
-   , output logic [`BSG_SAFE_MINUS(width_lp,1):0] wrap_o
+   // the stream beat address using the wraparound count
+   , output logic [addr_width_p-1:0]              addr_o
+   // full width count, wraps at end of block
+   , output logic [`BSG_SAFE_MINUS(width_lp,1):0] cnt_o
+
+   , output logic                                 first_o
+   , output logic                                 last_o
    );
 
   // parameter check
   if ((max_val_p > 0) && !`BSG_IS_POW2(max_val_p+1))
     $error("max_val_p+1 of %0d is not a power of two...wrap-around counting will break.", max_val_p+1);
 
+  enum logic {e_ready, e_stream} state_n, state_r;
+  wire is_ready  = (state_r == e_ready);
+  wire is_stream = (state_r == e_stream);
+
   if (max_val_p == 0)
     begin : z
-      assign full_o = '0;
-      assign wrap_o = '0;
+      assign addr_o  = '0;
+      assign cnt_o   = '0;
+      assign first_o = 1'b1;
+      assign last_o  = 1'b1;
     end
   else
     begin : nz
       logic [width_lp-1:0] cnt_r;
-      wire [width_lp-1:0] cnt_val_li = val_i + en_i;
+
+      wire [width_lp-1:0] base_cnt = base_i[offset_width_p+:width_lp];
+      wire [width_lp-1:0] cnt_val_li = base_cnt + en_i;
       bsg_counter_set_en
        #(.max_val_p(max_val_p), .reset_val_p('0))
        counter
         (.clk_i(clk_i)
          ,.reset_i(reset_i)
 
-         ,.set_i(set_i)
+         ,.set_i(is_ready & en_i)
          ,.en_i(en_i)
          ,.val_i(cnt_val_li)
          ,.count_o(cnt_r)
          );
 
-      // block-wrapped count (stream word)
-      assign full_o = cnt_r;
-
       // Dynamically generate sub-block wrapped stream count
-      // The count is wrapped within the size_i aligned portion of the block containing val_i
+      // The count is wrapped within the size_i aligned portion of the block containing base_cnt
       //
       // A canonical block address can be viewed as:
       // __________________________________________________________
@@ -94,22 +102,22 @@ module bp_me_stream_wraparound
       //
       // To produce wrap_o, which is the sub-block aligned and wrapped count, the sub-block number
       // field is held constant while sub-block count comes from the counter. The number of bits
-      // derived from the counter versus the initial stream word input (val_i) is determined by
+      // derived from the counter versus the initial stream word input (base_cnt) is determined by
       // the transaction size (size_i) input. A transaction with size_i == max_val_p uses the
-      // stream count (full_o) directly as it already handles block-aligned wrapping.
+      // stream count (cnt_o) directly as it already handles block-aligned wrapping.
       //
       // For example, consider a system with max_val_p = 7 (8 stream words per block), where a block
       // comprises stream words [7, 6, 5, 4, 3, 2, 1, 0], listed most to least significant.
       // An exampe system like this could have 512 bit blocks with a stream data width of 64 bits.
       // 3 bits = log2(512/64) are required for the stream count. The transaction size (size_i)
-      // determines how many bits are used from val_i and full_o (cnt_r) to produce wrap_o.
+      // determines how many bits are used from base_cnt and cnt_o (cnt_r) to produce wrap_o.
 
       // E.g., max_val_p = 7 for a system with 512-bit blocks and 64-bit stream data width
       // A 512-bit transaction sets size_i = 7 and a 256-bit transactions sets size_i = 3
-      // 512-bit, size_i = 7, val_i = 2: full_o and wrap_o = 2, 3, 4, 5, 6, 7, 0, 1
-      // 256-bit, size_i = 3, val_i = 2: full_o = 2, 3, 4, 5 and wrap_o = 2, 3, 0, 1
-      // 512-bit, size_i = 7, val_i = 6: full_o and wrap_o = 6, 7, 0, 1, 2, 3, 4, 5
-      // 256-bit, size_i = 3, val_i = 6: full_o = 6, 7, 0, 1 and wrap_o = 6, 7, 4, 5
+      // 512-bit, size_i = 7, base_cnt = 2: cnt_o and wrap_o = 2, 3, 4, 5, 6, 7, 0, 1
+      // 256-bit, size_i = 3, base_cnt = 2: cnt_o = 2, 3, 4, 5 and wrap_o = 2, 3, 0, 1
+      // 512-bit, size_i = 7, base_cnt = 6: cnt_o and wrap_o = 6, 7, 0, 1, 2, 3, 4, 5
+      // 256-bit, size_i = 3, base_cnt = 6: cnt_o = 6, 7, 0, 1 and wrap_o = 6, 7, 4, 5
 
       // if size_i+1 is not a power of two, the transaction wraps as if size_i+1 is the next
       // power of two (e.g., max_val_p = 3, then size_i = 2 wraps same as size_i = 3)
@@ -121,15 +129,39 @@ module bp_me_stream_wraparound
           assign cnt_sel_li[i] = size_i >= 2**i;
         end
 
+      wire [width_lp-1:0] last_cnt = base_cnt + size_i;
       // sub-block wrapped and aligned count (stream word)
+      logic [width_lp-1:0] wrap_cnt;
       bsg_mux_bitwise
        #(.width_p(width_lp))
        wrap_mux
-        (.data0_i(val_i)
+        (.data0_i(base_cnt)
          ,.data1_i(cnt_r)
          ,.sel_i(cnt_sel_li)
-         ,.data_o(wrap_o)
+         ,.data_o(wrap_cnt)
          );
+      assign first_o = is_ready;
+      assign last_o  = (is_ready && (size_i == '0)) || (is_stream && (cnt_r == last_cnt));
+      assign cnt_o   = is_ready ? base_cnt : cnt_r;
+
+      wire [addr_width_p-1:0] wrap_addr =
+        {base_i[addr_width_p-1:offset_width_p+width_lp], wrap_cnt, base_i[0+:offset_width_p]};
+
+      assign addr_o = is_ready ? base_i : wrap_addr;
+
+      always_comb
+        case (state_r)
+          e_stream: state_n = (last_o & en_i) ? e_ready : e_stream;
+          // e_ready :
+          default : state_n = (first_o & en_i & (size_i > '0)) ? e_stream : e_ready;
+        endcase
+
+      //synopsys sync_set_reset "reset_i"
+      always_ff @(posedge clk_i)
+        if (reset_i)
+          state_r <= e_ready;
+        else
+          state_r <= state_n;
     end
 
 endmodule

--- a/bp_me/src/v/network/bp_me_xbar_stream.sv
+++ b/bp_me/src/v/network/bp_me_xbar_stream.sv
@@ -17,57 +17,101 @@ module bp_me_xbar_stream
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
 
-   , parameter `BSG_INV_PARAM(data_width_p)
    , parameter `BSG_INV_PARAM(payload_width_p)
+   , parameter `BSG_INV_PARAM(payload_mask_p)
    , parameter `BSG_INV_PARAM(num_source_p)
    , parameter `BSG_INV_PARAM(num_sink_p)
-   `declare_bp_bedrock_if_widths(paddr_width_p, payload_width_p, xbar)
+
+   , parameter `BSG_INV_PARAM(xbar_data_width_p)
+   , parameter int `BSG_INV_PARAM(source_data_width_p) [num_source_p:0]
+   , parameter int `BSG_INV_PARAM(sink_data_width_p) [num_sink_p:0]
 
    , localparam lg_num_source_lp = `BSG_SAFE_CLOG2(num_source_p)
    , localparam lg_num_sink_lp   = `BSG_SAFE_CLOG2(num_sink_p)
+
+   , localparam source_data_width_lp = source_data_width_p[num_source_p]
+   , localparam sink_data_width_lp = sink_data_width_p[num_sink_p]
+
+   `declare_bp_bedrock_if_widths(paddr_width_p, payload_width_p, xbar)
    )
   (input                                                              clk_i
    , input                                                            reset_i
 
    , input [num_source_p-1:0][xbar_header_width_lp-1:0]               msg_header_i
-   , input [num_source_p-1:0][data_width_p-1:0]                       msg_data_i
+   , input [source_data_width_lp-1:0]                                 msg_data_i
    , input [num_source_p-1:0]                                         msg_v_i
    , output logic [num_source_p-1:0]                                  msg_ready_and_o
    , input [num_source_p-1:0]                                         msg_last_i
    , input [num_source_p-1:0][lg_num_sink_lp-1:0]                     msg_dst_i
 
    , output logic [num_sink_p-1:0][xbar_header_width_lp-1:0]          msg_header_o
-   , output logic [num_sink_p-1:0][data_width_p-1:0]                  msg_data_o
+   , output logic [sink_data_width_lp-1:0]                            msg_data_o
    , output logic [num_sink_p-1:0]                                    msg_v_o
    , input [num_sink_p-1:0]                                           msg_ready_and_i
    , output logic [num_sink_p-1:0]                                    msg_last_o
    );
 
   `declare_bp_bedrock_if(paddr_width_p, payload_width_p, lce_id_width_p, lce_assoc_p, xbar);
-   bp_bedrock_xbar_header_s [num_source_p-1:0] msg_header_li;
-   logic [num_source_p-1:0][data_width_p-1:0] msg_data_li;
-   logic [num_source_p-1:0] msg_v_li, msg_yumi_lo, msg_last_li;
-   logic [num_source_p-1:0][lg_num_sink_lp-1:0] msg_dst_li;
+  bp_bedrock_xbar_header_s [num_source_p-1:0] xbar_header_li;
+  logic [num_source_p-1:0][xbar_data_width_p-1:0] xbar_data_li;
+  logic [num_source_p-1:0] xbar_v_li, xbar_yumi_lo, xbar_last_li;
 
+  bp_bedrock_xbar_header_s [num_sink_p-1:0] xbar_header_lo;
+  logic [num_sink_p-1:0][xbar_data_width_p-1:0] xbar_data_lo;
+  logic [num_sink_p-1:0] xbar_v_lo, xbar_ready_and_li, xbar_last_lo;
+
+  logic [num_source_p-1:0][lg_num_sink_lp-1:0] xbar_dst_li;
   for (genvar i = 0; i < num_source_p; i++)
     begin : buffer
+      localparam dw = source_data_width_p[i+1] - source_data_width_p[i];
+
+      // Optimal buffering strategy depends on data width
+      bp_bedrock_xbar_header_s msg_header_li;
+      logic [dw-1:0] msg_data_li;
+      logic msg_v_li, msg_ready_and_lo, msg_last_li;
+      logic [lg_num_sink_lp-1:0] msg_dst_li;
+      wire [dw-1:0] msg_data_slice = msg_data_i[source_data_width_p[i+1]-1:source_data_width_p[i]];
       bsg_two_fifo
-       #(.width_p(lg_num_sink_lp+1+data_width_p+xbar_header_width_lp))
+       #(.width_p(lg_num_sink_lp+1+dw+xbar_header_width_lp))
        in_fifo
         (.clk_i(clk_i)
          ,.reset_i(reset_i)
 
-         ,.data_i({msg_dst_i[i], msg_last_i[i], msg_data_i[i], msg_header_i[i]})
+         ,.data_i({msg_dst_i[i], msg_last_i[i], msg_data_slice, msg_header_i[i]})
          ,.v_i(msg_v_i[i])
          ,.ready_o(msg_ready_and_o[i])
 
-         ,.data_o({msg_dst_li[i], msg_last_li[i], msg_data_li[i], msg_header_li[i]})
-         ,.v_o(msg_v_li[i])
-         ,.yumi_i(msg_yumi_lo[i])
+         ,.data_o({msg_dst_li, msg_last_li, msg_data_li, msg_header_li})
+         ,.v_o(msg_v_li)
+         ,.yumi_i(msg_ready_and_lo & msg_v_li)
+         );
+      assign xbar_dst_li[i] = msg_dst_li;
+
+      bp_me_stream_gearbox
+       #(.bp_params_p(bp_params_p)
+         ,.in_data_width_p(dw)
+         ,.out_data_width_p(xbar_data_width_p)
+         ,.payload_width_p($bits(xbar_header_li[i].payload))
+         ,.payload_mask_p(payload_mask_p)
+         )
+       source_gearbox
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+         ,.msg_header_i(msg_header_li)
+         ,.msg_data_i(msg_data_li)
+         ,.msg_v_i(msg_v_li)
+         ,.msg_ready_and_o(msg_ready_and_lo)
+         ,.msg_last_i(msg_last_li)
+
+         ,.msg_header_o(xbar_header_li[i])
+         ,.msg_data_o(xbar_data_li[i])
+         ,.msg_v_o(xbar_v_li[i])
+         ,.msg_ready_and_i(xbar_yumi_lo[i])
+         ,.msg_last_o(xbar_last_li[i])
          );
     end
 
-  logic [num_sink_p-1:0] msg_unlock_li;
+  logic [num_sink_p-1:0] xbar_unlock_li;
   logic [num_sink_p-1:0][num_source_p-1:0] grants_oi_one_hot_lo;
   bsg_crossbar_control_locking_o_by_i
    #(.i_els_p(num_source_p), .o_els_p(num_sink_p))
@@ -75,30 +119,56 @@ module bp_me_xbar_stream
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.valid_i(msg_v_li)
-     ,.sel_io_i(msg_dst_li)
-     ,.yumi_o(msg_yumi_lo)
+     ,.valid_i(xbar_v_li)
+     ,.sel_io_i(xbar_dst_li)
+     ,.yumi_o(xbar_yumi_lo)
 
-     ,.ready_and_i(msg_ready_and_i)
-     ,.valid_o(msg_v_o)
-     ,.unlock_i(msg_unlock_li)
+     ,.ready_and_i(xbar_ready_and_li)
+     ,.valid_o(xbar_v_lo)
+     ,.unlock_i(xbar_unlock_li)
      ,.grants_oi_one_hot_o(grants_oi_one_hot_lo)
      );
 
-  logic [num_source_p-1:0][xbar_header_width_lp+data_width_p+1-1:0] source_combine;
-  logic [num_sink_p-1:0][xbar_header_width_lp+data_width_p+1-1:0] sink_combine;
+  logic [num_source_p-1:0][xbar_header_width_lp+xbar_data_width_p+1-1:0] source_combine;
+  logic [num_sink_p-1:0][xbar_header_width_lp+xbar_data_width_p+1-1:0] sink_combine;
   for (genvar i = 0; i < num_source_p; i++)
     begin : source_comb
-      assign source_combine[i] = {msg_last_li[i], msg_header_li[i], msg_data_li[i]};
+      assign source_combine[i] = {xbar_v_li[i] & xbar_last_li[i], xbar_header_li[i], xbar_data_li[i]};
     end
   for (genvar i = 0; i < num_sink_p; i++)
     begin : sink_comb
-      assign {msg_last_o[i], msg_header_o[i], msg_data_o[i]} = sink_combine[i];
-      assign msg_unlock_li[i] = msg_ready_and_i[i] & msg_v_o[i] & msg_last_o[i];
+      localparam dw = sink_data_width_p[i+1] - sink_data_width_p[i];
+
+      bp_me_stream_gearbox
+       #(.bp_params_p(bp_params_p)
+         ,.in_data_width_p(xbar_data_width_p)
+         ,.out_data_width_p(dw)
+         ,.payload_width_p($bits(xbar_header_lo[i].payload))
+         ,.payload_mask_p(payload_mask_p)
+         )
+       sink_gearbox
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+
+         ,.msg_header_i(xbar_header_lo[i])
+         ,.msg_data_i(xbar_data_lo[i])
+         ,.msg_v_i(xbar_v_lo[i])
+         ,.msg_ready_and_o(xbar_ready_and_li[i])
+         ,.msg_last_i(xbar_last_lo[i])
+
+         ,.msg_header_o(msg_header_o[i])
+         ,.msg_data_o(msg_data_o[sink_data_width_p[i+1]-1:sink_data_width_p[i]])
+         ,.msg_v_o(msg_v_o[i])
+         ,.msg_ready_and_i(msg_ready_and_i[i])
+         ,.msg_last_o(msg_last_o[i])
+         );
+
+      assign {xbar_last_lo[i], xbar_header_lo[i], xbar_data_lo[i]} = sink_combine[i];
+      assign xbar_unlock_li[i] = xbar_ready_and_li[i] & xbar_v_lo[i] & xbar_last_lo[i];
     end
 
   bsg_crossbar_o_by_i
-   #(.i_els_p(num_source_p), .o_els_p(num_sink_p), .width_p(1+xbar_header_width_lp+data_width_p))
+   #(.i_els_p(num_source_p), .o_els_p(num_sink_p), .width_p(1+xbar_header_width_lp+xbar_data_width_p))
    cb
     (.i(source_combine)
      ,.sel_oi_one_hot_i(grants_oi_one_hot_lo)

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -112,20 +112,15 @@ module bp_unicore_lite
 
   logic timer_irq_li, software_irq_li, external_irq_li;
 
-  // proc_cmd[2:0] = {IO cmd, BE UCE, FE UCE}
   bp_bedrock_mem_header_s [2:0] proc_cmd_header_lo;
-  logic [2:0][uce_fill_width_p-1:0] proc_cmd_data_lo;
   logic [2:0] proc_cmd_v_lo, proc_cmd_ready_and_li, proc_cmd_last_lo;
   bp_bedrock_mem_header_s [2:0] proc_resp_header_li;
-  logic [2:0][uce_fill_width_p-1:0] proc_resp_data_li;
   logic [2:0] proc_resp_v_li, proc_resp_ready_and_lo, proc_resp_last_li;
 
   // dev_cmd[4:0] = {CCE loopback, Mem cmd, IO cmd, CLINT, CFG}
   bp_bedrock_mem_header_s [4:0] dev_cmd_header_li;
-  logic [4:0][uce_fill_width_p-1:0] dev_cmd_data_li;
   logic [4:0] dev_cmd_v_li, dev_cmd_ready_and_lo, dev_cmd_last_li;
   bp_bedrock_mem_header_s [4:0] dev_resp_header_lo;
-  logic [4:0][uce_fill_width_p-1:0] dev_resp_data_lo;
   logic [4:0] dev_resp_v_lo, dev_resp_ready_and_li, dev_resp_last_lo;
 
   bp_cfg_bus_s cfg_bus_lo;
@@ -196,9 +191,64 @@ module bp_unicore_lite
      );
 
   wire [1:0][lce_id_width_p-1:0] lce_id_li = {cfg_bus_lo.dcache_id, cfg_bus_lo.icache_id};
+  logic [uce_fill_width_p-1:0] icache_cmd_data_lo, icache_resp_data_li;
   bp_uce
    #(.bp_params_p(bp_params_p)
-     ,.mem_data_width_p(uce_fill_width_p)
+     ,.assoc_p(icache_assoc_p)
+     ,.sets_p(icache_sets_p)
+     ,.block_width_p(icache_block_width_p)
+     ,.fill_width_p(icache_fill_width_p)
+     ,.metadata_latency_p(1)
+     )
+   icache_uce
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.lce_id_i(lce_id_li[0])
+
+     ,.cache_req_i(icache_req_lo)
+     ,.cache_req_v_i(icache_req_v_lo)
+     ,.cache_req_yumi_o(icache_req_yumi_li)
+     ,.cache_req_busy_o(icache_req_busy_li)
+     ,.cache_req_metadata_i(icache_req_metadata_lo)
+     ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
+     ,.cache_req_critical_tag_o(icache_req_critical_tag_li)
+     ,.cache_req_critical_data_o(icache_req_critical_data_li)
+     ,.cache_req_complete_o(icache_req_complete_li)
+     ,.cache_req_credits_full_o(icache_req_credits_full_li)
+     ,.cache_req_credits_empty_o(icache_req_credits_empty_li)
+
+     ,.tag_mem_pkt_o(icache_tag_mem_pkt_li)
+     ,.tag_mem_pkt_v_o(icache_tag_mem_pkt_v_li)
+     ,.tag_mem_pkt_yumi_i(icache_tag_mem_pkt_yumi_lo)
+     ,.tag_mem_i(icache_tag_mem_lo)
+
+     ,.data_mem_pkt_o(icache_data_mem_pkt_li)
+     ,.data_mem_pkt_v_o(icache_data_mem_pkt_v_li)
+     ,.data_mem_pkt_yumi_i(icache_data_mem_pkt_yumi_lo)
+     ,.data_mem_i(icache_data_mem_lo)
+
+     ,.stat_mem_pkt_o(icache_stat_mem_pkt_li)
+     ,.stat_mem_pkt_v_o(icache_stat_mem_pkt_v_li)
+     ,.stat_mem_pkt_yumi_i(icache_stat_mem_pkt_yumi_lo)
+     ,.stat_mem_i(icache_stat_mem_lo)
+
+     ,.mem_cmd_header_o(proc_cmd_header_lo[0])
+     ,.mem_cmd_data_o(icache_cmd_data_lo)
+     ,.mem_cmd_v_o(proc_cmd_v_lo[0])
+     ,.mem_cmd_ready_and_i(proc_cmd_ready_and_li[0])
+     ,.mem_cmd_last_o(proc_cmd_last_lo[0])
+
+     ,.mem_resp_header_i(proc_resp_header_li[0])
+     ,.mem_resp_data_i(icache_resp_data_li)
+     ,.mem_resp_v_i(proc_resp_v_li[0])
+     ,.mem_resp_ready_and_o(proc_resp_ready_and_lo[0])
+     ,.mem_resp_last_i(proc_resp_last_li[0])
+     );
+
+  logic [uce_fill_width_p-1:0] dcache_cmd_data_lo, dcache_resp_data_li;
+  bp_uce
+   #(.bp_params_p(bp_params_p)
      ,.assoc_p(dcache_assoc_p)
      ,.sets_p(dcache_sets_p)
      ,.block_width_p(dcache_block_width_p)
@@ -242,110 +292,123 @@ module bp_unicore_lite
     ,.stat_mem_i(dcache_stat_mem_lo)
 
     ,.mem_cmd_header_o(proc_cmd_header_lo[1])
-    ,.mem_cmd_data_o(proc_cmd_data_lo[1])
+    ,.mem_cmd_data_o(dcache_cmd_data_lo)
     ,.mem_cmd_v_o(proc_cmd_v_lo[1])
     ,.mem_cmd_ready_and_i(proc_cmd_ready_and_li[1])
     ,.mem_cmd_last_o(proc_cmd_last_lo[1])
-
     ,.mem_resp_header_i(proc_resp_header_li[1])
-    ,.mem_resp_data_i(proc_resp_data_li[1])
+    ,.mem_resp_data_i(dcache_resp_data_li)
     ,.mem_resp_v_i(proc_resp_v_li[1])
     ,.mem_resp_ready_and_o(proc_resp_ready_and_lo[1])
     ,.mem_resp_last_i(proc_resp_last_li[1])
     );
 
-  bp_uce
-   #(.bp_params_p(bp_params_p)
-     ,.mem_data_width_p(uce_fill_width_p)
-     ,.assoc_p(icache_assoc_p)
-     ,.sets_p(icache_sets_p)
-     ,.block_width_p(icache_block_width_p)
-     ,.fill_width_p(icache_fill_width_p)
-     ,.metadata_latency_p(1)
-     )
-   icache_uce
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.lce_id_i(lce_id_li[0])
-
-     ,.cache_req_i(icache_req_lo)
-     ,.cache_req_v_i(icache_req_v_lo)
-     ,.cache_req_yumi_o(icache_req_yumi_li)
-     ,.cache_req_busy_o(icache_req_busy_li)
-     ,.cache_req_metadata_i(icache_req_metadata_lo)
-     ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
-     ,.cache_req_critical_tag_o(icache_req_critical_tag_li)
-     ,.cache_req_critical_data_o(icache_req_critical_data_li)
-     ,.cache_req_complete_o(icache_req_complete_li)
-     ,.cache_req_credits_full_o(icache_req_credits_full_li)
-     ,.cache_req_credits_empty_o(icache_req_credits_empty_li)
-
-     ,.tag_mem_pkt_o(icache_tag_mem_pkt_li)
-     ,.tag_mem_pkt_v_o(icache_tag_mem_pkt_v_li)
-     ,.tag_mem_pkt_yumi_i(icache_tag_mem_pkt_yumi_lo)
-     ,.tag_mem_i(icache_tag_mem_lo)
-
-     ,.data_mem_pkt_o(icache_data_mem_pkt_li)
-     ,.data_mem_pkt_v_o(icache_data_mem_pkt_v_li)
-     ,.data_mem_pkt_yumi_i(icache_data_mem_pkt_yumi_lo)
-     ,.data_mem_i(icache_data_mem_lo)
-
-     ,.stat_mem_pkt_o(icache_stat_mem_pkt_li)
-     ,.stat_mem_pkt_v_o(icache_stat_mem_pkt_v_li)
-     ,.stat_mem_pkt_yumi_i(icache_stat_mem_pkt_yumi_lo)
-     ,.stat_mem_i(icache_stat_mem_lo)
-
-     ,.mem_cmd_header_o(proc_cmd_header_lo[0])
-     ,.mem_cmd_data_o(proc_cmd_data_lo[0])
-     ,.mem_cmd_v_o(proc_cmd_v_lo[0])
-     ,.mem_cmd_ready_and_i(proc_cmd_ready_and_li[0])
-     ,.mem_cmd_last_o(proc_cmd_last_lo[0])
-
-     ,.mem_resp_header_i(proc_resp_header_li[0])
-     ,.mem_resp_data_i(proc_resp_data_li[0])
-     ,.mem_resp_v_i(proc_resp_v_li[0])
-     ,.mem_resp_ready_and_o(proc_resp_ready_and_lo[0])
-     ,.mem_resp_last_i(proc_resp_last_li[0])
-     );
-
   // Assign incoming I/O as basically another UCE interface
   assign proc_cmd_header_lo[2] = io_cmd_header_cast_i;
-  assign proc_cmd_data_lo[2] = io_cmd_data_i;
   assign proc_cmd_v_lo[2] = io_cmd_v_i;
   assign io_cmd_ready_and_o = proc_cmd_ready_and_li[2];
   assign proc_cmd_last_lo[2] = io_cmd_last_i;
 
   assign io_resp_header_cast_o = proc_resp_header_li[2];
-  assign io_resp_data_o = proc_resp_data_li[2];
   assign io_resp_v_o = proc_resp_v_li[2];
   assign proc_resp_ready_and_lo[2] = io_resp_ready_and_i & io_resp_v_o;
   assign io_resp_last_o = proc_resp_last_li[2];
 
-  // Assign I/O and mem as another device
-  assign io_cmd_header_cast_o = dev_cmd_header_li[2];
-  assign io_cmd_data_o = dev_cmd_data_li[2];
-  assign io_cmd_v_o = dev_cmd_v_li[2];
-  assign dev_cmd_ready_and_lo[2] = io_cmd_ready_and_i;
-  assign io_cmd_last_o = dev_cmd_last_li[2];
+  logic [dword_width_gp-1:0] cfg_resp_data_lo, cfg_cmd_data_li;
+  bp_me_cfg_slice
+   #(.bp_params_p(bp_params_p))
+   cfgs
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
 
+     ,.mem_cmd_header_i(dev_cmd_header_li[0])
+     ,.mem_cmd_data_i(cfg_cmd_data_li)
+     ,.mem_cmd_v_i(dev_cmd_v_li[0])
+     ,.mem_cmd_ready_and_o(dev_cmd_ready_and_lo[0])
+     ,.mem_cmd_last_i(dev_cmd_last_li[0])
+
+     ,.mem_resp_header_o(dev_resp_header_lo[0])
+     ,.mem_resp_data_o(cfg_resp_data_lo)
+     ,.mem_resp_v_o(dev_resp_v_lo[0])
+     ,.mem_resp_ready_and_i(dev_resp_ready_and_li[0])
+     ,.mem_resp_last_o(dev_resp_last_lo[0])
+
+     ,.cfg_bus_o(cfg_bus_lo)
+     ,.did_i(my_did_i)
+     ,.host_did_i(host_did_i)
+     ,.cord_i(my_cord_i)
+
+     ,.cce_ucode_v_o()
+     ,.cce_ucode_w_o()
+     ,.cce_ucode_addr_o()
+     ,.cce_ucode_data_o()
+     ,.cce_ucode_data_i('0)
+     );
+
+  logic [dword_width_gp-1:0] clint_resp_data_lo, clint_cmd_data_li;
+  bp_me_clint_slice
+   #(.bp_params_p(bp_params_p))
+   clint
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.id_i(cfg_bus_lo.core_id)
+
+     ,.mem_cmd_header_i(dev_cmd_header_li[1])
+     ,.mem_cmd_data_i(clint_cmd_data_li)
+     ,.mem_cmd_v_i(dev_cmd_v_li[1])
+     ,.mem_cmd_ready_and_o(dev_cmd_ready_and_lo[1])
+     ,.mem_cmd_last_i(dev_cmd_last_li[1])
+
+     ,.mem_resp_header_o(dev_resp_header_lo[1])
+     ,.mem_resp_data_o(clint_resp_data_lo)
+     ,.mem_resp_v_o(dev_resp_v_lo[1])
+     ,.mem_resp_ready_and_i(dev_resp_ready_and_li[1])
+     ,.mem_resp_last_o(dev_resp_last_lo[1])
+     ,.timer_irq_o(timer_irq_li)
+     ,.software_irq_o(software_irq_li)
+     ,.external_irq_o(external_irq_li)
+     );
+
+  logic [dword_width_gp-1:0] loopback_resp_data_lo, loopback_cmd_data_li;
+  bp_me_loopback
+   #(.bp_params_p(bp_params_p))
+   loopback
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.mem_cmd_header_i(dev_cmd_header_li[2])
+     ,.mem_cmd_data_i(loopback_cmd_data_li)
+     ,.mem_cmd_v_i(dev_cmd_v_li[2])
+     ,.mem_cmd_ready_and_o(dev_cmd_ready_and_lo[2])
+     ,.mem_cmd_last_i(dev_cmd_last_li[2])
+
+     ,.mem_resp_header_o(dev_resp_header_lo[2])
+     ,.mem_resp_data_o(loopback_resp_data_lo)
+     ,.mem_resp_v_o(dev_resp_v_lo[2])
+     ,.mem_resp_ready_and_i(dev_resp_ready_and_li[2])
+     ,.mem_resp_last_o(dev_resp_last_lo[2])
+     );
+
+  // Assign I/O and mem as another device
   assign mem_cmd_header_cast_o = dev_cmd_header_li[3];
-  assign mem_cmd_data_o = dev_cmd_data_li[3];
   assign mem_cmd_v_o = dev_cmd_v_li[3];
   assign dev_cmd_ready_and_lo[3] = mem_cmd_ready_and_i;
   assign mem_cmd_last_o = dev_cmd_last_li[3];
 
-  assign dev_resp_header_lo[2] = io_resp_header_cast_i;
-  assign dev_resp_data_lo[2] = io_resp_data_i;
-  assign dev_resp_v_lo[2] = io_resp_v_i;
-  assign io_resp_ready_and_o = dev_resp_ready_and_li[2];
-  assign dev_resp_last_lo[2] = io_resp_last_i;
-
   assign dev_resp_header_lo[3] = mem_resp_header_cast_i;
-  assign dev_resp_data_lo[3] = mem_resp_data_i;
   assign dev_resp_v_lo[3] = mem_resp_v_i;
   assign mem_resp_ready_and_o = dev_resp_ready_and_li[3];
   assign dev_resp_last_lo[3] = mem_resp_last_i;
+
+  assign io_cmd_header_cast_o = dev_cmd_header_li[4];
+  assign io_cmd_v_o = dev_cmd_v_li[4];
+  assign dev_cmd_ready_and_lo[4] = io_cmd_ready_and_i;
+  assign io_cmd_last_o = dev_cmd_last_li[4];
+
+  assign dev_resp_header_lo[4] = io_resp_header_cast_i;
+  assign dev_resp_v_lo[4] = io_resp_v_i;
+  assign io_resp_ready_and_o = dev_resp_ready_and_li[4];
+  assign dev_resp_last_lo[4] = io_resp_last_i;
 
   // Select destination of commands
   localparam lg_num_dev_lp = `BSG_SAFE_CLOG2(5);
@@ -369,14 +432,14 @@ module bp_unicore_lite
       bsg_encode_one_hot
        #(.width_p(5), .lo_to_hi_p(1))
        cmd_pe
-        (.i({is_loopback_cmd, is_mem_cmd, is_io_cmd, is_clint_cmd, is_cfg_cmd})
+        (.i({is_io_cmd, is_mem_cmd, is_loopback_cmd, is_clint_cmd, is_cfg_cmd})
          ,.addr_o(proc_cmd_dst_lo[i])
          ,.v_o()
          );
     end
 
   // Select destination of responses. Were there a way to transpose structs...
-  localparam lg_num_proc_lp = `BSG_SAFE_CLOG2(3);
+  localparam lg_num_proc_lp = `BSG_SAFE_CLOG2(4);
   logic [4:0][lg_num_proc_lp-1:0] dev_resp_dst_lo;
   assign dev_resp_dst_lo[4] = dev_resp_header_lo[4].payload.lce_id[0+:lg_num_proc_lp];
   assign dev_resp_dst_lo[3] = dev_resp_header_lo[3].payload.lce_id[0+:lg_num_proc_lp];
@@ -386,24 +449,28 @@ module bp_unicore_lite
 
   bp_me_xbar_stream
    #(.bp_params_p(bp_params_p)
-     ,.data_width_p(uce_fill_width_p)
      ,.payload_width_p(mem_payload_width_lp)
+     ,.payload_mask_p(mem_cmd_payload_mask_gp)
      ,.num_source_p(3)
      ,.num_sink_p(5)
+     // TODO: Parameterize for area/perf tradeoff
+     ,.xbar_data_width_p(uce_fill_width_p)
+     ,.source_data_width_p({uce_fill_width_p*3, uce_fill_width_p*2, uce_fill_width_p*1, 0})
+     ,.sink_data_width_p({uce_fill_width_p*2+dword_width_gp*3, uce_fill_width_p*1+dword_width_gp*3, dword_width_gp*3, dword_width_gp*2, dword_width_gp*1, 0})
      )
    cmd_xbar
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
      ,.msg_header_i(proc_cmd_header_lo)
-     ,.msg_data_i(proc_cmd_data_lo)
+     ,.msg_data_i({io_cmd_data_i, dcache_cmd_data_lo, icache_cmd_data_lo})
      ,.msg_v_i(proc_cmd_v_lo)
      ,.msg_ready_and_o(proc_cmd_ready_and_li)
      ,.msg_last_i(proc_cmd_last_lo)
      ,.msg_dst_i(proc_cmd_dst_lo)
 
      ,.msg_header_o(dev_cmd_header_li)
-     ,.msg_data_o(dev_cmd_data_li)
+     ,.msg_data_o({io_cmd_data_o, mem_cmd_data_o, loopback_cmd_data_li, clint_cmd_data_li, cfg_cmd_data_li})
      ,.msg_v_o(dev_cmd_v_li)
      ,.msg_ready_and_i(dev_cmd_ready_and_lo)
      ,.msg_last_o(dev_cmd_last_li)
@@ -411,110 +478,32 @@ module bp_unicore_lite
 
   bp_me_xbar_stream
    #(.bp_params_p(bp_params_p)
-     ,.data_width_p(uce_fill_width_p)
      ,.payload_width_p(mem_payload_width_lp)
+     ,.payload_mask_p(mem_resp_payload_mask_gp)
      ,.num_source_p(5)
      ,.num_sink_p(3)
+     // TODO: Parameterize for area/perf tradeoff
+     ,.xbar_data_width_p(uce_fill_width_p)
+     ,.source_data_width_p({uce_fill_width_p*2+dword_width_gp*3, uce_fill_width_p*1+dword_width_gp*3, dword_width_gp*3, dword_width_gp*2, dword_width_gp*1, 0})
+     ,.sink_data_width_p({uce_fill_width_p*3, uce_fill_width_p*2, uce_fill_width_p*1, 0})
      )
    resp_xbar
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
      ,.msg_header_i(dev_resp_header_lo)
-     ,.msg_data_i(dev_resp_data_lo)
+     ,.msg_data_i({io_resp_data_i, mem_resp_data_i, loopback_resp_data_lo, clint_resp_data_lo, cfg_resp_data_lo})
      ,.msg_v_i(dev_resp_v_lo)
      ,.msg_ready_and_o(dev_resp_ready_and_li)
      ,.msg_last_i(dev_resp_last_lo)
      ,.msg_dst_i(dev_resp_dst_lo)
 
      ,.msg_header_o(proc_resp_header_li)
-     ,.msg_data_o(proc_resp_data_li)
+     ,.msg_data_o({io_resp_data_o, dcache_resp_data_li, icache_resp_data_li})
      ,.msg_v_o(proc_resp_v_li)
      ,.msg_ready_and_i(proc_resp_ready_and_lo)
      ,.msg_last_o(proc_resp_last_li)
      );
-
-  logic [dword_width_gp-1:0] cfg_data_lo, cfg_data_li;
-  bp_me_cfg_slice
-   #(.bp_params_p(bp_params_p))
-   cfgs
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.mem_cmd_header_i(dev_cmd_header_li[0])
-     ,.mem_cmd_data_i(cfg_data_li)
-     ,.mem_cmd_v_i(dev_cmd_v_li[0])
-     ,.mem_cmd_ready_and_o(dev_cmd_ready_and_lo[0])
-     ,.mem_cmd_last_i(dev_cmd_last_li[0])
-
-     ,.mem_resp_header_o(dev_resp_header_lo[0])
-     ,.mem_resp_data_o(cfg_data_lo)
-     ,.mem_resp_v_o(dev_resp_v_lo[0])
-     ,.mem_resp_ready_and_i(dev_resp_ready_and_li[0])
-     ,.mem_resp_last_o(dev_resp_last_lo[0])
-
-     ,.cfg_bus_o(cfg_bus_lo)
-     ,.did_i(my_did_i)
-     ,.host_did_i(host_did_i)
-     ,.cord_i(my_cord_i)
-
-     ,.cce_ucode_v_o()
-     ,.cce_ucode_w_o()
-     ,.cce_ucode_addr_o()
-     ,.cce_ucode_data_o()
-     ,.cce_ucode_data_i('0)
-     );
-  assign cfg_data_li = dev_cmd_data_li[0];
-  assign dev_resp_data_lo[0] = cfg_data_lo;
-
-  logic [dword_width_gp-1:0] clint_data_lo, clint_data_li;
-  bp_me_clint_slice
-   #(.bp_params_p(bp_params_p))
-   clint
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-     ,.id_i(cfg_bus_lo.core_id)
-
-     ,.mem_cmd_header_i(dev_cmd_header_li[1])
-     ,.mem_cmd_data_i(clint_data_li)
-     ,.mem_cmd_v_i(dev_cmd_v_li[1])
-     ,.mem_cmd_ready_and_o(dev_cmd_ready_and_lo[1])
-     ,.mem_cmd_last_i(dev_cmd_last_li[1])
-
-     ,.mem_resp_header_o(dev_resp_header_lo[1])
-     ,.mem_resp_data_o(clint_data_lo)
-     ,.mem_resp_v_o(dev_resp_v_lo[1])
-     ,.mem_resp_ready_and_i(dev_resp_ready_and_li[1])
-     ,.mem_resp_last_o(dev_resp_last_lo[1])
-
-     ,.timer_irq_o(timer_irq_li)
-     ,.software_irq_o(software_irq_li)
-     ,.external_irq_o(external_irq_li)
-     );
-  assign clint_data_li = dev_cmd_data_li[1];
-  assign dev_resp_data_lo[1] = clint_data_lo;
-
-  logic [dword_width_gp-1:0] loopback_data_lo, loopback_data_li;
-  bp_me_loopback
-   #(.bp_params_p(bp_params_p))
-   loopback
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.mem_cmd_header_i(dev_cmd_header_li[4])
-     ,.mem_cmd_data_i(loopback_data_li)
-     ,.mem_cmd_v_i(dev_cmd_v_li[4])
-     ,.mem_cmd_ready_and_o(dev_cmd_ready_and_lo[4])
-     ,.mem_cmd_last_i(dev_cmd_last_li[4])
-
-     ,.mem_resp_header_o(dev_resp_header_lo[4])
-     ,.mem_resp_data_o(loopback_data_lo)
-     ,.mem_resp_v_o(dev_resp_v_lo[4])
-     ,.mem_resp_ready_and_i(dev_resp_ready_and_li[4])
-     ,.mem_resp_last_o(dev_resp_last_lo[4])
-     );
-  assign loopback_data_li = dev_cmd_data_li[4];
-  assign dev_resp_data_lo[4] = loopback_data_lo;
 
 endmodule
 

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -296,6 +296,7 @@ $BP_ME_DIR/src/v/network/bp_me_burst_to_stream.sv
 $BP_ME_DIR/src/v/network/bp_me_stream_pump_in.sv
 $BP_ME_DIR/src/v/network/bp_me_stream_pump_out.sv
 $BP_ME_DIR/src/v/network/bp_me_stream_fifo.sv
+$BP_ME_DIR/src/v/network/bp_me_stream_gearbox.sv
 $BP_ME_DIR/src/v/network/bp_me_stream_wraparound.sv
 ## TOP
 $BP_TOP_DIR/src/v/bp_nd_socket.sv


### PR DESCRIPTION
## Summary
This PR adds gearboxing modules to the xbar interconnect. This simplifies the interconnect to module requirements and removes some responsibility from the users

## Issue Fixed
Several related to gearboxing, will find them once finished

## Area
tiles, unicore, xbars

## Reasoning (outdated, confusing, verbose, etc.)
It's non-trivial to up/downconvert bedrock stream, so providing plumbing modules is essential for correctness and usability.

## Additional Changes Required (if any)
Add gearboxing to burst xbar

## Analysis
There should be minimal PPA impact, since this doesn't add extra buffers, instead using PISO/SIPO passthrough

## Verification
ASIC backend and configuration sweep

## Additional Context
There is some problem with Verilator that should be fixed before this goes to mainline

