### PR TITLE
Debug Mode Interrupt

### DIFF
--- a/bp_be/src/include/bp_be_ctl_pkgdef.svh
+++ b/bp_be/src/include/bp_be_ctl_pkgdef.svh
@@ -239,6 +239,7 @@
     logic instr_misaligned;
 
     // BP "exceptions"
+    logic unfreeze;
     logic itlb_miss;
     logic icache_miss;
     logic dcache_fail;

--- a/bp_be/src/include/bp_be_ctl_pkgdef.svh
+++ b/bp_be/src/include/bp_be_ctl_pkgdef.svh
@@ -249,6 +249,7 @@
     logic dtlb_fill;
     logic _interrupt;
     logic cmd_full;
+    logic dentry;
   }  bp_be_exception_s;
 
   typedef struct packed

--- a/bp_be/src/include/bp_be_ctl_pkgdef.svh
+++ b/bp_be/src/include/bp_be_ctl_pkgdef.svh
@@ -249,7 +249,6 @@
     logic dtlb_fill;
     logic _interrupt;
     logic cmd_full;
-    logic dentry;
   }  bp_be_exception_s;
 
   typedef struct packed

--- a/bp_be/src/include/bp_be_defines.svh
+++ b/bp_be/src/include/bp_be_defines.svh
@@ -142,6 +142,7 @@
       logic                           translation_en_n;                                            \
       logic                           exception;                                                   \
       logic                           _interrupt;                                                  \
+      logic                           unfreeze;                                                    \
       logic                           eret;                                                        \
       logic                           fencei;                                                      \
       logic                           sfence;                                                      \
@@ -246,7 +247,7 @@
     (paddr_width_mp - page_offset_width_gp + 7)
 
   `define bp_be_commit_pkt_width(vaddr_width_mp, paddr_width_mp) \
-    (3 + `bp_be_pte_leaf_width(paddr_width_mp) +  3*vaddr_width_mp + instr_width_gp + rv64_priv_width_gp + 16)
+    (3 + `bp_be_pte_leaf_width(paddr_width_mp) +  3*vaddr_width_mp + instr_width_gp + rv64_priv_width_gp + 17)
 
   `define bp_be_wb_pkt_width(vaddr_width_mp) \
     (3                                                                                             \

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -60,6 +60,7 @@ module bp_be_calculator_top
   , input                                           software_irq_i
   , input                                           m_external_irq_i
   , input                                           s_external_irq_i
+  , input                                           debug_irq_i
   , output logic                                    irq_waiting_o
   , output logic                                    irq_pending_o
 
@@ -230,6 +231,7 @@ module bp_be_calculator_top
      ,.software_irq_i(software_irq_i)
      ,.m_external_irq_i(m_external_irq_i)
      ,.s_external_irq_i(s_external_irq_i)
+     ,.debug_irq_i(debug_irq_i)
      ,.irq_pending_o(irq_pending_o)
      ,.irq_waiting_o(irq_waiting_o)
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -56,11 +56,12 @@ module bp_be_calculator_top
   , output logic [wb_pkt_width_lp-1:0]              fwb_pkt_o
   , output logic [ptw_fill_pkt_width_lp-1:0]        ptw_fill_pkt_o
 
+  , input                                           unfreeze_irq_i
+  , input                                           debug_irq_i
   , input                                           timer_irq_i
   , input                                           software_irq_i
   , input                                           m_external_irq_i
   , input                                           s_external_irq_i
-  , input                                           debug_irq_i
   , output logic                                    irq_waiting_o
   , output logic                                    irq_pending_o
 
@@ -227,11 +228,12 @@ module bp_be_calculator_top
      ,.iwb_pkt_i(iwb_pkt_o)
      ,.fwb_pkt_i(fwb_pkt_o)
 
+     ,.unfreeze_irq_i(unfreeze_irq_i)
+     ,.debug_irq_i(debug_irq_i)
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)
      ,.m_external_irq_i(m_external_irq_i)
      ,.s_external_irq_i(s_external_irq_i)
-     ,.debug_irq_i(debug_irq_i)
      ,.irq_pending_o(irq_pending_o)
      ,.irq_waiting_o(irq_waiting_o)
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -24,7 +24,7 @@ module bp_be_calculator_top
     `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
 
    // Generated parameters
-   , localparam cfg_bus_width_lp        = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp        = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam dispatch_pkt_width_lp   = `bp_be_dispatch_pkt_width(vaddr_width_p)
    , localparam branch_pkt_width_lp     = `bp_be_branch_pkt_width(vaddr_width_p)
    , localparam commit_pkt_width_lp     = `bp_be_commit_pkt_width(vaddr_width_p, paddr_width_p)
@@ -93,7 +93,7 @@ module bp_be_calculator_top
   );
 
   // Declare parameterizable structs
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 
   `bp_cast_i(bp_be_dispatch_pkt_s, dispatch_pkt);

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -56,7 +56,6 @@ module bp_be_calculator_top
   , output logic [wb_pkt_width_lp-1:0]              fwb_pkt_o
   , output logic [ptw_fill_pkt_width_lp-1:0]        ptw_fill_pkt_o
 
-  , input                                           unfreeze_irq_i
   , input                                           debug_irq_i
   , input                                           timer_irq_i
   , input                                           software_irq_i
@@ -228,7 +227,6 @@ module bp_be_calculator_top
      ,.iwb_pkt_i(iwb_pkt_o)
      ,.fwb_pkt_i(fwb_pkt_o)
 
-     ,.unfreeze_irq_i(unfreeze_irq_i)
      ,.debug_irq_i(debug_irq_i)
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -35,7 +35,6 @@ module bp_be_csr
    , input                                   frf_w_v_i
 
    // Interrupts
-   , input                                   unfreeze_irq_i
    , input                                   debug_irq_i
    , input                                   timer_irq_i
    , input                                   software_irq_i
@@ -238,7 +237,6 @@ module bp_be_csr
       endcase
     end
 
-  wire unfreeze = unfreeze_irq_i;
   logic enter_debug, exit_debug;
   bsg_dff_reset_set_clear
    #(.width_p(1))
@@ -264,7 +262,7 @@ module bp_be_csr
   assign apc_n = retire_pkt_cast_i.special.sret ? sepc_lo : retire_pkt_cast_i.special.mret ? mepc_lo : retire_pkt_cast_i.special.dret ? dpc_lo
                  : (exception_v_lo | interrupt_v_lo)
                    ? ((priv_mode_n == `PRIV_MODE_S) ? {stvec_lo.base, 2'b00} : {mtvec_lo.base, 2'b00})
-                   : (unfreeze | enter_debug)
+                   : (commit_pkt_cast_o.unfreeze | enter_debug)
                      ? cfg_bus_cast_i.npc
                      : retire_pkt_cast_i.instret
                        ? retire_pkt_cast_i.npc
@@ -646,14 +644,14 @@ module bp_be_csr
   assign commit_pkt_cast_o.priv_n           = priv_mode_n;
   assign commit_pkt_cast_o.translation_en_n = translation_en_n;
   assign commit_pkt_cast_o.exception        = exception_v_lo;
-  // Unfreezing and debug mode act as a pseudo-interrupt
-  assign commit_pkt_cast_o._interrupt       = interrupt_v_lo | unfreeze | enter_debug;
-  assign commit_pkt_cast_o.unfreeze         = unfreeze;
+  // Debug mode acts as a pseudo-interrupt
+  assign commit_pkt_cast_o._interrupt       = interrupt_v_lo | enter_debug;
   assign commit_pkt_cast_o.fencei           = retire_pkt_cast_i.special.fencei_clean;
   assign commit_pkt_cast_o.sfence           = retire_pkt_cast_i.special.sfence_vma;
   assign commit_pkt_cast_o.wfi              = retire_pkt_cast_i.special.wfi;
   assign commit_pkt_cast_o.eret             = |{retire_pkt_cast_i.special.dret, retire_pkt_cast_i.special.mret, retire_pkt_cast_i.special.sret};
   assign commit_pkt_cast_o.csrw             = retire_pkt_cast_i.special.csrw;
+  assign commit_pkt_cast_o.unfreeze         = retire_pkt_cast_i.exception.unfreeze;
   assign commit_pkt_cast_o.itlb_miss        = retire_pkt_cast_i.exception.itlb_miss;
   assign commit_pkt_cast_o.icache_miss      = retire_pkt_cast_i.exception.icache_miss;
   assign commit_pkt_cast_o.dtlb_store_miss  = retire_pkt_cast_i.exception.dtlb_store_miss;

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -260,13 +260,13 @@ module bp_be_csr
      ,.data_o(apc_r)
      );
   assign apc_n = retire_pkt_cast_i.special.sret ? sepc_lo : retire_pkt_cast_i.special.mret ? mepc_lo : retire_pkt_cast_i.special.dret ? dpc_lo
-                 : (exception_v_lo | interrupt_v_lo)
-                   ? ((priv_mode_n == `PRIV_MODE_S) ? {stvec_lo.base, 2'b00} : {mtvec_lo.base, 2'b00})
-                   : (commit_pkt_cast_o.unfreeze | enter_debug)
-                     ? cfg_bus_cast_i.npc
-                     : retire_pkt_cast_i.instret
-                       ? retire_pkt_cast_i.npc
-                       : apc_r;
+                 : (commit_pkt_cast_o.unfreeze | enter_debug)
+                   ? cfg_bus_cast_i.npc
+                   : (exception_v_lo | interrupt_v_lo)
+                     ? ((priv_mode_n == `PRIV_MODE_S) ? {stvec_lo.base, 2'b00} : {mtvec_lo.base, 2'b00})
+                       : retire_pkt_cast_i.instret
+                         ? retire_pkt_cast_i.npc
+                         : apc_r;
 
 
   assign translation_en_n = ((priv_mode_n < `PRIV_MODE_M) & (satp_li.mode == 4'd8));

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -251,8 +251,8 @@ module bp_be_csr
 
   logic [vaddr_width_p-1:0] apc_n, apc_r;
   bsg_dff_reset
-   #(.width_p(vaddr_width_p), .reset_val_p(dram_base_addr_gp))
-   apc
+   #(.width_p(vaddr_width_p))
+   apc_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -167,7 +167,6 @@ module bp_be_csr
 
   assign irq_waiting_o = |interrupt_icode_dec_li;
 
-  wire ebreak_v_li = ~is_debug_mode | (is_m_mode & ~dcsr_lo.ebreakm) | (is_s_mode & ~dcsr_lo.ebreaks) | (is_u_mode & ~dcsr_lo.ebreaku);
   rv64_exception_dec_s exception_dec_li;
   assign exception_dec_li =
       '{instr_misaligned    : retire_pkt_cast_i.exception.instr_misaligned

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -254,7 +254,7 @@ module bp_be_csr
 
   logic [vaddr_width_p-1:0] apc_n, apc_r;
   bsg_dff_reset
-   #(.width_p(vaddr_width_p))
+   #(.width_p(vaddr_width_p), .reset_val_p(dram_base_addr_gp))
    apc
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
@@ -649,6 +649,7 @@ module bp_be_csr
   assign commit_pkt_cast_o.exception        = exception_v_lo;
   // Unfreezing and debug mode act as a pseudo-interrupt
   assign commit_pkt_cast_o._interrupt       = interrupt_v_lo | unfreeze | enter_debug;
+  assign commit_pkt_cast_o.unfreeze         = unfreeze;
   assign commit_pkt_cast_o.fencei           = retire_pkt_cast_i.special.fencei_clean;
   assign commit_pkt_cast_o.sfence           = retire_pkt_cast_i.special.sfence_vma;
   assign commit_pkt_cast_o.wfi              = retire_pkt_cast_i.special.wfi;

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -10,7 +10,7 @@ module bp_be_csr
 
    , localparam csr_cmd_width_lp = $bits(bp_be_csr_cmd_s)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
 
    , localparam commit_pkt_width_lp = `bp_be_commit_pkt_width(vaddr_width_p, paddr_width_p)
    , localparam decode_info_width_lp = `bp_be_decode_info_width
@@ -53,7 +53,7 @@ module bp_be_csr
    );
 
   // Declare parameterizable structs
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 
   `declare_csr_structs(vaddr_width_p, paddr_width_p);

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -20,7 +20,7 @@ module bp_be_pipe_mem
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
    // Generated parameters
-   , localparam cfg_bus_width_lp       = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp       = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam dispatch_pkt_width_lp  = `bp_be_dispatch_pkt_width(vaddr_width_p)
    , localparam ptw_fill_pkt_width_lp  = `bp_be_ptw_fill_pkt_width(vaddr_width_p, paddr_width_p)
    , localparam trans_info_width_lp    = `bp_be_trans_info_width(ptag_width_p)
@@ -103,7 +103,7 @@ module bp_be_pipe_mem
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache);
   `declare_bp_be_dcache_pkt_s(vaddr_width_p);
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
@@ -55,6 +55,7 @@ module bp_be_pipe_sys
    , input                                   software_irq_i
    , input                                   m_external_irq_i
    , input                                   s_external_irq_i
+   , input                                   debug_irq_i
    , output logic                            irq_pending_o
    , output logic                            irq_waiting_o
 
@@ -121,6 +122,7 @@ module bp_be_pipe_sys
      ,.software_irq_i(software_irq_i)
      ,.m_external_irq_i(m_external_irq_i)
      ,.s_external_irq_i(s_external_irq_i)
+     ,.debug_irq_i(debug_irq_i)
      ,.irq_pending_o(irq_pending_o)
      ,.irq_waiting_o(irq_waiting_o)
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
@@ -51,7 +51,6 @@ module bp_be_pipe_sys
    , input [wb_pkt_width_lp-1:0]             fwb_pkt_i
    , output logic [commit_pkt_width_lp-1:0]  commit_pkt_o
 
-   , input                                   unfreeze_irq_i
    , input                                   debug_irq_i
    , input                                   timer_irq_i
    , input                                   software_irq_i
@@ -119,7 +118,6 @@ module bp_be_pipe_sys
      ,.fflags_acc_i(({5{iwb_pkt.fflags_w_v}} & iwb_pkt.fflags) | ({5{fwb_pkt.fflags_w_v}} & fwb_pkt.fflags))
      ,.frf_w_v_i(fwb_pkt.frd_w_v)
 
-     ,.unfreeze_irq_i(unfreeze_irq_i)
      ,.debug_irq_i(debug_irq_i)
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
@@ -51,11 +51,12 @@ module bp_be_pipe_sys
    , input [wb_pkt_width_lp-1:0]             fwb_pkt_i
    , output logic [commit_pkt_width_lp-1:0]  commit_pkt_o
 
+   , input                                   unfreeze_irq_i
+   , input                                   debug_irq_i
    , input                                   timer_irq_i
    , input                                   software_irq_i
    , input                                   m_external_irq_i
    , input                                   s_external_irq_i
-   , input                                   debug_irq_i
    , output logic                            irq_pending_o
    , output logic                            irq_waiting_o
 
@@ -118,11 +119,12 @@ module bp_be_pipe_sys
      ,.fflags_acc_i(({5{iwb_pkt.fflags_w_v}} & iwb_pkt.fflags) | ({5{fwb_pkt.fflags_w_v}} & fwb_pkt.fflags))
      ,.frf_w_v_i(fwb_pkt.frd_w_v)
 
+     ,.unfreeze_irq_i(unfreeze_irq_i)
+     ,.debug_irq_i(debug_irq_i)
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)
      ,.m_external_irq_i(m_external_irq_i)
      ,.s_external_irq_i(s_external_irq_i)
-     ,.debug_irq_i(debug_irq_i)
      ,.irq_pending_o(irq_pending_o)
      ,.irq_waiting_o(irq_waiting_o)
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
@@ -17,7 +17,7 @@ module bp_be_pipe_sys
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
 
-   , localparam cfg_bus_width_lp       = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp       = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam csr_cmd_width_lp       = $bits(bp_be_csr_cmd_s)
    // Generated parameters
    , localparam dispatch_pkt_width_lp = `bp_be_dispatch_pkt_width(vaddr_width_p)

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -248,7 +248,6 @@ module bp_be_detector
                       & ((dep_status_r[0].instr_v)
                          | (dep_status_r[1].instr_v)
                          | (dep_status_r[2].instr_v)
-                         | (dep_status_r[3].instr_v)
                          );
 
       control_haz_v = fence_haz_v | csr_haz_v | fflags_haz_v | long_haz_v;

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -248,6 +248,7 @@ module bp_be_detector
                       & ((dep_status_r[0].instr_v)
                          | (dep_status_r[1].instr_v)
                          | (dep_status_r[2].instr_v)
+                         | (dep_status_r[3].instr_v)
                          );
 
       control_haz_v = fence_haz_v | csr_haz_v | fflags_haz_v | long_haz_v;
@@ -273,7 +274,7 @@ module bp_be_detector
 
   // Generate calculator control signals
   assign dispatch_v_o  = ~(control_haz_v | data_haz_v | struct_haz_v);
-  assign interrupt_v_o = irq_pending_i & ~ptw_busy_i & ~cfg_bus_cast_i.freeze;
+  assign interrupt_v_o = irq_pending_i & ~ptw_busy_i;
 
   bp_be_dep_status_s dep_status_n;
   always_comb

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -21,7 +21,7 @@ module bp_be_detector
    `declare_bp_proc_params(bp_params_p)
 
    // Generated parameters
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam isd_status_width_lp = `bp_be_isd_status_width(vaddr_width_p, branch_metadata_fwd_width_p)
    , localparam dispatch_pkt_width_lp = `bp_be_dispatch_pkt_width(vaddr_width_p)
    , localparam commit_pkt_width_lp = `bp_be_commit_pkt_width(vaddr_width_p, paddr_width_p)
@@ -52,7 +52,7 @@ module bp_be_detector
    , input [wb_pkt_width_lp-1:0]       fwb_pkt_i
    );
 
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -264,12 +264,11 @@ module bp_be_detector
                    | (frs1_sb_raw_haz_v | frs2_sb_raw_haz_v | frs3_sb_raw_haz_v | frd_sb_waw_haz_v);
 
       // Combine all structural hazard information
-      struct_haz_v = cfg_bus_cast_i.freeze
-                     | ptw_busy_i
+      struct_haz_v = ptw_busy_i
+                     | cmd_haz_v
                      | (~mem_ready_i & isd_status_cast_i.mem_v)
                      | (~fdiv_ready_i & isd_status_cast_i.long_v)
-                     | (~idiv_ready_i & isd_status_cast_i.long_v)
-                     | cmd_haz_v;
+                     | (~idiv_ready_i & isd_status_cast_i.long_v);
     end
 
   // Generate calculator control signals

--- a/bp_be/src/v/bp_be_checker/bp_be_director.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.sv
@@ -83,8 +83,8 @@ module bp_be_director
   wire npc_w_v = commit_pkt_cast_i.npc_w_v | br_pkt_cast_i.v;
   assign npc_n = commit_pkt_cast_i.npc_w_v ? commit_pkt_cast_i.npc : br_pkt_cast_i.npc;
   bsg_dff_reset_en
-   #(.width_p(vaddr_width_p), .reset_val_p(dram_base_addr_gp))
-   npc
+   #(.width_p(vaddr_width_p))
+   npc_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
      ,.en_i(npc_w_v)

--- a/bp_be/src/v/bp_be_checker/bp_be_director.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.sv
@@ -82,7 +82,7 @@ module bp_be_director
   wire npc_w_v = commit_pkt_cast_i.npc_w_v | br_pkt_cast_i.v;
   assign npc_n = commit_pkt_cast_i.npc_w_v ? commit_pkt_cast_i.npc : br_pkt_cast_i.npc;
   bsg_dff_reset_en
-   #(.width_p(vaddr_width_p), .reset_val_p($unsigned(boot_pc_p)))
+   #(.width_p(vaddr_width_p))
    npc
     (.clk_i(clk_i)
      ,.reset_i(reset_i)

--- a/bp_be/src/v/bp_be_checker/bp_be_director.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.sv
@@ -22,7 +22,7 @@ module bp_be_director
    `declare_bp_core_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
 
    // Generated parameters
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam isd_status_width_lp = `bp_be_isd_status_width(vaddr_width_p, branch_metadata_fwd_width_p)
    , localparam branch_pkt_width_lp = `bp_be_branch_pkt_width(vaddr_width_p)
    , localparam commit_pkt_width_lp = `bp_be_commit_pkt_width(vaddr_width_p, paddr_width_p)
@@ -53,7 +53,7 @@ module bp_be_director
    );
 
   // Declare parameterized structures
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 

--- a/bp_be/src/v/bp_be_checker/bp_be_instr_decoder.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_instr_decoder.sv
@@ -290,6 +290,7 @@ module bp_be_instr_decoder
                 end
               `RV64_WFI:
                 begin
+                  // WFI operates as NOP in debug mode
                   illegal_instr_o = decode_info_cast_i.tw;
                   wfi_o = ~illegal_instr_o & ~decode_info_cast_i.debug_mode;
                 end

--- a/bp_be/src/v/bp_be_checker/bp_be_instr_decoder.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_instr_decoder.sv
@@ -291,7 +291,7 @@ module bp_be_instr_decoder
               `RV64_WFI:
                 begin
                   illegal_instr_o = decode_info_cast_i.tw;
-                  wfi_o = ~illegal_instr_o;
+                  wfi_o = ~illegal_instr_o & ~decode_info_cast_i.debug_mode;
                 end
               `RV64_SFENCE_VMA:
                 begin

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -225,7 +225,7 @@ module bp_be_scheduler
       dispatch_pkt.exception.store_page_fault |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.store_page_fault_v;
       dispatch_pkt.exception.itlb_fill        |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.itlb_fill_v;
       dispatch_pkt.exception.dtlb_fill        |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.dtlb_fill_v;
-      dispatch_pkt.exception._interrupt       |= be_exc_not_instr_li & interrupt_v_i;
+      dispatch_pkt.exception._interrupt       |= be_exc_not_instr_li & interrupt_v_i & ~unfreeze_i;
       dispatch_pkt.exception.unfreeze         |= be_exc_not_instr_li & unfreeze_i;
 
       dispatch_pkt.exception.illegal_instr |= fe_instr_not_exc_li & illegal_instr_lo;

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -21,7 +21,7 @@ module bp_be_scheduler
    `declare_bp_proc_params(bp_params_p)
 
    // Generated parameters
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam fe_queue_width_lp = `bp_fe_queue_width(vaddr_width_p, branch_metadata_fwd_width_p)
    , localparam issue_pkt_width_lp = `bp_be_issue_pkt_width(vaddr_width_p, branch_metadata_fwd_width_p)
    , localparam dispatch_pkt_width_lp = `bp_be_dispatch_pkt_width(vaddr_width_p)
@@ -59,7 +59,7 @@ module bp_be_scheduler
   );
 
   // Declare parameterizable structures
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -33,6 +33,7 @@ module bp_be_scheduler
    )
   (input                               clk_i
    , input                             reset_i
+   , input [cfg_bus_width_lp-1:0]      cfg_bus_i
 
   , output [isd_status_width_lp-1:0]   isd_status_o
   , input [vaddr_width_p-1:0]          expected_npc_i
@@ -66,6 +67,7 @@ module bp_be_scheduler
   `bp_cast_i(bp_be_commit_pkt_s, commit_pkt);
   `bp_cast_i(bp_be_wb_pkt_s, iwb_pkt);
   `bp_cast_i(bp_be_wb_pkt_s, fwb_pkt);
+  `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
   bp_fe_queue_s fe_queue_lo;
   logic fe_queue_v_lo, fe_queue_yumi_li;
@@ -159,7 +161,7 @@ module bp_be_scheduler
 
   wire fe_exc_not_instr_li = fe_queue_yumi_li & (fe_queue_lo.msg_type == e_fe_exception);
   wire [vaddr_width_p-1:0] fe_exc_vaddr_li = fe_queue_lo.msg.exception.vaddr;
-  wire be_exc_not_instr_li = ptw_fill_pkt_cast_i.v | interrupt_v_i;
+  wire be_exc_not_instr_li = ptw_fill_pkt_cast_i.v | interrupt_v_i | cfg_bus_cast_i.debug;
   wire [vaddr_width_p-1:0] be_exc_vaddr_li = ptw_fill_pkt_cast_i.vaddr;
   wire [dpath_width_gp-1:0] be_exc_data_li = ptw_fill_pkt_cast_i.entry;
 
@@ -223,6 +225,7 @@ module bp_be_scheduler
       dispatch_pkt.exception.itlb_fill        |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.itlb_fill_v;
       dispatch_pkt.exception.dtlb_fill        |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.dtlb_fill_v;
       dispatch_pkt.exception._interrupt       |= be_exc_not_instr_li & interrupt_v_i;
+      dispatch_pkt.exception.dentry           |= be_exc_not_instr_li & cfg_bus_cast_i.debug;
 
       dispatch_pkt.exception.illegal_instr |= fe_instr_not_exc_li & illegal_instr_lo;
       dispatch_pkt.exception.ecall_m       |= fe_instr_not_exc_li & ecall_m_lo;

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -41,6 +41,7 @@ module bp_be_scheduler
   , input                              dispatch_v_i
   , input                              interrupt_v_i
   , input                              suppress_iss_i
+  , input                              unfreeze_i
   , input [decode_info_width_lp-1:0]   decode_info_i
 
   // Fetch interface
@@ -161,7 +162,7 @@ module bp_be_scheduler
 
   wire fe_exc_not_instr_li = fe_queue_yumi_li & (fe_queue_lo.msg_type == e_fe_exception);
   wire [vaddr_width_p-1:0] fe_exc_vaddr_li = fe_queue_lo.msg.exception.vaddr;
-  wire be_exc_not_instr_li = ptw_fill_pkt_cast_i.v | interrupt_v_i;
+  wire be_exc_not_instr_li = ptw_fill_pkt_cast_i.v | interrupt_v_i | unfreeze_i;
   wire [vaddr_width_p-1:0] be_exc_vaddr_li = ptw_fill_pkt_cast_i.vaddr;
   wire [dpath_width_gp-1:0] be_exc_data_li = ptw_fill_pkt_cast_i.entry;
 
@@ -225,6 +226,7 @@ module bp_be_scheduler
       dispatch_pkt.exception.itlb_fill        |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.itlb_fill_v;
       dispatch_pkt.exception.dtlb_fill        |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.dtlb_fill_v;
       dispatch_pkt.exception._interrupt       |= be_exc_not_instr_li & interrupt_v_i;
+      dispatch_pkt.exception.unfreeze         |= be_exc_not_instr_li & unfreeze_i;
 
       dispatch_pkt.exception.illegal_instr |= fe_instr_not_exc_li & illegal_instr_lo;
       dispatch_pkt.exception.ecall_m       |= fe_instr_not_exc_li & ecall_m_lo;

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -161,7 +161,7 @@ module bp_be_scheduler
 
   wire fe_exc_not_instr_li = fe_queue_yumi_li & (fe_queue_lo.msg_type == e_fe_exception);
   wire [vaddr_width_p-1:0] fe_exc_vaddr_li = fe_queue_lo.msg.exception.vaddr;
-  wire be_exc_not_instr_li = ptw_fill_pkt_cast_i.v | interrupt_v_i | cfg_bus_cast_i.debug;
+  wire be_exc_not_instr_li = ptw_fill_pkt_cast_i.v | interrupt_v_i;
   wire [vaddr_width_p-1:0] be_exc_vaddr_li = ptw_fill_pkt_cast_i.vaddr;
   wire [dpath_width_gp-1:0] be_exc_data_li = ptw_fill_pkt_cast_i.entry;
 
@@ -225,7 +225,6 @@ module bp_be_scheduler
       dispatch_pkt.exception.itlb_fill        |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.itlb_fill_v;
       dispatch_pkt.exception.dtlb_fill        |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.dtlb_fill_v;
       dispatch_pkt.exception._interrupt       |= be_exc_not_instr_li & interrupt_v_i;
-      dispatch_pkt.exception.dentry           |= be_exc_not_instr_li & cfg_bus_cast_i.debug;
 
       dispatch_pkt.exception.illegal_instr |= fe_instr_not_exc_li & illegal_instr_lo;
       dispatch_pkt.exception.ecall_m       |= fe_instr_not_exc_li & ecall_m_lo;

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -115,7 +115,7 @@ module bp_be_dcache
    , parameter fill_width_p   = dcache_fill_width_p
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, dcache)
 
-   , localparam cfg_bus_width_lp    = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp    = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam dcache_pkt_width_lp = `bp_be_dcache_pkt_width(vaddr_width_p)
    )
   (input                                             clk_i
@@ -1358,7 +1358,7 @@ module bp_be_dcache
   assign late_v_o       = is_late & v_dm_r;
 
   // synopsys translate_off
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
   always_ff @(negedge clk_i)

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -71,6 +71,7 @@ module bp_be_top
    , input                                           software_irq_i
    , input                                           m_external_irq_i
    , input                                           s_external_irq_i
+   , input                                           unfreeze_irq_i
    , input                                           debug_irq_i
    );
 
@@ -226,11 +227,12 @@ module bp_be_top
      ,.stat_mem_o(stat_mem_o)
      ,.stat_mem_pkt_yumi_o(stat_mem_pkt_yumi_o)
 
+     ,.unfreeze_irq_i(unfreeze_irq_i)
+     ,.debug_irq_i(debug_irq_i)
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)
      ,.m_external_irq_i(m_external_irq_i)
      ,.s_external_irq_i(s_external_irq_i)
-     ,.debug_irq_i(debug_irq_i)
      ,.irq_pending_o(irq_pending_lo)
      ,.irq_waiting_o(irq_waiting_lo)
      ,.cmd_full_n_i(cmd_full_n_lo)

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -17,7 +17,7 @@ module bp_be_top
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
 
    // Default parameters
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
   )
   (input                                             clk_i
    , input                                           reset_i

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -154,6 +154,7 @@ module bp_be_top
    scheduler
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
+     ,.cfg_bus_i(cfg_bus_i)
 
      ,.isd_status_o(isd_status)
      ,.expected_npc_i(expected_npc_lo)

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -67,12 +67,11 @@ module bp_be_top
    , output logic [dcache_stat_info_width_lp-1:0]    stat_mem_o
    , output logic                                    stat_mem_pkt_yumi_o
 
+   , input                                           debug_irq_i
    , input                                           timer_irq_i
    , input                                           software_irq_i
    , input                                           m_external_irq_i
    , input                                           s_external_irq_i
-   , input                                           unfreeze_irq_i
-   , input                                           debug_irq_i
    );
 
   // Declare parameterized structures
@@ -93,7 +92,7 @@ module bp_be_top
 
   bp_be_isd_status_s isd_status;
   logic [vaddr_width_p-1:0] expected_npc_lo;
-  logic poison_isd_lo, suppress_iss_lo;
+  logic poison_isd_lo, suppress_iss_lo, unfreeze_lo;
   logic waiting_for_irq_lo;
 
   logic cmd_full_n_lo, cmd_full_r_lo, cmd_empty_lo;
@@ -114,6 +113,7 @@ module bp_be_top
      ,.fe_cmd_v_o(fe_cmd_v_o)
      ,.fe_cmd_yumi_i(fe_cmd_yumi_i)
 
+     ,.unfreeze_o(unfreeze_lo)
      ,.suppress_iss_o(suppress_iss_lo)
      ,.poison_isd_o(poison_isd_lo)
      ,.irq_waiting_i(irq_waiting_lo)
@@ -163,6 +163,7 @@ module bp_be_top
      ,.poison_isd_i(poison_isd_lo)
      ,.dispatch_v_i(dispatch_v)
      ,.interrupt_v_i(interrupt_v)
+     ,.unfreeze_i(unfreeze_lo)
      ,.suppress_iss_i(suppress_iss_lo)
      ,.decode_info_i(decode_info_lo)
 
@@ -227,7 +228,6 @@ module bp_be_top
      ,.stat_mem_o(stat_mem_o)
      ,.stat_mem_pkt_yumi_o(stat_mem_pkt_yumi_o)
 
-     ,.unfreeze_irq_i(unfreeze_irq_i)
      ,.debug_irq_i(debug_irq_i)
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -71,6 +71,7 @@ module bp_be_top
    , input                                           software_irq_i
    , input                                           m_external_irq_i
    , input                                           s_external_irq_i
+   , input                                           debug_irq_i
    );
 
   // Declare parameterized structures
@@ -229,6 +230,7 @@ module bp_be_top
      ,.software_irq_i(software_irq_i)
      ,.m_external_irq_i(m_external_irq_i)
      ,.s_external_irq_i(s_external_irq_i)
+     ,.debug_irq_i(debug_irq_i)
      ,.irq_pending_o(irq_pending_lo)
      ,.irq_waiting_o(irq_waiting_lo)
      ,.cmd_full_n_i(cmd_full_n_lo)

--- a/bp_be/test/tb/bp_be_dcache/testbench.sv
+++ b/bp_be/test/tb/bp_be_dcache/testbench.sv
@@ -32,7 +32,7 @@ module testbench
    , parameter dram_type_p                 = BP_DRAM_FLOWVAR // Replaced by the flow with a specific dram_type
 
    // Derived parameters
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam dcache_pkt_width_lp = `bp_be_dcache_pkt_width(vaddr_width_p)
    , localparam trace_replay_data_width_lp = ptag_width_p + dcache_pkt_width_lp + 1 // The 1 extra bit is for uncached accesses
    , localparam trace_rom_addr_width_lp = 8
@@ -58,7 +58,7 @@ module testbench
     $error("Please provide a valid number of caches");
 
   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
 
   // Bit to deal with initial X->0 transition detection
   bit clk_i;

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -24,7 +24,7 @@ module wrapper
    , parameter debug_p=0
    , parameter lock_max_limit_p=8
 
-   , localparam cfg_bus_width_lp= `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp= `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
 
    , localparam dcache_pkt_width_lp = `bp_be_dcache_pkt_width(vaddr_width_p)
 
@@ -136,7 +136,7 @@ module wrapper
   logic [num_caches_p-1:0] lce_fill_has_data_lo, lce_fill_last_lo;
   logic [num_caches_p-1:0][lg_num_lce_lp-1:0] lce_fill_dst;
 
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
   for (genvar i = 0; i < num_caches_p; i++)

--- a/bp_common/software/py/nbf.py
+++ b/bp_common/software/py/nbf.py
@@ -26,32 +26,35 @@ import math
 import os
 import subprocess
 
-#  // The overall memory map of the config link is:
-#  //   16'h0000 - 16'h01ff: chip level config
-#  //   16'h0200 - 16'h03ff: fe config
-#  //   16'h0400 - 16'h05ff: be config
-#  //   16'h0600 - 16'h06ff: me config
-#  //   16'h0800 - 16'h7fff: reserved
-#  //   16'h8000 - 16'h8fff: cce ucode
-#
-#  localparam cfg_addr_width_gp = 20;
-#  localparam cfg_data_width_gp = 64;
-#
-#  localparam cfg_base_addr_gp          = 'h0200_0000;
-#  localparam cfg_reg_unused_gp         = 'h0004;
-#  localparam cfg_reg_freeze_gp         = 'h0008;
-#  localparam cfg_reg_core_id_gp        = 'h000c;
-#  localparam cfg_reg_did_gp            = 'h0010;
-#  localparam cfg_reg_cord_gp           = 'h0014;
-#  localparam cfg_reg_host_did_gp       = 'h0018;
-#  localparam cfg_reg_hio_mask_gp       = 'h001c;
-#  localparam cfg_reg_icache_id_gp      = 'h0200;
-#  localparam cfg_reg_icache_mode_gp    = 'h0204;
-#  localparam cfg_reg_dcache_id_gp      = 'h0400;
-#  localparam cfg_reg_dcache_mode_gp    = 'h0404;
-#  localparam cfg_reg_cce_id_gp         = 'h0600;
-#  localparam cfg_reg_cce_mode_gp       = 'h0604;
-#  localparam cfg_mem_base_cce_ucode_gp = 'h8000;
+##  // The overall memory map of the config link is:
+##  //   16'h0000 - 16'h01ff: chip level config
+##  //   16'h0200 - 16'h03ff: fe config
+##  //   16'h0400 - 16'h05ff: be config
+##  //   16'h0600 - 16'h07ff: me config
+##  //   16'h0800 - 16'h7fff: reserved
+##  //   16'h8000 - 16'h8fff: cce ucode
+##
+##  localparam cfg_base_addr_gp           = (dev_id_width_gp+dev_addr_width_gp)'('h0020_0000);
+##  localparam cfg_match_addr_gp          = (dev_id_width_gp+dev_addr_width_gp)'('h002?_????);
+##
+##  localparam cfg_reg_unused_gp          = (dev_addr_width_gp)'('h0_0004);
+##  localparam cfg_reg_freeze_gp          = (dev_addr_width_gp)'('h0_0008);
+##  localparam cfg_reg_core_id_gp         = (dev_addr_width_gp)'('h0_000c);
+##  localparam cfg_reg_did_gp             = (dev_addr_width_gp)'('h0_0010);
+##  localparam cfg_reg_cord_gp            = (dev_addr_width_gp)'('h0_0014);
+##  localparam cfg_reg_host_did_gp        = (dev_addr_width_gp)'('h0_0018);
+##  // Used until PMP are setup properly
+##  localparam cfg_reg_hio_mask_gp        = (dev_addr_width_gp)'('h0_001c);
+##  localparam cfg_reg_debug_gp           = (dev_addr_width_gp)'('h0_0020);
+##  localparam cfg_reg_debug_pc_gp        = (dev_addr_width_gp)'('h0_0024);
+##  localparam cfg_reg_icache_id_gp       = (dev_addr_width_gp)'('h0_0200);
+##  localparam cfg_reg_icache_mode_gp     = (dev_addr_width_gp)'('h0_0204);
+##  localparam cfg_reg_dcache_id_gp       = (dev_addr_width_gp)'('h0_0400);
+##  localparam cfg_reg_dcache_mode_gp     = (dev_addr_width_gp)'('h0_0404);
+##  localparam cfg_reg_cce_id_gp          = (dev_addr_width_gp)'('h0_0600);
+##  localparam cfg_reg_cce_mode_gp        = (dev_addr_width_gp)'('h0_0604);
+##  localparam cfg_mem_cce_ucode_base_gp  = (dev_addr_width_gp)'('h0_8000);
+##  localparam cfg_mem_cce_ucode_match_gp = (dev_addr_width_gp)'('h0_8???);
 
 cfg_base_addr          = 0x200000
 cfg_reg_unused         = 0x0004
@@ -61,6 +64,8 @@ cfg_reg_did            = 0x0010
 cfg_reg_cord           = 0x0014
 cfg_reg_host_did       = 0x0018
 cfg_reg_hio_mask       = 0x001c
+cfg_reg_debug          = 0x0020
+cfg_reg_debug_pc       = 0x0024
 cfg_reg_icache_id      = 0x0200
 cfg_reg_icache_mode    = 0x0204
 cfg_reg_dcache_id      = 0x0400
@@ -223,6 +228,9 @@ class NBF:
 
     # Freeze set
     self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_freeze, 1)
+    # Debug set
+    self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_debug_pc, 0x00110000)
+    self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_debug, 1)
 
     self.print_fence()
 

--- a/bp_common/software/py/nbf.py
+++ b/bp_common/software/py/nbf.py
@@ -45,8 +45,7 @@ import subprocess
 ##  localparam cfg_reg_host_did_gp        = (dev_addr_width_gp)'('h0_0018);
 ##  // Used until PMP are setup properly
 ##  localparam cfg_reg_hio_mask_gp        = (dev_addr_width_gp)'('h0_001c);
-##  localparam cfg_reg_debug_gp           = (dev_addr_width_gp)'('h0_0020);
-##  localparam cfg_reg_debug_pc_gp        = (dev_addr_width_gp)'('h0_0024);
+##  localparam cfg_reg_debug_pc_gp        = (dev_addr_width_gp)'('h0_0020);
 ##  localparam cfg_reg_icache_id_gp       = (dev_addr_width_gp)'('h0_0200);
 ##  localparam cfg_reg_icache_mode_gp     = (dev_addr_width_gp)'('h0_0204);
 ##  localparam cfg_reg_dcache_id_gp       = (dev_addr_width_gp)'('h0_0400);
@@ -64,8 +63,7 @@ cfg_reg_did            = 0x0010
 cfg_reg_cord           = 0x0014
 cfg_reg_host_did       = 0x0018
 cfg_reg_hio_mask       = 0x001c
-cfg_reg_debug          = 0x0020
-cfg_reg_debug_pc       = 0x0024
+cfg_reg_debug_pc       = 0x0020
 cfg_reg_icache_id      = 0x0200
 cfg_reg_icache_mode    = 0x0204
 cfg_reg_dcache_id      = 0x0400
@@ -76,6 +74,7 @@ cfg_mem_base_cce_ucode = 0x8000
 
 clint_base_addr       = 0x300000
 clint_reg_mtimesel    = 0x8000
+clint_reg_debug       = 0xc000
 
 cfg_core_offset = 24
 
@@ -230,9 +229,10 @@ class NBF:
     self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_freeze, 1)
     # Debug set
     self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_debug_pc, 0x00110000)
-    self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_debug, 1)
+    self.print_nbf_allcores(3, clint_base_addr + clint_reg_debug, 1)
 
     self.print_fence()
+    self.print_nbf_allcores(3, clint_base_addr + clint_reg_debug, 0)
 
     # For regular execution, the CCE ucode and cache/CCE modes are loaded by the bootrom
     if self.config:

--- a/bp_common/software/py/nbf.py
+++ b/bp_common/software/py/nbf.py
@@ -228,10 +228,10 @@ class NBF:
     self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_freeze, 1)
     # Debug set
     self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_npc, 0x00110000)
-    #self.print_nbf_allcores(3, clint_base_addr + clint_reg_debug, 1)
+    self.print_nbf_allcores(3, clint_base_addr + clint_reg_debug, 1)
 
     self.print_fence()
-    #self.print_nbf_allcores(3, clint_base_addr + clint_reg_debug, 0)
+    self.print_nbf_allcores(3, clint_base_addr + clint_reg_debug, 0)
 
     # For regular execution, the CCE ucode and cache/CCE modes are loaded by the bootrom
     if self.config:

--- a/bp_common/software/py/nbf.py
+++ b/bp_common/software/py/nbf.py
@@ -37,15 +37,15 @@ import subprocess
 ##  localparam cfg_base_addr_gp           = (dev_id_width_gp+dev_addr_width_gp)'('h0020_0000);
 ##  localparam cfg_match_addr_gp          = (dev_id_width_gp+dev_addr_width_gp)'('h002?_????);
 ##
-##  localparam cfg_reg_unused_gp          = (dev_addr_width_gp)'('h0_0004);
-##  localparam cfg_reg_freeze_gp          = (dev_addr_width_gp)'('h0_0008);
+##  localparam cfg_reg_freeze_gp          = (dev_addr_width_gp)'('h0_0004);
+##  localparam cfg_reg_npc_gp             = (dev_addr_width_gp)'('h0_0008);
 ##  localparam cfg_reg_core_id_gp         = (dev_addr_width_gp)'('h0_000c);
 ##  localparam cfg_reg_did_gp             = (dev_addr_width_gp)'('h0_0010);
 ##  localparam cfg_reg_cord_gp            = (dev_addr_width_gp)'('h0_0014);
 ##  localparam cfg_reg_host_did_gp        = (dev_addr_width_gp)'('h0_0018);
 ##  // Used until PMP are setup properly
 ##  localparam cfg_reg_hio_mask_gp        = (dev_addr_width_gp)'('h0_001c);
-##  localparam cfg_reg_debug_pc_gp        = (dev_addr_width_gp)'('h0_0020);
+##  localparam cfg_reg_npc_gp        = (dev_addr_width_gp)'('h0_0020);
 ##  localparam cfg_reg_icache_id_gp       = (dev_addr_width_gp)'('h0_0200);
 ##  localparam cfg_reg_icache_mode_gp     = (dev_addr_width_gp)'('h0_0204);
 ##  localparam cfg_reg_dcache_id_gp       = (dev_addr_width_gp)'('h0_0400);
@@ -56,14 +56,13 @@ import subprocess
 ##  localparam cfg_mem_cce_ucode_match_gp = (dev_addr_width_gp)'('h0_8???);
 
 cfg_base_addr          = 0x200000
-cfg_reg_unused         = 0x0004
-cfg_reg_freeze         = 0x0008
+cfg_reg_freeze         = 0x0004
+cfg_reg_npc            = 0x0008
 cfg_reg_core_id        = 0x000c
 cfg_reg_did            = 0x0010
 cfg_reg_cord           = 0x0014
 cfg_reg_host_did       = 0x0018
 cfg_reg_hio_mask       = 0x001c
-cfg_reg_debug_pc       = 0x0020
 cfg_reg_icache_id      = 0x0200
 cfg_reg_icache_mode    = 0x0204
 cfg_reg_dcache_id      = 0x0400
@@ -228,11 +227,11 @@ class NBF:
     # Freeze set
     self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_freeze, 1)
     # Debug set
-    self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_debug_pc, 0x00110000)
-    self.print_nbf_allcores(3, clint_base_addr + clint_reg_debug, 1)
+    self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_npc, 0x00110000)
+    #self.print_nbf_allcores(3, clint_base_addr + clint_reg_debug, 1)
 
     self.print_fence()
-    self.print_nbf_allcores(3, clint_base_addr + clint_reg_debug, 0)
+    #self.print_nbf_allcores(3, clint_base_addr + clint_reg_debug, 0)
 
     # For regular execution, the CCE ucode and cache/CCE modes are loaded by the bootrom
     if self.config:

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -93,12 +93,6 @@
     //   Currently unused, so set to 1 bit
     integer unsigned asid_width;
 
-    // The virtual address of the PC coming out of reset
-    integer unsigned boot_pc;
-    // 0: boots in M-mode, not debug-mode
-    // 1: boots in M-mode, debug-mode
-    integer unsigned boot_in_debug;
-
     // Branch metadata information for the Front End
     // Must be kept consistent with FE
     integer unsigned branch_metadata_fwd_width;
@@ -257,9 +251,6 @@
       ,caddr_width: 32
       ,asid_width : 1
 
-      ,boot_pc       : dram_base_addr_gp
-      ,boot_in_debug : 0
-
       ,branch_metadata_fwd_width: 39
       ,btb_tag_width            : 9
       ,btb_idx_width            : 6
@@ -363,9 +354,6 @@
       ,`bp_aviary_define_override(daddr_width, BP_DADDR_WIDTH, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(caddr_width, BP_CADDR_WIDTH, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(asid_width, BP_ASID_WIDTH, `BP_CUSTOM_BASE_CFG)
-
-      ,`bp_aviary_define_override(boot_pc, BP_BOOT_PC, `BP_CUSTOM_BASE_CFG)
-      ,`bp_aviary_define_override(boot_in_debug, BP_BOOT_IN_DEBUG, `BP_CUSTOM_BASE_CFG)
 
       ,`bp_aviary_define_override(fe_queue_fifo_els, BP_FE_QUEUE_WIDTH, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(fe_cmd_fifo_els, BP_FE_CMD_WIDTH, `BP_CUSTOM_BASE_CFG)

--- a/bp_common/src/include/bp_common_aviary_defines.svh
+++ b/bp_common/src/include/bp_common_aviary_defines.svh
@@ -44,9 +44,6 @@
     , localparam asid_width_p    = proc_param_lp.asid_width                                        \
     , localparam hio_width_p     = paddr_width_p - daddr_width_p                                   \
                                                                                                    \
-    , localparam boot_pc_p       = proc_param_lp.boot_pc                                           \
-    , localparam boot_in_debug_p = proc_param_lp.boot_in_debug                                     \
-                                                                                                   \
     , localparam branch_metadata_fwd_width_p = proc_param_lp.branch_metadata_fwd_width             \
     , localparam btb_tag_width_p             = proc_param_lp.btb_tag_width                         \
     , localparam btb_idx_width_p             = proc_param_lp.btb_idx_width                         \
@@ -198,9 +195,6 @@
           ,`bp_aviary_parameter_override(daddr_width, override_cfg_mp, default_cfg_mp)             \
           ,`bp_aviary_parameter_override(caddr_width, override_cfg_mp, default_cfg_mp)             \
           ,`bp_aviary_parameter_override(asid_width, override_cfg_mp, default_cfg_mp)              \
-                                                                                                   \
-          ,`bp_aviary_parameter_override(boot_pc, override_cfg_mp, default_cfg_mp)                 \
-          ,`bp_aviary_parameter_override(boot_in_debug, override_cfg_mp, default_cfg_mp)           \
                                                                                                    \
           ,`bp_aviary_parameter_override(fe_queue_fifo_els, override_cfg_mp, default_cfg_mp)       \
           ,`bp_aviary_parameter_override(fe_cmd_fifo_els, override_cfg_mp, default_cfg_mp)         \

--- a/bp_common/src/include/bp_common_aviary_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_pkgdef.svh
@@ -7,16 +7,6 @@
   // Default configuration is unicore
   localparam bp_proc_param_s bp_unicore_cfg_p = bp_default_cfg_p;
 
-  localparam bp_proc_param_s bp_unicore_bootrom_override_p =
-    '{boot_pc        : bootrom_base_addr_gp
-      ,boot_in_debug : 1
-      ,default : "inv"
-      };
-  `bp_aviary_derive_cfg(bp_unicore_bootrom_cfg_p
-                        ,bp_unicore_bootrom_override_p
-                        ,bp_unicore_cfg_p
-                        );
-
   localparam bp_proc_param_s bp_unicore_no_l2_override_p =
     '{l2_en : 0
       ,default : "inv"
@@ -226,16 +216,6 @@
       };
   `bp_aviary_derive_cfg(bp_multicore_1_l2e_cfg_p
                         ,bp_multicore_1_l2e_override_p
-                        ,bp_multicore_1_cfg_p
-                        );
-
-  localparam bp_proc_param_s bp_multicore_1_bootrom_override_p =
-    '{boot_pc        : bootrom_base_addr_gp
-      ,boot_in_debug : 1
-      ,default : "inv"
-      };
-  `bp_aviary_derive_cfg(bp_multicore_1_bootrom_cfg_p
-                        ,bp_multicore_1_bootrom_override_p
                         ,bp_multicore_1_cfg_p
                         );
 
@@ -449,16 +429,6 @@
                         ,bp_multicore_1_cfg_p
                         );
 
-  localparam bp_proc_param_s bp_multicore_1_cce_ucode_bootrom_override_p =
-    '{boot_pc        : bootrom_base_addr_gp
-      ,boot_in_debug : 1
-      ,default : "inv"
-      };
-  `bp_aviary_derive_cfg(bp_multicore_1_cce_ucode_bootrom_cfg_p
-                        ,bp_multicore_1_cce_ucode_bootrom_override_p
-                        ,bp_multicore_1_cfg_p
-                        );
-
   localparam bp_proc_param_s bp_multicore_1_cce_ucode_paddr_large_override_p =
     '{paddr_width : 44
       ,default : "inv"
@@ -564,7 +534,6 @@
     ,bp_multicore_2_cce_ucode_cfg_p
     ,bp_multicore_1_cce_ucode_paddr_small_cfg_p
     ,bp_multicore_1_cce_ucode_paddr_large_cfg_p
-    ,bp_multicore_1_cce_ucode_bootrom_cfg_p
     ,bp_multicore_1_cce_ucode_cfg_p
 
     // Multicore configurations
@@ -580,7 +549,6 @@
     ,bp_multicore_1_l1_small_cfg_p
     ,bp_multicore_1_l1_medium_cfg_p
     ,bp_multicore_1_no_l2_cfg_p
-    ,bp_multicore_1_bootrom_cfg_p
     ,bp_multicore_1_cfg_p
 
     // Unicore configurations
@@ -595,7 +563,6 @@
     ,bp_unicore_l1_small_cfg_p
     ,bp_unicore_l1_medium_cfg_p
     ,bp_unicore_no_l2_cfg_p
-    ,bp_unicore_bootrom_cfg_p
     ,bp_unicore_cfg_p
 
     // A custom BP configuration generated from Makefile
@@ -609,58 +576,55 @@
   typedef enum bit [lg_max_cfgs-1:0]
   {
     // L2 extension configurations
-    e_bp_multicore_4_l2e_cfg                        = 46
-    ,e_bp_multicore_2_l2e_cfg                       = 45
-    ,e_bp_multicore_1_l2e_cfg                       = 44
+    e_bp_multicore_4_l2e_cfg                        = 43
+    ,e_bp_multicore_2_l2e_cfg                       = 42
+    ,e_bp_multicore_1_l2e_cfg                       = 41
 
     // Accelerator configurations
-    ,e_bp_multicore_4_acc_vdp_cfg                   = 43
-    ,e_bp_multicore_4_acc_loopback_cfg              = 42
-    ,e_bp_multicore_1_acc_vdp_cfg                   = 41
-    ,e_bp_multicore_1_acc_loopback_cfg              = 40
+    ,e_bp_multicore_4_acc_vdp_cfg                   = 40
+    ,e_bp_multicore_4_acc_loopback_cfg              = 39
+    ,e_bp_multicore_1_acc_vdp_cfg                   = 38
+    ,e_bp_multicore_1_acc_loopback_cfg              = 37
 
     // Ucode configurations
-    ,e_bp_multicore_16_cce_ucode_cfg                = 39
-    ,e_bp_multicore_12_cce_ucode_cfg                = 38
-    ,e_bp_multicore_8_cce_ucode_cfg                 = 37
-    ,e_bp_multicore_6_cce_ucode_cfg                 = 36
-    ,e_bp_multicore_4_cce_ucode_cfg                 = 35
-    ,e_bp_multicore_3_cce_ucode_cfg                 = 34
-    ,e_bp_multicore_2_cce_ucode_cfg                 = 33
-    ,e_bp_multicore_1_cce_ucode_paddr_small_cfg     = 32
-    ,e_bp_multicore_1_cce_ucode_paddr_large_cfg     = 31
-    ,e_bp_multicore_1_cce_ucode_bootrom_cfg         = 30
-    ,e_bp_multicore_1_cce_ucode_cfg                 = 29
+    ,e_bp_multicore_16_cce_ucode_cfg                = 36
+    ,e_bp_multicore_12_cce_ucode_cfg                = 35
+    ,e_bp_multicore_8_cce_ucode_cfg                 = 34
+    ,e_bp_multicore_6_cce_ucode_cfg                 = 33
+    ,e_bp_multicore_4_cce_ucode_cfg                 = 32
+    ,e_bp_multicore_3_cce_ucode_cfg                 = 31
+    ,e_bp_multicore_2_cce_ucode_cfg                 = 30
+    ,e_bp_multicore_1_cce_ucode_paddr_small_cfg     = 29
+    ,e_bp_multicore_1_cce_ucode_paddr_large_cfg     = 28
+    ,e_bp_multicore_1_cce_ucode_cfg                 = 27
 
     // Multicore configurations
-    ,e_bp_multicore_16_cfg                          = 28
-    ,e_bp_multicore_12_cfg                          = 27
-    ,e_bp_multicore_8_cfg                           = 26
-    ,e_bp_multicore_6_cfg                           = 25
-    ,e_bp_multicore_4_cfg                           = 24
-    ,e_bp_multicore_3_cfg                           = 23
-    ,e_bp_multicore_2_cfg                           = 22
-    ,e_bp_multicore_1_paddr_small_cfg               = 21
-    ,e_bp_multicore_1_paddr_large_cfg               = 20
-    ,e_bp_multicore_1_l1_small_cfg                  = 19
-    ,e_bp_multicore_1_l1_medium_cfg                 = 18
-    ,e_bp_multicore_1_no_l2_cfg                     = 17
-    ,e_bp_multicore_1_bootrom_cfg                   = 16
-    ,e_bp_multicore_1_cfg                           = 15
+    ,e_bp_multicore_16_cfg                          = 26
+    ,e_bp_multicore_12_cfg                          = 25
+    ,e_bp_multicore_8_cfg                           = 24
+    ,e_bp_multicore_6_cfg                           = 23
+    ,e_bp_multicore_4_cfg                           = 22
+    ,e_bp_multicore_3_cfg                           = 21
+    ,e_bp_multicore_2_cfg                           = 20
+    ,e_bp_multicore_1_paddr_small_cfg               = 19
+    ,e_bp_multicore_1_paddr_large_cfg               = 18
+    ,e_bp_multicore_1_l1_small_cfg                  = 17
+    ,e_bp_multicore_1_l1_medium_cfg                 = 16
+    ,e_bp_multicore_1_no_l2_cfg                     = 15
+    ,e_bp_multicore_1_cfg                           = 14
 
     // Unicore configurations
-    ,e_bp_unicore_tinyparrot_cfg                    = 14
-    ,e_bp_unicore_paddr_small_cfg                   = 13
-    ,e_bp_unicore_paddr_large_cfg                   = 12
-    ,e_bp_unicore_writethrough_cfg                  = 11
-    ,e_bp_unicore_l2_atomic_cfg                     = 10
-    ,e_bp_unicore_l1_wide_cfg                       = 9
-    ,e_bp_unicore_l1_hetero_cfg                     = 8
-    ,e_bp_unicore_l1_tiny_cfg                       = 7
-    ,e_bp_unicore_l1_small_cfg                      = 6
-    ,e_bp_unicore_l1_medium_cfg                     = 5
-    ,e_bp_unicore_no_l2_cfg                         = 4
-    ,e_bp_unicore_bootrom_cfg                       = 3
+    ,e_bp_unicore_tinyparrot_cfg                    = 13
+    ,e_bp_unicore_paddr_small_cfg                   = 12
+    ,e_bp_unicore_paddr_large_cfg                   = 11
+    ,e_bp_unicore_writethrough_cfg                  = 10
+    ,e_bp_unicore_l2_atomic_cfg                     = 9
+    ,e_bp_unicore_l1_wide_cfg                       = 8
+    ,e_bp_unicore_l1_hetero_cfg                     = 7
+    ,e_bp_unicore_l1_tiny_cfg                       = 6
+    ,e_bp_unicore_l1_small_cfg                      = 5
+    ,e_bp_unicore_l1_medium_cfg                     = 4
+    ,e_bp_unicore_no_l2_cfg                         = 3
     ,e_bp_unicore_cfg                               = 2
 
     // A custom BP configuration generated from `defines

--- a/bp_common/src/include/bp_common_cfg_bus_defines.svh
+++ b/bp_common/src/include/bp_common_cfg_bus_defines.svh
@@ -6,7 +6,7 @@
     {                                                 \
       logic                        freeze;            \
       /* TODO: vaddr */                               \
-      logic [38:0]                 debug_pc;          \
+      logic [38:0]                 npc;               \
       logic [core_id_width_mp-1:0] core_id;           \
       logic [lce_id_width_mp-1:0]  icache_id;         \
       bp_lce_mode_e                icache_mode;       \
@@ -19,6 +19,7 @@
 
   `define bp_cfg_bus_width(hio_width_mp, core_id_width_mp, cce_id_width_mp, lce_id_width_mp) \
     (1                                \
+      /* TODO: vaddr */               \
      + 39                             \
      + core_id_width_mp               \
      + lce_id_width_mp                \

--- a/bp_common/src/include/bp_common_cfg_bus_defines.svh
+++ b/bp_common/src/include/bp_common_cfg_bus_defines.svh
@@ -5,6 +5,9 @@
     typedef struct packed                             \
     {                                                 \
       logic                        freeze;            \
+      logic                        debug;             \
+      /* TODO: vaddr */                               \
+      logic [38:0]                 debug_pc;          \
       logic [core_id_width_mp-1:0] core_id;           \
       logic [lce_id_width_mp-1:0]  icache_id;         \
       bp_lce_mode_e                icache_mode;       \
@@ -16,7 +19,8 @@
     }  bp_cfg_bus_s
 
   `define bp_cfg_bus_width(hio_width_mp, core_id_width_mp, cce_id_width_mp, lce_id_width_mp) \
-    (1                                \
+    (2                                \
+     + 39                             \
      + core_id_width_mp               \
      + lce_id_width_mp                \
      + $bits(bp_lce_mode_e)           \

--- a/bp_common/src/include/bp_common_cfg_bus_defines.svh
+++ b/bp_common/src/include/bp_common_cfg_bus_defines.svh
@@ -5,7 +5,6 @@
     typedef struct packed                             \
     {                                                 \
       logic                        freeze;            \
-      logic                        debug;             \
       /* TODO: vaddr */                               \
       logic [38:0]                 debug_pc;          \
       logic [core_id_width_mp-1:0] core_id;           \
@@ -19,7 +18,7 @@
     }  bp_cfg_bus_s
 
   `define bp_cfg_bus_width(hio_width_mp, core_id_width_mp, cce_id_width_mp, lce_id_width_mp) \
-    (2                                \
+    (1                                \
      + 39                             \
      + core_id_width_mp               \
      + lce_id_width_mp                \

--- a/bp_common/src/include/bp_common_cfg_bus_defines.svh
+++ b/bp_common/src/include/bp_common_cfg_bus_defines.svh
@@ -1,12 +1,11 @@
 `ifndef BP_COMMON_CFG_BUS_DEFINES_SVH
 `define BP_COMMON_CFG_BUS_DEFINES_SVH
 
-  `define declare_bp_cfg_bus_s(hio_width_mp, core_id_width_mp, cce_id_width_mp, lce_id_width_mp) \
+  `define declare_bp_cfg_bus_s(vaddr_width_mp, hio_width_mp, core_id_width_mp, cce_id_width_mp, lce_id_width_mp) \
     typedef struct packed                             \
     {                                                 \
       logic                        freeze;            \
-      /* TODO: vaddr */                               \
-      logic [38:0]                 npc;               \
+      logic [vaddr_width_mp-1:0]   npc;               \
       logic [core_id_width_mp-1:0] core_id;           \
       logic [lce_id_width_mp-1:0]  icache_id;         \
       bp_lce_mode_e                icache_mode;       \
@@ -17,10 +16,9 @@
       logic [hio_width_mp-1:0]     hio_mask;          \
     }  bp_cfg_bus_s
 
-  `define bp_cfg_bus_width(hio_width_mp, core_id_width_mp, cce_id_width_mp, lce_id_width_mp) \
+  `define bp_cfg_bus_width(vaddr_width_mp, hio_width_mp, core_id_width_mp, cce_id_width_mp, lce_id_width_mp) \
     (1                                \
-      /* TODO: vaddr */               \
-     + 39                             \
+     + vaddr_width_mp                 \
      + core_id_width_mp               \
      + lce_id_width_mp                \
      + $bits(bp_lce_mode_e)           \

--- a/bp_common/src/include/bp_common_cfg_bus_pkgdef.svh
+++ b/bp_common/src/include/bp_common_cfg_bus_pkgdef.svh
@@ -41,8 +41,7 @@
   localparam cfg_reg_host_did_gp        = (dev_addr_width_gp)'('h0_0018);
   // Used until PMP are setup properly
   localparam cfg_reg_hio_mask_gp        = (dev_addr_width_gp)'('h0_001c);
-  localparam cfg_reg_debug_gp           = (dev_addr_width_gp)'('h0_0020);
-  localparam cfg_reg_debug_pc_gp        = (dev_addr_width_gp)'('h0_0024);
+  localparam cfg_reg_debug_pc_gp        = (dev_addr_width_gp)'('h0_0020);
   localparam cfg_reg_icache_id_gp       = (dev_addr_width_gp)'('h0_0200);
   localparam cfg_reg_icache_mode_gp     = (dev_addr_width_gp)'('h0_0204);
   localparam cfg_reg_dcache_id_gp       = (dev_addr_width_gp)'('h0_0400);

--- a/bp_common/src/include/bp_common_cfg_bus_pkgdef.svh
+++ b/bp_common/src/include/bp_common_cfg_bus_pkgdef.svh
@@ -39,7 +39,10 @@
   localparam cfg_reg_did_gp             = (dev_addr_width_gp)'('h0_0010);
   localparam cfg_reg_cord_gp            = (dev_addr_width_gp)'('h0_0014);
   localparam cfg_reg_host_did_gp        = (dev_addr_width_gp)'('h0_0018);
+  // Used until PMP are setup properly
   localparam cfg_reg_hio_mask_gp        = (dev_addr_width_gp)'('h0_001c);
+  localparam cfg_reg_debug_gp           = (dev_addr_width_gp)'('h0_0020);
+  localparam cfg_reg_debug_pc_gp        = (dev_addr_width_gp)'('h0_0024);
   localparam cfg_reg_icache_id_gp       = (dev_addr_width_gp)'('h0_0200);
   localparam cfg_reg_icache_mode_gp     = (dev_addr_width_gp)'('h0_0204);
   localparam cfg_reg_dcache_id_gp       = (dev_addr_width_gp)'('h0_0400);

--- a/bp_common/src/include/bp_common_cfg_bus_pkgdef.svh
+++ b/bp_common/src/include/bp_common_cfg_bus_pkgdef.svh
@@ -33,15 +33,14 @@
   localparam cfg_base_addr_gp           = (dev_id_width_gp+dev_addr_width_gp)'('h0020_0000);
   localparam cfg_match_addr_gp          = (dev_id_width_gp+dev_addr_width_gp)'('h002?_????);
 
-  localparam cfg_reg_unused_gp          = (dev_addr_width_gp)'('h0_0004);
-  localparam cfg_reg_freeze_gp          = (dev_addr_width_gp)'('h0_0008);
+  localparam cfg_reg_freeze_gp          = (dev_addr_width_gp)'('h0_0004);
+  localparam cfg_reg_npc_gp             = (dev_addr_width_gp)'('h0_0008);
   localparam cfg_reg_core_id_gp         = (dev_addr_width_gp)'('h0_000c);
   localparam cfg_reg_did_gp             = (dev_addr_width_gp)'('h0_0010);
   localparam cfg_reg_cord_gp            = (dev_addr_width_gp)'('h0_0014);
   localparam cfg_reg_host_did_gp        = (dev_addr_width_gp)'('h0_0018);
   // Used until PMP are setup properly
   localparam cfg_reg_hio_mask_gp        = (dev_addr_width_gp)'('h0_001c);
-  localparam cfg_reg_debug_pc_gp        = (dev_addr_width_gp)'('h0_0020);
   localparam cfg_reg_icache_id_gp       = (dev_addr_width_gp)'('h0_0200);
   localparam cfg_reg_icache_mode_gp     = (dev_addr_width_gp)'('h0_0204);
   localparam cfg_reg_dcache_id_gp       = (dev_addr_width_gp)'('h0_0400);

--- a/bp_common/src/include/bp_common_clint_pkgdef.svh
+++ b/bp_common/src/include/bp_common_clint_pkgdef.svh
@@ -17,8 +17,12 @@
 
   localparam mtime_reg_addr_gp          = dev_addr_width_gp'('h0_bff8);
   localparam mtime_reg_match_addr_gp    = dev_addr_width_gp'('h0_bff?);
+
+  localparam plic_reg_base_addr_gp      = dev_addr_width_gp'('h0_b000);
   localparam plic_reg_match_addr_gp     = dev_addr_width_gp'('h0_b00?);
 
+  localparam debug_reg_base_addr_gp     = dev_addr_width_gp'('h0_c000);
+  localparam debug_reg_match_addr_gp    = dev_addr_width_gp'('h0_c???);
 
 `endif
 

--- a/bp_common/src/include/bp_common_rv64_csr_defines.svh
+++ b/bp_common/src/include/bp_common_rv64_csr_defines.svh
@@ -695,6 +695,7 @@
     logic       stepie;                                                                    \
     logic [3:0] cause;                                                                     \
     logic [1:0] prv;                                                                       \
+    logic       mprven;                                                                    \
     logic       step;                                                                      \
   }  bp_dcsr_s;                                                                            \
                                                                                            \
@@ -1008,6 +1009,7 @@
       ,cause  : data_cast_mp.cause   \
       ,prv    : data_cast_mp.prv     \
       ,step   : data_cast_mp.step    \
+      ,mprven : data_cast_mp.mprven  \
       }
 
   `define decompress_dcsr_s(data_comp_mp) \
@@ -1019,7 +1021,7 @@
       ,stopcount: 1'b0                  \
       ,stoptime : 1'b0                  \
       ,cause    : data_comp_mp.cause    \
-      ,mprven   : 1'b0                  \
+      ,mprven   : data_comp_mp.mprven   \
       ,nmip     : 1'b0                  \
       ,step     : data_comp_mp.step     \
       ,prv      : data_comp_mp.prv      \

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -43,7 +43,7 @@ module bp_fe_icache
    , parameter fill_width_p  = icache_fill_width_p
 
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, icache)
-   , localparam cfg_bus_width_lp    = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp    = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    , localparam icache_pkt_width_lp = `bp_fe_icache_pkt_width(vaddr_width_p)
    )
   (input                                              clk_i
@@ -106,7 +106,7 @@ module bp_fe_icache
    );
 
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, icache);
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
   // Various localparameters

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -14,7 +14,7 @@ module bp_fe_top
    `declare_bp_core_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    )
   (input                                              clk_i
    , input                                            reset_i
@@ -58,7 +58,7 @@ module bp_fe_top
    );
 
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_fe_branch_metadata_fwd_s(btb_tag_width_p, btb_idx_width_p, bht_idx_width_p, ghist_width_p, bht_row_width_p);
   bp_fe_cmd_s fe_cmd_cast_i;
   assign fe_cmd_cast_i = fe_cmd_i;

--- a/bp_fe/test/tb/bp_fe_icache/testbench.sv
+++ b/bp_fe/test/tb/bp_fe_icache/testbench.sv
@@ -22,7 +22,7 @@ module testbench
    // DRAM parameters
    , parameter dram_type_p                 = BP_DRAM_FLOWVAR // Replaced by the flow with a specific dram_type
 
-  , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+  , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
   , localparam trace_replay_data_width_lp = ptag_width_p + vaddr_width_p + 1
   , localparam trace_rom_addr_width_lp = 7
 
@@ -41,7 +41,7 @@ module testbench
     $error("Memory fetch block width does not match icache block width");
 
   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
 
   // Bit to deal with initial X->0 transition detection
   bit clk_i;

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -14,7 +14,7 @@ module wrapper
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    )
   (input                                     clk_i
    , input                                   reset_i
@@ -48,7 +48,7 @@ module wrapper
    , input                                   mem_resp_last_i
    );
 
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   bp_cfg_bus_s cfg_bus_cast_i;
   assign cfg_bus_cast_i = cfg_bus_i;
 

--- a/bp_me/src/v/cce/bp_cce.sv
+++ b/bp_me/src/v/cce/bp_cce.sv
@@ -27,7 +27,7 @@ module bp_cce
     , localparam lg_cce_way_groups_lp      = `BSG_SAFE_CLOG2(cce_way_groups_p)
 
     // Interface Widths
-    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
     `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
     `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
   )
@@ -101,7 +101,7 @@ module bp_cce
   `declare_bp_cce_mshr_s(lce_id_width_p, lce_assoc_p, paddr_width_p);
 
   // Config Interface
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
 
   // LCE-CCE Interface structs
   bp_bedrock_lce_req_header_s  lce_req_header_cast_li;

--- a/bp_me/src/v/cce/bp_cce_fsm.sv
+++ b/bp_me/src/v/cce/bp_cce_fsm.sv
@@ -37,7 +37,7 @@ module bp_cce_fsm
     , localparam num_way_groups_lp         = `BSG_CDIV(cce_way_groups_p, num_cce_p)
     , localparam lg_num_way_groups_lp      = `BSG_SAFE_CLOG2(num_way_groups_lp)
     , localparam inst_ram_addr_width_lp    = `BSG_SAFE_CLOG2(num_cce_instr_ram_els_p)
-    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
 
     // maximal number of tag sets stored in the directory for all LCE types
     , localparam max_tag_sets_lp           = `BSG_CDIV(lce_sets_p, num_cce_p)
@@ -220,7 +220,7 @@ module bp_cce_fsm
       );
 
   // Config bus
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   bp_cfg_bus_s cfg_bus_cast_i;
   assign cfg_bus_cast_i = cfg_bus_i;
   wire cce_normal_mode_li = (cfg_bus_cast_i.cce_mode == e_cce_mode_normal);

--- a/bp_me/src/v/cce/bp_cce_inst_ram.sv
+++ b/bp_me/src/v/cce/bp_cce_inst_ram.sv
@@ -24,7 +24,7 @@ module bp_cce_inst_ram
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
     // Derived parameters
-    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
   )
   (input                                         clk_i
    , input                                       reset_i
@@ -54,7 +54,7 @@ module bp_cce_inst_ram
   if ($bits(bp_cce_inst_s) != cce_instr_width_gp)
     $error("Param cce_instr_width_gp does not match width of bp_cce_inst_s");
 
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   bp_cfg_bus_s cfg_bus_cast_i;
   assign cfg_bus_cast_i = cfg_bus_i;
 

--- a/bp_me/src/v/cce/bp_cce_msg.sv
+++ b/bp_me/src/v/cce/bp_cce_msg.sv
@@ -34,7 +34,7 @@ module bp_cce_msg
 
     // Interface Widths
     , localparam mshr_width_lp             = `bp_cce_mshr_width(lce_id_width_p, lce_assoc_p, paddr_width_p)
-    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
     `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
     `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
@@ -157,7 +157,7 @@ module bp_cce_msg
   `bp_cast_i(bp_bedrock_lce_resp_header_s, lce_resp_header);
 
   // Config bus
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   bp_cfg_bus_s cfg_bus_cast_i;
   assign cfg_bus_cast_i = cfg_bus_i;
   wire cce_normal_mode_li = (cfg_bus_cast_i.cce_mode == e_cce_mode_normal);

--- a/bp_me/src/v/cce/bp_cce_src_sel.sv
+++ b/bp_me/src/v/cce/bp_cce_src_sel.sv
@@ -28,7 +28,7 @@ module bp_cce_src_sel
     , localparam num_way_groups_lp         = `BSG_CDIV(cce_way_groups_p, num_cce_p)
     , localparam lg_num_way_groups_lp      = `BSG_SAFE_CLOG2(num_way_groups_lp)
 
-    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
 
     `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
     `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
@@ -84,7 +84,7 @@ module bp_cce_src_sel
    , output bp_coh_states_e                      state_o
   );
 
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   bp_cfg_bus_s cfg_bus_cast;
   assign cfg_bus_cast = cfg_bus_i;
 

--- a/bp_me/src/v/cce/bp_cce_wrapper.sv
+++ b/bp_me/src/v/cce/bp_cce_wrapper.sv
@@ -23,7 +23,7 @@ module bp_cce_wrapper
     `declare_bp_proc_params(bp_params_p)
 
     // Interface Widths
-    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
     `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
     `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
   )
@@ -85,7 +85,7 @@ module bp_cce_wrapper
   );
 
   // Config Interface
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
 
   // Config bus casting
   bp_cfg_bus_s cfg_bus_cast_i;

--- a/bp_me/src/v/dev/bp_me_cache_slice.sv
+++ b/bp_me/src/v/dev/bp_me_cache_slice.sv
@@ -53,7 +53,7 @@ module bp_me_cache_slice
    , input [l2_banks_p-1:0]                              dma_data_ready_and_i
    );
 
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
 
   `declare_bsg_cache_pkt_s(daddr_width_p, l2_data_width_p);

--- a/bp_me/src/v/dev/bp_me_cfg_slice.sv
+++ b/bp_me/src/v/dev/bp_me_cfg_slice.sv
@@ -102,7 +102,7 @@ module bp_me_cfg_slice
     if (reset_i)
       begin
         freeze_r            <= 1'b1;
-        npc_r               <= dram_base_addr_gp;
+        npc_r               <= boot_base_addr_gp;
         icache_mode_r       <= e_lce_mode_uncached;
         dcache_mode_r       <= e_lce_mode_uncached;
         cce_mode_r          <= e_cce_mode_uncached;

--- a/bp_me/src/v/dev/bp_me_cfg_slice.sv
+++ b/bp_me/src/v/dev/bp_me_cfg_slice.sv
@@ -35,6 +35,7 @@ module bp_me_cfg_slice
    , output logic                                   mem_resp_last_o
 
    , output logic [cfg_bus_width_lp-1:0]            cfg_bus_o
+   , output logic                                   unfreeze_irq_o
    , input [did_width_p-1:0]                        did_i
    , input [did_width_p-1:0]                        host_did_i
    , input [coh_noc_cord_width_p-1:0]               cord_i
@@ -58,9 +59,9 @@ module bp_me_cfg_slice
   logic cord_r_v_li, did_r_v_li, host_did_r_v_li, hio_mask_r_v_li;
   logic cord_w_v_li, did_w_v_li, host_did_w_v_li, hio_mask_w_v_li;
   logic cce_ucode_r_v_li, cce_mode_r_v_li, dcache_mode_r_v_li, icache_mode_r_v_li;
-  logic debug_pc_r_v_li, freeze_r_v_li;
+  logic npc_r_v_li, freeze_r_v_li;
   logic cce_ucode_w_v_li, cce_mode_w_v_li, dcache_mode_w_v_li, icache_mode_w_v_li;
-  logic debug_pc_w_v_li, freeze_w_v_li;
+  logic npc_w_v_li, freeze_w_v_li;
   logic [dev_addr_width_gp-1:0] addr_lo;
   logic [dword_width_gp-1:0] data_lo;
   logic [reg_els_lp-1:0][dword_width_gp-1:0] data_li;
@@ -71,7 +72,7 @@ module bp_me_cfg_slice
      ,.base_addr_p({cfg_reg_cord_gp, cfg_reg_did_gp, cfg_reg_host_did_gp, cfg_reg_hio_mask_gp
                     ,cfg_reg_cce_mode_gp, cfg_reg_dcache_mode_gp, cfg_reg_icache_mode_gp
                     ,cfg_mem_cce_ucode_match_gp
-                    ,cfg_reg_debug_pc_gp, cfg_reg_freeze_gp
+                    ,cfg_reg_npc_gp, cfg_reg_freeze_gp
                     })
      )
    register
@@ -79,12 +80,12 @@ module bp_me_cfg_slice
      ,.r_v_o({cord_r_v_li, did_r_v_li, host_did_r_v_li, hio_mask_r_v_li
               ,cce_mode_r_v_li, dcache_mode_r_v_li, icache_mode_r_v_li
               ,cce_ucode_r_v_li
-              ,debug_pc_r_v_li, freeze_r_v_li
+              ,npc_r_v_li, freeze_r_v_li
               })
      ,.w_v_o({cord_w_v_li, did_w_v_li, host_did_w_v_li, hio_mask_w_v_li
               ,cce_mode_w_v_li, dcache_mode_w_v_li, icache_mode_w_v_li
               ,cce_ucode_w_v_li
-              ,debug_pc_w_v_li, freeze_w_v_li
+              ,npc_w_v_li, freeze_w_v_li
               })
      ,.addr_o(addr_lo)
      ,.size_o()
@@ -93,7 +94,7 @@ module bp_me_cfg_slice
      );
 
   logic         freeze_r;
-  logic [vaddr_width_p-1:0] debug_pc_r;
+  logic [vaddr_width_p-1:0] npc_r;
   bp_lce_mode_e icache_mode_r;
   bp_lce_mode_e dcache_mode_r;
   bp_cce_mode_e cce_mode_r;
@@ -102,21 +103,24 @@ module bp_me_cfg_slice
     if (reset_i)
       begin
         freeze_r            <= 1'b1;
+        npc_r               <= dram_base_addr_gp;
         icache_mode_r       <= e_lce_mode_uncached;
         dcache_mode_r       <= e_lce_mode_uncached;
         cce_mode_r          <= e_cce_mode_uncached;
         hio_mask_r          <= '0;
-        debug_pc_r          <= '0;
       end
     else
       begin
         freeze_r      <= freeze_w_v_li      ? data_lo                 : freeze_r;
+        npc_r         <= npc_w_v_li         ? data_lo                 : npc_r;
         icache_mode_r <= icache_mode_w_v_li ? bp_lce_mode_e'(data_lo) : icache_mode_r;
         dcache_mode_r <= dcache_mode_w_v_li ? bp_lce_mode_e'(data_lo) : dcache_mode_r;
         cce_mode_r    <= cce_mode_w_v_li    ? bp_cce_mode_e'(data_lo) : cce_mode_r;
         hio_mask_r    <= hio_mask_w_v_li    ? data_lo                 : hio_mask_r;
-        debug_pc_r    <= debug_pc_w_v_li    ? data_lo                 : debug_pc_r;
       end
+
+  // IRQ on falling edge of freeze
+  assign unfreeze_irq_o = freeze_r & freeze_w_v_li & ~data_lo[0];
 
   // Access to CCE ucode memory must be aligned
   localparam cce_pc_offset_width_lp = `BSG_SAFE_CLOG2(`BSG_CDIV(cce_instr_width_gp,8));
@@ -141,7 +145,7 @@ module bp_me_cfg_slice
      );
 
   assign cfg_bus_cast_o = '{freeze: freeze_r
-                            ,debug_pc: debug_pc_r
+                            ,npc: npc_r
                             ,core_id: core_id_li
                             ,icache_id: icache_id_li
                             ,icache_mode: icache_mode_r
@@ -153,7 +157,7 @@ module bp_me_cfg_slice
                             };
 
   assign data_li[0] = freeze_r;
-  assign data_li[1] = debug_pc_r;
+  assign data_li[1] = npc_r;
   assign data_li[2] = cce_ucode_data_i;
   assign data_li[3] = icache_mode_r;
   assign data_li[4] = dcache_mode_r;

--- a/bp_me/src/v/dev/bp_me_cfg_slice.sv
+++ b/bp_me/src/v/dev/bp_me_cfg_slice.sv
@@ -53,14 +53,14 @@ module bp_me_cfg_slice
   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `bp_cast_o(bp_cfg_bus_s, cfg_bus);
 
-  localparam reg_els_lp = 11;
+  localparam reg_els_lp = 10;
 
   logic cord_r_v_li, did_r_v_li, host_did_r_v_li, hio_mask_r_v_li;
   logic cord_w_v_li, did_w_v_li, host_did_w_v_li, hio_mask_w_v_li;
   logic cce_ucode_r_v_li, cce_mode_r_v_li, dcache_mode_r_v_li, icache_mode_r_v_li;
-  logic debug_pc_r_v_li, debug_r_v_li, freeze_r_v_li;
+  logic debug_pc_r_v_li, freeze_r_v_li;
   logic cce_ucode_w_v_li, cce_mode_w_v_li, dcache_mode_w_v_li, icache_mode_w_v_li;
-  logic debug_pc_w_v_li, debug_w_v_li, freeze_w_v_li;
+  logic debug_pc_w_v_li, freeze_w_v_li;
   logic [dev_addr_width_gp-1:0] addr_lo;
   logic [dword_width_gp-1:0] data_lo;
   logic [reg_els_lp-1:0][dword_width_gp-1:0] data_li;
@@ -71,7 +71,7 @@ module bp_me_cfg_slice
      ,.base_addr_p({cfg_reg_cord_gp, cfg_reg_did_gp, cfg_reg_host_did_gp, cfg_reg_hio_mask_gp
                     ,cfg_reg_cce_mode_gp, cfg_reg_dcache_mode_gp, cfg_reg_icache_mode_gp
                     ,cfg_mem_cce_ucode_match_gp
-                    ,cfg_reg_debug_pc_gp, cfg_reg_debug_gp, cfg_reg_freeze_gp
+                    ,cfg_reg_debug_pc_gp, cfg_reg_freeze_gp
                     })
      )
    register
@@ -79,12 +79,12 @@ module bp_me_cfg_slice
      ,.r_v_o({cord_r_v_li, did_r_v_li, host_did_r_v_li, hio_mask_r_v_li
               ,cce_mode_r_v_li, dcache_mode_r_v_li, icache_mode_r_v_li
               ,cce_ucode_r_v_li
-              ,debug_pc_r_v_li, debug_r_v_li, freeze_r_v_li
+              ,debug_pc_r_v_li, freeze_r_v_li
               })
      ,.w_v_o({cord_w_v_li, did_w_v_li, host_did_w_v_li, hio_mask_w_v_li
               ,cce_mode_w_v_li, dcache_mode_w_v_li, icache_mode_w_v_li
               ,cce_ucode_w_v_li
-              ,debug_pc_w_v_li, debug_w_v_li, freeze_w_v_li
+              ,debug_pc_w_v_li, freeze_w_v_li
               })
      ,.addr_o(addr_lo)
      ,.size_o()
@@ -106,7 +106,7 @@ module bp_me_cfg_slice
         dcache_mode_r       <= e_lce_mode_uncached;
         cce_mode_r          <= e_cce_mode_uncached;
         hio_mask_r          <= '0;
-        debug_pc_r          <= bootrom_base_addr_gp;
+        debug_pc_r          <= '0;
       end
     else
       begin
@@ -117,17 +117,6 @@ module bp_me_cfg_slice
         hio_mask_r    <= hio_mask_w_v_li    ? data_lo                 : hio_mask_r;
         debug_pc_r    <= debug_pc_w_v_li    ? data_lo                 : debug_pc_r;
       end
-
-  // Debug register is a trigger, not a true register
-  logic debug_r;
-  bsg_dff_reset
-   #(.width_p(1))
-   debug_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-     ,.data_i(debug_w_v_li)
-     ,.data_o(debug_r)
-     );
 
   // Access to CCE ucode memory must be aligned
   localparam cce_pc_offset_width_lp = `BSG_SAFE_CLOG2(`BSG_CDIV(cce_instr_width_gp,8));
@@ -152,7 +141,6 @@ module bp_me_cfg_slice
      );
 
   assign cfg_bus_cast_o = '{freeze: freeze_r
-                            ,debug: debug_r
                             ,debug_pc: debug_pc_r
                             ,core_id: core_id_li
                             ,icache_id: icache_id_li
@@ -165,16 +153,15 @@ module bp_me_cfg_slice
                             };
 
   assign data_li[0] = freeze_r;
-  assign data_li[1] = debug_r;
-  assign data_li[2] = debug_pc_r;
-  assign data_li[3] = cce_ucode_data_i;
-  assign data_li[4] = icache_mode_r;
-  assign data_li[5] = dcache_mode_r;
-  assign data_li[6] = cce_mode_r;
-  assign data_li[7] = hio_mask_r;
-  assign data_li[8] = host_did_i;
-  assign data_li[9] = did_i;
-  assign data_li[10] = cord_i;
+  assign data_li[1] = debug_pc_r;
+  assign data_li[2] = cce_ucode_data_i;
+  assign data_li[3] = icache_mode_r;
+  assign data_li[4] = dcache_mode_r;
+  assign data_li[5] = cce_mode_r;
+  assign data_li[6] = hio_mask_r;
+  assign data_li[7] = host_did_i;
+  assign data_li[8] = did_i;
+  assign data_li[9] = cord_i;
 
 endmodule
 

--- a/bp_me/src/v/dev/bp_me_cfg_slice.sv
+++ b/bp_me/src/v/dev/bp_me_cfg_slice.sv
@@ -35,7 +35,6 @@ module bp_me_cfg_slice
    , output logic                                   mem_resp_last_o
 
    , output logic [cfg_bus_width_lp-1:0]            cfg_bus_o
-   , output logic                                   unfreeze_irq_o
    , input [did_width_p-1:0]                        did_i
    , input [did_width_p-1:0]                        host_did_i
    , input [coh_noc_cord_width_p-1:0]               cord_i
@@ -118,9 +117,6 @@ module bp_me_cfg_slice
         cce_mode_r    <= cce_mode_w_v_li    ? bp_cce_mode_e'(data_lo) : cce_mode_r;
         hio_mask_r    <= hio_mask_w_v_li    ? data_lo                 : hio_mask_r;
       end
-
-  // IRQ on falling edge of freeze
-  assign unfreeze_irq_o = freeze_r & freeze_w_v_li & ~data_lo[0];
 
   // Access to CCE ucode memory must be aligned
   localparam cce_pc_offset_width_lp = `BSG_SAFE_CLOG2(`BSG_CDIV(cce_instr_width_gp,8));

--- a/bp_me/src/v/dev/bp_me_cfg_slice.sv
+++ b/bp_me/src/v/dev/bp_me_cfg_slice.sv
@@ -17,7 +17,7 @@ module bp_me_cfg_slice
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    )
   (input                                            clk_i
    , input                                          reset_i
@@ -49,7 +49,7 @@ module bp_me_cfg_slice
 
   if (dword_width_gp != 64) $error("BedRock interface data width must be 64-bits");
 
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `bp_cast_o(bp_cfg_bus_s, cfg_bus);
 

--- a/bp_me/src/v/dev/bp_me_clint_slice.sv
+++ b/bp_me/src/v/dev/bp_me_clint_slice.sv
@@ -40,7 +40,6 @@ module bp_me_clint_slice
    , output logic                                       mem_resp_last_o
 
    // Local interrupts
-   , output logic                                       unfreeze_irq_o
    , output logic                                       debug_irq_o
    , output logic                                       software_irq_o
    , output logic                                       timer_irq_o
@@ -192,17 +191,6 @@ module bp_me_clint_slice
   wire plic_lo = plic_r[plic_addr_li];
   assign m_external_irq_o = plic_r[0];
   assign s_external_irq_o = plic_r[1];
-
-  logic unfreeze;
-  bsg_edge_detect
-   #(.falling_not_rising_p(1))
-   unfreeze_detect
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-     ,.sig_i(cfg_bus_cast_i.freeze)
-     ,.detect_o(unfreeze)
-     );
-  assign unfreeze_irq_o = unfreeze;
 
   logic debug_r;
   wire debug_n = data_lo[0];

--- a/bp_me/src/v/dev/bp_me_clint_slice.sv
+++ b/bp_me/src/v/dev/bp_me_clint_slice.sv
@@ -19,7 +19,7 @@ module bp_me_clint_slice
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    )
   (input                                                clk_i
    , input                                              rt_clk_i
@@ -49,7 +49,7 @@ module bp_me_clint_slice
 
   if (dword_width_gp != 64) $error("BedRock interface data width must be 64-bits");
 
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, caddr_width_p);
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);

--- a/bp_me/src/v/dev/bp_me_clint_slice.sv
+++ b/bp_me/src/v/dev/bp_me_clint_slice.sv
@@ -42,6 +42,7 @@ module bp_me_clint_slice
    , output logic                                       timer_irq_o
    , output logic                                       m_external_irq_o
    , output logic                                       s_external_irq_o
+   , output logic                                       debug_irq_o
    );
 
   if (dword_width_gp != 64) $error("BedRock interface data width must be 64-bits");
@@ -49,22 +50,25 @@ module bp_me_clint_slice
   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, caddr_width_p);
 
+  localparam reg_els_lp = 6;
+
   logic [dev_addr_width_gp-1:0] addr_lo;
   logic [dword_width_gp-1:0] data_lo;
-  logic [4:0][dword_width_gp-1:0] data_li;
+  logic [reg_els_lp-1:0][dword_width_gp-1:0] data_li;
+  logic debug_w_v_li;
   logic plic_w_v_li;
   logic mtime_w_v_li, mtimesel_w_v_li, mtimecmp_w_v_li, mipi_w_v_li;
   bp_me_bedrock_register
    #(.bp_params_p(bp_params_p)
-     ,.els_p(5)
+     ,.els_p(reg_els_lp)
      ,.reg_addr_width_p(dev_addr_width_gp)
-     ,.base_addr_p({plic_reg_match_addr_gp, mtime_reg_addr_gp, mtimesel_reg_match_addr_gp, mtimecmp_reg_match_addr_gp, mipi_reg_match_addr_gp})
+     ,.base_addr_p({debug_reg_match_addr_gp, plic_reg_match_addr_gp, mtime_reg_addr_gp, mtimesel_reg_match_addr_gp, mtimecmp_reg_match_addr_gp, mipi_reg_match_addr_gp})
      )
    register
     (.*
      // We ignore reads because these are all asynchronous registers
      ,.r_v_o()
-     ,.w_v_o({plic_w_v_li, mtime_w_v_li, mtimesel_w_v_li, mtimecmp_w_v_li, mipi_w_v_li})
+     ,.w_v_o({debug_w_v_li, plic_w_v_li, mtime_w_v_li, mtimesel_w_v_li, mtimecmp_w_v_li, mipi_w_v_li})
      ,.addr_o(addr_lo)
      ,.size_o()
      ,.data_o(data_lo)
@@ -182,6 +186,19 @@ module bp_me_clint_slice
      );
   wire plic_lo = plic_r[plic_addr_li];
 
+  logic debug_r;
+  wire debug_n = data_lo[0];
+  bsg_dff_reset_en
+   #(.width_p(1))
+   debug_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.en_i(debug_w_v_li)
+     ,.data_i(debug_n)
+     ,.data_o(debug_r)
+     );
+  assign debug_irq_o = debug_r;
+
   assign m_external_irq_o = plic_r[0];
   assign s_external_irq_o = plic_r[1];
 
@@ -190,6 +207,7 @@ module bp_me_clint_slice
   assign data_li[2] = mtimesel_r;
   assign data_li[3] = mtime_r;
   assign data_li[4] = plic_lo;
+  assign data_li[5] = debug_r;
 
 endmodule
 

--- a/bp_me/test/common/bp_me_nonsynth_dev_tracer.sv
+++ b/bp_me/test/common/bp_me_nonsynth_dev_tracer.sv
@@ -22,6 +22,7 @@ module bp_me_nonsynth_dev_tracer
   )
   (input                                            clk_i
    , input                                          reset_i
+   , input                                          freeze_i
 
    , input [core_id_width_p-1:0]                    id_i
 
@@ -48,10 +49,12 @@ module bp_me_nonsynth_dev_tracer
   integer file;
   string file_name;
 
-  always_ff @(negedge reset_i) begin
-    file_name = $sformatf("%s_%x.trace", trace_file_p, id_i);
-    file      = $fopen(file_name, "w");
-  end
+  wire delay_li = reset_i | freeze_i;
+  always_ff @(negedge delay_li)
+    begin
+      file_name = $sformatf("%s_%x.trace", trace_file_p, id_i);
+      file      = $fopen(file_name, "w");
+    end
 
   // Tracer
   always_ff @(negedge clk_i) begin

--- a/bp_me/test/tb/bp_cce/testbench.sv
+++ b/bp_me/test/tb/bp_cce/testbench.sv
@@ -69,7 +69,7 @@ module testbench
     return (`BP_SIM_CLK_PERIOD);
   endfunction
 
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `declare_bp_me_nonsynth_tr_pkt_s(paddr_width_p, dword_width_gp);

--- a/bp_me/test/tb/bp_cce/wrapper.sv
+++ b/bp_me/test/tb/bp_cce/wrapper.sv
@@ -16,7 +16,7 @@ module wrapper
    // interface widths
    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    )
   (input                                            clk_i
    , input                                          reset_i

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -13,7 +13,7 @@ module bp_cacc_vdp
     `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
     `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, acache_sets_p, acache_assoc_p, dword_width_gp, acache_block_width_p, acache_fill_width_p, cache)
 
-    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
     )
    (input                                         clk_i
     , input                                       reset_i
@@ -91,7 +91,7 @@ module bp_cacc_vdp
   logic                     dcache_dram;
   logic                     dcache_pkt_v;
 
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   bp_cfg_bus_s cfg_bus_cast_i;
   assign cfg_bus_cast_i.dcache_id = lce_id_i;
   assign cfg_bus_cast_i.dcache_mode = e_lce_mode_normal;

--- a/bp_top/src/v/bp_core.sv
+++ b/bp_top/src/v/bp_core.sv
@@ -19,7 +19,7 @@ module bp_core
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
   )
  (input                                              clk_i
   , input                                            reset_i
@@ -80,7 +80,7 @@ module bp_core
   , input                                            s_external_irq_i
   );
 
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache);
 

--- a/bp_top/src/v/bp_core.sv
+++ b/bp_top/src/v/bp_core.sv
@@ -73,7 +73,6 @@ module bp_core
   , input [1:0]                                      lce_resp_data_ready_and_i
   , output logic [1:0]                               lce_resp_last_o
 
-  , input                                            unfreeze_irq_i
   , input                                            debug_irq_i
   , input                                            timer_irq_i
   , input                                            software_irq_i
@@ -192,7 +191,6 @@ module bp_core
      ,.dcache_stat_mem_pkt_yumi_o(dcache_stat_mem_pkt_yumi_lo)
      ,.dcache_stat_mem_o(dcache_stat_mem_lo)
 
-     ,.unfreeze_irq_i(unfreeze_irq_i)
      ,.debug_irq_i(debug_irq_i)
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)

--- a/bp_top/src/v/bp_core.sv
+++ b/bp_top/src/v/bp_core.sv
@@ -73,6 +73,8 @@ module bp_core
   , input [1:0]                                      lce_resp_data_ready_and_i
   , output logic [1:0]                               lce_resp_last_o
 
+  , input                                            unfreeze_irq_i
+  , input                                            debug_irq_i
   , input                                            timer_irq_i
   , input                                            software_irq_i
   , input                                            m_external_irq_i
@@ -190,6 +192,8 @@ module bp_core
      ,.dcache_stat_mem_pkt_yumi_o(dcache_stat_mem_pkt_yumi_lo)
      ,.dcache_stat_mem_o(dcache_stat_mem_lo)
 
+     ,.unfreeze_irq_i(unfreeze_irq_i)
+     ,.debug_irq_i(debug_irq_i)
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)
      ,.m_external_irq_i(m_external_irq_i)

--- a/bp_top/src/v/bp_core_complex.sv
+++ b/bp_top/src/v/bp_core_complex.sv
@@ -65,7 +65,7 @@ module bp_core_complex
    , output [N:N][cc_x_dim_p-1:0][mem_noc_ral_link_width_lp-1:0] mem_resp_ver_link_o
    );
 
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, coh_noc_ral_link_s);
   `declare_bsg_ready_and_link_sif_s(mem_noc_flit_width_p, mem_noc_ral_link_s);
 

--- a/bp_top/src/v/bp_core_minimal.sv
+++ b/bp_top/src/v/bp_core_minimal.sv
@@ -79,6 +79,7 @@ module bp_core_minimal
    , input                                           software_irq_i
    , input                                           m_external_irq_i
    , input                                           s_external_irq_i
+   , input                                           debug_irq_i
    );
 
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
@@ -182,6 +183,7 @@ module bp_core_minimal
      ,.software_irq_i(software_irq_i)
      ,.m_external_irq_i(m_external_irq_i)
      ,.s_external_irq_i(s_external_irq_i)
+     ,.debug_irq_i(debug_irq_i)
      );
 
 endmodule

--- a/bp_top/src/v/bp_core_minimal.sv
+++ b/bp_top/src/v/bp_core_minimal.sv
@@ -14,7 +14,7 @@ module bp_core_minimal
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    )
   (input                                             clk_i
    , input                                           reset_i
@@ -83,7 +83,7 @@ module bp_core_minimal
    );
 
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
 
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 

--- a/bp_top/src/v/bp_core_minimal.sv
+++ b/bp_top/src/v/bp_core_minimal.sv
@@ -75,7 +75,6 @@ module bp_core_minimal
    , output logic                                    dcache_stat_mem_pkt_yumi_o
    , output logic [dcache_stat_info_width_lp-1:0]    dcache_stat_mem_o
 
-   , input                                           unfreeze_irq_i
    , input                                           debug_irq_i
    , input                                           timer_irq_i
    , input                                           software_irq_i
@@ -180,7 +179,6 @@ module bp_core_minimal
      ,.stat_mem_pkt_yumi_o(dcache_stat_mem_pkt_yumi_o)
      ,.stat_mem_o(dcache_stat_mem_o)
 
-     ,.unfreeze_irq_i(unfreeze_irq_i)
      ,.debug_irq_i(debug_irq_i)
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)

--- a/bp_top/src/v/bp_core_minimal.sv
+++ b/bp_top/src/v/bp_core_minimal.sv
@@ -75,11 +75,12 @@ module bp_core_minimal
    , output logic                                    dcache_stat_mem_pkt_yumi_o
    , output logic [dcache_stat_info_width_lp-1:0]    dcache_stat_mem_o
 
+   , input                                           unfreeze_irq_i
+   , input                                           debug_irq_i
    , input                                           timer_irq_i
    , input                                           software_irq_i
    , input                                           m_external_irq_i
    , input                                           s_external_irq_i
-   , input                                           debug_irq_i
    );
 
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
@@ -179,11 +180,12 @@ module bp_core_minimal
      ,.stat_mem_pkt_yumi_o(dcache_stat_mem_pkt_yumi_o)
      ,.stat_mem_o(dcache_stat_mem_o)
 
+     ,.unfreeze_irq_i(unfreeze_irq_i)
+     ,.debug_irq_i(debug_irq_i)
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)
      ,.m_external_irq_i(m_external_irq_i)
      ,.s_external_irq_i(s_external_irq_i)
-     ,.debug_irq_i(debug_irq_i)
      );
 
 endmodule

--- a/bp_top/src/v/bp_l2e_tile.sv
+++ b/bp_top/src/v/bp_l2e_tile.sv
@@ -24,7 +24,7 @@ module bp_l2e_tile
    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
-    , localparam cfg_bus_width_lp        = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp        = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    // Wormhole parameters
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
@@ -49,7 +49,7 @@ module bp_l2e_tile
    , input [mem_noc_ral_link_width_lp-1:0]                    mem_resp_link_i
    );
 
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, daddr_width_p);

--- a/bp_top/src/v/bp_multicore.sv
+++ b/bp_top/src/v/bp_multicore.sv
@@ -48,7 +48,7 @@ module bp_multicore
    , input [mc_x_dim_p-1:0][mem_noc_ral_link_width_lp-1:0]  dram_resp_link_i
    );
 
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, bp_coh_ready_and_link_s);
   `declare_bsg_ready_and_link_sif_s(io_noc_flit_width_p, bp_io_ready_and_link_s);
   `declare_bsg_ready_and_link_sif_s(mem_noc_flit_width_p, bp_mem_ready_and_link_s);

--- a/bp_top/src/v/bp_sacc_loopback.sv
+++ b/bp_top/src/v/bp_sacc_loopback.sv
@@ -8,7 +8,7 @@ module bp_sacc_loopback
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
-   , localparam cfg_bus_width_lp= `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp= `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    )
   (input                                        clk_i
    , input                                      reset_i

--- a/bp_top/src/v/bp_sacc_vdp.sv
+++ b/bp_top/src/v/bp_sacc_vdp.sv
@@ -8,7 +8,7 @@ module bp_sacc_vdp
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
-   , localparam cfg_bus_width_lp= `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp= `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    )
   (input                                        clk_i
    , input                                      reset_i

--- a/bp_top/src/v/bp_tile.sv
+++ b/bp_top/src/v/bp_tile.sv
@@ -543,7 +543,7 @@ module bp_tile
      );
 
   // Processor
-  logic timer_irq_li, software_irq_li, m_external_irq_li, s_external_irq_li;
+  logic unfreeze_irq_li, debug_irq_li, timer_irq_li, software_irq_li, m_external_irq_li, s_external_irq_li;
   bp_core
    #(.bp_params_p(bp_params_p))
    core
@@ -597,6 +597,8 @@ module bp_tile
      ,.lce_fill_data_ready_and_i(lce_fill_data_ready_and_li)
      ,.lce_fill_last_o(lce_fill_last_lo)
 
+     ,.unfreeze_irq_i(unfreeze_irq_li)
+     ,.debug_irq_i(debug_irq_li)
      ,.timer_irq_i(timer_irq_li)
      ,.software_irq_i(software_irq_li)
      ,.m_external_irq_i(m_external_irq_li)
@@ -662,7 +664,7 @@ module bp_tile
     (.clk_i(clk_i)
      ,.rt_clk_i(rt_clk_i)
      ,.reset_i(reset_r)
-     ,.id_i(cfg_bus_lo.core_id)
+     ,.cfg_bus_i(cfg_bus_lo)
 
      ,.mem_cmd_header_i(dev_cmd_header_li[2])
      ,.mem_cmd_data_i(dev_cmd_data_li[2])
@@ -676,6 +678,8 @@ module bp_tile
      ,.mem_resp_ready_and_i(dev_resp_ready_and_li[2])
      ,.mem_resp_last_o(dev_resp_last_lo[2])
 
+     ,.unfreeze_irq_o(unfreeze_irq_li)
+     ,.debug_irq_o(debug_irq_li)
      ,.timer_irq_o(timer_irq_li)
      ,.software_irq_o(software_irq_li)
      ,.m_external_irq_o(m_external_irq_li)

--- a/bp_top/src/v/bp_tile.sv
+++ b/bp_top/src/v/bp_tile.sv
@@ -543,7 +543,7 @@ module bp_tile
      );
 
   // Processor
-  logic unfreeze_irq_li, debug_irq_li, timer_irq_li, software_irq_li, m_external_irq_li, s_external_irq_li;
+  logic debug_irq_li, timer_irq_li, software_irq_li, m_external_irq_li, s_external_irq_li;
   bp_core
    #(.bp_params_p(bp_params_p))
    core
@@ -597,7 +597,6 @@ module bp_tile
      ,.lce_fill_data_ready_and_i(lce_fill_data_ready_and_li)
      ,.lce_fill_last_o(lce_fill_last_lo)
 
-     ,.unfreeze_irq_i(unfreeze_irq_li)
      ,.debug_irq_i(debug_irq_li)
      ,.timer_irq_i(timer_irq_li)
      ,.software_irq_i(software_irq_li)
@@ -678,7 +677,6 @@ module bp_tile
      ,.mem_resp_ready_and_i(dev_resp_ready_and_li[2])
      ,.mem_resp_last_o(dev_resp_last_lo[2])
 
-     ,.unfreeze_irq_o(unfreeze_irq_li)
      ,.debug_irq_o(debug_irq_li)
      ,.timer_irq_o(timer_irq_li)
      ,.software_irq_o(software_irq_li)

--- a/bp_top/src/v/bp_tile.sv
+++ b/bp_top/src/v/bp_tile.sv
@@ -24,7 +24,7 @@ module bp_tile
    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
 
    // Wormhole parameters
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
@@ -55,7 +55,7 @@ module bp_tile
    , input [mem_noc_ral_link_width_lp-1:0]                    mem_resp_link_i
    );
 
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, daddr_width_p);

--- a/bp_top/src/v/bp_unicore.sv
+++ b/bp_top/src/v/bp_unicore.sv
@@ -110,7 +110,7 @@ module bp_unicore
   logic [4:0][uce_fill_width_p-1:0] dev_resp_data_lo;
   logic [4:0] dev_resp_v_lo, dev_resp_ready_and_li, dev_resp_last_lo;
 
-  logic timer_irq_li, software_irq_li, m_external_irq_li, s_external_irq_li;
+  logic timer_irq_li, software_irq_li, m_external_irq_li, s_external_irq_li, debug_irq_li;
   bp_unicore_lite
    #(.bp_params_p(bp_params_p))
    unicore_lite
@@ -134,6 +134,7 @@ module bp_unicore
      ,.software_irq_i(software_irq_li)
      ,.m_external_irq_i(m_external_irq_li)
      ,.s_external_irq_i(s_external_irq_li)
+     ,.debug_irq_i(debug_irq_li)
      );
 
   // Assign incoming I/O as basically another UCE interface
@@ -293,6 +294,7 @@ module bp_unicore
      ,.software_irq_o(software_irq_li)
      ,.m_external_irq_o(m_external_irq_li)
      ,.s_external_irq_o(s_external_irq_li)
+     ,.debug_irq_o(debug_irq_li)
      );
   assign clint_data_li = dev_cmd_data_li[1];
   assign dev_resp_data_lo[1] = clint_data_lo;

--- a/bp_top/src/v/bp_unicore.sv
+++ b/bp_top/src/v/bp_unicore.sv
@@ -257,7 +257,6 @@ module bp_unicore
      ,.mem_resp_last_o(dev_resp_last_lo[0])
 
      ,.cfg_bus_o(cfg_bus_lo)
-     ,.unfreeze_irq_o(unfreeze_irq_li)
      ,.did_i(my_did_i)
      ,.host_did_i(host_did_i)
      ,.cord_i(my_cord_i)
@@ -278,7 +277,7 @@ module bp_unicore
     (.clk_i(clk_i)
      ,.rt_clk_i(rt_clk_i)
      ,.reset_i(reset_i)
-     ,.id_i(cfg_bus_lo.core_id)
+     ,.cfg_bus_i(cfg_bus_lo)
 
      ,.mem_cmd_header_i(dev_cmd_header_li[1])
      ,.mem_cmd_data_i(clint_data_li)
@@ -292,6 +291,7 @@ module bp_unicore
      ,.mem_resp_ready_and_i(dev_resp_ready_and_li[1])
      ,.mem_resp_last_o(dev_resp_last_lo[1])
 
+     ,.unfreeze_irq_o(unfreeze_irq_li)
      ,.debug_irq_o(debug_irq_li)
      ,.timer_irq_o(timer_irq_li)
      ,.software_irq_o(software_irq_li)

--- a/bp_top/src/v/bp_unicore.sv
+++ b/bp_top/src/v/bp_unicore.sv
@@ -110,7 +110,7 @@ module bp_unicore
   logic [4:0][uce_fill_width_p-1:0] dev_resp_data_lo;
   logic [4:0] dev_resp_v_lo, dev_resp_ready_and_li, dev_resp_last_lo;
 
-  logic unfreeze_irq_li, debug_irq_li, timer_irq_li, software_irq_li, m_external_irq_li, s_external_irq_li;
+  logic debug_irq_li, timer_irq_li, software_irq_li, m_external_irq_li, s_external_irq_li;
   bp_unicore_lite
    #(.bp_params_p(bp_params_p))
    unicore_lite
@@ -130,7 +130,6 @@ module bp_unicore
      ,.mem_resp_ready_and_o(proc_resp_ready_and_lo[0+:2])
      ,.mem_resp_last_i(proc_resp_last_li[0+:2])
 
-     ,.unfreeze_irq_i(unfreeze_irq_li)
      ,.debug_irq_i(debug_irq_li)
      ,.timer_irq_i(timer_irq_li)
      ,.software_irq_i(software_irq_li)
@@ -291,7 +290,6 @@ module bp_unicore
      ,.mem_resp_ready_and_i(dev_resp_ready_and_li[1])
      ,.mem_resp_last_o(dev_resp_last_lo[1])
 
-     ,.unfreeze_irq_o(unfreeze_irq_li)
      ,.debug_irq_o(debug_irq_li)
      ,.timer_irq_o(timer_irq_li)
      ,.software_irq_o(software_irq_li)

--- a/bp_top/src/v/bp_unicore.sv
+++ b/bp_top/src/v/bp_unicore.sv
@@ -110,7 +110,7 @@ module bp_unicore
   logic [4:0][uce_fill_width_p-1:0] dev_resp_data_lo;
   logic [4:0] dev_resp_v_lo, dev_resp_ready_and_li, dev_resp_last_lo;
 
-  logic timer_irq_li, software_irq_li, m_external_irq_li, s_external_irq_li, debug_irq_li;
+  logic unfreeze_irq_li, debug_irq_li, timer_irq_li, software_irq_li, m_external_irq_li, s_external_irq_li;
   bp_unicore_lite
    #(.bp_params_p(bp_params_p))
    unicore_lite
@@ -130,11 +130,12 @@ module bp_unicore
      ,.mem_resp_ready_and_o(proc_resp_ready_and_lo[0+:2])
      ,.mem_resp_last_i(proc_resp_last_li[0+:2])
 
+     ,.unfreeze_irq_i(unfreeze_irq_li)
+     ,.debug_irq_i(debug_irq_li)
      ,.timer_irq_i(timer_irq_li)
      ,.software_irq_i(software_irq_li)
      ,.m_external_irq_i(m_external_irq_li)
      ,.s_external_irq_i(s_external_irq_li)
-     ,.debug_irq_i(debug_irq_li)
      );
 
   // Assign incoming I/O as basically another UCE interface
@@ -256,6 +257,7 @@ module bp_unicore
      ,.mem_resp_last_o(dev_resp_last_lo[0])
 
      ,.cfg_bus_o(cfg_bus_lo)
+     ,.unfreeze_irq_o(unfreeze_irq_li)
      ,.did_i(my_did_i)
      ,.host_did_i(host_did_i)
      ,.cord_i(my_cord_i)
@@ -290,11 +292,11 @@ module bp_unicore
      ,.mem_resp_ready_and_i(dev_resp_ready_and_li[1])
      ,.mem_resp_last_o(dev_resp_last_lo[1])
 
+     ,.debug_irq_o(debug_irq_li)
      ,.timer_irq_o(timer_irq_li)
      ,.software_irq_o(software_irq_li)
      ,.m_external_irq_o(m_external_irq_li)
      ,.s_external_irq_o(s_external_irq_li)
-     ,.debug_irq_o(debug_irq_li)
      );
   assign clint_data_li = dev_cmd_data_li[1];
   assign dev_resp_data_lo[1] = clint_data_lo;

--- a/bp_top/src/v/bp_unicore.sv
+++ b/bp_top/src/v/bp_unicore.sv
@@ -85,7 +85,7 @@ module bp_unicore
    , input [l2_banks_p-1:0]                              dma_data_ready_and_i
    );
 
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, daddr_width_p);
   `bp_cast_o(bp_bedrock_mem_header_s, io_cmd_header);

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -33,7 +33,6 @@ module bp_unicore_lite
    , output logic [1:0]                                mem_resp_ready_and_o
    , input [1:0]                                       mem_resp_last_i
 
-   , input                                             unfreeze_irq_i
    , input                                             debug_irq_i
    , input                                             timer_irq_i
    , input                                             software_irq_i
@@ -141,7 +140,6 @@ module bp_unicore_lite
      ,.dcache_stat_mem_pkt_yumi_o(dcache_stat_mem_pkt_yumi_lo)
      ,.dcache_stat_mem_o(dcache_stat_mem_lo)
 
-     ,.unfreeze_irq_i(unfreeze_irq_i)
      ,.debug_irq_i(debug_irq_i)
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -33,11 +33,12 @@ module bp_unicore_lite
    , output logic [1:0]                                mem_resp_ready_and_o
    , input [1:0]                                       mem_resp_last_i
 
+   , input                                             unfreeze_irq_i
+   , input                                             debug_irq_i
    , input                                             timer_irq_i
    , input                                             software_irq_i
    , input                                             m_external_irq_i
    , input                                             s_external_irq_i
-   , input                                             debug_irq_i
    );
 
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
@@ -140,11 +141,12 @@ module bp_unicore_lite
      ,.dcache_stat_mem_pkt_yumi_o(dcache_stat_mem_pkt_yumi_lo)
      ,.dcache_stat_mem_o(dcache_stat_mem_lo)
 
+     ,.unfreeze_irq_i(unfreeze_irq_i)
+     ,.debug_irq_i(debug_irq_i)
      ,.timer_irq_i(timer_irq_i)
      ,.software_irq_i(software_irq_i)
      ,.m_external_irq_i(m_external_irq_i)
      ,.s_external_irq_i(s_external_irq_i)
-     ,.debug_irq_i(debug_irq_i)
      );
 
   bp_uce

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -37,6 +37,7 @@ module bp_unicore_lite
    , input                                             software_irq_i
    , input                                             m_external_irq_i
    , input                                             s_external_irq_i
+   , input                                             debug_irq_i
    );
 
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
@@ -143,6 +144,7 @@ module bp_unicore_lite
      ,.software_irq_i(software_irq_i)
      ,.m_external_irq_i(m_external_irq_i)
      ,.s_external_irq_i(s_external_irq_i)
+     ,.debug_irq_i(debug_irq_i)
      );
 
   bp_uce

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -13,7 +13,7 @@ module bp_unicore_lite
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    )
   (input                                               clk_i
    , input                                             reset_i
@@ -40,7 +40,7 @@ module bp_unicore_lite
    , input                                             s_external_irq_i
    );
 
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache);
   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);

--- a/bp_top/test/common/bp_nonsynth_if_verif.sv
+++ b/bp_top/test/common/bp_nonsynth_if_verif.sv
@@ -15,14 +15,14 @@ module bp_nonsynth_if_verif
    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    )
   ();
 
   bp_proc_param_s proc_param;
   assign proc_param = all_cfgs_gp[bp_params_p];
 
-  `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
   `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);

--- a/bp_top/test/tb/bp_tethered/Makefile.vcs
+++ b/bp_top/test/tb/bp_tethered/Makefile.vcs
@@ -80,6 +80,7 @@ ifeq ($(PRELOAD_MEM_P), 0)
 NBF_INPUTS += --mem=prog.mem --skip_zeros
 endif
 NBF_INPUTS += --addr_width=$(PADDR_WIDTH)
+NBF_INPUTS += --debug
 
 $(SIM_DIR)/prog.nbf: $(SIM_DIR)/cce_ucode.mem $(SIM_DIR)/prog.mem
 	cd $(@D); python $(MEM2NBF) $(NBF_INPUTS) > $@

--- a/bp_top/test/tb/bp_tethered/Makefile.vcs
+++ b/bp_top/test/tb/bp_tethered/Makefile.vcs
@@ -79,9 +79,6 @@ endif
 ifeq ($(PRELOAD_MEM_P), 0)
 NBF_INPUTS += --mem=prog.mem --skip_zeros
 endif
-ifeq ($(NBF_CONFIG_P), 1)
-NBF_INPUTS += --config
-endif
 NBF_INPUTS += --addr_width=$(PADDR_WIDTH)
 
 $(SIM_DIR)/prog.nbf: $(SIM_DIR)/cce_ucode.mem $(SIM_DIR)/prog.mem

--- a/bp_top/test/tb/bp_tethered/Makefile.verilator
+++ b/bp_top/test/tb/bp_tethered/Makefile.verilator
@@ -56,6 +56,7 @@ NBF_INPUTS += --ucode=cce_ucode.mem
 endif
 NBF_INPUTS += --mem=prog.mem --skip_zeros
 NBF_INPUTS += --addr_width=$(PADDR_WIDTH)
+NBF_INPUTS += --debug
 
 $(SIM_DIR)/prog.nbf: $(SIM_DIR)/cce_ucode.mem $(SIM_DIR)/prog.mem
 	cd $(@D); python $(MEM2NBF) $(NBF_INPUTS) > $@

--- a/bp_top/test/tb/bp_tethered/Makefile.verilator
+++ b/bp_top/test/tb/bp_tethered/Makefile.verilator
@@ -55,9 +55,6 @@ ifeq ($(UCODE), 1)
 NBF_INPUTS += --ucode=cce_ucode.mem
 endif
 NBF_INPUTS += --mem=prog.mem --skip_zeros
-ifeq ($(NBF_CONFIG_P), 1)
-NBF_INPUTS += --config
-endif
 NBF_INPUTS += --addr_width=$(PADDR_WIDTH)
 
 $(SIM_DIR)/prog.nbf: $(SIM_DIR)/cce_ucode.mem $(SIM_DIR)/prog.mem

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -575,7 +575,8 @@ module testbench
          clint_tracer
           (.clk_i(clk_i & testbench.dev_trace_en_lo)
            ,.reset_i(reset_i)
-           ,.id_i(id_i)
+           ,.id_i(cfg_bus_cast_i.core_id)
+           ,.freeze_i(cfg_bus_cast_i.freeze)
 
            ,.mem_cmd_header_i(mem_cmd_header_i)
            ,.mem_cmd_data_i(mem_cmd_data_i)

--- a/docs/debug_boot.md
+++ b/docs/debug_boot.md
@@ -77,7 +77,8 @@ test_bp.tb.wrapper.unicore.dut.cache):
 
 ## Boot Process (Method 2: Bootrom)
 
-The second method of boot involves BlackParrot bootstrapping itself using an external bootrom. This method is supported for bootrom configurations such as e_bp_unicore_bootrom_cfg. This version of BlackParrot will go through exactly the same steps as Method 1. However, the process is not driven through an NBF loader. Instead, BlackParrot will start fetching from the bootrom, which contains the configuration registers and cce microcode for a core. This self-bootstrapping bootrom can be found here: https://github.com/black-parrot-sdk/bootrom/blob/master/bootrom.S.
+The second method of boot involves BlackParrot bootstrapping itself using an external bootrom. This version of BlackParrot will go through exactly the same steps as Method 1. However, the process is not driven through an NBF loader. Instead, BlackParrot will start fetching from the bootrom, which contains the configuration registers and cce microcode for a core. This self-bootstrapping bootrom can be found here: https://github.com/black-parrot-sdk/bootrom/blob/master/bootrom.S.
 
-In the tethered testbench, this bootrom lives in the host https://github.com/black-parrot/black-parrot/blob/master/bp_top/test/common/bp_nonsynth_host.sv#L228. Any environment constructed using a bootrom configuration will need the bootrom mapped onto the I/O bus, beginning at the address found here: https://github.com/black-parrot/black-parrot/blob/master/bp_common/src/include/bp_common_addr_pkgdef.svh#L31.
+In the tethered testbench, this bootrom lives in the host
+https://github.com/black-parrot/black-parrot/blob/master/bp_top/test/common/bp_nonsynth_host.sv#L228. Any environment constructed without a tether will need the runrom mapped onto the I/O bus, beginning at the address found here: https://github.com/black-parrot/black-parrot/blob/master/bp_common/src/include/bp_common_addr_pkgdef.svh#L31.
 

--- a/docs/debug_boot.md
+++ b/docs/debug_boot.md
@@ -80,5 +80,5 @@ test_bp.tb.wrapper.unicore.dut.cache):
 The second method of boot involves BlackParrot bootstrapping itself using an external bootrom. This version of BlackParrot will go through exactly the same steps as Method 1. However, the process is not driven through an NBF loader. Instead, BlackParrot will start fetching from the bootrom, which contains the configuration registers and cce microcode for a core. This self-bootstrapping bootrom can be found here: https://github.com/black-parrot-sdk/bootrom/blob/master/bootrom.S.
 
 In the tethered testbench, this bootrom lives in the host
-https://github.com/black-parrot/black-parrot/blob/master/bp_top/test/common/bp_nonsynth_host.sv#L228. Any environment constructed without a tether will need the runrom mapped onto the I/O bus, beginning at the address found here: https://github.com/black-parrot/black-parrot/blob/master/bp_common/src/include/bp_common_addr_pkgdef.svh#L31.
+https://github.com/black-parrot/black-parrot/blob/master/bp_top/test/common/bp_nonsynth_host.sv#L228. Any environment constructed without a tether will need the bootrom mapped onto the I/O bus, beginning at the address found here: https://github.com/black-parrot/black-parrot/blob/master/bp_common/src/include/bp_common_addr_pkgdef.svh#L31.
 

--- a/docs/platform_guide.md
+++ b/docs/platform_guide.md
@@ -139,13 +139,14 @@ These addresses are per-tile. To access them on a tile N, prepend N to the addre
 
 | Device   | Name        | Address         | Description                                                                                                                       |
 |----------|-------------|-----------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| Bootrom* | Bootrom     | 01_0000-01_ffff | The bootrom which bootstraps BlackParrot in bootrom configurations                                                                |
 | Host*    | getchar     | 10_0000         | A polling implementation to get a single char from a tethered host                                                                |
 |          | putchar     | 10_1000         | Puts a character onto the terminal of a tethered host                                                                             |
 |          | finish      | 10_2000-10_2fff | Terminates a multicore BlackParrot simulation, when finish[x] is received for each core x in the system                           |
 |          | putch       | 10_3000-10_3fff | putch[x] puts a character into a private terminal for core x. This is useful for debugging multicore simulations                  |
-| CFG      | freeze      | 20_0004         | Freezes the core, preventing all fetch operations. Will drain the pipeline if set during runtime.                                 |
-|          | npc         | 20_0008         | When freeze is lowered or a debug interrupt is raised,this becomes the architectural NPC.                                         |
+| Bootrom* | bootrom     | 11_0000-11_ffff | The bootrom which bootstraps BlackParrot in bootrom configurations                                                                |
+| CFG      | unused      | 20_0000         | Unused.                                                                                                                           |
+|          | freeze      | 20_0004         | Freezes the core, preventing all fetch operations. Will drain the pipeline if set during runtime. Defaults to frozen.             |
+|          | npc         | 20_0008         | When freeze is lowered or a debug interrupt is raised,this becomes the architectural NPC. Defaults to bootrom address.            |
 |          | core_id     | 20_000c         | Read-only. This tile's core id. This is a local id within the chip                                                                |
 |          | did         | 20_0010         | Read-only. This tile's domain id. This is an chip-wide identifier                                                                 |
 |          | cord        | 20_0014         | Read-only. This tile's coordinate. In {y,x} format                                                                                |

--- a/docs/platform_guide.md
+++ b/docs/platform_guide.md
@@ -146,7 +146,6 @@ These addresses are per-tile. To access them on a tile N, prepend N to the addre
 |          | putch       | 10_3000-10_3fff | putch[x] puts a character into a private terminal for core x. This is useful for debugging multicore simulations                  |
 | CFG      | freeze      | 20_0004         | Freezes the core, preventing all fetch operations. Will drain the pipeline if set during runtime.                                 |
 |          | npc         | 20_0008         | When freeze is lowered or a debug interrupt is raised,this becomes the architectural NPC.                                         |
-|          |             |                 | Note: Freeze must go high->low to use NPC. If freeze is constantly low, fetch will start at the default bootrom address           |
 |          | core_id     | 20_000c         | Read-only. This tile's core id. This is a local id within the chip                                                                |
 |          | did         | 20_0010         | Read-only. This tile's domain id. This is an chip-wide identifier                                                                 |
 |          | cord        | 20_0014         | Read-only. This tile's coordinate. In {y,x} format                                                                                |

--- a/docs/platform_guide.md
+++ b/docs/platform_guide.md
@@ -144,7 +144,9 @@ These addresses are per-tile. To access them on a tile N, prepend N to the addre
 |          | putchar     | 10_1000         | Puts a character onto the terminal of a tethered host                                                                             |
 |          | finish      | 10_2000-10_2fff | Terminates a multicore BlackParrot simulation, when finish[x] is received for each core x in the system                           |
 |          | putch       | 10_3000-10_3fff | putch[x] puts a character into a private terminal for core x. This is useful for debugging multicore simulations                  |
-| CFG      | freeze      | 20_0008         | Freezes the core, preventing all fetch operations. Will drain the pipeline if set during runtime.                                 |
+| CFG      | freeze      | 20_0004         | Freezes the core, preventing all fetch operations. Will drain the pipeline if set during runtime.                                 |
+|          | npc         | 20_0008         | When freeze is lowered or a debug interrupt is raised,this becomes the architectural NPC.                                         |
+|          |             |                 | Note: Freeze must go high->low to use NPC. If freeze is constantly low, fetch will start at the default bootrom address           |
 |          | core_id     | 20_000c         | Read-only. This tile's core id. This is a local id within the chip                                                                |
 |          | did         | 20_0010         | Read-only. This tile's domain id. This is an chip-wide identifier                                                                 |
 |          | cord        | 20_0014         | Read-only. This tile's coordinate. In {y,x} format                                                                                |
@@ -159,8 +161,9 @@ These addresses are per-tile. To access them on a tile N, prepend N to the addre
 |          | cce_ucode   | 20_8000-20_8fff | The CCE instruction RAM. Must be written before enabling cached mode in a microcoded CCE                                          |
 | CLINT    | mipi        | 30_0000         | mip (software interrupt) bit                                                                                                      |
 |          | mtimecmp    | 30_4000         | Timer compare register. When mtime > mtimecmp, a timer irq is raised in the core                                                  |
-|          | mtimesel    | 30_8000         | Timer select register. 0=core_clk, 1=core_clk/8, 2=external RTC, 3=disable
+|          | mtimesel    | 30_8000         | Timer select register. 0=core_clk, 1=core_clk/8, 2=external RTC, 3=disable                                                        |
 |          | mtime       | 30_bff8         | A real-time counter. Currently implemented as mcycle/8                                                                            |
 |          | plic        | 30_b000         | A fake PLIC implementation. Effectively a redundant implementation of mipi                                                        |
+|          | debug       | 30_c000         | A request to take a debug interrupt to cfg.npc, and switch into debug mode                                                        |
 
 * This lives outside of the unicore/tile, residing in the tethered host. Implementations must map this correctly for full software support


### PR DESCRIPTION

## Summary
This PR adds support for a debug mode interrupt, as well as piggybacking support for changing the boot PC. This is accomplished by overriding the existing interrupt mechanism and enhancing it.

## Area
CFG, CLINT, BE boot sequence

## Reasoning (outdated, confusing, verbose, etc.)
The debug mechanism is needed for debug mode support. The PC mechanism is a nice to have for users which do not want to touch BP RTL (or if a chip is already taped out), but would like to redirect the PC at runtime. The debug mode switch can safely happen at runtime, while the freeze trigger can happen any time you want to destructively restart or switch programs.

## Additional Changes Required (if any)
Aviary in the SDK needs to update.
Zynq-parrot needs extra verification, although it should work out of box.
Any users (don't know of any) that are directly using core-minimal and want to leverage the variable boot address need to update to trigger freeze on reset.

## Analysis
This PR has impact on the boot flow for BP, hopefully positively. It should more elegantly support the different use-cases of tethered, untethered and bootrom-based.

## Verification
Manual inspection of bootrom / non-bootrom / debug-mode / non-debug-mode starts

## Additional Context
Relies on:
- [ ] https://github.com/black-parrot/black-parrot/pull/1071
