### PR TITLE
Fixing bootrom configurations

### DIFF
--- a/bp_common/software/py/nbf.py
+++ b/bp_common/software/py/nbf.py
@@ -236,9 +236,9 @@ class NBF:
             self.print_nbf(3, full_addr, self.ucode[i])
 
       # Write I$, D$, and CCE modes
+      self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_cce_mode, 1)
       self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_icache_mode, 1)
       self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_dcache_mode, 1)
-      self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_cce_mode, 1)
 
       # Write RTC
       self.print_nbf_allcores(3, clint_base_addr + clint_reg_mtimesel, 1)

--- a/bp_common/src/include/bp_common_addr_pkgdef.svh
+++ b/bp_common/src/include/bp_common_addr_pkgdef.svh
@@ -8,14 +8,12 @@
   localparam dev_id_width_gp   = 4;
   localparam dev_addr_width_gp = 20;
 
-  localparam boot_dev_gp  = 0;
   localparam host_dev_gp  = 1;
   localparam cfg_dev_gp   = 2;
   localparam clint_dev_gp = 3;
   localparam cache_dev_gp = 4;
 
                              // 0x00_0(nnnN)(D)(A_AAAA)
-  localparam boot_dev_base_addr_gp     = 32'h0000_0000;
   localparam host_dev_base_addr_gp     = 32'h0010_0000;
   localparam cfg_dev_base_addr_gp      = 32'h0020_0000;
   localparam clint_dev_base_addr_gp    = 32'h0030_0000;
@@ -23,6 +21,7 @@
 
   // TODO: This is hardcoded for a 32-bit DRAM address, will need to be adjusted
   //   for a different address space
+  localparam boot_base_addr_gp         = 40'h00_0011_0000;
   localparam dram_base_addr_gp         = 40'h00_8000_0000;
   localparam dram_uc_base_addr_gp      = 40'h01_0000_0000;
   localparam coproc_base_addr_gp       = 40'h02_0000_0000;

--- a/bp_me/src/v/dev/bp_me_cfg_slice.sv
+++ b/bp_me/src/v/dev/bp_me_cfg_slice.sv
@@ -113,8 +113,10 @@ module bp_me_cfg_slice
 
   // Access to CCE ucode memory must be aligned
   localparam cce_pc_offset_width_lp = `BSG_SAFE_CLOG2(`BSG_CDIV(cce_instr_width_gp,8));
-  assign cce_ucode_v_o    = cce_ucode_r_v_li | cce_ucode_w_v_li;
-  assign cce_ucode_w_o    = cce_ucode_w_v_li;
+  // Prevent writing CCE ucode if we're already out of cached mode.
+  //   We could also handle this by software, but seems dangerous to allow in hardware
+  assign cce_ucode_v_o    = (cce_mode_r == e_cce_mode_uncached) & (cce_ucode_r_v_li | cce_ucode_w_v_li);
+  assign cce_ucode_w_o    = (cce_mode_r == e_cce_mode_uncached) & cce_ucode_w_v_li;
   assign cce_ucode_addr_o = addr_lo[cce_pc_offset_width_lp+:cce_pc_width_p];
   assign cce_ucode_data_o = data_lo[0+:cce_instr_width_gp];
 

--- a/bp_me/src/v/network/bp_me_addr_to_cce_id.sv
+++ b/bp_me/src/v/network/bp_me_addr_to_cce_id.sv
@@ -64,7 +64,7 @@ module bp_me_addr_to_cce_id
   always_comb
     begin
       cce_id_o = '0;
-      if (external_io_v_li || (core_local_addr_v_li && (local_addr_li.dev inside {boot_dev_gp, host_dev_gp})))
+      if (external_io_v_li || (core_local_addr_v_li && (local_addr_li.dev inside {host_dev_gp})))
         // Stripe by 4kiB page, start at io CCE id
         cce_id_o = (num_io_p > 1)
                    ? max_sac_cce_lp + paddr_i[page_offset_width_gp+:`BSG_SAFE_CLOG2(num_io_p)]

--- a/bp_top/src/v/bp_io_tile.sv
+++ b/bp_top/src/v/bp_io_tile.sv
@@ -350,7 +350,7 @@ module bp_io_tile
   assign global_addr_lo = cce_io_cmd_header_lo.addr;
   assign local_addr_lo  = cce_io_cmd_header_lo.addr;
 
-  wire is_host_addr  = (~local_addr_lo.nonlocal && (local_addr_lo.dev inside {boot_dev_gp, host_dev_gp}));
+  wire is_host_addr  = (~local_addr_lo.nonlocal && (local_addr_lo.dev inside {host_dev_gp}));
   assign dst_did_lo  = is_host_addr ? host_did_i : global_addr_lo.hio;
   assign dst_cord_lo = dst_did_lo;
 

--- a/bp_top/src/v/bp_unicore.sv
+++ b/bp_top/src/v/bp_unicore.sv
@@ -162,7 +162,7 @@ module bp_unicore
       wire is_other_hio    = (proc_cmd_header_lo[i].addr[paddr_width_p-1-:hio_width_p] != 0);
       wire is_cfg_cmd      = local_cmd_li & (device_cmd_li == cfg_dev_gp);
       wire is_clint_cmd    = local_cmd_li & (device_cmd_li == clint_dev_gp);
-      wire is_io_cmd       = (local_cmd_li & (device_cmd_li inside {boot_dev_gp, host_dev_gp}))
+      wire is_io_cmd       = (local_cmd_li & (device_cmd_li == host_dev_gp))
                              | is_other_hio | is_other_core;
       wire is_mem_cmd      = (~local_cmd_li & ~is_other_hio) || (local_cmd_li & (device_cmd_li == cache_dev_gp));
       wire is_loopback_cmd = local_cmd_li & ~is_cfg_cmd & ~is_clint_cmd & ~is_io_cmd & ~is_mem_cmd;

--- a/bp_top/test/common/bp_nonsynth_perf.sv
+++ b/bp_top/test/common/bp_nonsynth_perf.sv
@@ -22,37 +22,37 @@ module bp_nonsynth_perf
    , input is_debug_mode_i
    );
 
-logic [29:0] warmup_cnt;
-logic warm;
-bsg_counter_clear_up
- #(.max_val_p(2**30-1), .init_val_p(0))
- warmup_counter
-  (.clk_i(clk_i)
-   ,.reset_i(reset_i | freeze_i)
+  logic [29:0] warmup_cnt;
+  logic warm;
+  bsg_counter_clear_up
+   #(.max_val_p(2**30-1), .init_val_p(0))
+   warmup_counter
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i | freeze_i)
 
-   ,.clear_i(1'b0)
-   ,.up_i(commit_v_i & ~warm)
-   ,.count_o(warmup_cnt)
-   );
-assign warm = (warmup_cnt == warmup_instr_i);
+     ,.clear_i(1'b0)
+     ,.up_i(commit_v_i & ~warm)
+     ,.count_o(warmup_cnt)
+     );
+  assign warm = (warmup_cnt == warmup_instr_i);
 
-logic [63:0] clk_cnt_r;
-logic [63:0] instr_cnt_r;
+  logic [63:0] clk_cnt_r;
+  logic [63:0] instr_cnt_r;
 
-logic [num_core_p-1:0] program_finish_r;
-always_ff @(posedge clk_i)
-  begin
-    if (reset_i | freeze_i | ~warm | is_debug_mode_i)
-      begin
-        clk_cnt_r <= '0;
-        instr_cnt_r <= '0;
-      end
-    else
-      begin
-        clk_cnt_r <= clk_cnt_r + 64'b1;
-        instr_cnt_r <= instr_cnt_r + commit_v_i;
-      end
-  end
+  logic [num_core_p-1:0] program_finish_r;
+  always_ff @(posedge clk_i)
+    begin
+      if (reset_i | freeze_i | ~warm | is_debug_mode_i)
+        begin
+          clk_cnt_r <= '0;
+          instr_cnt_r <= '0;
+        end
+      else
+        begin
+          clk_cnt_r <= clk_cnt_r + 64'b1;
+          instr_cnt_r <= instr_cnt_r + commit_v_i;
+        end
+    end
 
   logic [`BSG_SAFE_CLOG2(max_instr_lp+1)-1:0] instr_cnt;
   bsg_counter_clear_up

--- a/bp_top/test/tb/bp_tethered/Makefile.cfgs
+++ b/bp_top/test/tb/bp_tethered/Makefile.cfgs
@@ -57,9 +57,10 @@ endif
 e_bp_custom_cfg_ucode := 1
 $(CFG)_ucode ?= $(findstring cce_ucode,$(CFG))
 
-_UCODE_CFG ?= $($(CFG)_ucode)
-ifeq ($(_UCODE_CFG),)
-	export UCODE_CFG ?= 0
+_UCODE ?= $($(CFG)_ucode)
+ifeq ($(_UCODE),)
+	export UCODE ?= 0
 else
-	export UCODE_CFG ?= 1
+	export UCODE ?= 1
 endif
+

--- a/bp_top/test/tb/bp_tethered/Makefile.vcs
+++ b/bp_top/test/tb/bp_tethered/Makefile.vcs
@@ -61,19 +61,19 @@ $(SIM_DIR)/prog.riscv: $(BP_SDK_PROG_DIR)/$(SUITE)/$(PROG).riscv
 $(SIM_DIR)/prog.elf: $(SIM_DIR)/prog.riscv
 	cp $^ $@
 
-ifeq ($(UCODE_CFG), 1)
+ifeq ($(UCODE), 1)
 CCE_UCODE_FILE ?= $(BP_SDK_UCODE_DIR)/$(CCE_MEM)
 else
 CCE_UCODE_FILE ?=
 endif
 
 $(SIM_DIR)/cce_ucode.mem: $(CCE_UCODE_FILE)
-ifeq ($(UCODE_CFG), 1)
+ifeq ($(UCODE), 1)
 	cp $< $@
 endif
 
 NBF_INPUTS ?= --ncpus=$(NCPUS)
-ifeq ($(UCODE_CFG), 1)
+ifeq ($(UCODE), 1)
 NBF_INPUTS += --ucode=cce_ucode.mem
 endif
 ifeq ($(PRELOAD_MEM_P), 0)
@@ -92,6 +92,7 @@ $(SIM_DIR)/bootrom.riscv: $(BP_SDK_PROG_DIR)/bootrom/bootrom.riscv
 
 $(SIM_DIR)/bootrom.mem: $(SIM_DIR)/bootrom.riscv
 	$(RISCV_OBJCOPY) -O verilog --verilog-data-width=8 $< $@
+	$(SED) -i "s/@0011/@0000/g" $@
 
 SIM_COLLATERAL  = $(addprefix $(SIM_DIR)/, simv simv.daidir)
 SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, prog.riscv prog.elf prog.mem prog.nbf prog.dump)

--- a/bp_top/test/tb/bp_tethered/Makefile.verilator
+++ b/bp_top/test/tb/bp_tethered/Makefile.verilator
@@ -39,19 +39,19 @@ $(SIM_DIR)/prog.riscv: $(BP_SDK_PROG_DIR)/$(SUITE)/$(PROG).riscv
 $(SIM_DIR)/prog.elf: $(SIM_DIR)/prog.riscv
 	cp $^ $@
 
-ifeq ($(UCODE_CFG), 1)
+ifeq ($(UCODE), 1)
 CCE_UCODE_FILE ?= $(BP_SDK_UCODE_DIR)/$(CCE_MEM)
 else
 CCE_UCODE_FILE ?=
 endif
 
 $(SIM_DIR)/cce_ucode.mem: $(CCE_UCODE_FILE)
-ifeq ($(UCODE_CFG), 1)
+ifeq ($(UCODE), 1)
 	cp $< $@
 endif
 
 NBF_INPUTS ?= --ncpus=$(NCPUS)
-ifeq ($(UCODE_CFG), 1)
+ifeq ($(UCODE), 1)
 NBF_INPUTS += --ucode=cce_ucode.mem
 endif
 NBF_INPUTS += --mem=prog.mem --skip_zeros
@@ -68,6 +68,7 @@ $(SIM_DIR)/bootrom.riscv: $(BP_SDK_PROG_DIR)/bootrom/bootrom.riscv
 
 $(SIM_DIR)/bootrom.mem: $(SIM_DIR)/bootrom.riscv
 	$(RISCV_OBJCOPY) -O verilog --verilog-data-width=8 $< $@
+	$(SED) -i "s/@0011/@0000/g" $@
 
 SIM_COLLATERAL  = $(addprefix $(SIM_DIR)/, simsc)
 SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, prog.riscv prog.elf prog.mem prog.nbf prog.dump)


### PR DESCRIPTION
This PR fixes bootrom configurations, by removing them entirely. That is, it makes BlackParrot always boot from bootrom. This is much less error prone than trying to manage several configurations of BlackParrot, some of which are only valid in certain environments, etc. There is a followup PR which will restore the ability to boot from DRAM, useful for some tethered environments

Depends on:
- [ ] https://github.com/black-parrot-sdk/bedrock/pull/new/termination
- [ ] https://github.com/black-parrot-sdk/bootrom/pull/new/incbin