### PR TITLE
small LCE logic tweaks

### DIFF
--- a/bp_me/src/v/lce/bp_lce_cmd.sv
+++ b/bp_me/src/v/lce/bp_lce_cmd.sv
@@ -800,7 +800,7 @@ module bp_lce_cmd
         stat_mem_pkt_cast_o.index = lce_cmd_addr_index;
         stat_mem_pkt_cast_o.way_id = lce_cmd_way_id;
         stat_mem_pkt_cast_o.opcode = e_cache_stat_mem_read;
-        stat_mem_pkt_v_o = lce_fill_data_v_o & lce_fill_data_ready_and_i & lce_fill_last_o
+        stat_mem_pkt_v_o = lce_fill_data_v_o & lce_fill_last_o
                            & (lce_cmd_header_cast_li.msg_type.cmd == e_bedrock_cmd_st_tr_wb);
 
         // move to next state when last data beat sends

--- a/bp_me/src/v/lce/bp_lce_req.sv
+++ b/bp_me/src/v/lce/bp_lce_req.sv
@@ -194,12 +194,13 @@ module bp_lce_req
   assign req_sent = (lce_req_header_v_o & lce_req_header_ready_and_i & ~lce_req_has_data_o)
                     | (lce_req_data_v_o & lce_req_data_ready_and_i & lce_req_last_o);
 
-  // LCE is ready for a new request if not in reset, mode is uncached or cached with sync done
-  // and either no current valid request or a valid request that is sending last beat
-  assign ready_o = ~is_reset & (sync_done_i | (lce_mode_i == e_lce_mode_uncached))
-    & (~cache_req_v_r
-       | (cache_req_v_r & req_sent)
-       );
+  // LCE is ready for a new request if not in reset, mode is uncached or cached with sync done,
+  // either no current valid request or a valid request that is sending last beat, and
+  // there is an available credit
+  assign ready_o = ~is_reset
+                   & (sync_done_i | (lce_mode_i == e_lce_mode_uncached))
+                   & (~cache_req_v_r | (cache_req_v_r & req_sent))
+                   & ~credits_full_o;
 
   // note: this could create a crazy loop if the cache uses ready_o to determine when to send a
   // new cache request to the LCE


### PR DESCRIPTION
Two small tweaks to LCE logic:
- in LCE Request module, ready_o should not be raised if there are no available credits
- in LCE Command module, opportunistic stat memory read for writeback should occur when the last beat is being output, not when the last beat is consumed, to shorten the logic path for timing