### PR TITLE
Clean up Cache Engine Synchronization

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - be_dev_fix_sync
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - be_dev_fix_sync
   before_script:
       - git submodule update --init --checkout --recursive external/
   artifacts:

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -260,7 +260,7 @@ module bp_be_pipe_mem
      ,.page_idx_width_p(sv39_page_idx_width_gp)
      )
    ptw
-    (.clk_i(~clk_i)
+    (.clk_i(clk_i)
      ,.reset_i(reset_i)
      ,.base_ppn_i(trans_info.satp_ppn)
      ,.priv_mode_i(trans_info.priv_mode)

--- a/bp_be/src/v/bp_be_calculator/bp_be_ptw.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_ptw.sv
@@ -44,19 +44,15 @@ module bp_be_ptw
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
   `declare_bp_be_dcache_pkt_s(vaddr_width_p);
   `bp_cast_o(bp_be_dcache_pkt_s, dcache_pkt);
+  `bp_cast_i(bp_be_ptw_miss_pkt_s, ptw_miss_pkt);
+  `bp_cast_o(bp_be_ptw_fill_pkt_s, ptw_fill_pkt);
 
-  enum logic [2:0] {e_idle, e_send_load, e_send_tag, e_recv_load, e_writeback} state_n, state_r;
+  enum logic [2:0] {e_idle, e_send_load, e_recv_load, e_check_load, e_writeback} state_n, state_r;
   wire is_idle  = (state_r == e_idle);
   wire is_send  = (state_r == e_send_load);
-  wire is_tag   = (state_r == e_send_tag );
   wire is_recv  = (state_r == e_recv_load);
+  wire is_check = (state_r == e_check_load);
   wire is_write = (state_r == e_writeback);
-
-  bp_be_ptw_miss_pkt_s ptw_miss_pkt_cast_i;
-  bp_be_ptw_fill_pkt_s ptw_fill_pkt_cast_o;
-
-  assign ptw_miss_pkt_cast_i = ptw_miss_pkt_i;
-  assign ptw_fill_pkt_o = ptw_fill_pkt_cast_o;
 
   localparam lg_page_table_depth_lp = `BSG_SAFE_CLOG2(page_table_depth_p);
   logic start;
@@ -73,27 +69,35 @@ module bp_be_ptw
 
   logic tlb_miss_v, page_fault_v;
 
-  sv39_pte_s dcache_pte;
-  assign dcache_pte = dcache_early_data_i[0+:dword_width_gp];
+  sv39_pte_s dcache_pte_n, dcache_pte_r;
+  assign dcache_pte_n = dcache_early_data_i[0+:dword_width_gp];
+  bsg_dff_en
+   #(.width_p($bits(sv39_pte_s)))
+   dcache_pte_reg
+    (.clk_i(clk_i)
+     ,.en_i(is_recv)
+     ,.data_i(dcache_pte_n)
+     ,.data_o(dcache_pte_r)
+     );
 
-   for(genvar i=0; i<page_table_depth_p; i++) begin : rof1
-      assign partial_vpn[i] = vpn[page_idx_width_p*i +: page_idx_width_p];
-    end
-   for(genvar i=0; i<page_table_depth_p-1; i++) begin : rof2
-      assign partial_ppn[i] = ppn_r[page_idx_width_p*i +: page_idx_width_p];
-      assign partial_pte_misaligned[i] = (level_cntr > i)? |dcache_pte.ppn[page_idx_width_p*i +: page_idx_width_p] : 1'b0;
-      assign writeback_ppn[page_idx_width_p*i +: page_idx_width_p] = (level_cntr > i) ? partial_vpn[i] : partial_ppn[i];
-    end
-    assign writeback_ppn[ptag_width_p-1 : (page_table_depth_p-1)*page_idx_width_p] = ppn_r[ptag_width_p-1 : (page_table_depth_p-1)*page_idx_width_p];
+  for(genvar i=0; i<page_table_depth_p; i++) begin : rof1
+     assign partial_vpn[i] = vpn[page_idx_width_p*i +: page_idx_width_p];
+   end
+  for(genvar i=0; i<page_table_depth_p-1; i++) begin : rof2
+     assign partial_ppn[i] = ppn_r[page_idx_width_p*i +: page_idx_width_p];
+     assign partial_pte_misaligned[i] = (level_cntr > i)? |dcache_pte_r.ppn[page_idx_width_p*i +: page_idx_width_p] : 1'b0;
+     assign writeback_ppn[page_idx_width_p*i +: page_idx_width_p] = (level_cntr > i) ? partial_vpn[i] : partial_ppn[i];
+   end
+   assign writeback_ppn[ptag_width_p-1 : (page_table_depth_p-1)*page_idx_width_p] = ppn_r[ptag_width_p-1 : (page_table_depth_p-1)*page_idx_width_p];
 
   assign dcache_ptag_o          = ppn_r;
-  assign dcache_ptag_v_o        = (state_r == e_send_tag);
+  assign dcache_ptag_v_o        = is_recv;
 
   // PMA attributes
   localparam lg_pte_size_in_bytes_lp = `BSG_SAFE_CLOG2(pte_size_in_bytes_p);
-  assign dcache_v_o                    = (state_r == e_send_load);
+  assign dcache_v_o                    = is_send;
   assign dcache_pkt_cast_o.opcode      = e_dcache_op_ptw_ld;
-  assign dcache_pkt_cast_o.vaddr       = vaddr_width_p'({partial_vpn[level_cntr], (lg_pte_size_in_bytes_lp)'(0)});
+  assign dcache_pkt_cast_o.vaddr       = partial_vpn[level_cntr] << lg_pte_size_in_bytes_lp;
   assign dcache_pkt_cast_o.data        = '0;
   assign dcache_pkt_cast_o.rd_addr     = '0;
 
@@ -101,25 +105,25 @@ module bp_be_ptw
 
   assign start                  = is_idle & tlb_miss_v;
 
-  wire pte_is_leaf              = dcache_pte.x | dcache_pte.w | dcache_pte.r;
+  wire pte_is_leaf              = dcache_pte_r.x | dcache_pte_r.w | dcache_pte_r.r;
   wire pte_is_megapage          = (level_cntr == 2'd1);
   wire pte_is_gigapage          = (level_cntr == 2'd2);
 
-  assign level_cntr_en          = is_recv & dcache_early_hit_v_i & ~pte_is_leaf & ~page_fault_v;
+  assign level_cntr_en          = is_check & ~pte_is_leaf & ~page_fault_v;
 
-  assign ppn_en                 = start | (is_recv & dcache_early_hit_v_i);
-  assign ppn_n                  = (state_r == e_idle) ? base_ppn_i : dcache_pte.ppn[0+:ptag_width_p];
+  assign ppn_en                 = start | is_check;
+  assign ppn_n                  = is_idle ? base_ppn_i : dcache_pte_r.ppn[0+:ptag_width_p];
 
-  wire pte_invalid              = (~dcache_pte.v) | (~dcache_pte.r & dcache_pte.w);
+  wire pte_invalid              = (~dcache_pte_r.v) | (~dcache_pte_r.r & dcache_pte_r.w);
   wire leaf_not_found           = (level_cntr == '0) & (~pte_is_leaf);
-  wire priv_fault               = pte_is_leaf & ((dcache_pte.u & (priv_mode_i == `PRIV_MODE_S) & (ptw_miss_pkt_r.instr_miss_v | ~mstatus_sum_i)) | (~dcache_pte.u & (priv_mode_i == `PRIV_MODE_U)));
+  wire priv_fault               = pte_is_leaf & ((dcache_pte_r.u & (priv_mode_i == `PRIV_MODE_S) & (ptw_miss_pkt_r.instr_miss_v | ~mstatus_sum_i)) | (~dcache_pte_r.u & (priv_mode_i == `PRIV_MODE_U)));
   wire misaligned_superpage     = pte_is_leaf & (|partial_pte_misaligned);
-  wire ad_fault                 = pte_is_leaf & (~dcache_pte.a | (ptw_miss_pkt_r.store_miss_v & ~dcache_pte.d));
+  wire ad_fault                 = pte_is_leaf & (~dcache_pte_r.a | (ptw_miss_pkt_r.store_miss_v & ~dcache_pte_r.d));
   wire common_faults            = pte_invalid | leaf_not_found | priv_fault | misaligned_superpage | ad_fault;
 
-  wire instr_page_fault         = ptw_miss_pkt_r.instr_miss_v & (common_faults | (pte_is_leaf & ~dcache_pte.x));
-  wire load_page_fault          = ptw_miss_pkt_r.load_miss_v  & (common_faults | (pte_is_leaf & ~dcache_pte.r));
-  wire store_page_fault         = ptw_miss_pkt_r.store_miss_v & (common_faults | (pte_is_leaf & ~dcache_pte.w));
+  wire instr_page_fault         = ptw_miss_pkt_r.instr_miss_v & (common_faults | (pte_is_leaf & ~dcache_pte_r.x));
+  wire load_page_fault          = ptw_miss_pkt_r.load_miss_v  & (common_faults | (pte_is_leaf & ~dcache_pte_r.r));
+  wire store_page_fault         = ptw_miss_pkt_r.store_miss_v & (common_faults | (pte_is_leaf & ~dcache_pte_r.w));
   assign page_fault_v           = (instr_page_fault | load_page_fault | store_page_fault);
 
   wire itlb_fill_v              = ptw_miss_pkt_r.instr_miss_v & ~page_fault_v;
@@ -128,19 +132,19 @@ module bp_be_ptw
   bp_be_pte_leaf_s tlb_w_entry;
   assign tlb_w_entry.ptag       = writeback_ppn;
   assign tlb_w_entry.gigapage   = pte_is_gigapage;
-  assign tlb_w_entry.a          = dcache_pte.a;
-  assign tlb_w_entry.d          = dcache_pte.d;
-  assign tlb_w_entry.u          = dcache_pte.u;
-  assign tlb_w_entry.x          = dcache_pte.x;
-  assign tlb_w_entry.w          = dcache_pte.w;
-  assign tlb_w_entry.r          = dcache_pte.r;
+  assign tlb_w_entry.a          = dcache_pte_r.a;
+  assign tlb_w_entry.d          = dcache_pte_r.d;
+  assign tlb_w_entry.u          = dcache_pte_r.u;
+  assign tlb_w_entry.x          = dcache_pte_r.x;
+  assign tlb_w_entry.w          = dcache_pte_r.w;
+  assign tlb_w_entry.r          = dcache_pte_r.r;
 
-  assign ptw_fill_pkt_cast_o.v                  = (state_r == e_writeback);
-  assign ptw_fill_pkt_cast_o.itlb_fill_v        = (state_r == e_writeback) & itlb_fill_v;
-  assign ptw_fill_pkt_cast_o.dtlb_fill_v        = (state_r == e_writeback) & dtlb_fill_v;
-  assign ptw_fill_pkt_cast_o.instr_page_fault_v = (state_r == e_writeback) & instr_page_fault;
-  assign ptw_fill_pkt_cast_o.load_page_fault_v  = (state_r == e_writeback) & load_page_fault;
-  assign ptw_fill_pkt_cast_o.store_page_fault_v = (state_r == e_writeback) & store_page_fault;
+  assign ptw_fill_pkt_cast_o.v                  = is_write;
+  assign ptw_fill_pkt_cast_o.itlb_fill_v        = is_write & itlb_fill_v;
+  assign ptw_fill_pkt_cast_o.dtlb_fill_v        = is_write & dtlb_fill_v;
+  assign ptw_fill_pkt_cast_o.instr_page_fault_v = is_write & instr_page_fault;
+  assign ptw_fill_pkt_cast_o.load_page_fault_v  = is_write & load_page_fault;
+  assign ptw_fill_pkt_cast_o.store_page_fault_v = is_write & store_page_fault;
   assign ptw_fill_pkt_cast_o.vaddr              = ptw_miss_pkt_r.vaddr;
   assign ptw_fill_pkt_cast_o.entry              = tlb_w_entry;
 
@@ -186,12 +190,10 @@ module bp_be_ptw
   //   are non-speculative
   always_comb begin
     case(state_r)
-      e_idle     :  state_n = tlb_miss_v ? e_send_load : e_idle;
-      e_send_load:  state_n = (dcache_ready_i & dcache_v_o) ? e_send_tag : e_send_load;
-      e_send_tag :  state_n = e_recv_load;
-      e_recv_load:  state_n = dcache_early_hit_v_i & (pte_is_leaf | page_fault_v)
-                              ? e_writeback
-                              : e_send_load;
+      e_idle      :  state_n = tlb_miss_v ? e_send_load : e_idle;
+      e_send_load :  state_n = (dcache_ready_i & dcache_v_o) ? e_recv_load : e_send_load;
+      e_recv_load :  state_n = dcache_early_hit_v_i ? e_check_load : e_send_load;
+      e_check_load:  state_n = (pte_is_leaf | page_fault_v) ? e_writeback : e_send_load;
       default: // e_writeback
                     state_n = e_idle;
     endcase

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -269,9 +269,7 @@ module wrapper
              ,.fill_width_p(fill_width_p)
              ,.timeout_max_limit_p(4)
              ,.credits_p(coh_noc_max_credits_p)
-             ,.req_invert_clk_p(1)
-             ,.data_mem_invert_clk_p(1)
-             ,.tag_mem_invert_clk_p(1)
+             ,.metadata_latency_p(1)
              )
            dcache_lce
             (.clk_i(clk_i)
@@ -365,10 +363,7 @@ module wrapper
             ,.sets_p(sets_p)
             ,.block_width_p(block_width_p)
             ,.fill_width_p(fill_width_p)
-            ,.req_invert_clk_p(1)
-            ,.data_mem_invert_clk_p(1)
-            ,.tag_mem_invert_clk_p(1)
-            ,.stat_mem_invert_clk_p(1)
+            ,.metadata_latency_p(1)
             )
           dcache_uce
            (.clk_i(clk_i)

--- a/bp_common/src/v/bsg_dff_sync_read.v
+++ b/bp_common/src/v/bsg_dff_sync_read.v
@@ -5,23 +5,18 @@
 //   things like an synchronous SRAM read
 module bsg_dff_sync_read
  #(parameter `BSG_INV_PARAM(width_p)
-
-   // Whether to bypass the read data so that it doesn't create a bubble
+   // Whether data is available synchronously or asynchronously
    , parameter bypass_p = 0
    )
   (input clk_i
    , input reset_i
 
    // v_n_i is high the cycle before the data comes in
-   // The stored data will always be overwritten and valid always set, regardless
-   //   of the current valid state or incoming yumi
+   // The stored data will always be overwritten
    , input                      v_n_i
    , input [width_p-1:0]        data_i
 
    , output logic [width_p-1:0] data_o
-   , output logic               v_o
-   // yumi_i clears the valid signal
-   , input                      yumi_i
    );
 
   logic v_r;
@@ -34,18 +29,7 @@ module bsg_dff_sync_read
      ,.data_o(v_r)
      );
 
-  bsg_dff_reset_set_clear
-   #(.width_p(1))
-   v_o_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.set_i(v_r)
-     ,.clear_i(yumi_i)
-     ,.data_o(v_o)
-     );
-
-  if (bypass_p)
+  if (bypass_p == 1)
     begin : bypass
       bsg_dff_en_bypass
        #(.width_p(width_p))

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -396,6 +396,7 @@ module wrapper
        ,.sets_p(icache_sets_p)
        ,.block_width_p(icache_block_width_p)
        ,.fill_width_p(icache_fill_width_p)
+       ,.metadata_latency_p(1)
        )
      icache_uce
       (.clk_i(clk_i)

--- a/bp_me/src/v/lce/bp_lce.sv
+++ b/bp_me/src/v/lce/bp_lce.sv
@@ -29,12 +29,6 @@ module bp_lce
    , parameter fill_buffer_els_p = 2
    , parameter fill_data_buffer_els_p = 2
 
-   // clocking options
-   , parameter req_invert_clk_p = 0
-   , parameter data_mem_invert_clk_p = 0
-   , parameter tag_mem_invert_clk_p = 0
-   , parameter stat_mem_invert_clk_p = 0
-
    // LCE-cache interface timeout in cycles
    , parameter timeout_max_limit_p=4
    // maximum number of outstanding transactions
@@ -152,9 +146,8 @@ module bp_lce
   // LCE only supports single data beat for requests
   if (fill_width_p < dword_width_gp)
     $error("fill width must be greater or equal than cache request data width");
-  // Request metadata latency must be 0 or 1
-  if ((metadata_latency_p < 0) || (metadata_latency_p > 1))
-    $error("Cache request metadata latency must be 0 or 1");
+  if ((metadata_latency_p > 1))
+    $error("metadata needs to arrive <2 cycles after the request");
   if (cmd_buffer_els_p < 1 || fill_buffer_els_p < 1)
     $error("LCEs require buffers for at least 1 command and fill header");
   if (cmd_data_buffer_els_p < 1 || fill_data_buffer_els_p < 1)
@@ -292,8 +285,7 @@ module bp_lce
       ,.ready_o(req_ready_lo)
 
       ,.cache_req_i(cache_req_i)
-      // Gate the cache_req_v_i signal to prevent yumis when busy
-      ,.cache_req_v_i(~cache_req_busy_o & cache_req_v_i)
+      ,.cache_req_v_i(cache_req_v_i)
       ,.cache_req_yumi_o(cache_req_yumi_o)
       ,.cache_req_metadata_i(cache_req_metadata_i)
       ,.cache_req_metadata_v_i(cache_req_metadata_v_i)
@@ -315,9 +307,6 @@ module bp_lce
       ,.sets_p(sets_p)
       ,.block_width_p(block_width_p)
       ,.fill_width_p(fill_width_p)
-      ,.data_mem_invert_clk_p(data_mem_invert_clk_p)
-      ,.tag_mem_invert_clk_p(tag_mem_invert_clk_p)
-      ,.stat_mem_invert_clk_p(stat_mem_invert_clk_p)
       ,.cmd_buffer_els_p(cmd_buffer_els_p)
       ,.cmd_data_buffer_els_p(cmd_data_buffer_els_p)
       )

--- a/bp_me/src/v/lce/bp_lce_fill.sv
+++ b/bp_me/src/v/lce/bp_lce_fill.sv
@@ -134,7 +134,7 @@ module bp_lce_fill
   // LCE fill data buffer
   // required to prevent deadlock in multicore networks
   logic [fill_width_p-1:0] lce_fill_data_li;
-  logic lce_fill_data_v_li, lce_fill_last_li, lce_fill_data_ready_and_lo, lce_fill_data_yumi_lo;
+  logic lce_fill_data_v_li, lce_fill_last_li, lce_fill_data_yumi_lo;
   bsg_fifo_1r1w_small
     #(.width_p(fill_width_p+1)
       ,.els_p(fill_data_buffer_els_p)
@@ -149,7 +149,6 @@ module bp_lce_fill
       ,.yumi_i(lce_fill_data_yumi_lo)
       ,.data_o({lce_fill_last_li, lce_fill_data_li})
       );
-  assign lce_fill_data_yumi_lo = lce_fill_data_v_li & lce_fill_data_ready_and_lo;
 
   // tag sent tracking
   // clears when header consumed
@@ -178,7 +177,7 @@ module bp_lce_fill
      (.clk_i(clk_i)
       ,.reset_i(reset_i)
       ,.set_i(critical_data_sent)
-      ,.clear_i(lce_fill_data_v_li & lce_fill_data_ready_and_lo & lce_fill_last_li)
+      ,.clear_i(lce_fill_data_yumi_lo & lce_fill_last_li)
       ,.data_o(critical_data_sent_r)
       );
   assign cache_req_critical_data_o = ~critical_data_sent_r & critical_data_sent;
@@ -189,7 +188,9 @@ module bp_lce_fill
     `BSG_MAX((1'b1 << lce_fill_header_cast_li.size)/fill_bytes_lp, 1'b1) - 'd1;
   // first fill index of arriving command
   wire [fill_select_width_lp-1:0] first_cnt =
-    lce_fill_header_cast_li.addr[fill_byte_offset_lp+:fill_select_width_lp];
+    (block_size_in_fill_lp > 1)
+    ? lce_fill_header_cast_li.addr[fill_byte_offset_lp+:fill_select_width_lp]
+    : '0;
 
   logic wrap_cnt_set, wrap_cnt_up;
   logic [fill_select_width_lp-1:0] wrap_cnt_size, full_cnt, wrap_cnt;
@@ -262,7 +263,7 @@ module bp_lce_fill
 
     // LCE-CCE Interface signals
     lce_fill_header_yumi_lo = 1'b0;
-    lce_fill_data_ready_and_lo = 1'b0;
+    lce_fill_data_yumi_lo = 1'b0;
 
     lce_resp_header_cast_o = '0;
     lce_resp_header_v_o = 1'b0;
@@ -299,7 +300,7 @@ module bp_lce_fill
             wrap_cnt_set = tag_mem_pkt_yumi_i;
 
             // do not consume header since it is needed to compute fill index for cache data writes
-            state_n = (tag_mem_pkt_yumi_i)
+            state_n = tag_mem_pkt_yumi_i
                       ? e_data_to_cache
                       : state_r;
           end
@@ -320,15 +321,15 @@ module bp_lce_fill
         data_mem_pkt_cast_o.opcode = e_cache_data_mem_write;
         data_mem_pkt_v_o = lce_fill_data_v_li;
         // consume data beat when write to cache occurs
-        lce_fill_data_ready_and_lo = data_mem_pkt_yumi_i;
+        lce_fill_data_yumi_lo = data_mem_pkt_yumi_i;
         // increment wrap around count as each data beat sends
-        wrap_cnt_up = lce_fill_data_v_li & lce_fill_data_ready_and_lo;
+        wrap_cnt_up = lce_fill_data_yumi_lo;
         // critical beat is first data beat
         critical_data_sent = data_mem_pkt_yumi_i & ~critical_data_sent_r;
 
         // do not consume header yet, will be consumed by sending coherence ack
 
-        state_n = (lce_fill_data_v_li & lce_fill_data_ready_and_lo & lce_fill_last_li)
+        state_n = (lce_fill_data_yumi_lo & lce_fill_last_li)
                   ? e_coh_ack
                   : state_r;
 

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -208,9 +208,6 @@ module bp_cacc_vdp
      ,.fill_width_p(acache_fill_width_p)
      ,.timeout_max_limit_p(4)
      ,.credits_p(coh_noc_max_credits_p)
-     ,.req_invert_clk_p(1)
-     ,.data_mem_invert_clk_p(1)
-     ,.tag_mem_invert_clk_p(1)
      )
    lce
     (.clk_i(clk_i)

--- a/bp_top/src/v/bp_core.sv
+++ b/bp_top/src/v/bp_core.sv
@@ -80,6 +80,7 @@ module bp_core
   );
 
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache);
 
@@ -129,10 +130,13 @@ module bp_core
   logic dcache_stat_mem_pkt_yumi_lo;
   bp_dcache_stat_info_s dcache_stat_mem_lo;
 
+  wire posedge_clk = clk_i;
+  wire negedge_clk = ~clk_i;
+
   bp_core_minimal
    #(.bp_params_p(bp_params_p))
    core_minimal
-    (.clk_i(clk_i)
+    (.clk_i(posedge_clk)
      ,.reset_i(reset_i)
      ,.cfg_bus_i(cfg_bus_cast_i)
 
@@ -208,7 +212,7 @@ module bp_core
      ,.metadata_latency_p(1)
      )
    fe_lce
-    (.clk_i(clk_i)
+    (.clk_i(posedge_clk)
      ,.reset_i(reset_i)
 
      ,.lce_id_i(cfg_bus_cast_i.icache_id)
@@ -287,6 +291,50 @@ module bp_core
      ,.lce_resp_data_ready_and_i(lce_resp_data_ready_and_i[0])
      );
 
+  logic [1:1][lce_req_header_width_lp-1:0]  _lce_req_header_o;
+  logic [1:1]                               _lce_req_header_v_o;
+  logic [1:1]                               _lce_req_header_ready_and_i;
+  logic [1:1]                               _lce_req_has_data_o;
+  logic [1:1][icache_fill_width_p-1:0]      _lce_req_data_o;
+  logic [1:1]                               _lce_req_data_v_o;
+  logic [1:1]                               _lce_req_data_ready_and_i;
+  logic [1:1]                               _lce_req_last_o;
+
+  logic [1:1][lce_cmd_header_width_lp-1:0]  _lce_cmd_header_i;
+  logic [1:1]                               _lce_cmd_header_v_i;
+  logic [1:1]                               _lce_cmd_header_ready_and_o;
+  logic [1:1]                               _lce_cmd_has_data_i;
+  logic [1:1][icache_fill_width_p-1:0]      _lce_cmd_data_i;
+  logic [1:1]                               _lce_cmd_data_v_i;
+  logic [1:1]                               _lce_cmd_data_ready_and_o;
+  logic [1:1]                               _lce_cmd_last_i;
+
+  logic [1:1][lce_fill_header_width_lp-1:0] _lce_fill_header_i;
+  logic [1:1]                               _lce_fill_header_v_i;
+  logic [1:1]                               _lce_fill_header_ready_and_o;
+  logic [1:1]                               _lce_fill_has_data_i;
+  logic [1:1][icache_fill_width_p-1:0]      _lce_fill_data_i;
+  logic [1:1]                               _lce_fill_data_v_i;
+  logic [1:1]                               _lce_fill_data_ready_and_o;
+  logic [1:1]                               _lce_fill_last_i;
+
+  logic [1:1][lce_fill_header_width_lp-1:0] _lce_fill_header_o;
+  logic [1:1]                               _lce_fill_header_v_o;
+  logic [1:1]                               _lce_fill_header_ready_and_i;
+  logic [1:1]                               _lce_fill_has_data_o;
+  logic [1:1][icache_fill_width_p-1:0]      _lce_fill_data_o;
+  logic [1:1]                               _lce_fill_data_v_o;
+  logic [1:1]                               _lce_fill_data_ready_and_i;
+  logic [1:1]                               _lce_fill_last_o;
+
+  logic [1:1][lce_resp_header_width_lp-1:0] _lce_resp_header_o;
+  logic [1:1]                               _lce_resp_header_v_o;
+  logic [1:1]                               _lce_resp_header_ready_and_i;
+  logic [1:1]                               _lce_resp_has_data_o;
+  logic [1:1][icache_fill_width_p-1:0]      _lce_resp_data_o;
+  logic [1:1]                               _lce_resp_data_v_o;
+  logic [1:1]                               _lce_resp_data_ready_and_i;
+  logic [1:1]                               _lce_resp_last_o;
   bp_lce
    #(.bp_params_p(bp_params_p)
      ,.assoc_p(dcache_assoc_p)
@@ -295,13 +343,10 @@ module bp_core
      ,.fill_width_p(dcache_fill_width_p)
      ,.timeout_max_limit_p(4)
      ,.credits_p(coh_noc_max_credits_p)
-     ,.req_invert_clk_p(1)
-     ,.data_mem_invert_clk_p(1)
-     ,.tag_mem_invert_clk_p(1)
      ,.metadata_latency_p(1)
      )
    be_lce
-    (.clk_i(clk_i)
+    (.clk_i(negedge_clk)
      ,.reset_i(reset_i)
 
      ,.lce_id_i(cfg_bus_cast_i.dcache_id)
@@ -334,50 +379,80 @@ module bp_core
      ,.stat_mem_pkt_yumi_i(dcache_stat_mem_pkt_yumi_lo)
      ,.stat_mem_i(dcache_stat_mem_lo)
 
-     ,.lce_req_header_o(lce_req_header_o[1])
-     ,.lce_req_header_v_o(lce_req_header_v_o[1])
-     ,.lce_req_has_data_o(lce_req_has_data_o[1])
-     ,.lce_req_header_ready_and_i(lce_req_header_ready_and_i[1])
-     ,.lce_req_data_o(lce_req_data_o[1])
-     ,.lce_req_data_v_o(lce_req_data_v_o[1])
-     ,.lce_req_last_o(lce_req_last_o[1])
-     ,.lce_req_data_ready_and_i(lce_req_data_ready_and_i[1])
+     ,.lce_req_header_o(_lce_req_header_o[1])
+     ,.lce_req_header_v_o(_lce_req_header_v_o[1])
+     ,.lce_req_has_data_o(_lce_req_has_data_o[1])
+     ,.lce_req_header_ready_and_i(_lce_req_header_ready_and_i[1])
+     ,.lce_req_data_o(_lce_req_data_o[1])
+     ,.lce_req_data_v_o(_lce_req_data_v_o[1])
+     ,.lce_req_last_o(_lce_req_last_o[1])
+     ,.lce_req_data_ready_and_i(_lce_req_data_ready_and_i[1])
 
-     ,.lce_cmd_header_i(lce_cmd_header_i[1])
-     ,.lce_cmd_header_v_i(lce_cmd_header_v_i[1])
-     ,.lce_cmd_has_data_i(lce_cmd_has_data_i[1])
-     ,.lce_cmd_header_ready_and_o(lce_cmd_header_ready_and_o[1])
-     ,.lce_cmd_data_i(lce_cmd_data_i[1])
-     ,.lce_cmd_data_v_i(lce_cmd_data_v_i[1])
-     ,.lce_cmd_last_i(lce_cmd_last_i[1])
-     ,.lce_cmd_data_ready_and_o(lce_cmd_data_ready_and_o[1])
+     ,.lce_cmd_header_i(_lce_cmd_header_i[1])
+     ,.lce_cmd_header_v_i(_lce_cmd_header_v_i[1])
+     ,.lce_cmd_has_data_i(_lce_cmd_has_data_i[1])
+     ,.lce_cmd_header_ready_and_o(_lce_cmd_header_ready_and_o[1])
+     ,.lce_cmd_data_i(_lce_cmd_data_i[1])
+     ,.lce_cmd_data_v_i(_lce_cmd_data_v_i[1])
+     ,.lce_cmd_last_i(_lce_cmd_last_i[1])
+     ,.lce_cmd_data_ready_and_o(_lce_cmd_data_ready_and_o[1])
 
-     ,.lce_fill_header_i(lce_fill_header_i[1])
-     ,.lce_fill_header_v_i(lce_fill_header_v_i[1])
-     ,.lce_fill_has_data_i(lce_fill_has_data_i[1])
-     ,.lce_fill_header_ready_and_o(lce_fill_header_ready_and_o[1])
-     ,.lce_fill_data_i(lce_fill_data_i[1])
-     ,.lce_fill_data_v_i(lce_fill_data_v_i[1])
-     ,.lce_fill_last_i(lce_fill_last_i[1])
-     ,.lce_fill_data_ready_and_o(lce_fill_data_ready_and_o[1])
+     ,.lce_fill_header_i(_lce_fill_header_i[1])
+     ,.lce_fill_header_v_i(_lce_fill_header_v_i[1])
+     ,.lce_fill_has_data_i(_lce_fill_has_data_i[1])
+     ,.lce_fill_header_ready_and_o(_lce_fill_header_ready_and_o[1])
+     ,.lce_fill_data_i(_lce_fill_data_i[1])
+     ,.lce_fill_data_v_i(_lce_fill_data_v_i[1])
+     ,.lce_fill_last_i(_lce_fill_last_i[1])
+     ,.lce_fill_data_ready_and_o(_lce_fill_data_ready_and_o[1])
 
-     ,.lce_fill_header_o(lce_fill_header_o[1])
-     ,.lce_fill_header_v_o(lce_fill_header_v_o[1])
-     ,.lce_fill_has_data_o(lce_fill_has_data_o[1])
-     ,.lce_fill_header_ready_and_i(lce_fill_header_ready_and_i[1])
-     ,.lce_fill_data_o(lce_fill_data_o[1])
-     ,.lce_fill_data_v_o(lce_fill_data_v_o[1])
-     ,.lce_fill_last_o(lce_fill_last_o[1])
-     ,.lce_fill_data_ready_and_i(lce_fill_data_ready_and_i[1])
+     ,.lce_fill_header_o(_lce_fill_header_o[1])
+     ,.lce_fill_header_v_o(_lce_fill_header_v_o[1])
+     ,.lce_fill_has_data_o(_lce_fill_has_data_o[1])
+     ,.lce_fill_header_ready_and_i(_lce_fill_header_ready_and_i[1])
+     ,.lce_fill_data_o(_lce_fill_data_o[1])
+     ,.lce_fill_data_v_o(_lce_fill_data_v_o[1])
+     ,.lce_fill_last_o(_lce_fill_last_o[1])
+     ,.lce_fill_data_ready_and_i(_lce_fill_data_ready_and_i[1])
 
-     ,.lce_resp_header_o(lce_resp_header_o[1])
-     ,.lce_resp_header_v_o(lce_resp_header_v_o[1])
-     ,.lce_resp_has_data_o(lce_resp_has_data_o[1])
-     ,.lce_resp_header_ready_and_i(lce_resp_header_ready_and_i[1])
-     ,.lce_resp_data_o(lce_resp_data_o[1])
-     ,.lce_resp_data_v_o(lce_resp_data_v_o[1])
-     ,.lce_resp_last_o(lce_resp_last_o[1])
-     ,.lce_resp_data_ready_and_i(lce_resp_data_ready_and_i[1])
+     ,.lce_resp_header_o(_lce_resp_header_o[1])
+     ,.lce_resp_header_v_o(_lce_resp_header_v_o[1])
+     ,.lce_resp_has_data_o(_lce_resp_has_data_o[1])
+     ,.lce_resp_header_ready_and_i(_lce_resp_header_ready_and_i[1])
+     ,.lce_resp_data_o(_lce_resp_data_o[1])
+     ,.lce_resp_data_v_o(_lce_resp_data_v_o[1])
+     ,.lce_resp_last_o(_lce_resp_last_o[1])
+     ,.lce_resp_data_ready_and_i(_lce_resp_data_ready_and_i[1])
+     );
+
+  bsg_dlatch
+   #(.width_p($bits(bp_bedrock_lce_req_header_s)+$bits(bp_bedrock_lce_fill_header_s)+$bits(bp_bedrock_lce_resp_header_s)+3*icache_fill_width_p+3*4+6), .i_know_this_is_a_bad_idea_p(1))
+   posedge_latch
+    (.clk_i(posedge_clk)
+     ,.data_i({_lce_req_header_o[1], _lce_req_header_v_o[1], _lce_req_has_data_o[1], _lce_req_data_o[1], _lce_req_data_v_o[1], _lce_req_last_o[1]
+              ,_lce_fill_header_o[1], _lce_fill_header_v_o[1], _lce_fill_has_data_o[1], _lce_fill_data_o[1], _lce_fill_data_v_o[1], _lce_fill_last_o[1]
+              ,_lce_resp_header_o[1], _lce_resp_header_v_o[1], _lce_resp_has_data_o[1], _lce_resp_data_o[1], _lce_resp_data_v_o[1], _lce_resp_last_o[1]
+              ,lce_req_header_ready_and_i[1], lce_req_data_ready_and_i[1], lce_fill_header_ready_and_i[1], lce_fill_data_ready_and_i[1], lce_resp_header_ready_and_i[1], lce_resp_data_ready_and_i[1]
+              })
+     ,.data_o({lce_req_header_o[1], lce_req_header_v_o[1], lce_req_has_data_o[1], lce_req_data_o[1], lce_req_data_v_o[1], lce_req_last_o[1]
+              ,lce_fill_header_o[1], lce_fill_header_v_o[1], lce_fill_has_data_o[1], lce_fill_data_o[1], lce_fill_data_v_o[1], lce_fill_last_o[1]
+              ,lce_resp_header_o[1], lce_resp_header_v_o[1], lce_resp_has_data_o[1], lce_resp_data_o[1], lce_resp_data_v_o[1], lce_resp_last_o[1]
+              ,_lce_req_header_ready_and_i[1], _lce_req_data_ready_and_i[1], _lce_fill_header_ready_and_i[1], _lce_fill_data_ready_and_i[1], _lce_resp_header_ready_and_i[1], _lce_resp_data_ready_and_i[1]
+              })
+     );
+
+  bsg_dlatch
+   #(.width_p($bits(bp_bedrock_lce_cmd_header_s)+$bits(bp_bedrock_lce_fill_header_s)+2*icache_fill_width_p+2*4+4), .i_know_this_is_a_bad_idea_p(1))
+   negedge_latch
+    (.clk_i(negedge_clk)
+     ,.data_i({lce_cmd_header_i[1], lce_cmd_header_v_i[1], lce_cmd_has_data_i[1], lce_cmd_data_i[1], lce_cmd_data_v_i[1], lce_cmd_last_i[1]
+               ,lce_fill_header_i[1], lce_fill_header_v_i[1], lce_fill_has_data_i[1], lce_fill_data_i[1], lce_fill_data_v_i[1], lce_fill_last_i[1]
+               ,_lce_cmd_header_ready_and_o[1], _lce_cmd_data_ready_and_o[1], _lce_fill_header_ready_and_o[1], _lce_fill_data_ready_and_o[1]
+               })
+     ,.data_o({_lce_cmd_header_i[1], _lce_cmd_header_v_i[1], _lce_cmd_has_data_i[1], _lce_cmd_data_i[1], _lce_cmd_data_v_i[1], _lce_cmd_last_i[1]
+               ,_lce_fill_header_i[1], _lce_fill_header_v_i[1], _lce_fill_has_data_i[1], _lce_fill_data_i[1], _lce_fill_data_v_i[1], _lce_fill_last_i[1]
+               ,lce_cmd_header_ready_and_o[1], lce_cmd_data_ready_and_o[1], lce_fill_header_ready_and_o[1], lce_fill_data_ready_and_o[1]
+               })
      );
 
 endmodule

--- a/bp_top/src/v/bp_core.sv
+++ b/bp_top/src/v/bp_core.sv
@@ -425,10 +425,21 @@ module bp_core
      ,.lce_resp_data_ready_and_i(_lce_resp_data_ready_and_i[1])
      );
 
+  // These latches are optimized out in Verilator 4.220...
+  //   but bsg_deff_reset is more heavy_weight. It's possible that FPGAs would prefer
+  //   the alternate implementation as well. But ASICs will appreciate the time-borrowing
+`ifdef VERILATOR
+  bsg_deff_reset
+   #(.width_p($bits(bp_bedrock_lce_req_header_s)+$bits(bp_bedrock_lce_fill_header_s)+$bits(bp_bedrock_lce_resp_header_s)+3*icache_fill_width_p+3*4+6))
+   posedge_latch
+    (.clk_i(posedge_clk)
+     ,.reset_i(reset_i)
+`else
   bsg_dlatch
    #(.width_p($bits(bp_bedrock_lce_req_header_s)+$bits(bp_bedrock_lce_fill_header_s)+$bits(bp_bedrock_lce_resp_header_s)+3*icache_fill_width_p+3*4+6), .i_know_this_is_a_bad_idea_p(1))
    posedge_latch
     (.clk_i(posedge_clk)
+`endif
      ,.data_i({_lce_req_header_o[1], _lce_req_header_v_o[1], _lce_req_has_data_o[1], _lce_req_data_o[1], _lce_req_data_v_o[1], _lce_req_last_o[1]
               ,_lce_fill_header_o[1], _lce_fill_header_v_o[1], _lce_fill_has_data_o[1], _lce_fill_data_o[1], _lce_fill_data_v_o[1], _lce_fill_last_o[1]
               ,_lce_resp_header_o[1], _lce_resp_header_v_o[1], _lce_resp_has_data_o[1], _lce_resp_data_o[1], _lce_resp_data_v_o[1], _lce_resp_last_o[1]
@@ -441,10 +452,18 @@ module bp_core
               })
      );
 
+`ifdef VERILATOR
+  bsg_deff_reset
+   #(.width_p($bits(bp_bedrock_lce_cmd_header_s)+$bits(bp_bedrock_lce_fill_header_s)+2*icache_fill_width_p+2*4+4))
+   negedge_latch
+    (.clk_i(negedge_clk)
+     ,.reset_i(reset_i)
+`else
   bsg_dlatch
    #(.width_p($bits(bp_bedrock_lce_cmd_header_s)+$bits(bp_bedrock_lce_fill_header_s)+2*icache_fill_width_p+2*4+4), .i_know_this_is_a_bad_idea_p(1))
    negedge_latch
     (.clk_i(negedge_clk)
+`endif
      ,.data_i({lce_cmd_header_i[1], lce_cmd_header_v_i[1], lce_cmd_has_data_i[1], lce_cmd_data_i[1], lce_cmd_data_v_i[1], lce_cmd_last_i[1]
                ,lce_fill_header_i[1], lce_fill_header_v_i[1], lce_fill_has_data_i[1], lce_fill_data_i[1], lce_fill_data_v_i[1], lce_fill_last_i[1]
                ,_lce_cmd_header_ready_and_o[1], _lce_cmd_data_ready_and_o[1], _lce_fill_header_ready_and_o[1], _lce_fill_data_ready_and_o[1]

--- a/bp_top/src/v/bp_core_minimal.sv
+++ b/bp_top/src/v/bp_core_minimal.sv
@@ -48,6 +48,8 @@ module bp_core_minimal
    , output logic                                    icache_stat_mem_pkt_yumi_o
    , output logic [icache_stat_info_width_lp-1:0]    icache_stat_mem_o
 
+   // D$ Engine Interface is clocked on the negedge of the clock. Must be attached to
+   //   a negative-edge cache engine and synchronized before getting to the memory system
    , output logic [dcache_req_width_lp-1:0]          dcache_req_o
    , output logic                                    dcache_req_v_o
    , input                                           dcache_req_yumi_i

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -264,11 +264,22 @@ module bp_unicore_lite
      ,.mem_resp_last_i(_mem_resp_last_i[1])
      );
 
+  // These latches are optimized out in Verilator 4.220...
+  //   but bsg_deff_reset is more heavy_weight. It's possible that FPGAs would prefer
+  //   the alternate implementation as well. But ASICs will appreciate the time-borrowing
   // Synchronize back to posedge clk
+`ifdef VERILATOR
+  bsg_deff_reset
+   #(.width_p($bits(bp_bedrock_mem_header_s)+uce_fill_width_p+3))
+   posedge_latch
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+`else
   bsg_dlatch
    #(.width_p($bits(bp_bedrock_mem_header_s)+uce_fill_width_p+3), .i_know_this_is_a_bad_idea_p(1))
    posedge_latch
-    (.clk_i(posedge_clk)
+    (.clk_i(clk_i)
+`endif
      ,.data_i({_mem_cmd_header_o[1], _mem_cmd_data_o[1], _mem_cmd_v_o[1], _mem_cmd_last_o[1]
                ,mem_cmd_ready_and_i[1]
                })
@@ -278,10 +289,18 @@ module bp_unicore_lite
      );
 
   // Synchronize back to negedge clk
+`ifdef VERILATOR
+  bsg_deff_reset
+   #(.width_p($bits(bp_bedrock_mem_header_s)+uce_fill_width_p+3))
+   negedge_latch
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+`else
   bsg_dlatch
    #(.width_p($bits(bp_bedrock_mem_header_s)+uce_fill_width_p+3), .i_know_this_is_a_bad_idea_p(1))
    negedge_latch
-    (.clk_i(negedge_clk)
+    (.clk_i(clk_i)
+`endif
      ,.data_i({mem_resp_header_i[1], mem_resp_data_i[1], mem_resp_v_i[1], mem_resp_last_i[1]
                ,_mem_resp_ready_and_o[1]
                })

--- a/bp_top/test/tb/bp_tethered/flist.vcs
+++ b/bp_top/test/tb/bp_tethered/flist.vcs
@@ -3,7 +3,6 @@
 $BASEJUMP_STL_DIR/bsg_dmc/bsg_dmc_pkg.v
 $BASEJUMP_STL_DIR/bsg_tag/bsg_tag_pkg.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_dramsim3_pkg.v
-$BASEJUMP_STL_DIR/bsg_async/bsg_sync_sync.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_to_axi.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_to_axi_rx.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_to_axi_tx.v


### PR DESCRIPTION
## Summary
The PR adds an explicit synchronization layer between the cache engine and memory system interfaces

## Area
bp_core, bp_unicore_lite, D$ / cache engines

## Reasoning (outdated, confusing, verbose, etc.)
The current implementation of explicitly extending handshakes is error-prone and counter-intuitive. Additionally, by clocking the cache different than the cache engine, we exposed half cycle paths to the rams. By moving the synchronization to the memory system, additional latency can be recaptured by explicit buffers which would exist for synchronization regardless. 

## Analysis
Although there is an increase in latches, this implementation is much safer. In the previous implementation, there was an implicit assumption that data and address would be held constant during a transaction, even though a state machine could change during the posedge/negedge of the cycle and cause a different value to be muxed in

## Verification
Standard regression, + synthesis runs

