### PR TITLE
Take $(CMAKE) into account for building Surelog

### DIFF
--- a/Makefile.tools
+++ b/Makefile.tools
@@ -35,8 +35,10 @@ dromajo_build:
 	cp $(dromajo_dir)/include/dromajo_cosim.h $(BP_TOOLS_INCLUDE_DIR)
 
 surelog_build:
-	$(MAKE) -C $(surelog_dir)
-	$(MAKE) -C $(surelog_dir) PREFIX=$(BP_TOOLS_INSTALL_DIR) install
+	mkdir -p $(surelog_dir)/build
+	$(CMAKE) -S $(surelog_dir) -B $(surelog_dir)/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(BP_TOOLS_INSTALL_DIR)
+	$(MAKE) -C $(surelog_dir)/build
+	$(MAKE) -C $(surelog_dir)/build install
 
 verilator_build:
 	cd $(verilator_dir); \


### PR DESCRIPTION
## Summary
This PR modifies `Makefile.tools` to reflect the `$(CMAKE)` variable when Surelog is built.

## Issue Fixed
Related to https://github.com/black-parrot/black-parrot-sim/issues/5

## Area
tools

## Reasoning (outdated, confusing, verbose, etc.)
Surelog failed to build where `cmake` is either CMake 2.x or not available.

## Additional Changes Required (if any)
None.

## Analysis
No impact on functionalities. It fixes build failures in certain environments.

## Verification
Execute `make surelog CMAKE=cmake3` where `cmake` is not CMake 3. (ex. vanilla CentOS 7)

## Additional Context
None.