### PR TITLE
Bump Surelog

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,7 +34,7 @@
     update = checkout
 [submodule "tools/Surelog"]
     path = tools/Surelog
-    url = https://github.com/alainmarcel/Surelog
+    url = https://github.com/chipsalliance/Surelog
     branch = master
     ignore = untracked
     update = checkout

--- a/docs/testbench_guide.md
+++ b/docs/testbench_guide.md
@@ -1,16 +1,16 @@
 # BlackParrot Testbench Guide
 ## Prerequisites
-### CentOS
+### CentOS 7+
 
-    yum install centos-release-scl
     yum install autoconf automake libmpc-devel mpfr-devel gmp-devel gawk \
                 bison flex texinfo patchutils gcc gcc-c++ zlib-devel \
                 expat-devel dtc gtkwave vim-common virtualenv
 
-The default GCC package on CentOS is too old to build some components. We suggest using
+The default GCC package on CentOS is often too old to build some components. We suggest using
 [devtoolset-9](https://centos.pkgs.org/7/centos-sclo-rh-x86_64/devtoolset-9-9.0-3.el7.x86_64.rpm.html)
 to gain access to a more modern gcc.
 
+    yum install centos-release-scl
     yum install devtoolset-9
     scl enable devtoolset-9 bash
     # To automatically enable on new terminals, add "source scl_source enable devtoolset-9" to ~/.bashrc

--- a/docs/testbench_guide.md
+++ b/docs/testbench_guide.md
@@ -4,13 +4,16 @@
 
     yum install centos-release-scl
     yum install autoconf automake libmpc-devel mpfr-devel gmp-devel gawk \
-                bison flex texinfo patchutils devtoolset-9 zlib-devel \
+                bison flex texinfo patchutils gcc gcc-c++ zlib-devel \
                 expat-devel dtc gtkwave vim-common virtualenv
 
-The default GCC package on CentOS 7 is version 4.8 that is too old to build
-some components. Please execute the following commant before compilation:
+The default GCC package on CentOS is too old to build some components. We suggest using
+[devtoolset-9](https://centos.pkgs.org/7/centos-sclo-rh-x86_64/devtoolset-9-9.0-3.el7.x86_64.rpm.html)
+to gain access to a more modern gcc.
 
+    yum install devtoolset-9
     scl enable devtoolset-9 bash
+    # To automatically enable on new terminals, add "source scl_source enable devtoolset-9" to ~/.bashrc
 
 ### Ubuntu
 

--- a/docs/testbench_guide.md
+++ b/docs/testbench_guide.md
@@ -6,7 +6,7 @@
                 bison flex texinfo patchutils gcc gcc-c++ zlib-devel \
                 expat-devel dtc gtkwave vim-common virtualenv
 
-The default GCC package on CentOS is often too old to build some components. We suggest using
+The default GCC package on CentOS 7+ is often too old to build some components. We suggest using
 [devtoolset-9](https://centos.pkgs.org/7/centos-sclo-rh-x86_64/devtoolset-9-9.0-3.el7.x86_64.rpm.html)
 to gain access to a more modern gcc.
 

--- a/docs/testbench_guide.md
+++ b/docs/testbench_guide.md
@@ -1,15 +1,16 @@
 # BlackParrot Testbench Guide
 ## Prerequisites
-### Centos
+### CentOS
 
+    yum install centos-release-scl
     yum install autoconf automake libmpc-devel mpfr-devel gmp-devel gawk \
-                bison flex texinfo patchutils gcc gcc-c++ zlib-devel \
+                bison flex texinfo patchutils devtoolset-9 zlib-devel \
                 expat-devel dtc gtkwave vim-common virtualenv
 
-CentOS 7 requires a more modern gcc to build Linux. If you receive an error such as "These critical
-programs are missing or too old: make" try
+The default GCC package on CentOS 7 is version 4.8 that is too old to build
+some components. Please execute the following commant before compilation:
 
-    scl enable devtoolset-8 bash
+    scl enable devtoolset-9 bash
 
 ### Ubuntu
 


### PR DESCRIPTION
## Summary
This PR bumps Surelog to https://github.com/chipsalliance/Surelog/commit/7772b03bbeb16888d4ac37e17568a690905794a7 and update related documentation to reflect the current build prerequisites.

## Issue Fixed
N/A

## Area
tools

## Reasoning (outdated, confusing, verbose, etc.)
It updates outdated dependencies and documentation.

## Additional Changes Required (if any)
`black-parrot-sim` and `black-parrot-sdk` may need similar documentation updates.

## Analysis
No impact on functionalities.

## Verification
Executing `make surelog; make -C bp_top/syn parse.surelog`.

## Additional Context
N/A