### PR TITLE
Update dev to be_dev

### DIFF
--- a/bp_be/src/include/bp_be_defines.svh
+++ b/bp_be/src/include/bp_be_defines.svh
@@ -170,10 +170,15 @@
                                                                                                    \
     typedef struct packed                                                                          \
     {                                                                                              \
-      logic instr_miss_v;                                                                          \
-      logic load_miss_v;                                                                           \
-      logic store_miss_v;                                                                          \
-      logic [vaddr_width_mp-1:0] vaddr;                                                            \
+      /* Trans info */                                                                             \
+      logic [ptag_width_p-1:0]       base_ppn;                                                     \
+      logic [rv64_priv_width_gp-1:0] priv_mode;                                                    \
+      logic                          mstatus_sum;                                                  \
+      logic                          mstatus_mxr;                                                  \
+      logic                          instr_miss_v;                                                 \
+      logic                          load_miss_v;                                                  \
+      logic                          store_miss_v;                                                 \
+      logic [vaddr_width_mp-1:0]     vaddr;                                                        \
     }  bp_be_ptw_miss_pkt_s;                                                                       \
                                                                                                    \
     typedef struct packed                                                                          \
@@ -191,7 +196,7 @@
     typedef struct packed                                                                          \
     {                                                                                              \
       logic [rv64_priv_width_gp-1:0] priv_mode;                                                    \
-      logic [ptag_width_p-1:0]       satp_ppn;                                                     \
+      logic [ptag_width_p-1:0]       base_ppn;                                                     \
       logic                          translation_en;                                               \
       logic                          mstatus_sum;                                                  \
       logic                          mstatus_mxr;                                                  \
@@ -256,8 +261,8 @@
      + $bits(rv64_fflags_s)                                                                        \
      )
 
-  `define bp_be_ptw_miss_pkt_width(vaddr_width_mp) \
-    (3 + vaddr_width_mp)
+  `define bp_be_ptw_miss_pkt_width(vaddr_width_mp, ptag_width_mp) \
+    (ptag_width_mp + rv64_priv_width_gp + 5 + vaddr_width_mp)
 
   `define bp_be_ptw_fill_pkt_width(vaddr_width_mp, paddr_width_mp) \
     (6                                                                                             \

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -377,9 +377,9 @@ module bp_be_csr
           else
             begin
               unique casez ({csr_r_v_li, csr_cmd_cast_i.csr_addr})
-                {1'b1, `CSR_ADDR_FFLAGS       }: csr_data_lo = fcsr_lo.fflags;
+                {1'b1, `CSR_ADDR_FFLAGS       }: csr_data_lo = fcsr_lo.fflags | fflags_acc_i;
                 {1'b1, `CSR_ADDR_FRM          }: csr_data_lo = fcsr_lo.frm;
-                {1'b1, `CSR_ADDR_FCSR         }: csr_data_lo = fcsr_lo;
+                {1'b1, `CSR_ADDR_FCSR         }: csr_data_lo = fcsr_lo | fflags_acc_i;
                 {1'b1, `CSR_ADDR_CYCLE        }: csr_data_lo = mcycle_lo;
                 // Time must be done by trapping, since we can't stall at this point
                 {1'b1, `CSR_ADDR_INSTRET      }: csr_data_lo = minstret_lo;
@@ -602,8 +602,9 @@ module bp_be_csr
       mip_li.msip = software_irq_i;
       mip_li.meip = m_external_irq_i;
 
-      // Accumulate FFLAGS
-      fcsr_li.fflags |= fflags_acc_i;
+      // Accumulate FFLAGS if we're not writing them this cycle
+      if (~(csr_w_v_li & csr_cmd_cast_i.csr_addr inside {`CSR_ADDR_FFLAGS, `CSR_ADDR_FCSR}))
+        fcsr_li.fflags |= fflags_acc_i;
 
       // Set FS to dirty if: fflags set, frf written, fcsr written
       mstatus_li.fs |= {2{(csr_w_v_li & csr_fany_li & ~csr_illegal_instr_o)}};

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -649,8 +649,8 @@ module bp_be_csr
   assign commit_pkt_cast_o.itlb_fill_v      = retire_pkt_cast_i.exception.itlb_fill;
   assign commit_pkt_cast_o.dtlb_fill_v      = retire_pkt_cast_i.exception.dtlb_fill;
 
-  assign trans_info_cast_o.priv_mode = priv_mode_r;
-  assign trans_info_cast_o.satp_ppn  = satp_lo.ppn;
+  assign trans_info_cast_o.priv_mode      = priv_mode_r;
+  assign trans_info_cast_o.base_ppn       = satp_lo.ppn;
   assign trans_info_cast_o.translation_en = translation_en_r
     | ((~is_debug_mode | dcsr_lo.mprven) & mstatus_lo.mprv & (mstatus_lo.mpp < `PRIV_MODE_M) & (satp_lo.mode == 4'd8));
   assign trans_info_cast_o.mstatus_sum = mstatus_lo.sum;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_fma.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_fma.sv
@@ -16,7 +16,7 @@
  *
  *   This module:
  *            ...
- *            fma 4 cycles     reservation
+ *            fma 3 cycles     reservation
  *           /   \                 |
  *        round  imul_out      imul meta
  *          |                      |
@@ -128,15 +128,15 @@ module bp_be_pipe_fma
 
   // Here, we switch the implementation based on synthesizing for Vivado or not. If this is
   //   a knob you'd like to turn, consider modifying the define yourself.
-  localparam fma_latency_lp  = 5;
-  localparam imul_latency_lp = 4;
+  localparam fma_latency_lp  = 4;
+  localparam imul_latency_lp = 3;
   `ifdef SYNTHESIS
     `ifdef DC
       localparam int fma_pipeline_stages_lp [1:0] = '{0,0};
     `elsif CDS_TOOL_DEFINE
       localparam int fma_pipeline_stages_lp [1:0] = '{0,0};
     `else
-      localparam int fma_pipeline_stages_lp [1:0] = '{1,3};
+      localparam int fma_pipeline_stages_lp [1:0] = '{1,imul_latency_lp-1};
     `endif
   `else
       localparam int fma_pipeline_stages_lp [1:0] = '{0,0};

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -209,6 +209,7 @@ module bp_be_pipe_mem
      ,.flush_i(sfence_i)
      ,.priv_mode_i(trans_info.priv_mode)
      ,.sum_i(trans_info.mstatus_sum)
+     ,.mxr_i(trans_info.mstatus_mxr)
      ,.trans_en_i(trans_info.translation_en)
      ,.uncached_mode_i((cfg_bus.dcache_mode == e_lce_mode_uncached))
      ,.nonspec_mode_i((cfg_bus.dcache_mode == e_lce_mode_nonspec))
@@ -250,6 +251,10 @@ module bp_be_pipe_mem
       ,store_miss_v : commit_pkt.dtlb_store_miss
       ,load_miss_v  : commit_pkt.dtlb_load_miss
       ,vaddr        : commit_pkt.itlb_miss ? commit_pkt.pc : commit_pkt.vaddr
+      ,mstatus_mxr  : trans_info.mstatus_mxr
+      ,mstatus_sum  : trans_info.mstatus_sum
+      ,base_ppn     : trans_info.base_ppn
+      ,priv_mode    : trans_info.priv_mode
       };
 
   bp_be_ptw
@@ -262,10 +267,6 @@ module bp_be_pipe_mem
    ptw
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
-     ,.base_ppn_i(trans_info.satp_ppn)
-     ,.priv_mode_i(trans_info.priv_mode)
-     ,.mstatus_sum_i(trans_info.mstatus_sum)
-     ,.mstatus_mxr_i(trans_info.mstatus_mxr)
 
      ,.busy_o(ptw_busy)
      ,.ptw_miss_pkt_i(ptw_miss_pkt)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -260,7 +260,7 @@ module bp_be_pipe_mem
      ,.page_idx_width_p(sv39_page_idx_width_gp)
      )
    ptw
-    (.clk_i(~clk_i)
+    (.clk_i(clk_i)
      ,.reset_i(reset_i)
      ,.base_ppn_i(trans_info.satp_ppn)
      ,.priv_mode_i(trans_info.priv_mode)

--- a/bp_be/src/v/bp_be_calculator/bp_be_ptw.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_ptw.sv
@@ -44,19 +44,15 @@ module bp_be_ptw
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
   `declare_bp_be_dcache_pkt_s(vaddr_width_p);
   `bp_cast_o(bp_be_dcache_pkt_s, dcache_pkt);
+  `bp_cast_i(bp_be_ptw_miss_pkt_s, ptw_miss_pkt);
+  `bp_cast_o(bp_be_ptw_fill_pkt_s, ptw_fill_pkt);
 
-  enum logic [2:0] {e_idle, e_send_load, e_send_tag, e_recv_load, e_writeback} state_n, state_r;
+  enum logic [2:0] {e_idle, e_send_load, e_recv_load, e_check_load, e_writeback} state_n, state_r;
   wire is_idle  = (state_r == e_idle);
   wire is_send  = (state_r == e_send_load);
-  wire is_tag   = (state_r == e_send_tag );
   wire is_recv  = (state_r == e_recv_load);
+  wire is_check = (state_r == e_check_load);
   wire is_write = (state_r == e_writeback);
-
-  bp_be_ptw_miss_pkt_s ptw_miss_pkt_cast_i;
-  bp_be_ptw_fill_pkt_s ptw_fill_pkt_cast_o;
-
-  assign ptw_miss_pkt_cast_i = ptw_miss_pkt_i;
-  assign ptw_fill_pkt_o = ptw_fill_pkt_cast_o;
 
   localparam lg_page_table_depth_lp = `BSG_SAFE_CLOG2(page_table_depth_p);
   logic start;
@@ -73,27 +69,35 @@ module bp_be_ptw
 
   logic tlb_miss_v, page_fault_v;
 
-  sv39_pte_s dcache_pte;
-  assign dcache_pte = dcache_early_data_i[0+:dword_width_gp];
+  sv39_pte_s dcache_pte_n, dcache_pte_r;
+  assign dcache_pte_n = dcache_early_data_i[0+:dword_width_gp];
+  bsg_dff_en
+   #(.width_p($bits(sv39_pte_s)))
+   dcache_pte_reg
+    (.clk_i(clk_i)
+     ,.en_i(is_recv)
+     ,.data_i(dcache_pte_n)
+     ,.data_o(dcache_pte_r)
+     );
 
-   for(genvar i=0; i<page_table_depth_p; i++) begin : rof1
-      assign partial_vpn[i] = vpn[page_idx_width_p*i +: page_idx_width_p];
-    end
-   for(genvar i=0; i<page_table_depth_p-1; i++) begin : rof2
-      assign partial_ppn[i] = ppn_r[page_idx_width_p*i +: page_idx_width_p];
-      assign partial_pte_misaligned[i] = (level_cntr > i)? |dcache_pte.ppn[page_idx_width_p*i +: page_idx_width_p] : 1'b0;
-      assign writeback_ppn[page_idx_width_p*i +: page_idx_width_p] = (level_cntr > i) ? partial_vpn[i] : partial_ppn[i];
-    end
-    assign writeback_ppn[ptag_width_p-1 : (page_table_depth_p-1)*page_idx_width_p] = ppn_r[ptag_width_p-1 : (page_table_depth_p-1)*page_idx_width_p];
+  for(genvar i=0; i<page_table_depth_p; i++) begin : rof1
+     assign partial_vpn[i] = vpn[page_idx_width_p*i +: page_idx_width_p];
+   end
+  for(genvar i=0; i<page_table_depth_p-1; i++) begin : rof2
+     assign partial_ppn[i] = ppn_r[page_idx_width_p*i +: page_idx_width_p];
+     assign partial_pte_misaligned[i] = (level_cntr > i)? |dcache_pte_r.ppn[page_idx_width_p*i +: page_idx_width_p] : 1'b0;
+     assign writeback_ppn[page_idx_width_p*i +: page_idx_width_p] = (level_cntr > i) ? partial_vpn[i] : partial_ppn[i];
+   end
+   assign writeback_ppn[ptag_width_p-1 : (page_table_depth_p-1)*page_idx_width_p] = ppn_r[ptag_width_p-1 : (page_table_depth_p-1)*page_idx_width_p];
 
   assign dcache_ptag_o          = ppn_r;
-  assign dcache_ptag_v_o        = (state_r == e_send_tag);
+  assign dcache_ptag_v_o        = is_recv;
 
   // PMA attributes
   localparam lg_pte_size_in_bytes_lp = `BSG_SAFE_CLOG2(pte_size_in_bytes_p);
-  assign dcache_v_o                    = (state_r == e_send_load);
+  assign dcache_v_o                    = is_send;
   assign dcache_pkt_cast_o.opcode      = e_dcache_op_ptw_ld;
-  assign dcache_pkt_cast_o.vaddr       = vaddr_width_p'({partial_vpn[level_cntr], (lg_pte_size_in_bytes_lp)'(0)});
+  assign dcache_pkt_cast_o.vaddr       = partial_vpn[level_cntr] << lg_pte_size_in_bytes_lp;
   assign dcache_pkt_cast_o.data        = '0;
   assign dcache_pkt_cast_o.rd_addr     = '0;
 
@@ -101,25 +105,25 @@ module bp_be_ptw
 
   assign start                  = is_idle & tlb_miss_v;
 
-  wire pte_is_leaf              = dcache_pte.x | dcache_pte.w | dcache_pte.r;
+  wire pte_is_leaf              = dcache_pte_r.x | dcache_pte_r.w | dcache_pte_r.r;
   wire pte_is_megapage          = (level_cntr == 2'd1);
   wire pte_is_gigapage          = (level_cntr == 2'd2);
 
-  assign level_cntr_en          = is_recv & dcache_early_hit_v_i & ~pte_is_leaf & ~page_fault_v;
+  assign level_cntr_en          = is_check & ~pte_is_leaf & ~page_fault_v;
 
-  assign ppn_en                 = start | (is_recv & dcache_early_hit_v_i);
-  assign ppn_n                  = (state_r == e_idle) ? base_ppn_i : dcache_pte.ppn[0+:ptag_width_p];
+  assign ppn_en                 = start | is_check;
+  assign ppn_n                  = is_idle ? base_ppn_i : dcache_pte_r.ppn[0+:ptag_width_p];
 
-  wire pte_invalid              = (~dcache_pte.v) | (~dcache_pte.r & dcache_pte.w);
+  wire pte_invalid              = (~dcache_pte_r.v) | (~dcache_pte_r.r & dcache_pte_r.w);
   wire leaf_not_found           = (level_cntr == '0) & (~pte_is_leaf);
-  wire priv_fault               = pte_is_leaf & ((dcache_pte.u & (priv_mode_i == `PRIV_MODE_S) & (ptw_miss_pkt_r.instr_miss_v | ~mstatus_sum_i)) | (~dcache_pte.u & (priv_mode_i == `PRIV_MODE_U)));
+  wire priv_fault               = pte_is_leaf & ((dcache_pte_r.u & (priv_mode_i == `PRIV_MODE_S) & (ptw_miss_pkt_r.instr_miss_v | ~mstatus_sum_i)) | (~dcache_pte_r.u & (priv_mode_i == `PRIV_MODE_U)));
   wire misaligned_superpage     = pte_is_leaf & (|partial_pte_misaligned);
-  wire ad_fault                 = pte_is_leaf & (~dcache_pte.a | (ptw_miss_pkt_r.store_miss_v & ~dcache_pte.d));
+  wire ad_fault                 = pte_is_leaf & (~dcache_pte_r.a | (ptw_miss_pkt_r.store_miss_v & ~dcache_pte_r.d));
   wire common_faults            = pte_invalid | leaf_not_found | priv_fault | misaligned_superpage | ad_fault;
 
-  wire instr_page_fault         = ptw_miss_pkt_r.instr_miss_v & (common_faults | (pte_is_leaf & ~dcache_pte.x));
-  wire load_page_fault          = ptw_miss_pkt_r.load_miss_v  & (common_faults | (pte_is_leaf & ~dcache_pte.r));
-  wire store_page_fault         = ptw_miss_pkt_r.store_miss_v & (common_faults | (pte_is_leaf & ~dcache_pte.w));
+  wire instr_page_fault         = ptw_miss_pkt_r.instr_miss_v & (common_faults | (pte_is_leaf & ~dcache_pte_r.x));
+  wire load_page_fault          = ptw_miss_pkt_r.load_miss_v  & (common_faults | (pte_is_leaf & ~dcache_pte_r.r));
+  wire store_page_fault         = ptw_miss_pkt_r.store_miss_v & (common_faults | (pte_is_leaf & ~dcache_pte_r.w));
   assign page_fault_v           = (instr_page_fault | load_page_fault | store_page_fault);
 
   wire itlb_fill_v              = ptw_miss_pkt_r.instr_miss_v & ~page_fault_v;
@@ -128,19 +132,19 @@ module bp_be_ptw
   bp_be_pte_leaf_s tlb_w_entry;
   assign tlb_w_entry.ptag       = writeback_ppn;
   assign tlb_w_entry.gigapage   = pte_is_gigapage;
-  assign tlb_w_entry.a          = dcache_pte.a;
-  assign tlb_w_entry.d          = dcache_pte.d;
-  assign tlb_w_entry.u          = dcache_pte.u;
-  assign tlb_w_entry.x          = dcache_pte.x;
-  assign tlb_w_entry.w          = dcache_pte.w;
-  assign tlb_w_entry.r          = dcache_pte.r;
+  assign tlb_w_entry.a          = dcache_pte_r.a;
+  assign tlb_w_entry.d          = dcache_pte_r.d;
+  assign tlb_w_entry.u          = dcache_pte_r.u;
+  assign tlb_w_entry.x          = dcache_pte_r.x;
+  assign tlb_w_entry.w          = dcache_pte_r.w;
+  assign tlb_w_entry.r          = dcache_pte_r.r;
 
-  assign ptw_fill_pkt_cast_o.v                  = (state_r == e_writeback);
-  assign ptw_fill_pkt_cast_o.itlb_fill_v        = (state_r == e_writeback) & itlb_fill_v;
-  assign ptw_fill_pkt_cast_o.dtlb_fill_v        = (state_r == e_writeback) & dtlb_fill_v;
-  assign ptw_fill_pkt_cast_o.instr_page_fault_v = (state_r == e_writeback) & instr_page_fault;
-  assign ptw_fill_pkt_cast_o.load_page_fault_v  = (state_r == e_writeback) & load_page_fault;
-  assign ptw_fill_pkt_cast_o.store_page_fault_v = (state_r == e_writeback) & store_page_fault;
+  assign ptw_fill_pkt_cast_o.v                  = is_write;
+  assign ptw_fill_pkt_cast_o.itlb_fill_v        = is_write & itlb_fill_v;
+  assign ptw_fill_pkt_cast_o.dtlb_fill_v        = is_write & dtlb_fill_v;
+  assign ptw_fill_pkt_cast_o.instr_page_fault_v = is_write & instr_page_fault;
+  assign ptw_fill_pkt_cast_o.load_page_fault_v  = is_write & load_page_fault;
+  assign ptw_fill_pkt_cast_o.store_page_fault_v = is_write & store_page_fault;
   assign ptw_fill_pkt_cast_o.vaddr              = ptw_miss_pkt_r.vaddr;
   assign ptw_fill_pkt_cast_o.entry              = tlb_w_entry;
 
@@ -186,12 +190,10 @@ module bp_be_ptw
   //   are non-speculative
   always_comb begin
     case(state_r)
-      e_idle     :  state_n = tlb_miss_v ? e_send_load : e_idle;
-      e_send_load:  state_n = (dcache_ready_i & dcache_v_o) ? e_send_tag : e_send_load;
-      e_send_tag :  state_n = e_recv_load;
-      e_recv_load:  state_n = dcache_early_hit_v_i & (pte_is_leaf | page_fault_v)
-                              ? e_writeback
-                              : e_send_load;
+      e_idle      :  state_n = tlb_miss_v ? e_send_load : e_idle;
+      e_send_load :  state_n = (dcache_ready_i & dcache_v_o) ? e_recv_load : e_send_load;
+      e_recv_load :  state_n = dcache_early_hit_v_i ? e_check_load : e_send_load;
+      e_check_load:  state_n = (pte_is_leaf | page_fault_v) ? e_writeback : e_send_load;
       default: // e_writeback
                     state_n = e_idle;
     endcase

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -69,10 +69,10 @@ module bp_be_detector
   // Floating point data hazards
   logic frs1_sb_raw_haz_v, frs2_sb_raw_haz_v, frs3_sb_raw_haz_v;
   logic frd_sb_waw_haz_v;
-  logic [3:0] frs1_data_haz_v , frs2_data_haz_v, frs3_data_haz_v;
-  logic [3:0] rs1_match_vector, rs2_match_vector, rs3_match_vector;
+  logic [2:0] frs1_data_haz_v , frs2_data_haz_v, frs3_data_haz_v;
+  logic [2:0] rs1_match_vector, rs2_match_vector, rs3_match_vector;
 
-  bp_be_dep_status_s [4:0] dep_status_r;
+  bp_be_dep_status_s [3:0] dep_status_r;
 
   logic fence_haz_v, cmd_haz_v, fflags_haz_v, csr_haz_v;
   logic data_haz_v, control_haz_v, struct_haz_v;
@@ -139,7 +139,7 @@ module bp_be_detector
       // Generate matches for rs1, rs2. rs3
       // 3 stages because we only care about ex1, ex2, and iwb dependencies. fwb dependencies
       //   can be handled through forwarding
-      for (integer i = 0; i < 4; i++)
+      for (integer i = 0; i < 3; i++)
         begin
           rs1_match_vector[i] = (isd_status_cast_i.rs1_addr == dep_status_r[i].rd_addr);
           rs2_match_vector[i] = (isd_status_cast_i.rs2_addr == dep_status_r[i].rd_addr);
@@ -193,13 +193,9 @@ module bp_be_detector
       frs3_data_haz_v[1] = (isd_status_cast_i.frs3_v & rs3_match_vector[1])
                            & (dep_status_r[1].fmem_fwb_v | dep_status_r[1].fma_fwb_v);
 
-      irs1_data_haz_v[2] = (isd_status_cast_i.irs1_v & rs1_match_vector[2])
-                           & (isd_status_cast_i.rs1_addr != '0)
-                           & (dep_status_r[2].mul_iwb_v);
+      irs1_data_haz_v[2] = '0;
 
-      irs2_data_haz_v[2] = (isd_status_cast_i.irs2_v & rs2_match_vector[2])
-                           & (isd_status_cast_i.rs2_addr != '0)
-                           & (dep_status_r[2].mul_iwb_v);
+      irs2_data_haz_v[2] = '0;
 
       frs1_data_haz_v[2] = (isd_status_cast_i.frs1_v & rs1_match_vector[2])
                            & (dep_status_r[2].fma_fwb_v);
@@ -210,27 +206,17 @@ module bp_be_detector
       frs3_data_haz_v[2] = (isd_status_cast_i.frs3_v & rs3_match_vector[2])
                            & (dep_status_r[2].fma_fwb_v);
 
-      frs1_data_haz_v[3] = (isd_status_cast_i.frs1_v & rs1_match_vector[3])
-                           & (dep_status_r[3].fma_fwb_v);
-
-      frs2_data_haz_v[3] = (isd_status_cast_i.frs2_v & rs2_match_vector[3])
-                           & (dep_status_r[3].fma_fwb_v);
-
-      frs3_data_haz_v[3] = (isd_status_cast_i.frs3_v & rs3_match_vector[3])
-                           & (dep_status_r[3].fma_fwb_v);
-
       mem_in_pipe_v      = dep_status_r[0].mem_v | dep_status_r[1].mem_v | dep_status_r[2].mem_v;
       fence_haz_v        = (isd_status_cast_i.fence_v & (~credits_empty_i | mem_in_pipe_v | ~mem_ready_i))
                            | (isd_status_cast_i.mem_v & credits_full_i);
       cmd_haz_v          = cmd_full_i;
 
-      // TODO: Pessimistic, could have a separate fflags w_v
+      // TODO: Pessimistic, could have a separate fflags r/w_v
       fflags_haz_v = isd_status_cast_i.csr_v
                      & ((dep_status_r[0].fflags_w_v)
                         | (dep_status_r[1].fflags_w_v)
                         | (dep_status_r[2].fflags_w_v)
                         | (dep_status_r[3].fflags_w_v)
-                        | (dep_status_r[4].fflags_w_v)
                         | ~fdiv_ready_i
                         );
 
@@ -299,7 +285,7 @@ module bp_be_detector
   always_ff @(posedge clk_i)
     begin
       dep_status_r[0]   <= dispatch_pkt_cast_i.v ? dep_status_n : '0;
-      dep_status_r[4:1] <= dep_status_r[3:0];
+      dep_status_r[3:1] <= dep_status_r[2:0];
     end
 
 endmodule

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -1278,7 +1278,7 @@ module bp_be_dcache
       // Invalidates from other harts which match the reservation address clear the reservation
       // Also invalidate on trap
       wire clear_reservation = (v_tv_r & decode_tv_r.sc_op)
-        || (tag_mem_pkt_yumi_lo
+        || (tag_mem_pkt_yumi_o
             & load_reserved_v_r
             & (tag_mem_pkt_cast_i.index == load_reserved_index_r)
             & (tag_mem_pkt_cast_i.tag == load_reserved_tag_r)

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -213,10 +213,9 @@ module bp_be_dcache
     : byte_offset_width_lp;
 
   // State machine declaration
-  enum logic [2:0] {e_ready, e_miss, e_fence, e_resume, e_late} state_n, state_r;
+  enum logic [2:0] {e_ready, e_miss, e_resume, e_late} state_n, state_r;
   wire is_ready  = (state_r == e_ready);
   wire is_miss   = (state_r == e_miss);
-  wire is_fence  = (state_r == e_fence);
   wire is_resume = (state_r == e_resume);
   wire is_late   = (state_r == e_late);
 
@@ -229,36 +228,6 @@ module bp_be_dcache
 
   wire posedge_clk =  clk_i;
   wire negedge_clk = ~clk_i;
-
-  //
-  // In order to handle posedge/negedge handshakes, it's important to note the
-  //   instant that the handshake "commits". This is the moment that the
-  //   handshake is observed from some non-speculative action similar to the
-  //   processor definition. For the cache, that happens when memories are
-  //   accessed, either by the fast or slow paths. Because the memories are
-  //   accessed on the negedge, we need to extend their handshakes to the positive edge
-  // Similar logic requires us to extend the request handshake as it's latched by the
-  //   consumer cache engine earlier.
-
-  // Handshakes that are consumed at negedge are extended to the next posedge
-  logic data_mem_pkt_yumi_lo, tag_mem_pkt_yumi_lo;
-  bsg_dlatch
-   #(.width_p(2), .i_know_this_is_a_bad_idea_p(1))
-   posedge_extend
-    (.clk_i(posedge_clk)
-     ,.data_i({data_mem_pkt_yumi_lo, tag_mem_pkt_yumi_lo})
-     ,.data_o({data_mem_pkt_yumi_o, tag_mem_pkt_yumi_o})
-     );
-
-  // Handshakes that are consumed at posedge are extended to the next negedge
-  logic stat_mem_pkt_yumi_lo, cache_req_yumi_li;
-  bsg_dlatch
-   #(.width_p(2), .i_know_this_is_a_bad_idea_p(1))
-   negedge_extend
-    (.clk_i(negedge_clk)
-     ,.data_i({stat_mem_pkt_yumi_lo, cache_req_yumi_i})
-     ,.data_o({stat_mem_pkt_yumi_o, cache_req_yumi_li})
-     );
 
   wire flush_self = tag_mem_write_hazard | data_mem_write_hazard;
 
@@ -411,7 +380,7 @@ module bp_be_dcache
   // TV Stage
   /////////////////////////////////////////////////////////////////////////////
   localparam snoop_offset_width_lp = `BSG_SAFE_CLOG2(fill_width_p/dword_width_gp);
-  logic uncached_op_tv_r, cached_op_tv_r, dram_op_tv_r, uncached_hit_tv_r;
+  logic uncached_op_tv_r, cached_op_tv_r, dram_op_tv_r, fill_tv_r;
   logic [paddr_width_p-1:0] paddr_tv_r;
   logic [dword_width_gp-1:0] st_data_tv_r;
   rv64_fflags_s st_fflags_tv_r;
@@ -435,7 +404,7 @@ module bp_be_dcache
      );
 
   logic [assoc_p-1:0] way_v_tv_n, store_hit_tv_n, load_hit_tv_n;
-  wire uncached_hit_tv_n = cache_req_critical_tag_i;
+  wire fill_tv_n = cache_req_critical_tag_i;
   wire [assoc_p-1:0] tag_mem_pseudo_hit = 1'b1 << tag_mem_pkt_cast_i.way_id;
   bsg_mux
    #(.width_p(3*assoc_p), .els_p(2))
@@ -451,8 +420,8 @@ module bp_be_dcache
     (.clk_i(negedge_clk)
      ,.reset_i(reset_i)
      ,.en_i(tv_we | cache_req_critical_tag_i)
-     ,.data_i({uncached_hit_tv_n, way_v_tv_n, store_hit_tv_n, load_hit_tv_n})
-     ,.data_o({uncached_hit_tv_r, way_v_tv_r, store_hit_tv_r, load_hit_tv_r})
+     ,.data_i({fill_tv_n, way_v_tv_n, store_hit_tv_n, load_hit_tv_n})
+     ,.data_o({fill_tv_r, way_v_tv_r, store_hit_tv_r, load_hit_tv_r})
      );
 
   // Snoop logic
@@ -615,7 +584,7 @@ module bp_be_dcache
   wire lr_miss_tv       = cached_op_tv_r & decode_tv_r.lr_op & ~lr_hit_tv;
   wire load_miss_tv     = cached_op_tv_r & decode_tv_r.load_op & ~decode_tv_r.sc_op & ~load_hit_tv;
   wire fencei_miss_tv   = decode_tv_r.fencei_op & gdirty_r & (coherent_p == 0);
-  wire uncached_miss_tv = uncached_op_tv_r & decode_tv_r.load_op & ~uncached_hit_tv_r;
+  wire uncached_miss_tv = uncached_op_tv_r & decode_tv_r.load_op & ~fill_tv_r;
   wire engine_miss_tv   = cache_req_v_o & ~cache_req_yumi_i;
   wire any_miss_tv      = store_miss_tv | lr_miss_tv | load_miss_tv | fencei_miss_tv | uncached_miss_tv | engine_miss_tv;
 
@@ -623,9 +592,9 @@ module bp_be_dcache
     ? (sc_success_tv != 1'b1)
     : early_data;
 
-  assign early_hit_v_o  = v_tv_r & ~any_miss_tv;
+  assign early_hit_v_o  = v_tv_r & ~any_miss_tv & ~fill_tv_r;
   assign early_fencei_o = decode_tv_r.fencei_op;
-  assign early_miss_v_o = v_tv_r &  any_miss_tv & cache_req_yumi_li;
+  assign early_miss_v_o = v_tv_r &  any_miss_tv & cache_req_yumi_i;
   assign early_fflags_o = st_fflags_tv_r;
 
   ///////////////////////////
@@ -645,7 +614,7 @@ module bp_be_dcache
      ,.latch_last_read_p(1)
      )
    stat_mem
-    (.clk_i(posedge_clk)
+    (.clk_i(negedge_clk)
     ,.reset_i(reset_i)
     ,.v_i(stat_mem_v_li)
     ,.w_i(stat_mem_w_li)
@@ -668,6 +637,7 @@ module bp_be_dcache
   logic [dword_width_gp-1:0] ld_data_dm_r;
   logic [paddr_width_p-1:0] paddr_dm_r;
   bp_be_dcache_decode_s decode_dm_r;
+  logic fill_dm_r;
   wire [sindex_width_lp-1:0] paddr_index_dm = paddr_dm_r[block_offset_width_lp+:sindex_width_lp];
   wire [ctag_width_p-1:0]    paddr_tag_dm   = paddr_dm_r[block_offset_width_lp+sindex_width_lp+:ctag_width_p];
 
@@ -684,12 +654,12 @@ module bp_be_dcache
      );
 
   bsg_dff_en
-   #(.width_p(dword_width_gp+paddr_width_p+$bits(bp_be_dcache_decode_s)))
+   #(.width_p(1+dword_width_gp+paddr_width_p+$bits(bp_be_dcache_decode_s)))
    dm_stage_reg
     (.clk_i(posedge_clk)
      ,.en_i(dm_we)
-     ,.data_i({result_data, paddr_tv_r, decode_tv_r})
-     ,.data_o({ld_data_dm_r, paddr_dm_r, decode_dm_r})
+     ,.data_i({fill_tv_r, result_data, paddr_tv_r, decode_tv_r})
+     ,.data_o({fill_dm_r, ld_data_dm_r, paddr_dm_r, decode_dm_r})
      );
 
   logic [3:0][dword_width_gp-1:0] sigext_byte;
@@ -730,7 +700,7 @@ module bp_be_dcache
      );
 
   assign final_data_o = decode_dm_r.float_op ? final_float_data : final_int_data;
-  assign final_v_o = is_ready & v_dm_r;
+  assign final_v_o = v_dm_r & ~fill_dm_r;
 
   ///////////////////////////
   // Write buffer
@@ -860,7 +830,16 @@ module bp_be_dcache
      );
   wire [bindex_width_lp-1:0] wbuf_entry_out_bank_offset = wbuf_entry_out.paddr[byte_offset_width_lp+:bindex_width_lp];
   wire [sindex_width_lp-1:0] wbuf_entry_out_index = wbuf_entry_out.paddr[block_offset_width_lp+:sindex_width_lp];
-
+  
+  //          ____     ____      ____
+  //              |___|    |____|    |____
+  //               ________
+  // _wbuf_v_lo:  |        |_________
+  //
+  //                   ____
+  //  wbuf_v_lo:  |___|    |_________
+  //                       ^
+  //                       | data mem write happens on negedge
   bsg_deff_reset
    #(.width_p(1))
    wbuf_v_reg
@@ -879,12 +858,12 @@ module bp_be_dcache
 
   wire cached_req          = (store_miss_tv | lr_miss_tv | load_miss_tv);
   wire fencei_req          = fencei_miss_tv;
-  wire uncached_amo_req    = decode_tv_r.amo_op & uncached_op_tv_r & ~uncached_hit_tv_r & (decode_tv_r.rd_addr != '0);
-  wire uncached_load_req   = decode_tv_r.load_op & uncached_op_tv_r & ~uncached_hit_tv_r;
+  wire uncached_amo_req    = decode_tv_r.amo_op & uncached_op_tv_r & ~fill_tv_r & (decode_tv_r.rd_addr != '0);
+  wire uncached_load_req   = decode_tv_r.load_op & uncached_op_tv_r & ~fill_tv_r;
                              // Regular uncached store
-  wire uncached_store_req  = (decode_tv_r.store_op & uncached_op_tv_r & ~uncached_hit_tv_r)
+  wire uncached_store_req  = (decode_tv_r.store_op & uncached_op_tv_r & ~fill_tv_r)
                              // L2 amo uncached store
-                             || (decode_tv_r.amo_op & uncached_op_tv_r & ~uncached_hit_tv_r & (decode_tv_r.rd_addr == '0));
+                             || (decode_tv_r.amo_op & uncached_op_tv_r & ~fill_tv_r & (decode_tv_r.rd_addr == '0));
   wire wt_req              = (decode_tv_r.store_op & ~sc_fail_tv & ~uncached_op_tv_r & (writethrough_p == 1));
 
   // Uncached stores and writethrough requests are non-blocking
@@ -950,13 +929,11 @@ module bp_be_dcache
         cache_req_cast_o.msg_type = e_wt_store;
     end
 
-  // Cache metadata is valid after the request goes out,
-  //   but no metadata for flushes
   wire cache_req_metadata_v = cache_req_yumi_i;
   bsg_dff_reset
    #(.width_p(1))
    cache_req_v_reg
-    (.clk_i(posedge_clk)
+    (.clk_i(negedge_clk)
      ,.reset_i(reset_i)
 
      ,.data_i(cache_req_metadata_v)
@@ -968,7 +945,7 @@ module bp_be_dcache
   bsg_dff
    #(.width_p(1+lg_dcache_assoc_lp))
    cached_hit_reg
-    (.clk_i(posedge_clk)
+    (.clk_i(negedge_clk)
      ,.data_i({load_hit_tv, load_hit_way_tv})
      ,.data_o({metadata_hit_r, metadata_hit_index_r})
      );
@@ -981,21 +958,19 @@ module bp_be_dcache
   // State machine
   //   e_ready  : Cache is ready to accept requests
   //   e_miss   : Cache is waiting for a miss to be serviced
-  //   e_fence  : Cache is waiting for a fence to be resolved
   //   e_resume : Cache is syncing up after a fill. This is due to negedge
   //                nonsense and probably not strictly necessary
   //   e_late   : Cache is waiting for a late acknowledgement
   /////////////////////////////////////////////////////////////////////////////
   always_comb
     case (state_r)
-      e_ready : state_n = (cache_req_yumi_li & decode_tv_r.fencei_op)
-                          ? e_fence
-                          : (cache_req_yumi_li & ~nonblocking_req)
-                            ? e_miss
-                            : e_ready;
-      e_miss  : state_n = cache_req_complete_i ? e_resume : e_miss;
-      e_fence : state_n = cache_req_complete_i ? e_ready : e_fence;
-      e_resume: state_n = (decode_tv_r.load_op & ~decode_tv_r.ptw_op) ? e_late : e_ready;
+      e_ready : state_n = (cache_req_yumi_i & ~nonblocking_req) ? e_miss : e_ready;
+      e_miss  : state_n = cache_req_complete_i
+                          ? (decode_tv_r.ptw_op | decode_tv_r.fencei_op)
+                            ? e_ready
+                            : e_resume
+                          : e_miss;
+      e_resume: state_n = decode_tv_r.load_op ? e_late : e_ready;
       e_late  : state_n = late_yumi_i ? e_ready : e_late;
       default: state_n = e_ready;
     endcase
@@ -1017,9 +992,9 @@ module bp_be_dcache
   // Tag Mem Control
   ///////////////////////////
   wire tag_mem_fast_read = (safe_tl_we & ~decode_lo.fencei_op) & ~tag_mem_write_hazard;
-  wire tag_mem_slow_read = tag_mem_pkt_yumi_lo & (tag_mem_pkt_cast_i.opcode == e_cache_tag_mem_read);
-  wire tag_mem_slow_write = tag_mem_pkt_yumi_lo & (tag_mem_pkt_cast_i.opcode != e_cache_tag_mem_read);
-  wire tag_mem_fast_write = v_tv_r & (uncached_op_tv_r & dram_op_tv_r & ~uncached_hit_tv_r & load_hit_tv);
+  wire tag_mem_slow_read = tag_mem_pkt_yumi_o & (tag_mem_pkt_cast_i.opcode == e_cache_tag_mem_read);
+  wire tag_mem_slow_write = tag_mem_pkt_yumi_o & (tag_mem_pkt_cast_i.opcode != e_cache_tag_mem_read);
+  wire tag_mem_fast_write = v_tv_r & (uncached_op_tv_r & dram_op_tv_r & ~fill_tv_r & load_hit_tv);
   assign tag_mem_write_hazard = tag_mem_fast_write;
 
   assign tag_mem_v_li = tag_mem_fast_read | tag_mem_slow_read | tag_mem_slow_write | tag_mem_fast_write;
@@ -1029,7 +1004,7 @@ module bp_be_dcache
     : tag_mem_fast_read
       ? vaddr_index
       : tag_mem_pkt_cast_i.index;
-  assign tag_mem_pkt_yumi_lo = ~cache_lock & tag_mem_pkt_v_i & ~tag_mem_fast_read & ~tag_mem_fast_write;
+  assign tag_mem_pkt_yumi_o = ~cache_lock & tag_mem_pkt_v_i & ~tag_mem_fast_read & ~tag_mem_fast_write;
 
   logic [assoc_p-1:0] tag_mem_way_one_hot;
   bsg_decode
@@ -1131,9 +1106,9 @@ module bp_be_dcache
   for (genvar i = 0; i < assoc_p; i++)
     begin : data_mem_lines
       assign data_mem_force_write[i] = wbuf_v_lo & wbuf_force_lo & wbuf_bank_sel_one_hot[i];
-      assign data_mem_slow_write[i] = data_mem_pkt_yumi_lo
+      assign data_mem_slow_write[i] = data_mem_pkt_yumi_o
         & (data_mem_pkt_cast_i.opcode == e_cache_data_mem_write) & data_mem_write_bank_mask[i];
-      assign data_mem_slow_read[i] = data_mem_pkt_yumi_lo
+      assign data_mem_slow_read[i] = data_mem_pkt_yumi_o
         & (data_mem_pkt_cast_i.opcode == e_cache_data_mem_read);
       assign data_mem_fast_read[i] = safe_tl_we & decode_lo.load_op & ~data_mem_force_write[i];
       assign data_mem_fast_write[i] = wbuf_yumi_li & wbuf_bank_sel_one_hot[i];
@@ -1169,7 +1144,7 @@ module bp_be_dcache
   //   a snoop match. However, this is a critical path, so we drain the write buffer on invalidations.
   // A similar scheme could be adopted for a non-blocking version, where we snoop the bank
   // TODO: With blocking TL and TV, we really should implement snooping for performance
-  assign data_mem_pkt_yumi_lo = (data_mem_pkt_cast_i.opcode == e_cache_data_mem_uncached)
+  assign data_mem_pkt_yumi_o = (data_mem_pkt_cast_i.opcode == e_cache_data_mem_uncached)
     ? ~cache_lock & data_mem_pkt_v_i
     : ~cache_lock & data_mem_pkt_v_i & ~|data_mem_fast_read & ~wbuf_v_lo & ~(v_tl_r & decode_tl_r.store_op) & ~(v_tv_r & decode_tv_r.store_op);
 
@@ -1195,16 +1170,16 @@ module bp_be_dcache
   // Stat Mem Control
   ///////////////////////////
   wire stat_mem_fast_read  = (early_miss_v_o | (v_tv_r & load_hit_tv & uncached_op_tv_r));
-  wire stat_mem_fast_write = (early_hit_v_o & cached_op_tv_r);
-  wire stat_mem_slow_write = stat_mem_pkt_yumi_lo & (stat_mem_pkt_cast_i.opcode != e_cache_stat_mem_read);
-  wire stat_mem_slow_read  = stat_mem_pkt_yumi_lo & (stat_mem_pkt_cast_i.opcode == e_cache_stat_mem_read);
+  wire stat_mem_fast_write = (v_tv_r & ~any_miss_tv & cached_op_tv_r);
+  wire stat_mem_slow_write = stat_mem_pkt_yumi_o & (stat_mem_pkt_cast_i.opcode != e_cache_stat_mem_read);
+  wire stat_mem_slow_read  = stat_mem_pkt_yumi_o & (stat_mem_pkt_cast_i.opcode == e_cache_stat_mem_read);
   assign stat_mem_v_li = stat_mem_fast_read | stat_mem_fast_write
       | (stat_mem_slow_write | stat_mem_slow_read);
   assign stat_mem_w_li = stat_mem_fast_write | stat_mem_slow_write;
   assign stat_mem_addr_li = (stat_mem_fast_write | stat_mem_fast_read)
     ? paddr_tv_r[block_offset_width_lp+:sindex_width_lp]
     : stat_mem_pkt_cast_i.index;
-  assign stat_mem_pkt_yumi_lo = ~cache_lock & stat_mem_pkt_v_i & ~stat_mem_fast_read & ~stat_mem_fast_write;
+  assign stat_mem_pkt_yumi_o = ~cache_lock & stat_mem_pkt_v_i & ~stat_mem_fast_read & ~stat_mem_fast_write;
 
   logic [`BSG_SAFE_MINUS(assoc_p, 2):0] lru_decode_data_lo;
   logic [`BSG_SAFE_MINUS(assoc_p, 2):0] lru_decode_mask_lo;
@@ -1238,7 +1213,7 @@ module bp_be_dcache
       //   2) If dirty bit is not set, we do not send a request and simply return valid flush.
       //        The CSR unit is now responsible for sending the clear request to the I$.
       wire set_dirty = wbuf_v_li;
-      wire clear_dirty = (is_fence & cache_req_complete_i);
+      wire clear_dirty = (cache_req_complete_i & decode_tv_r.fencei_op);
       bsg_dff_reset_set_clear
        #(.width_p(1))
        gdirty_reg
@@ -1281,7 +1256,7 @@ module bp_be_dcache
   bsg_dff
    #(.width_p(lg_dcache_assoc_lp))
    stat_mem_pkt_way_reg
-    (.clk_i(posedge_clk)
+    (.clk_i(negedge_clk)
      ,.data_i(stat_mem_pkt_cast_i.way_id)
      ,.data_o(stat_mem_pkt_way_r)
      );

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -269,9 +269,7 @@ module wrapper
              ,.fill_width_p(fill_width_p)
              ,.timeout_max_limit_p(4)
              ,.credits_p(coh_noc_max_credits_p)
-             ,.req_invert_clk_p(1)
-             ,.data_mem_invert_clk_p(1)
-             ,.tag_mem_invert_clk_p(1)
+             ,.metadata_latency_p(1)
              )
            dcache_lce
             (.clk_i(clk_i)
@@ -365,10 +363,7 @@ module wrapper
             ,.sets_p(sets_p)
             ,.block_width_p(block_width_p)
             ,.fill_width_p(fill_width_p)
-            ,.req_invert_clk_p(1)
-            ,.data_mem_invert_clk_p(1)
-            ,.tag_mem_invert_clk_p(1)
-            ,.stat_mem_invert_clk_p(1)
+            ,.metadata_latency_p(1)
             )
           dcache_uce
            (.clk_i(clk_i)

--- a/bp_common/src/v/bp_mmu.sv
+++ b/bp_common/src/v/bp_mmu.sv
@@ -20,6 +20,7 @@ module bp_mmu
    , input [1:0]                                      priv_mode_i
    , input                                            trans_en_i
    , input                                            sum_i
+   , input                                            mxr_i
    , input                                            uncached_mode_i
    , input                                            nonspec_mode_i
    , input [hio_width_p-1:0]                          hio_mask_i
@@ -56,15 +57,15 @@ module bp_mmu
 
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 
-  logic trans_en_r, r_v_r, r_instr_r, r_load_r, r_store_r, sum_r;
+  logic trans_en_r, r_v_r, r_instr_r, r_load_r, r_store_r, sum_r, mxr_r;
   logic [1:0] priv_mode_r;
   bsg_dff_reset
-   #(.width_p(8))
+   #(.width_p(9))
    r_v_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
-     ,.data_i({sum_i, priv_mode_i, trans_en_i, r_v_i, r_instr_i, r_load_i, r_store_i})
-     ,.data_o({sum_r, priv_mode_r, trans_en_r, r_v_r, r_instr_r, r_load_r, r_store_r})
+     ,.data_i({mxr_i, sum_i, priv_mode_i, trans_en_i, r_v_i, r_instr_i, r_load_i, r_store_i})
+     ,.data_o({mxr_r, sum_r, priv_mode_r, trans_en_r, r_v_r, r_instr_r, r_load_r, r_store_r})
      );
 
   logic [etag_width_p-1:0] r_etag_r;
@@ -164,9 +165,10 @@ module bp_mmu
   wire data_priv_page_fault = tlb_v_lo & (((priv_mode_r == `PRIV_MODE_S) & ~sum_r & tlb_entry_lo.u)
                                            | ((priv_mode_r == `PRIV_MODE_U) & ~tlb_entry_lo.u)
                                           );
-  wire data_write_page_fault = r_store_r & tlb_v_lo & (~tlb_entry_lo.w | ~tlb_entry_lo.d);
+  wire data_read_page_fault  = tlb_v_lo & ~(tlb_entry_lo.r | (tlb_entry_lo.x & mxr_r));
+  wire data_write_page_fault = tlb_v_lo & ~(tlb_entry_lo.w & tlb_entry_lo.d);
   wire instr_page_fault_v = trans_en_r & r_instr_r & (instr_priv_page_fault_v | instr_exe_page_fault_v);
-  wire load_page_fault_v  = trans_en_r & r_load_r & (data_priv_page_fault | eaddr_fault_v);
+  wire load_page_fault_v  = trans_en_r & r_load_r & (data_priv_page_fault | data_read_page_fault  | eaddr_fault_v);
   wire store_page_fault_v = trans_en_r & r_store_r & (data_priv_page_fault | data_write_page_fault | eaddr_fault_v);
   wire any_page_fault_v   = |{instr_page_fault_v, load_page_fault_v, store_page_fault_v};
 
@@ -184,9 +186,9 @@ module bp_mmu
 
   assign r_v_o                   = r_v_r &  tlb_v_lo & ~any_access_fault_v & ~any_page_fault_v;
   assign r_ptag_o                = ptag_lo;
-  assign r_instr_miss_o          = r_v_r & ~tlb_v_lo & r_instr_r & ~any_access_fault_v & ~any_page_fault_v;;
-  assign r_load_miss_o           = r_v_r & ~tlb_v_lo & r_load_r  & ~any_access_fault_v & ~any_page_fault_v;;
-  assign r_store_miss_o          = r_v_r & ~tlb_v_lo & r_store_r & ~any_access_fault_v & ~any_page_fault_v;;
+  assign r_instr_miss_o          = r_v_r & ~tlb_v_lo & r_instr_r & ~any_access_fault_v & ~any_page_fault_v;
+  assign r_load_miss_o           = r_v_r & ~tlb_v_lo & r_load_r  & ~any_access_fault_v & ~any_page_fault_v;
+  assign r_store_miss_o          = r_v_r & ~tlb_v_lo & r_store_r & ~any_access_fault_v & ~any_page_fault_v;
   assign r_uncached_o            = r_v_r &  tlb_v_lo & ptag_uncached_lo;
   assign r_nonidem_o             = r_v_r &  tlb_v_lo & ptag_nonidem_lo;
   assign r_dram_o                = r_v_r &  tlb_v_lo & ptag_dram_lo;

--- a/bp_common/src/v/bsg_dff_sync_read.v
+++ b/bp_common/src/v/bsg_dff_sync_read.v
@@ -5,23 +5,18 @@
 //   things like an synchronous SRAM read
 module bsg_dff_sync_read
  #(parameter `BSG_INV_PARAM(width_p)
-
-   // Whether to bypass the read data so that it doesn't create a bubble
+   // Whether data is available synchronously or asynchronously
    , parameter bypass_p = 0
    )
   (input clk_i
    , input reset_i
 
    // v_n_i is high the cycle before the data comes in
-   // The stored data will always be overwritten and valid always set, regardless
-   //   of the current valid state or incoming yumi
+   // The stored data will always be overwritten
    , input                      v_n_i
    , input [width_p-1:0]        data_i
 
    , output logic [width_p-1:0] data_o
-   , output logic               v_o
-   // yumi_i clears the valid signal
-   , input                      yumi_i
    );
 
   logic v_r;
@@ -34,18 +29,7 @@ module bsg_dff_sync_read
      ,.data_o(v_r)
      );
 
-  bsg_dff_reset_set_clear
-   #(.width_p(1))
-   v_o_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.set_i(v_r)
-     ,.clear_i(yumi_i)
-     ,.data_o(v_o)
-     );
-
-  if (bypass_p)
+  if (bypass_p == 1)
     begin : bypass
       bsg_dff_en_bypass
        #(.width_p(width_p))

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -234,6 +234,8 @@ module bp_fe_top
      ,.trans_en_i(shadow_translation_en_r)
      // Supervisor use of user memory is always disabled for immu
      ,.sum_i('0)
+     // Immu does not handle dcache loads
+     ,.mxr_i('0)
      ,.uncached_mode_i((cfg_bus_cast_i.icache_mode == e_lce_mode_uncached))
      ,.nonspec_mode_i((cfg_bus_cast_i.icache_mode == e_lce_mode_nonspec))
      ,.hio_mask_i(cfg_bus_cast_i.hio_mask)

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -396,6 +396,7 @@ module wrapper
        ,.sets_p(icache_sets_p)
        ,.block_width_p(icache_block_width_p)
        ,.fill_width_p(icache_fill_width_p)
+       ,.metadata_latency_p(1)
        )
      icache_uce
       (.clk_i(clk_i)

--- a/bp_me/src/v/lce/bp_lce.sv
+++ b/bp_me/src/v/lce/bp_lce.sv
@@ -29,12 +29,6 @@ module bp_lce
    , parameter fill_buffer_els_p = 2
    , parameter fill_data_buffer_els_p = 2
 
-   // clocking options
-   , parameter req_invert_clk_p = 0
-   , parameter data_mem_invert_clk_p = 0
-   , parameter tag_mem_invert_clk_p = 0
-   , parameter stat_mem_invert_clk_p = 0
-
    // LCE-cache interface timeout in cycles
    , parameter timeout_max_limit_p=4
    // maximum number of outstanding transactions
@@ -152,9 +146,8 @@ module bp_lce
   // LCE only supports single data beat for requests
   if (fill_width_p < dword_width_gp)
     $error("fill width must be greater or equal than cache request data width");
-  // Request metadata latency must be 0 or 1
-  if ((metadata_latency_p < 0) || (metadata_latency_p > 1))
-    $error("Cache request metadata latency must be 0 or 1");
+  if ((metadata_latency_p > 1))
+    $error("metadata needs to arrive <2 cycles after the request");
   if (cmd_buffer_els_p < 1 || fill_buffer_els_p < 1)
     $error("LCEs require buffers for at least 1 command and fill header");
   if (cmd_data_buffer_els_p < 1 || fill_data_buffer_els_p < 1)
@@ -292,8 +285,7 @@ module bp_lce
       ,.ready_o(req_ready_lo)
 
       ,.cache_req_i(cache_req_i)
-      // Gate the cache_req_v_i signal to prevent yumis when busy
-      ,.cache_req_v_i(~cache_req_busy_o & cache_req_v_i)
+      ,.cache_req_v_i(cache_req_v_i)
       ,.cache_req_yumi_o(cache_req_yumi_o)
       ,.cache_req_metadata_i(cache_req_metadata_i)
       ,.cache_req_metadata_v_i(cache_req_metadata_v_i)
@@ -315,9 +307,6 @@ module bp_lce
       ,.sets_p(sets_p)
       ,.block_width_p(block_width_p)
       ,.fill_width_p(fill_width_p)
-      ,.data_mem_invert_clk_p(data_mem_invert_clk_p)
-      ,.tag_mem_invert_clk_p(tag_mem_invert_clk_p)
-      ,.stat_mem_invert_clk_p(stat_mem_invert_clk_p)
       ,.cmd_buffer_els_p(cmd_buffer_els_p)
       ,.cmd_data_buffer_els_p(cmd_data_buffer_els_p)
       )

--- a/bp_me/src/v/lce/bp_lce_cmd.sv
+++ b/bp_me/src/v/lce/bp_lce_cmd.sv
@@ -27,11 +27,6 @@ module bp_lce_cmd
    // number of LCE command data buffer elements
    , parameter cmd_data_buffer_els_p = cmd_buffer_els_p*(block_width_p/fill_width_p)
 
-   // clocking options
-   , parameter data_mem_invert_clk_p = 0
-   , parameter tag_mem_invert_clk_p = 0
-   , parameter stat_mem_invert_clk_p = 0
-
    // derived parameters
    , localparam lg_assoc_lp = `BSG_SAFE_CLOG2(assoc_p)
    , localparam lg_sets_lp = `BSG_SAFE_CLOG2(sets_p)
@@ -163,7 +158,7 @@ module bp_lce_cmd
   // LCE command data buffer
   // required to prevent deadlock in multicore networks
   logic [fill_width_p-1:0] lce_cmd_data_li;
-  logic lce_cmd_data_v_li, lce_cmd_last_li, lce_cmd_data_ready_and_lo, lce_cmd_data_yumi_lo;
+  logic lce_cmd_data_v_li, lce_cmd_last_li, lce_cmd_data_yumi_lo;
   bsg_fifo_1r1w_small
     #(.width_p(fill_width_p+1)
       ,.els_p(cmd_data_buffer_els_p)
@@ -178,7 +173,6 @@ module bp_lce_cmd
       ,.yumi_i(lce_cmd_data_yumi_lo)
       ,.data_o({lce_cmd_last_li, lce_cmd_data_li})
       );
-  assign lce_cmd_data_yumi_lo = lce_cmd_data_v_li & lce_cmd_data_ready_and_lo;
 
   // first fill index of arriving command
   wire [fill_select_width_lp-1:0] first_cnt =
@@ -269,78 +263,65 @@ module bp_lce_cmd
   // sync done register - goes high when all sync command/acks complete
   logic sync_done_en, sync_done_li;
   bsg_dff_reset_en
-    #(.width_p(1))
-    sync_done_reg
-     (.clk_i(clk_i)
-      ,.reset_i(reset_i)
-      ,.en_i(sync_done_en)
-      ,.data_i(sync_done_li)
-      ,.data_o(sync_done_o)
-      );
+   #(.width_p(1))
+   sync_done_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.en_i(sync_done_en)
+     ,.data_i(sync_done_li)
+     ,.data_o(sync_done_o)
+     );
 
   logic [block_width_p-1:0] dirty_data_r;
-  logic dirty_data_v_r;
   wire dirty_data_read = data_mem_pkt_yumi_i & (data_mem_pkt_cast_o.opcode == e_cache_data_mem_read);
-  wire data_mem_clk = (data_mem_invert_clk_p ? ~clk_i : clk_i);
   bsg_dff_sync_read
-   #(.width_p(block_width_p))
+   #(.width_p(block_width_p), .bypass_p(1))
    dirty_data_reg
-    (.clk_i(data_mem_clk)
+    (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
      ,.data_i(data_mem_i)
      ,.v_n_i(dirty_data_read)
 
      ,.data_o(dirty_data_r)
-     ,.v_o(dirty_data_v_r)
-     ,.yumi_i(dirty_data_read)
      );
 
   // data mux to pick fill word for sending in command/response data beat
   logic [fill_width_p-1:0] dirty_data_selected;
   bsg_mux
-    #(.width_p(fill_width_p)
-      ,.els_p(block_size_in_fill_lp))
-    dirty_data_mux
-     (.data_i(dirty_data_r)
-      ,.sel_i(wrap_cnt)
-      ,.data_o(dirty_data_selected)
-      );
+   #(.width_p(fill_width_p), .els_p(block_size_in_fill_lp))
+   dirty_data_mux
+    (.data_i(dirty_data_r)
+     ,.sel_i(wrap_cnt)
+     ,.data_o(dirty_data_selected)
+     );
 
   bp_cache_tag_info_s dirty_tag_r;
-  logic dirty_tag_v_r;
   wire dirty_tag_read = tag_mem_pkt_yumi_i & (tag_mem_pkt_cast_o.opcode == e_cache_tag_mem_read);
-  wire tag_mem_clk = (tag_mem_invert_clk_p ? ~clk_i : clk_i);
   bsg_dff_sync_read
-   #(.width_p($bits(bp_cache_tag_info_s)))
+   #(.width_p($bits(bp_cache_tag_info_s)), .bypass_p(1))
    dirty_tag_reg
-    (.clk_i(tag_mem_clk)
+    (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
      ,.data_i(tag_mem_i)
      ,.v_n_i(dirty_tag_read)
 
      ,.data_o(dirty_tag_r)
-     ,.v_o(dirty_tag_v_r)
-     ,.yumi_i(dirty_tag_read)
      );
 
   bp_cache_stat_info_s dirty_stat_r;
-  logic dirty_stat_v_r;
   wire dirty_stat_read = stat_mem_pkt_yumi_i & (stat_mem_pkt_cast_o.opcode == e_cache_stat_mem_read);
-  wire stat_mem_clk = (stat_mem_invert_clk_p ? ~clk_i : clk_i);
   bsg_dff_sync_read
-   #(.width_p($bits(bp_cache_stat_info_s)))
+   #(.width_p($bits(bp_cache_stat_info_s)), .bypass_p(1))
    dirty_stat_reg
-    (.clk_i(stat_mem_clk)
+    (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
      ,.data_i(stat_mem_i)
      ,.v_n_i(dirty_stat_read)
 
      ,.data_o(dirty_stat_r)
-     ,.v_o(dirty_stat_v_r)
-     ,.yumi_i(dirty_stat_read)
      );
 
   // common fields from LCE Command used in many states for responses or pkt fields
@@ -391,7 +372,7 @@ module bp_lce_cmd
 
     // LCE-CCE Interface signals
     lce_cmd_header_yumi_lo = 1'b0;
-    lce_cmd_data_ready_and_lo = 1'b0;
+    lce_cmd_data_yumi_lo = 1'b0;
 
     lce_fill_header_cast_o = '0;
     lce_fill_header_v_o = 1'b0;
@@ -597,7 +578,7 @@ module bp_lce_cmd
             data_mem_pkt_v_o = lce_cmd_header_v_li & lce_cmd_data_v_li;
 
             // consume single data beat and header when data packet is consumed by cache
-            lce_cmd_data_ready_and_lo = data_mem_pkt_yumi_i;
+            lce_cmd_data_yumi_lo = data_mem_pkt_yumi_i;
             lce_cmd_header_yumi_lo = data_mem_pkt_yumi_i;
 
             // raise request complete signal when data consumed
@@ -728,15 +709,15 @@ module bp_lce_cmd
         data_mem_pkt_cast_o.opcode = e_cache_data_mem_write;
         data_mem_pkt_v_o = lce_cmd_data_v_li;
         // consume data beat when write to cache occurs
-        lce_cmd_data_ready_and_lo = data_mem_pkt_yumi_i;
+        lce_cmd_data_yumi_lo = data_mem_pkt_yumi_i;
         // increment wrap around count as each data beat sends
-        wrap_cnt_up = lce_cmd_data_v_li & lce_cmd_data_ready_and_lo;
+        wrap_cnt_up = lce_cmd_data_yumi_lo;
         // critical beat is first data beat
         critical_data_sent = data_mem_pkt_yumi_i & ~critical_data_sent_r;
 
         // do not consume header yet, will be consumed by sending coherence ack
 
-        state_n = (lce_cmd_data_v_li & lce_cmd_data_ready_and_lo & lce_cmd_last_li)
+        state_n = (lce_cmd_data_yumi_lo & lce_cmd_last_li)
                   ? e_coh_ack
                   : state_r;
 
@@ -772,13 +753,12 @@ module bp_lce_cmd
       end // e_tr
 
       // Transfer Data to target LCE
-      // dirty_data_r holds valid data when dirty_data_v_r is high
       // three commands enter this state: tr, st_tr, and st_tr_wb
       e_tr_data: begin
 
         lce_fill_data_o = dirty_data_selected;
         lce_fill_last_o = is_last_cnt;
-        lce_fill_data_v_o = dirty_data_v_r;
+        lce_fill_data_v_o = 1'b1;
 
         // hold wraparound counter size input constant
         wrap_cnt_size = fill_select_width_lp'(block_size_in_fill_lp-1);
@@ -839,8 +819,7 @@ module bp_lce_cmd
         lce_resp_header_cast_o.size = (lce_resp_has_data_o)
                                       ? cmd_block_size_lp
                                       : e_bedrock_msg_size_1;
-        // send if stat read is valid
-        lce_resp_header_v_o = dirty_stat_v_r;
+        lce_resp_header_v_o = 1'b1;
 
         // dequeue command only if sending null writeback
         lce_cmd_header_yumi_lo = lce_resp_header_v_o & lce_resp_header_ready_and_i
@@ -885,7 +864,7 @@ module bp_lce_cmd
 
         lce_resp_data_o = dirty_data_selected;
         lce_resp_last_o = is_last_cnt;
-        lce_resp_data_v_o = dirty_data_v_r;
+        lce_resp_data_v_o = 1'b1;
 
         // hold wraparound counter size input constant
         wrap_cnt_size = fill_select_width_lp'(block_size_in_fill_lp-1);

--- a/bp_me/src/v/lce/bp_lce_req.sv
+++ b/bp_me/src/v/lce/bp_lce_req.sv
@@ -24,10 +24,6 @@ module bp_lce_req
    , parameter `BSG_INV_PARAM(block_width_p)
    , parameter `BSG_INV_PARAM(fill_width_p)
 
-   // clocking options
-   , parameter req_invert_clk_p = 0
-   , parameter tag_mem_invert_clk_p = 0
-
    // LCE-cache interface timeout in cycles
    , parameter timeout_max_limit_p=4
    // maximum number of outstanding transactions
@@ -116,36 +112,22 @@ module bp_lce_req
      ,.data_o(cache_req_v_r)
      );
 
-  wire req_clk = (req_invert_clk_p ? ~clk_i : clk_i);
   bp_cache_req_s cache_req_r;
   bsg_dff_en
-    #(.width_p($bits(bp_cache_req_s)))
-    req_reg
-     (.clk_i(req_clk)
-      ,.en_i(cache_req_yumi_o)
-      ,.data_i(cache_req_i)
-      ,.data_o(cache_req_r)
-      );
-
-  // cache request metadata valid and register
-  logic cache_req_metadata_v_r;
-  bsg_dff_reset_set_clear
-   #(.width_p(1)
-     ,.clear_over_set_p((metadata_latency_p == 1))
-     )
-   metadata_v_reg
+   #(.width_p($bits(bp_cache_req_s)))
+   req_reg
     (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-     ,.set_i(cache_req_metadata_v_i)
-     ,.clear_i(cache_req_yumi_o)
-     ,.data_o(cache_req_metadata_v_r)
+     ,.en_i(cache_req_yumi_o)
+     ,.data_i(cache_req_i)
+     ,.data_o(cache_req_r)
      );
 
   bp_cache_req_metadata_s cache_req_metadata_r;
-  bsg_dff_en
+  bsg_dff_reset_en_bypass
    #(.width_p($bits(bp_cache_req_metadata_s)))
    metadata_reg
-    (.clk_i(req_clk)
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
      ,.en_i(cache_req_metadata_v_i)
      ,.data_i(cache_req_metadata_i)
      ,.data_o(cache_req_metadata_r)
@@ -285,7 +267,7 @@ module bp_lce_req
                       : state_r;
           end
           e_miss_load: begin
-            lce_req_header_v_o = cache_req_v_with_credit & cache_req_metadata_v_r;
+            lce_req_header_v_o = cache_req_v_with_credit;
             lce_req_header_cast_o.size = req_block_size_lp;
             // align address to data width and send address of critical beat
             lce_req_header_cast_o.addr = critical_req_addr;
@@ -297,7 +279,7 @@ module bp_lce_req
             // no data to send, stay in e_ready
           end
           e_miss_store: begin
-            lce_req_header_v_o = cache_req_v_with_credit & cache_req_metadata_v_r;
+            lce_req_header_v_o = cache_req_v_with_credit;
             lce_req_header_cast_o.size = req_block_size_lp;
             // align address to data width and send address of critical beat
             lce_req_header_cast_o.addr = critical_req_addr;

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -208,9 +208,6 @@ module bp_cacc_vdp
      ,.fill_width_p(acache_fill_width_p)
      ,.timeout_max_limit_p(4)
      ,.credits_p(coh_noc_max_credits_p)
-     ,.req_invert_clk_p(1)
-     ,.data_mem_invert_clk_p(1)
-     ,.tag_mem_invert_clk_p(1)
      )
    lce
     (.clk_i(clk_i)

--- a/bp_top/src/v/bp_core.sv
+++ b/bp_top/src/v/bp_core.sv
@@ -80,6 +80,7 @@ module bp_core
   );
 
   `declare_bp_cfg_bus_s(hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache);
 
@@ -129,10 +130,13 @@ module bp_core
   logic dcache_stat_mem_pkt_yumi_lo;
   bp_dcache_stat_info_s dcache_stat_mem_lo;
 
+  wire posedge_clk = clk_i;
+  wire negedge_clk = ~clk_i;
+
   bp_core_minimal
    #(.bp_params_p(bp_params_p))
    core_minimal
-    (.clk_i(clk_i)
+    (.clk_i(posedge_clk)
      ,.reset_i(reset_i)
      ,.cfg_bus_i(cfg_bus_cast_i)
 
@@ -208,7 +212,7 @@ module bp_core
      ,.metadata_latency_p(1)
      )
    fe_lce
-    (.clk_i(clk_i)
+    (.clk_i(posedge_clk)
      ,.reset_i(reset_i)
 
      ,.lce_id_i(cfg_bus_cast_i.icache_id)
@@ -287,6 +291,50 @@ module bp_core
      ,.lce_resp_data_ready_and_i(lce_resp_data_ready_and_i[0])
      );
 
+  logic [1:1][lce_req_header_width_lp-1:0]  _lce_req_header_o;
+  logic [1:1]                               _lce_req_header_v_o;
+  logic [1:1]                               _lce_req_header_ready_and_i;
+  logic [1:1]                               _lce_req_has_data_o;
+  logic [1:1][icache_fill_width_p-1:0]      _lce_req_data_o;
+  logic [1:1]                               _lce_req_data_v_o;
+  logic [1:1]                               _lce_req_data_ready_and_i;
+  logic [1:1]                               _lce_req_last_o;
+
+  logic [1:1][lce_cmd_header_width_lp-1:0]  _lce_cmd_header_i;
+  logic [1:1]                               _lce_cmd_header_v_i;
+  logic [1:1]                               _lce_cmd_header_ready_and_o;
+  logic [1:1]                               _lce_cmd_has_data_i;
+  logic [1:1][icache_fill_width_p-1:0]      _lce_cmd_data_i;
+  logic [1:1]                               _lce_cmd_data_v_i;
+  logic [1:1]                               _lce_cmd_data_ready_and_o;
+  logic [1:1]                               _lce_cmd_last_i;
+
+  logic [1:1][lce_fill_header_width_lp-1:0] _lce_fill_header_i;
+  logic [1:1]                               _lce_fill_header_v_i;
+  logic [1:1]                               _lce_fill_header_ready_and_o;
+  logic [1:1]                               _lce_fill_has_data_i;
+  logic [1:1][icache_fill_width_p-1:0]      _lce_fill_data_i;
+  logic [1:1]                               _lce_fill_data_v_i;
+  logic [1:1]                               _lce_fill_data_ready_and_o;
+  logic [1:1]                               _lce_fill_last_i;
+
+  logic [1:1][lce_fill_header_width_lp-1:0] _lce_fill_header_o;
+  logic [1:1]                               _lce_fill_header_v_o;
+  logic [1:1]                               _lce_fill_header_ready_and_i;
+  logic [1:1]                               _lce_fill_has_data_o;
+  logic [1:1][icache_fill_width_p-1:0]      _lce_fill_data_o;
+  logic [1:1]                               _lce_fill_data_v_o;
+  logic [1:1]                               _lce_fill_data_ready_and_i;
+  logic [1:1]                               _lce_fill_last_o;
+
+  logic [1:1][lce_resp_header_width_lp-1:0] _lce_resp_header_o;
+  logic [1:1]                               _lce_resp_header_v_o;
+  logic [1:1]                               _lce_resp_header_ready_and_i;
+  logic [1:1]                               _lce_resp_has_data_o;
+  logic [1:1][icache_fill_width_p-1:0]      _lce_resp_data_o;
+  logic [1:1]                               _lce_resp_data_v_o;
+  logic [1:1]                               _lce_resp_data_ready_and_i;
+  logic [1:1]                               _lce_resp_last_o;
   bp_lce
    #(.bp_params_p(bp_params_p)
      ,.assoc_p(dcache_assoc_p)
@@ -295,13 +343,10 @@ module bp_core
      ,.fill_width_p(dcache_fill_width_p)
      ,.timeout_max_limit_p(4)
      ,.credits_p(coh_noc_max_credits_p)
-     ,.req_invert_clk_p(1)
-     ,.data_mem_invert_clk_p(1)
-     ,.tag_mem_invert_clk_p(1)
      ,.metadata_latency_p(1)
      )
    be_lce
-    (.clk_i(clk_i)
+    (.clk_i(negedge_clk)
      ,.reset_i(reset_i)
 
      ,.lce_id_i(cfg_bus_cast_i.dcache_id)
@@ -334,50 +379,99 @@ module bp_core
      ,.stat_mem_pkt_yumi_i(dcache_stat_mem_pkt_yumi_lo)
      ,.stat_mem_i(dcache_stat_mem_lo)
 
-     ,.lce_req_header_o(lce_req_header_o[1])
-     ,.lce_req_header_v_o(lce_req_header_v_o[1])
-     ,.lce_req_has_data_o(lce_req_has_data_o[1])
-     ,.lce_req_header_ready_and_i(lce_req_header_ready_and_i[1])
-     ,.lce_req_data_o(lce_req_data_o[1])
-     ,.lce_req_data_v_o(lce_req_data_v_o[1])
-     ,.lce_req_last_o(lce_req_last_o[1])
-     ,.lce_req_data_ready_and_i(lce_req_data_ready_and_i[1])
+     ,.lce_req_header_o(_lce_req_header_o[1])
+     ,.lce_req_header_v_o(_lce_req_header_v_o[1])
+     ,.lce_req_has_data_o(_lce_req_has_data_o[1])
+     ,.lce_req_header_ready_and_i(_lce_req_header_ready_and_i[1])
+     ,.lce_req_data_o(_lce_req_data_o[1])
+     ,.lce_req_data_v_o(_lce_req_data_v_o[1])
+     ,.lce_req_last_o(_lce_req_last_o[1])
+     ,.lce_req_data_ready_and_i(_lce_req_data_ready_and_i[1])
 
-     ,.lce_cmd_header_i(lce_cmd_header_i[1])
-     ,.lce_cmd_header_v_i(lce_cmd_header_v_i[1])
-     ,.lce_cmd_has_data_i(lce_cmd_has_data_i[1])
-     ,.lce_cmd_header_ready_and_o(lce_cmd_header_ready_and_o[1])
-     ,.lce_cmd_data_i(lce_cmd_data_i[1])
-     ,.lce_cmd_data_v_i(lce_cmd_data_v_i[1])
-     ,.lce_cmd_last_i(lce_cmd_last_i[1])
-     ,.lce_cmd_data_ready_and_o(lce_cmd_data_ready_and_o[1])
+     ,.lce_cmd_header_i(_lce_cmd_header_i[1])
+     ,.lce_cmd_header_v_i(_lce_cmd_header_v_i[1])
+     ,.lce_cmd_has_data_i(_lce_cmd_has_data_i[1])
+     ,.lce_cmd_header_ready_and_o(_lce_cmd_header_ready_and_o[1])
+     ,.lce_cmd_data_i(_lce_cmd_data_i[1])
+     ,.lce_cmd_data_v_i(_lce_cmd_data_v_i[1])
+     ,.lce_cmd_last_i(_lce_cmd_last_i[1])
+     ,.lce_cmd_data_ready_and_o(_lce_cmd_data_ready_and_o[1])
 
-     ,.lce_fill_header_i(lce_fill_header_i[1])
-     ,.lce_fill_header_v_i(lce_fill_header_v_i[1])
-     ,.lce_fill_has_data_i(lce_fill_has_data_i[1])
-     ,.lce_fill_header_ready_and_o(lce_fill_header_ready_and_o[1])
-     ,.lce_fill_data_i(lce_fill_data_i[1])
-     ,.lce_fill_data_v_i(lce_fill_data_v_i[1])
-     ,.lce_fill_last_i(lce_fill_last_i[1])
-     ,.lce_fill_data_ready_and_o(lce_fill_data_ready_and_o[1])
+     ,.lce_fill_header_i(_lce_fill_header_i[1])
+     ,.lce_fill_header_v_i(_lce_fill_header_v_i[1])
+     ,.lce_fill_has_data_i(_lce_fill_has_data_i[1])
+     ,.lce_fill_header_ready_and_o(_lce_fill_header_ready_and_o[1])
+     ,.lce_fill_data_i(_lce_fill_data_i[1])
+     ,.lce_fill_data_v_i(_lce_fill_data_v_i[1])
+     ,.lce_fill_last_i(_lce_fill_last_i[1])
+     ,.lce_fill_data_ready_and_o(_lce_fill_data_ready_and_o[1])
 
-     ,.lce_fill_header_o(lce_fill_header_o[1])
-     ,.lce_fill_header_v_o(lce_fill_header_v_o[1])
-     ,.lce_fill_has_data_o(lce_fill_has_data_o[1])
-     ,.lce_fill_header_ready_and_i(lce_fill_header_ready_and_i[1])
-     ,.lce_fill_data_o(lce_fill_data_o[1])
-     ,.lce_fill_data_v_o(lce_fill_data_v_o[1])
-     ,.lce_fill_last_o(lce_fill_last_o[1])
-     ,.lce_fill_data_ready_and_i(lce_fill_data_ready_and_i[1])
+     ,.lce_fill_header_o(_lce_fill_header_o[1])
+     ,.lce_fill_header_v_o(_lce_fill_header_v_o[1])
+     ,.lce_fill_has_data_o(_lce_fill_has_data_o[1])
+     ,.lce_fill_header_ready_and_i(_lce_fill_header_ready_and_i[1])
+     ,.lce_fill_data_o(_lce_fill_data_o[1])
+     ,.lce_fill_data_v_o(_lce_fill_data_v_o[1])
+     ,.lce_fill_last_o(_lce_fill_last_o[1])
+     ,.lce_fill_data_ready_and_i(_lce_fill_data_ready_and_i[1])
 
-     ,.lce_resp_header_o(lce_resp_header_o[1])
-     ,.lce_resp_header_v_o(lce_resp_header_v_o[1])
-     ,.lce_resp_has_data_o(lce_resp_has_data_o[1])
-     ,.lce_resp_header_ready_and_i(lce_resp_header_ready_and_i[1])
-     ,.lce_resp_data_o(lce_resp_data_o[1])
-     ,.lce_resp_data_v_o(lce_resp_data_v_o[1])
-     ,.lce_resp_last_o(lce_resp_last_o[1])
-     ,.lce_resp_data_ready_and_i(lce_resp_data_ready_and_i[1])
+     ,.lce_resp_header_o(_lce_resp_header_o[1])
+     ,.lce_resp_header_v_o(_lce_resp_header_v_o[1])
+     ,.lce_resp_has_data_o(_lce_resp_has_data_o[1])
+     ,.lce_resp_header_ready_and_i(_lce_resp_header_ready_and_i[1])
+     ,.lce_resp_data_o(_lce_resp_data_o[1])
+     ,.lce_resp_data_v_o(_lce_resp_data_v_o[1])
+     ,.lce_resp_last_o(_lce_resp_last_o[1])
+     ,.lce_resp_data_ready_and_i(_lce_resp_data_ready_and_i[1])
+     );
+
+  // These latches are optimized out in Verilator 4.220...
+  //   but bsg_deff_reset is more heavy_weight. It's possible that FPGAs would prefer
+  //   the alternate implementation as well. But ASICs will appreciate the time-borrowing
+`ifdef VERILATOR
+  bsg_deff_reset
+   #(.width_p($bits(bp_bedrock_lce_req_header_s)+$bits(bp_bedrock_lce_fill_header_s)+$bits(bp_bedrock_lce_resp_header_s)+3*icache_fill_width_p+3*4+6))
+   posedge_latch
+    (.clk_i(posedge_clk)
+     ,.reset_i(reset_i)
+`else
+  bsg_dlatch
+   #(.width_p($bits(bp_bedrock_lce_req_header_s)+$bits(bp_bedrock_lce_fill_header_s)+$bits(bp_bedrock_lce_resp_header_s)+3*icache_fill_width_p+3*4+6), .i_know_this_is_a_bad_idea_p(1))
+   posedge_latch
+    (.clk_i(posedge_clk)
+`endif
+     ,.data_i({_lce_req_header_o[1], _lce_req_header_v_o[1], _lce_req_has_data_o[1], _lce_req_data_o[1], _lce_req_data_v_o[1], _lce_req_last_o[1]
+              ,_lce_fill_header_o[1], _lce_fill_header_v_o[1], _lce_fill_has_data_o[1], _lce_fill_data_o[1], _lce_fill_data_v_o[1], _lce_fill_last_o[1]
+              ,_lce_resp_header_o[1], _lce_resp_header_v_o[1], _lce_resp_has_data_o[1], _lce_resp_data_o[1], _lce_resp_data_v_o[1], _lce_resp_last_o[1]
+              ,lce_req_header_ready_and_i[1], lce_req_data_ready_and_i[1], lce_fill_header_ready_and_i[1], lce_fill_data_ready_and_i[1], lce_resp_header_ready_and_i[1], lce_resp_data_ready_and_i[1]
+              })
+     ,.data_o({lce_req_header_o[1], lce_req_header_v_o[1], lce_req_has_data_o[1], lce_req_data_o[1], lce_req_data_v_o[1], lce_req_last_o[1]
+              ,lce_fill_header_o[1], lce_fill_header_v_o[1], lce_fill_has_data_o[1], lce_fill_data_o[1], lce_fill_data_v_o[1], lce_fill_last_o[1]
+              ,lce_resp_header_o[1], lce_resp_header_v_o[1], lce_resp_has_data_o[1], lce_resp_data_o[1], lce_resp_data_v_o[1], lce_resp_last_o[1]
+              ,_lce_req_header_ready_and_i[1], _lce_req_data_ready_and_i[1], _lce_fill_header_ready_and_i[1], _lce_fill_data_ready_and_i[1], _lce_resp_header_ready_and_i[1], _lce_resp_data_ready_and_i[1]
+              })
+     );
+
+`ifdef VERILATOR
+  bsg_deff_reset
+   #(.width_p($bits(bp_bedrock_lce_cmd_header_s)+$bits(bp_bedrock_lce_fill_header_s)+2*icache_fill_width_p+2*4+4))
+   negedge_latch
+    (.clk_i(negedge_clk)
+     ,.reset_i(reset_i)
+`else
+  bsg_dlatch
+   #(.width_p($bits(bp_bedrock_lce_cmd_header_s)+$bits(bp_bedrock_lce_fill_header_s)+2*icache_fill_width_p+2*4+4), .i_know_this_is_a_bad_idea_p(1))
+   negedge_latch
+    (.clk_i(negedge_clk)
+`endif
+     ,.data_i({lce_cmd_header_i[1], lce_cmd_header_v_i[1], lce_cmd_has_data_i[1], lce_cmd_data_i[1], lce_cmd_data_v_i[1], lce_cmd_last_i[1]
+               ,lce_fill_header_i[1], lce_fill_header_v_i[1], lce_fill_has_data_i[1], lce_fill_data_i[1], lce_fill_data_v_i[1], lce_fill_last_i[1]
+               ,_lce_cmd_header_ready_and_o[1], _lce_cmd_data_ready_and_o[1], _lce_fill_header_ready_and_o[1], _lce_fill_data_ready_and_o[1]
+               })
+     ,.data_o({_lce_cmd_header_i[1], _lce_cmd_header_v_i[1], _lce_cmd_has_data_i[1], _lce_cmd_data_i[1], _lce_cmd_data_v_i[1], _lce_cmd_last_i[1]
+               ,_lce_fill_header_i[1], _lce_fill_header_v_i[1], _lce_fill_has_data_i[1], _lce_fill_data_i[1], _lce_fill_data_v_i[1], _lce_fill_last_i[1]
+               ,lce_cmd_header_ready_and_o[1], lce_cmd_data_ready_and_o[1], lce_fill_header_ready_and_o[1], lce_fill_data_ready_and_o[1]
+               })
      );
 
 endmodule

--- a/bp_top/src/v/bp_core_minimal.sv
+++ b/bp_top/src/v/bp_core_minimal.sv
@@ -48,6 +48,8 @@ module bp_core_minimal
    , output logic                                    icache_stat_mem_pkt_yumi_o
    , output logic [icache_stat_info_width_lp-1:0]    icache_stat_mem_o
 
+   // D$ Engine Interface is clocked on the negedge of the clock. Must be attached to
+   //   a negative-edge cache engine and synchronized before getting to the memory system
    , output logic [dcache_req_width_lp-1:0]          dcache_req_o
    , output logic                                    dcache_req_v_o
    , input                                           dcache_req_yumi_i

--- a/bp_top/test/tb/bp_tethered/flist.vcs
+++ b/bp_top/test/tb/bp_tethered/flist.vcs
@@ -3,7 +3,6 @@
 $BASEJUMP_STL_DIR/bsg_dmc/bsg_dmc_pkg.v
 $BASEJUMP_STL_DIR/bsg_tag/bsg_tag_pkg.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_dramsim3_pkg.v
-$BASEJUMP_STL_DIR/bsg_async/bsg_sync_sync.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_to_axi.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_to_axi_rx.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_to_axi_tx.v

--- a/docs/platform_guide.md
+++ b/docs/platform_guide.md
@@ -4,9 +4,9 @@
 
 ## Instruction Latencies
 * RV64I arithmetic instructions have 1-cycle latency
-* RV64IA memory instructions have 3-cycle latency
-* RV64M instructions have a 4-cycle latency, except for division, which is iterative
-* Rv64FD instructions have a 5-cycle latency, exception for fdiv/fsqrt, which are iterative
+* RV64IA memory instructions have 2/3-cycle latency
+* RV64M instructions have a 3-cycle latency, except for division, which is iterative
+* Rv64FD instructions have a 4-cycle latency, exception for fdiv/fsqrt, which are iterative
 * BlackParrot has a load-to-use time of 2 cycles for dwords, 3 cycles for words, halfs, and bytes
 * BlackParrot has a 2-cycle L1 hit latency for integer loads
 * BlackParrot has a 3-cycle L1 hit latency for floating point loads 


### PR DESCRIPTION
- Reduces FMA latency (and mul) #1036 
- Cleans up cache interface from half cycle paths #1070 
- Latches PTW info to be a bit safer and critical path free