### PR TITLE
fix LCE fill when block size == fill width

### DIFF
--- a/bp_me/src/v/lce/bp_lce_cmd.sv
+++ b/bp_me/src/v/lce/bp_lce_cmd.sv
@@ -182,7 +182,9 @@ module bp_lce_cmd
 
   // first fill index of arriving command
   wire [fill_select_width_lp-1:0] first_cnt =
-    lce_cmd_header_cast_li.addr[fill_byte_offset_lp+:fill_select_width_lp];
+    (block_size_in_fill_lp > 1)
+    ? lce_cmd_header_cast_li.addr[fill_byte_offset_lp+:fill_select_width_lp]
+    : '0;
 
   // tag sent tracking
   // clears when header consumed

--- a/bp_me/src/v/lce/bp_lce_fill.sv
+++ b/bp_me/src/v/lce/bp_lce_fill.sv
@@ -189,7 +189,9 @@ module bp_lce_fill
     `BSG_MAX((1'b1 << lce_fill_header_cast_li.size)/fill_bytes_lp, 1'b1) - 'd1;
   // first fill index of arriving command
   wire [fill_select_width_lp-1:0] first_cnt =
-    lce_fill_header_cast_li.addr[fill_byte_offset_lp+:fill_select_width_lp];
+    (block_size_in_fill_lp > 1)
+    ? lce_fill_header_cast_li.addr[fill_byte_offset_lp+:fill_select_width_lp]
+    : '0;
 
   logic wrap_cnt_set, wrap_cnt_up;
   logic [fill_select_width_lp-1:0] wrap_cnt_size, full_cnt, wrap_cnt;


### PR DESCRIPTION
This change fixes a bug in the LCE when cache block size is equal to cache fill width size. In this case, there is only a single fill packet so the first count input to the stream counter used to generate the proper fill index should be zero.