### PR TITLE
Fixing RTC reset to not depend on lack of toggling

### DIFF
--- a/bp_common/software/py/nbf.py
+++ b/bp_common/software/py/nbf.py
@@ -69,6 +69,9 @@ cfg_reg_cce_id         = 0x0600
 cfg_reg_cce_mode       = 0x0604
 cfg_mem_base_cce_ucode = 0x8000
 
+clint_base_addr       = 0x300000
+clint_reg_mtimesel    = 0x8000
+
 cfg_core_offset = 24
 
 class NBF:
@@ -236,6 +239,9 @@ class NBF:
       self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_icache_mode, 1)
       self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_dcache_mode, 1)
       self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_cce_mode, 1)
+
+      # Write RTC
+      self.print_nbf_allcores(3, clint_base_addr + clint_reg_mtimesel, 1)
 
       if self.verify:
         # Read back I$, D$ and CCE modes for verification

--- a/bp_common/src/include/bp_common_clint_pkgdef.svh
+++ b/bp_common/src/include/bp_common_clint_pkgdef.svh
@@ -12,6 +12,9 @@
   localparam mtimecmp_reg_base_addr_gp  = dev_addr_width_gp'('h0_4000);
   localparam mtimecmp_reg_match_addr_gp = dev_addr_width_gp'('h0_4???);
 
+  localparam mtimesel_reg_base_addr_gp  = dev_addr_width_gp'('h0_8000);
+  localparam mtimesel_reg_match_addr_gp = dev_addr_width_gp'('h0_8???);
+
   localparam mtime_reg_addr_gp          = dev_addr_width_gp'('h0_bff8);
   localparam mtime_reg_match_addr_gp    = dev_addr_width_gp'('h0_bff?);
   localparam plic_reg_match_addr_gp     = dev_addr_width_gp'('h0_b00?);

--- a/bp_me/src/v/dev/bp_me_clint_slice.sv
+++ b/bp_me/src/v/dev/bp_me_clint_slice.sv
@@ -72,12 +72,22 @@ module bp_me_clint_slice
      ,.data_i(data_li)
      );
 
+  // Synchronize RTC reset
+  logic rt_reset_lo;
+  bsg_sync_sync
+   #(.width_p(1))
+   bss
+    (.oclk_i(rt_clk_i)
+     ,.iclk_data_i(reset_i)
+     ,.oclk_data_o(rt_reset_lo)
+     );
+
   logic [dword_width_gp-1:0] mtime_gray_r;
   bsg_async_ptr_gray
-   #(.lg_size_p(dword_width_gp), .use_async_reset_p(1))
+   #(.lg_size_p(dword_width_gp))
    mtime_gray
     (.w_clk_i(rt_clk_i)
-     ,.w_reset_i(reset_i) // async to rtc
+     ,.w_reset_i(rt_reset_lo)
      ,.w_inc_i(1'b1) // TODO: Enable / disable increment?
      ,.r_clk_i(clk_i)
      ,.w_ptr_binary_r_o()

--- a/bp_me/src/v/dev/bp_me_clint_slice.sv
+++ b/bp_me/src/v/dev/bp_me_clint_slice.sv
@@ -187,8 +187,9 @@ module bp_me_clint_slice
 
   assign data_li[0] = mipi_r;
   assign data_li[1] = mtimecmp_r;
-  assign data_li[2] = mtime_r;
-  assign data_li[3] = plic_lo;
+  assign data_li[2] = mtimesel_r;
+  assign data_li[3] = mtime_r;
+  assign data_li[4] = plic_lo;
 
 endmodule
 

--- a/bp_top/src/v/bp_axi_top.sv
+++ b/bp_top/src/v/bp_axi_top.sv
@@ -146,6 +146,7 @@ module bp_axi_top
        #(.bp_params_p(bp_params_p))
        unicore
        (.clk_i(clk_i)
+        ,.rt_clk_i('0)
         ,.reset_i(reset_i)
 
         // Irrelevant for current AXI wrapper
@@ -212,6 +213,7 @@ module bp_axi_top
        #(.bp_params_p(bp_params_p))
        multicore
         (.core_clk_i(clk_i)
+         ,.rt_clk_i('0)
          ,.core_reset_i(reset_i)
 
          ,.coh_clk_i(clk_i)

--- a/bp_top/src/v/bp_core_complex.sv
+++ b/bp_top/src/v/bp_core_complex.sv
@@ -22,7 +22,7 @@ module bp_core_complex
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    )
   (input                                                         core_clk_i
-   , input                                                       core_rt_clk_i
+   , input                                                       rt_clk_i
    , input                                                       core_reset_i
 
    , input                                                       coh_clk_i
@@ -90,7 +90,7 @@ module bp_core_complex
            #(.bp_params_p(bp_params_p))
            tile_node
             (.core_clk_i(core_clk_i)
-             ,.core_rt_clk_i(core_rt_clk_i)
+             ,.rt_clk_i(rt_clk_i)
              ,.core_reset_i(core_reset_i)
 
              ,.coh_clk_i(coh_clk_i)

--- a/bp_top/src/v/bp_multicore.sv
+++ b/bp_top/src/v/bp_multicore.sv
@@ -23,7 +23,7 @@ module bp_multicore
    , localparam io_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(io_noc_flit_width_p)
    )
   (input                                                    core_clk_i
-   , input                                                  core_rt_clk_i
+   , input                                                  rt_clk_i
    , input                                                  core_reset_i
 
    , input                                                  coh_clk_i
@@ -71,7 +71,7 @@ module bp_multicore
    #(.bp_params_p(bp_params_p))
    cc
     (.core_clk_i(core_clk_i)
-     ,.core_rt_clk_i(core_rt_clk_i)
+     ,.rt_clk_i(rt_clk_i)
      ,.core_reset_i(core_reset_i)
 
      ,.coh_clk_i(coh_clk_i)

--- a/bp_top/src/v/bp_tile_node.sv
+++ b/bp_top/src/v/bp_tile_node.sv
@@ -21,7 +21,7 @@ module bp_tile_node
    , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
    )
   (input                                         core_clk_i
-   , input                                       core_rt_clk_i
+   , input                                       rt_clk_i
    , input                                       core_reset_i
 
    , input                                       coh_clk_i
@@ -68,7 +68,7 @@ module bp_tile_node
    #(.bp_params_p(bp_params_p))
    tile
     (.clk_i(core_clk_i)
-     ,.rt_clk_i(core_rt_clk_i)
+     ,.rt_clk_i(rt_clk_i)
      ,.reset_i(core_reset_i)
 
      // Memory side connection

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -38,6 +38,7 @@ $BP_TOP_DIR/src/include/bp_top_pkg.sv
 ## BaseJump STL files
 $BASEJUMP_STL_DIR/bsg_async/bsg_async_fifo.v
 $BASEJUMP_STL_DIR/bsg_async/bsg_launch_sync_sync.v
+$BASEJUMP_STL_DIR/bsg_async/bsg_sync_sync.v
 $BASEJUMP_STL_DIR/bsg_async/bsg_async_ptr_gray.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_dma.v

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -105,6 +105,7 @@ $BASEJUMP_STL_DIR/bsg_misc/bsg_concentrate_static.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_counting_leading_zeros.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_counter_clear_up.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_counter_clear_up_one_hot.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_counter_clock_downsample.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_counter_set_down.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_counter_set_en.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_counter_up_down.v

--- a/bp_top/test/tb/bp_tethered/Makefile.params
+++ b/bp_top/test/tb/bp_tethered/Makefile.params
@@ -25,7 +25,8 @@ export SAMPLE_START_P   ?= 0
 export SAMPLE_WARMUP_P  ?= 0
 export SAMPLE_INSTR_P   ?= 0
 
-export BP_SIM_CLK_PERIOD  ?= 5000
+export BP_SIM_CLK_PERIOD ?= 1000
+export BP_RT_CLK_PERIOD  ?= 1000000
 
 export DUT_PARAMS =
 export TB_PARAMS  = \
@@ -51,6 +52,7 @@ export TB_PARAMS  = \
 
 export DUT_DEFINES = $(foreach def,$(DEFINES),+define+$(def))
 export TB_DEFINES  = +define+BP_SIM_CLK_PERIOD=$(BP_SIM_CLK_PERIOD) \
+					 +define+BP_RT_CLK_PERIOD=$(BP_RT_CLK_PERIOD) \
                      +define+den2048Mb+sg5+x16+FULL_MEM
 
 export HDL_DEFINES = $(DUT_DEFINES) $(TB_DEFINES)

--- a/bp_top/test/tb/bp_tethered/flist.vcs
+++ b/bp_top/test/tb/bp_tethered/flist.vcs
@@ -21,7 +21,6 @@ $BASEJUMP_STL_DIR/bsg_fsb/bsg_fsb_node_trace_replay.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_cam_1r1w_unmanaged.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_nonsynth_mem_1r1w_sync_mask_write_byte_dma.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_nonsynth_mem_1rw_sync_mask_write_byte_dma.v
-$BASEJUMP_STL_DIR/bsg_misc/bsg_counter_clock_downsample.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_mux2_gatestack.v
 $BASEJUMP_STL_DIR/bsg_tag/bsg_tag_trace_replay.v
 $BASEJUMP_STL_DIR/bsg_tag/bsg_tag_master.v

--- a/bp_top/test/tb/bp_tethered/wrapper.sv
+++ b/bp_top/test/tb/bp_tethered/wrapper.sv
@@ -92,7 +92,7 @@ module wrapper
        #(.bp_params_p(bp_params_p))
        dut
         (.core_clk_i(clk_i)
-         ,.core_rt_clk_i(rt_clk_i)
+         ,.rt_clk_i(rt_clk_i)
          ,.core_reset_i(reset_i)
 
          ,.coh_clk_i(clk_i)

--- a/docs/platform_guide.md
+++ b/docs/platform_guide.md
@@ -159,6 +159,7 @@ These addresses are per-tile. To access them on a tile N, prepend N to the addre
 |          | cce_ucode   | 20_8000-20_8fff | The CCE instruction RAM. Must be written before enabling cached mode in a microcoded CCE                                          |
 | CLINT    | mipi        | 30_0000         | mip (software interrupt) bit                                                                                                      |
 |          | mtimecmp    | 30_4000         | Timer compare register. When mtime > mtimecmp, a timer irq is raised in the core                                                  |
+|          | mtimesel    | 30_8000         | Timer select register. 0=core_clk, 1=core_clk/8, 2=external RTC, 3=disable
 |          | mtime       | 30_bff8         | A real-time counter. Currently implemented as mcycle/8                                                                            |
 |          | plic        | 30_b000         | A fake PLIC implementation. Effectively a redundant implementation of mipi                                                        |
 


### PR DESCRIPTION
Quick fix for RTC reset. bsg_async_ptr_gray cannot toggle during async_reset, but some systems use oscillators which constantly tick. Rather than gate the clock, we synchronize the reset coming in. This is a more robust reset (and fixes some FPGA builds).

@muwyse, we should incorporate this change into your zynqparrot patch