### PR TITLE
Reducing FMA latency

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - be_dev_fix_fmalatency
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - be_dev_fix_fmalatency
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -33,7 +33,7 @@ module bp_be_calculator_top
    , localparam decode_info_width_lp    = `bp_be_decode_info_width
 
    // From BP BE specifications
-   , localparam pipe_stage_els_lp = 6
+   , localparam pipe_stage_els_lp = 5
    )
  (input                                             clk_i
   , input                                           reset_i
@@ -58,7 +58,8 @@ module bp_be_calculator_top
 
   , input                                           timer_irq_i
   , input                                           software_irq_i
-  , input                                           external_irq_i
+  , input                                           m_external_irq_i
+  , input                                           s_external_irq_i
   , output logic                                    irq_waiting_o
   , output logic                                    irq_pending_o
 
@@ -139,11 +140,11 @@ module bp_be_calculator_top
   logic [pipe_stage_els_lp-1:0][dpath_width_gp-1:0] forward_data;
   for (genvar i = 0; i < pipe_stage_els_lp; i++)
     begin : forward_match
-      assign match_rs[0][i] = (dispatch_pkt_cast_i.queue_v & ~dispatch_pkt_cast_i.rs1_fp_v & comp_stage_r[i].ird_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs1_addr == comp_stage_r[i].rd_addr))
-                              || (dispatch_pkt_cast_i.queue_v & dispatch_pkt_cast_i.rs1_fp_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs1_addr == comp_stage_r[i].rd_addr));
-      assign match_rs[1][i] = (dispatch_pkt_cast_i.queue_v & ~dispatch_pkt_cast_i.rs2_fp_v & comp_stage_r[i].ird_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs2_addr == comp_stage_r[i].rd_addr))
-                              || (dispatch_pkt_cast_i.queue_v & dispatch_pkt_cast_i.rs2_fp_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs2_addr == comp_stage_r[i].rd_addr));
-      assign match_rs[2][i] = (dispatch_pkt_cast_i.queue_v & dispatch_pkt_cast_i.rs3_fp_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs3_addr == comp_stage_r[i].rd_addr));
+      assign match_rs[0][i] = ((i < 4) & dispatch_pkt_cast_i.queue_v & ~dispatch_pkt_cast_i.rs1_fp_v & comp_stage_r[i].ird_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs1_addr == comp_stage_r[i].rd_addr))
+                              || ((i > 0) & dispatch_pkt_cast_i.queue_v & dispatch_pkt_cast_i.rs1_fp_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs1_addr == comp_stage_r[i].rd_addr));
+      assign match_rs[1][i] = ((i < 4) & dispatch_pkt_cast_i.queue_v & ~dispatch_pkt_cast_i.rs2_fp_v & comp_stage_r[i].ird_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs2_addr == comp_stage_r[i].rd_addr))
+                              || ((i > 0) & dispatch_pkt_cast_i.queue_v & dispatch_pkt_cast_i.rs2_fp_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs2_addr == comp_stage_r[i].rd_addr));
+      assign match_rs[2][i] = ((i > 0) & dispatch_pkt_cast_i.queue_v & dispatch_pkt_cast_i.rs3_fp_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs3_addr == comp_stage_r[i].rd_addr));
 
       assign forward_data[i] = comp_stage_n[i+1].rd_data;
     end
@@ -227,7 +228,8 @@ module bp_be_calculator_top
 
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)
-     ,.external_irq_i(external_irq_i)
+     ,.m_external_irq_i(m_external_irq_i)
+     ,.s_external_irq_i(s_external_irq_i)
      ,.irq_pending_o(irq_pending_o)
      ,.irq_waiting_o(irq_waiting_o)
 
@@ -348,7 +350,7 @@ module bp_be_calculator_top
      ,.trans_info_i(trans_info_lo)
      );
 
-  // Floating point pipe: 4/5 cycle latency
+  // Floating point pipe: 3/4 cycle latency
   bp_be_pipe_fma
    #(.bp_params_p(bp_params_p))
    pipe_fma
@@ -413,12 +415,12 @@ module bp_be_calculator_top
       comp_stage_n[2].rd_data    |= pipe_mem_early_data_lo_v ? pipe_mem_early_data_lo   : '0;
       comp_stage_n[2].rd_data    |= pipe_aux_data_lo_v       ? pipe_aux_data_lo         : '0;
       comp_stage_n[3].rd_data    |= pipe_mem_final_data_lo_v ? pipe_mem_final_data_lo   : '0;
-      comp_stage_n[4].rd_data    |= pipe_mul_data_lo_v       ? pipe_mul_data_lo         : '0;
-      comp_stage_n[5].rd_data    |= pipe_fma_data_lo_v       ? pipe_fma_data_lo         : '0;
+      comp_stage_n[3].rd_data    |= pipe_mul_data_lo_v       ? pipe_mul_data_lo         : '0;
+      comp_stage_n[4].rd_data    |= pipe_fma_data_lo_v       ? pipe_fma_data_lo         : '0;
 
       comp_stage_n[2].fflags     |= pipe_mem_early_data_lo_v ? pipe_mem_early_fflags_lo : '0;
       comp_stage_n[2].fflags     |= pipe_aux_data_lo_v       ? pipe_aux_fflags_lo       : '0;
-      comp_stage_n[5].fflags     |= pipe_fma_data_lo_v       ? pipe_fma_fflags_lo       : '0;
+      comp_stage_n[4].fflags     |= pipe_fma_data_lo_v       ? pipe_fma_fflags_lo       : '0;
 
       comp_stage_n[0].ird_w_v    &= exc_stage_n[0].v;
       comp_stage_n[1].ird_w_v    &= exc_stage_n[1].v;
@@ -499,14 +501,14 @@ module bp_be_calculator_top
      ,.data_o(exc_stage_r)
      );
 
-  assign pipe_mem_late_iwb_pkt_yumi = pipe_mem_late_iwb_pkt_v & ~comp_stage_r[4].ird_w_v;
-  assign pipe_mem_late_fwb_pkt_yumi = pipe_mem_late_fwb_pkt_v & ~comp_stage_r[5].frd_w_v;
+  assign pipe_mem_late_iwb_pkt_yumi = pipe_mem_late_iwb_pkt_v & ~comp_stage_r[3].ird_w_v;
+  assign pipe_mem_late_fwb_pkt_yumi = pipe_mem_late_fwb_pkt_v & ~comp_stage_r[4].frd_w_v;
 
-  assign pipe_long_idata_lo_yumi = pipe_long_idata_lo_v & ~pipe_mem_late_iwb_pkt_v & ~comp_stage_r[4].ird_w_v;
-  assign pipe_long_fdata_lo_yumi = pipe_long_fdata_lo_v & ~pipe_mem_late_fwb_pkt_v & ~comp_stage_r[5].frd_w_v & ~comp_stage_r[5].fflags_w_v;
+  assign pipe_long_idata_lo_yumi = pipe_long_idata_lo_v & ~pipe_mem_late_iwb_pkt_v & ~comp_stage_r[3].ird_w_v;
+  assign pipe_long_fdata_lo_yumi = pipe_long_fdata_lo_v & ~pipe_mem_late_fwb_pkt_v & ~comp_stage_r[4].frd_w_v & ~comp_stage_r[4].fflags_w_v;
 
-  assign iwb_pkt_o = pipe_mem_late_iwb_pkt_yumi ? pipe_mem_late_iwb_pkt : pipe_long_idata_lo_yumi ? long_iwb_pkt : comp_stage_r[4];
-  assign fwb_pkt_o = pipe_mem_late_fwb_pkt_yumi ? pipe_mem_late_fwb_pkt : pipe_long_fdata_lo_yumi ? long_fwb_pkt : comp_stage_r[5];
+  assign iwb_pkt_o = pipe_mem_late_iwb_pkt_yumi ? pipe_mem_late_iwb_pkt : pipe_long_idata_lo_yumi ? long_iwb_pkt : comp_stage_r[3];
+  assign fwb_pkt_o = pipe_mem_late_fwb_pkt_yumi ? pipe_mem_late_fwb_pkt : pipe_long_fdata_lo_yumi ? long_fwb_pkt : comp_stage_r[4];
 
 endmodule
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -58,8 +58,7 @@ module bp_be_calculator_top
 
   , input                                           timer_irq_i
   , input                                           software_irq_i
-  , input                                           m_external_irq_i
-  , input                                           s_external_irq_i
+  , input                                           external_irq_i
   , output logic                                    irq_waiting_o
   , output logic                                    irq_pending_o
 
@@ -228,8 +227,7 @@ module bp_be_calculator_top
 
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)
-     ,.m_external_irq_i(m_external_irq_i)
-     ,.s_external_irq_i(s_external_irq_i)
+     ,.external_irq_i(external_irq_i)
      ,.irq_pending_o(irq_pending_o)
      ,.irq_waiting_o(irq_waiting_o)
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -37,8 +37,7 @@ module bp_be_csr
    // Interrupts
    , input                                   timer_irq_i
    , input                                   software_irq_i
-   , input                                   m_external_irq_i
-   , input                                   s_external_irq_i
+   , input                                   external_irq_i
    , output logic                            irq_pending_o
    , output logic                            irq_waiting_o
 
@@ -140,7 +139,7 @@ module bp_be_csr
 
   wire sti_v = mie_r.stie & mip_r.stip;
   wire ssi_v = mie_r.ssie & mip_r.ssip;
-  wire sei_v = mie_r.seie & (mip_r.seip | s_external_irq_i);
+  wire sei_v = mie_r.seie & mip_r.seip;
 
   // TODO: interrupt priority is non-compliant with the spec.
   wire [15:0] interrupt_icode_dec_li =
@@ -600,7 +599,7 @@ module bp_be_csr
       // Accumulate interrupts
       mip_li.mtip = timer_irq_i;
       mip_li.msip = software_irq_i;
-      mip_li.meip = m_external_irq_i;
+      mip_li.meip = external_irq_i;
 
       // Accumulate FFLAGS if we're not writing them this cycle
       if (~(csr_w_v_li & csr_cmd_cast_i.csr_addr inside {`CSR_ADDR_FFLAGS, `CSR_ADDR_FCSR}))
@@ -614,14 +613,7 @@ module bp_be_csr
   // Debug Mode masks all interrupts
   assign irq_pending_o = ~is_debug_mode & ((m_interrupt_icode_v_li & mgie) | (s_interrupt_icode_v_li & sgie));
 
-  // The supervisor external interrupt line does not impact the supervisor software interrupt bit of MIP.
-  // However, software read operations return as if it does. bit 9 is supervisor software interrupt
-  always_comb
-    unique casez (csr_cmd_cast_i.csr_addr)
-      `CSR_ADDR_SIP: csr_data_o = csr_data_lo | ((s_external_irq_i & sip_rmask_li) << 9);
-      `CSR_ADDR_MIP: csr_data_o = csr_data_lo | (s_external_irq_i << 9);
-      default: csr_data_o = csr_data_lo;
-    endcase
+  assign csr_data_o = dword_width_gp'(csr_data_lo);
 
   assign commit_pkt_cast_o.npc_w_v          = |{retire_pkt_cast_i.special, retire_pkt_cast_i.exception};
   assign commit_pkt_cast_o.queue_v          = retire_pkt_cast_i.queue_v & ~|retire_pkt_cast_i.exception;

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -37,7 +37,8 @@ module bp_be_csr
    // Interrupts
    , input                                   timer_irq_i
    , input                                   software_irq_i
-   , input                                   external_irq_i
+   , input                                   m_external_irq_i
+   , input                                   s_external_irq_i
    , output logic                            irq_pending_o
    , output logic                            irq_waiting_o
 
@@ -139,7 +140,7 @@ module bp_be_csr
 
   wire sti_v = mie_r.stie & mip_r.stip;
   wire ssi_v = mie_r.ssie & mip_r.ssip;
-  wire sei_v = mie_r.seie & mip_r.seip;
+  wire sei_v = mie_r.seie & (mip_r.seip | s_external_irq_i);
 
   // TODO: interrupt priority is non-compliant with the spec.
   wire [15:0] interrupt_icode_dec_li =
@@ -376,9 +377,9 @@ module bp_be_csr
           else
             begin
               unique casez ({csr_r_v_li, csr_cmd_cast_i.csr_addr})
-                {1'b1, `CSR_ADDR_FFLAGS       }: csr_data_lo = fcsr_lo.fflags;
+                {1'b1, `CSR_ADDR_FFLAGS       }: csr_data_lo = fcsr_lo.fflags | fflags_acc_i;
                 {1'b1, `CSR_ADDR_FRM          }: csr_data_lo = fcsr_lo.frm;
-                {1'b1, `CSR_ADDR_FCSR         }: csr_data_lo = fcsr_lo;
+                {1'b1, `CSR_ADDR_FCSR         }: csr_data_lo = fcsr_lo | fflags_acc_i;
                 {1'b1, `CSR_ADDR_CYCLE        }: csr_data_lo = mcycle_lo;
                 // Time must be done by trapping, since we can't stall at this point
                 {1'b1, `CSR_ADDR_INSTRET      }: csr_data_lo = minstret_lo;
@@ -595,13 +596,15 @@ module bp_be_csr
           dcsr_li.prv   = priv_mode_r;
         end
 
+
       // Accumulate interrupts
       mip_li.mtip = timer_irq_i;
       mip_li.msip = software_irq_i;
-      mip_li.meip = external_irq_i;
+      mip_li.meip = m_external_irq_i;
 
-      // Accumulate FFLAGS
-      fcsr_li.fflags |= fflags_acc_i;
+      // Accumulate FFLAGS if we're not writing them this cycle
+      if (~(csr_w_v_li & csr_cmd_cast_i.csr_addr inside {`CSR_ADDR_FFLAGS, `CSR_ADDR_FCSR}))
+        fcsr_li.fflags |= fflags_acc_i;
 
       // Set FS to dirty if: fflags set, frf written, fcsr written
       mstatus_li.fs |= {2{(csr_w_v_li & csr_fany_li & ~csr_illegal_instr_o)}};
@@ -611,7 +614,14 @@ module bp_be_csr
   // Debug Mode masks all interrupts
   assign irq_pending_o = ~is_debug_mode & ((m_interrupt_icode_v_li & mgie) | (s_interrupt_icode_v_li & sgie));
 
-  assign csr_data_o = dword_width_gp'(csr_data_lo);
+  // The supervisor external interrupt line does not impact the supervisor software interrupt bit of MIP.
+  // However, software read operations return as if it does. bit 9 is supervisor software interrupt
+  always_comb
+    unique casez (csr_cmd_cast_i.csr_addr)
+      `CSR_ADDR_SIP: csr_data_o = csr_data_lo | ((s_external_irq_i & sip_rmask_li) << 9);
+      `CSR_ADDR_MIP: csr_data_o = csr_data_lo | (s_external_irq_i << 9);
+      default: csr_data_o = csr_data_lo;
+    endcase
 
   assign commit_pkt_cast_o.npc_w_v          = |{retire_pkt_cast_i.special, retire_pkt_cast_i.exception};
   assign commit_pkt_cast_o.queue_v          = retire_pkt_cast_i.queue_v & ~|retire_pkt_cast_i.exception;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_fma.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_fma.sv
@@ -16,7 +16,7 @@
  *
  *   This module:
  *            ...
- *            fma 4 cycles     reservation
+ *            fma 3 cycles     reservation
  *           /   \                 |
  *        round  imul_out      imul meta
  *          |                      |
@@ -128,15 +128,15 @@ module bp_be_pipe_fma
 
   // Here, we switch the implementation based on synthesizing for Vivado or not. If this is
   //   a knob you'd like to turn, consider modifying the define yourself.
-  localparam fma_latency_lp  = 5;
-  localparam imul_latency_lp = 4;
+  localparam fma_latency_lp  = 4;
+  localparam imul_latency_lp = 3;
   `ifdef SYNTHESIS
     `ifdef DC
       localparam int fma_pipeline_stages_lp [1:0] = '{0,0};
     `elsif CDS_TOOL_DEFINE
       localparam int fma_pipeline_stages_lp [1:0] = '{0,0};
     `else
-      localparam int fma_pipeline_stages_lp [1:0] = '{1,3};
+      localparam int fma_pipeline_stages_lp [1:0] = '{1,imul_latency_lp};
     `endif
   `else
       localparam int fma_pipeline_stages_lp [1:0] = '{0,0};

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -69,10 +69,10 @@ module bp_be_detector
   // Floating point data hazards
   logic frs1_sb_raw_haz_v, frs2_sb_raw_haz_v, frs3_sb_raw_haz_v;
   logic frd_sb_waw_haz_v;
-  logic [3:0] frs1_data_haz_v , frs2_data_haz_v, frs3_data_haz_v;
-  logic [3:0] rs1_match_vector, rs2_match_vector, rs3_match_vector;
+  logic [2:0] frs1_data_haz_v , frs2_data_haz_v, frs3_data_haz_v;
+  logic [2:0] rs1_match_vector, rs2_match_vector, rs3_match_vector;
 
-  bp_be_dep_status_s [4:0] dep_status_r;
+  bp_be_dep_status_s [3:0] dep_status_r;
 
   logic fence_haz_v, cmd_haz_v, fflags_haz_v, csr_haz_v;
   logic data_haz_v, control_haz_v, struct_haz_v;
@@ -139,7 +139,7 @@ module bp_be_detector
       // Generate matches for rs1, rs2. rs3
       // 3 stages because we only care about ex1, ex2, and iwb dependencies. fwb dependencies
       //   can be handled through forwarding
-      for (integer i = 0; i < 4; i++)
+      for (integer i = 0; i < 3; i++)
         begin
           rs1_match_vector[i] = (isd_status_cast_i.rs1_addr == dep_status_r[i].rd_addr);
           rs2_match_vector[i] = (isd_status_cast_i.rs2_addr == dep_status_r[i].rd_addr);
@@ -193,13 +193,9 @@ module bp_be_detector
       frs3_data_haz_v[1] = (isd_status_cast_i.frs3_v & rs3_match_vector[1])
                            & (dep_status_r[1].fmem_fwb_v | dep_status_r[1].fma_fwb_v);
 
-      irs1_data_haz_v[2] = (isd_status_cast_i.irs1_v & rs1_match_vector[2])
-                           & (isd_status_cast_i.rs1_addr != '0)
-                           & (dep_status_r[2].mul_iwb_v);
+      irs1_data_haz_v[2] = '0;
 
-      irs2_data_haz_v[2] = (isd_status_cast_i.irs2_v & rs2_match_vector[2])
-                           & (isd_status_cast_i.rs2_addr != '0)
-                           & (dep_status_r[2].mul_iwb_v);
+      irs2_data_haz_v[2] = '0;
 
       frs1_data_haz_v[2] = (isd_status_cast_i.frs1_v & rs1_match_vector[2])
                            & (dep_status_r[2].fma_fwb_v);
@@ -210,27 +206,17 @@ module bp_be_detector
       frs3_data_haz_v[2] = (isd_status_cast_i.frs3_v & rs3_match_vector[2])
                            & (dep_status_r[2].fma_fwb_v);
 
-      frs1_data_haz_v[3] = (isd_status_cast_i.frs1_v & rs1_match_vector[3])
-                           & (dep_status_r[3].fma_fwb_v);
-
-      frs2_data_haz_v[3] = (isd_status_cast_i.frs2_v & rs2_match_vector[3])
-                           & (dep_status_r[3].fma_fwb_v);
-
-      frs3_data_haz_v[3] = (isd_status_cast_i.frs3_v & rs3_match_vector[3])
-                           & (dep_status_r[3].fma_fwb_v);
-
       mem_in_pipe_v      = dep_status_r[0].mem_v | dep_status_r[1].mem_v | dep_status_r[2].mem_v;
       fence_haz_v        = (isd_status_cast_i.fence_v & (~credits_empty_i | mem_in_pipe_v | ~mem_ready_i))
                            | (isd_status_cast_i.mem_v & credits_full_i);
       cmd_haz_v          = cmd_full_i;
 
-      // TODO: Pessimistic, could have a separate fflags w_v
+      // TODO: Pessimistic, could have a separate fflags r/w_v
       fflags_haz_v = isd_status_cast_i.csr_v
                      & ((dep_status_r[0].fflags_w_v)
                         | (dep_status_r[1].fflags_w_v)
                         | (dep_status_r[2].fflags_w_v)
                         | (dep_status_r[3].fflags_w_v)
-                        | (dep_status_r[4].fflags_w_v)
                         | ~fdiv_ready_i
                         );
 
@@ -299,7 +285,7 @@ module bp_be_detector
   always_ff @(posedge clk_i)
     begin
       dep_status_r[0]   <= dispatch_pkt_cast_i.v ? dep_status_n : '0;
-      dep_status_r[4:1] <= dep_status_r[3:0];
+      dep_status_r[3:1] <= dep_status_r[2:0];
     end
 
 endmodule

--- a/docs/platform_guide.md
+++ b/docs/platform_guide.md
@@ -4,9 +4,9 @@
 
 ## Instruction Latencies
 * RV64I arithmetic instructions have 1-cycle latency
-* RV64IA memory instructions have 3-cycle latency
-* RV64M instructions have a 4-cycle latency, except for division, which is iterative
-* Rv64FD instructions have a 5-cycle latency, exception for fdiv/fsqrt, which are iterative
+* RV64IA memory instructions have 2/3-cycle latency
+* RV64M instructions have a 3-cycle latency, except for division, which is iterative
+* Rv64FD instructions have a 4-cycle latency, exception for fdiv/fsqrt, which are iterative
 * BlackParrot has a load-to-use time of 2 cycles for dwords, 3 cycles for words, halfs, and bytes
 * BlackParrot has a 2-cycle L1 hit latency for integer loads
 * BlackParrot has a 3-cycle L1 hit latency for floating point loads 


### PR DESCRIPTION
## Summary
This PR reduces the FMA latency from 5 to 4 cycles. 

## Issue Fixed
none

## Area
FMA, hazard detection

## Reasoning (outdated, confusing, verbose, etc.)
This path was unnecessarily pessimistic. After #1001, there was a shorter path allocated for retiming the FPU. After confirming 3-cycle multiplication and 4-cycle FMA does not impact cycle time, we are reducing it to increase IPC for free.

## Additional Changes Required (if any)
none

## Analysis
PPA improvement, with fewer bypass paths, fewer flops and a shallower arithmetic retime

## Verification
Synthesis in GF14 and TSMC28


