### PR TITLE
Update dev to fe_dev

### DIFF
--- a/bp_be/syn/flist.vcs
+++ b/bp_be/syn/flist.vcs
@@ -75,8 +75,6 @@ $BASEJUMP_STL_DIR/bsg_mem/bsg_cam_1r1w_sync.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_cam_1r1w_tag_array.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_one_hot.v
-$BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_sync.v
-$BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_sync_synth.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_synth.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
@@ -275,4 +273,6 @@ $BP_ME_DIR/src/v/network/bp_me_xbar_burst.sv
 $BP_COMMON_DIR/src/v/bsg_async_noc_link.sv
 $BP_COMMON_DIR/src/v/bsg_deff_reset.v
 $BP_COMMON_DIR/src/v/bsg_dff_sync_read.v
+$BP_COMMON_DIR/src/v/bsg_mem_1r1w_sync.v
+$BP_COMMON_DIR/src/v/bsg_mem_1r1w_sync_synth.v
 

--- a/bp_common/src/v/bsg_mem_1r1w_sync.v
+++ b/bp_common/src/v/bsg_mem_1r1w_sync.v
@@ -1,0 +1,101 @@
+// MBT 7/7/2016
+//
+// 1 read-port, 1 write-port ram
+//
+// reads are synchronous
+//
+// although we could merge this with normal bsg_mem_1r1w
+// and select with a parameter, we do not do this because
+// it's typically a very big change to the instantiating code
+// to move to/from sync/async, and we want to reflect this.
+//
+
+`include "bsg_defines.v"
+
+module bsg_mem_1r1w_sync #(parameter `BSG_INV_PARAM(width_p)
+                           , parameter `BSG_INV_PARAM(els_p)
+                           , parameter read_write_same_addr_p=0
+                           , parameter latch_last_read_p=0
+                           , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
+                           , parameter harden_p=0
+                           , parameter disable_collision_warning_p=0
+                           , parameter enable_clock_gating_p=0
+                           , parameter verbose_if_synth_p=1
+                           )
+   (input   clk_i
+    , input reset_i
+
+    , input                     w_v_i
+    , input [addr_width_lp-1:0] w_addr_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0]       w_data_i
+
+    // currently unused
+    , input                      r_v_i
+    , input [addr_width_lp-1:0]  r_addr_i
+
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r_data_o
+    );
+
+   wire clk_lo;
+
+   if (enable_clock_gating_p)
+     begin
+       bsg_clkgate_optional icg
+         (.clk_i( clk_i )
+         ,.en_i( w_v_i | r_v_i )
+         ,.bypass_i( 1'b0 )
+         ,.gated_clock_o( clk_lo )
+         );
+     end
+   else
+     begin
+       assign clk_lo = clk_i;
+     end
+
+   bsg_mem_1r1w_sync_synth
+     #(.width_p(width_p)
+       ,.els_p(els_p)
+       ,.read_write_same_addr_p(read_write_same_addr_p)
+       ,.latch_last_read_p(latch_last_read_p)
+       ,.verbose_p(verbose_if_synth_p) // disables reprinting out a masked synth ram
+                                       //  that has been split into many synth rams
+       ) synth
+       (.clk_i( clk_lo )
+       ,.reset_i
+       ,.w_v_i
+       ,.w_addr_i
+       ,.w_data_i
+       ,.r_v_i
+       ,.r_addr_i
+       ,.r_data_o
+       );
+
+   //synopsys translate_off
+   initial
+     begin
+	// we warn if els_p >= 16 because it is a good candidate for hardening
+	// and we warn for width_p >= 128 because this starts to add up to some real memory
+	if ((els_p >= 16) || (width_p >= 128) || (width_p*els_p > 256))
+          $display("## %L: instantiating width_p=%d, els_p=%d, read_write_same_addr_p=%d, harden_p=%d (%m)",width_p,els_p,read_write_same_addr_p,harden_p);
+
+	if (disable_collision_warning_p)
+	  $display("## %L: disable_collision_warning_p is set; you should not have this on unless you have broken code. fix it!\n");
+     end
+
+	always_ff @(negedge clk_lo)
+     if (w_v_i)
+       begin
+          assert ((reset_i === 'X) || (reset_i === 1'b1) || (w_addr_i < els_p))
+            else $error("Invalid address %x to %m of size %x\n", w_addr_i, els_p);
+
+          assert ((reset_i === 'X) || (reset_i === 1'b1) || ~(r_addr_i == w_addr_i && w_v_i && r_v_i && !read_write_same_addr_p && !disable_collision_warning_p))
+            else
+              begin
+                 $error("X'ing matched read address %x (%m)",r_addr_i);
+              end
+       end
+   //synopsys translate_on
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mem_1r1w_sync)

--- a/bp_common/src/v/bsg_mem_1r1w_sync_synth.v
+++ b/bp_common/src/v/bsg_mem_1r1w_sync_synth.v
@@ -1,0 +1,125 @@
+// MBT 7/7/2016
+//
+// 1 read-port, 1 write-port ram
+//
+// reads are synchronous
+//
+// although we could merge this with normal bsg_mem_1r1w
+// and select with a parameter, we do not do this because
+// it's typically a very big change to the instantiating code
+// to move to/from sync/async, and we want to reflect this.
+//
+// NOTE: Users of BaseJump STL should not instantiate this module directly
+// they should use bsg_mem_1r1w_sync.
+
+`include "bsg_defines.v"
+
+module bsg_mem_1r1w_sync_synth #(parameter `BSG_INV_PARAM(width_p)
+				 , parameter `BSG_INV_PARAM(els_p)
+				 , parameter read_write_same_addr_p=0
+				 , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
+                                 , parameter latch_last_read_p=0
+                 , parameter verbose_p=1
+                 , parameter harden_p=0
+				 )
+   (input   clk_i
+    , input reset_i
+
+    , input                     w_v_i
+    , input [addr_width_lp-1:0] w_addr_i
+    , input [`BSG_SAFE_MINUS(width_p, 1):0]       w_data_i
+
+    // currently unused
+    , input                      r_v_i
+    , input [addr_width_lp-1:0]  r_addr_i
+
+    , output logic [`BSG_SAFE_MINUS(width_p, 1):0] r_data_o
+    );
+
+   wire                   unused = reset_i;
+
+   if (width_p == 0)
+    begin: z
+      wire unused0 = &{clk_i, w_v_i, w_addr_i, r_v_i, r_addr_i};
+      assign r_data_o = '0;
+    end
+   else
+    begin: nz
+
+   logic [width_p-1:0]    mem [els_p-1:0];
+   logic read_en;
+   logic [width_p-1:0] data_out;
+
+   // this treats the ram as an array of registers for which the
+   // read addr is latched on the clock, the write
+   // is done on the clock edge, and actually multiplexing
+   // of the registers for reading is done after the clock edge.
+
+   // logically, this means that reads happen in time after
+   // the writes, and "simultaneous" reads and writes to the
+   // register file are allowed -- IF read_write_same_addr is set.
+
+   // note that this behavior is generally incompatible with
+   // hardened 1r1w rams, so it's better not to take advantage
+   // of it if not necessary
+
+   // we explicitly 'X out the read address if valid is not set
+   // to avoid accidental use of data when the valid signal was not
+   // asserted. without this, the output of the register file would
+   // "auto-update" based on new writes to the ram, a spooky behavior
+   // that would never correspond to that of a hardened ram.
+
+   logic [addr_width_lp-1:0] r_addr_r;
+
+   assign read_en = r_v_i;
+   assign data_out = mem[r_addr_r];
+
+   always_ff @(posedge clk_i)
+     if (r_v_i)
+       r_addr_r <= r_addr_i;
+     else
+       r_addr_r <= 'X;
+
+  if (latch_last_read_p)
+    begin: llr
+      logic read_en_r; 
+
+      bsg_dff #(
+        .width_p(1)
+      ) read_en_dff (
+        .clk_i(clk_i)
+        ,.data_i(read_en)
+        ,.data_o(read_en_r)
+      );
+
+      bsg_dff_en_bypass #(
+        .width_p(width_p)
+      ) dff_bypass (
+        .clk_i(clk_i)
+        ,.en_i(read_en_r)
+        ,.data_i(data_out)
+        ,.data_o(r_data_o)
+      );
+    end
+  else
+    begin: no_llr
+      assign r_data_o = data_out;
+    end
+
+   always_ff @(posedge clk_i)
+     if (w_v_i)
+       mem[w_addr_i] <= w_data_i;
+
+   end
+
+   // synopsys translate_off
+   initial
+     begin
+        if (verbose_p)
+      $display("## %L: instantiating width_p=%d, els_p=%d (%m)",width_p,els_p);
+     end
+   // synopsys translate_on
+
+endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_mem_1r1w_sync_synth)

--- a/bp_fe/src/v/bp_fe_bht.sv
+++ b/bp_fe/src/v/bp_fe_bht.sv
@@ -97,7 +97,7 @@ module bp_fe_bht
   assign rw_same_addr = r_v_i & w_v_i & (r_idx_li == w_idx_li);
 
   bsg_mem_1r1w_sync
-   #(.width_p(bht_row_width_p), .els_p(bht_els_lp))
+   #(.width_p(bht_row_width_p), .els_p(bht_els_lp), .latch_last_read_p(1))
    bht_mem
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
@@ -130,25 +130,7 @@ module bp_fe_bht
      assign pred_idx_r = 1'b1;
    end
 
-  logic r_v_r;
-  bsg_dff_reset
-   #(.width_p(1))
-   r_v_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-     ,.data_i(r_v_li)
-     ,.data_o(r_v_r)
-     );
-
-  bsg_dff_reset_en_bypass
-   #(.width_p(bht_row_width_p))
-   bypass_reg
-   (.clk_i(clk_i)
-    ,.reset_i(reset_i)
-    ,.en_i(r_v_r)
-    ,.data_i(r_data_lo)
-    ,.data_o(val_o)
-    );
+  assign val_o = r_data_lo;
   assign pred_o = val_o[pred_idx_r];
 
 endmodule

--- a/bp_fe/src/v/bp_fe_btb.sv
+++ b/bp_fe/src/v/bp_fe_btb.sv
@@ -102,7 +102,7 @@ module bp_fe_btb
   wire                           tag_mem_r_v_li = r_v_i;
   wire [btb_idx_width_p-1:0]  tag_mem_r_addr_li = r_idx_li;
   bsg_mem_1r1w_sync
-   #(.width_p($bits(bp_btb_entry_s)), .els_p(btb_els_lp))
+   #(.width_p($bits(bp_btb_entry_s)), .els_p(btb_els_lp), .latch_last_read_p(1))
    tag_mem
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
@@ -129,32 +129,9 @@ module bp_fe_btb
      ,.data_o(r_tag_r)
      );
 
-  logic r_v_r;
-  bsg_dff_reset
-   #(.width_p(1))
-   r_v_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.data_i(tag_mem_r_v_li)
-     ,.data_o(r_v_r)
-     );
-
-  bp_btb_entry_s tag_mem_data_bypass_lo;
-  bsg_dff_reset_en_bypass
-   #(.width_p($bits(bp_btb_entry_s)))
-   btb_bypass_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-     ,.en_i(r_v_r)
-
-     ,.data_i(tag_mem_data_lo)
-     ,.data_o(tag_mem_data_bypass_lo)
-     );
-
-  assign br_tgt_v_o   = r_v_r & tag_mem_data_bypass_lo.v & (tag_mem_data_bypass_lo.tag == r_tag_r);
-  assign br_tgt_jmp_o = r_v_r & tag_mem_data_bypass_lo.v & tag_mem_data_bypass_lo.jmp;
-  assign br_tgt_o     = tag_mem_data_bypass_lo.tgt;
+  assign br_tgt_v_o   = tag_mem_data_lo.v & (tag_mem_data_lo.tag == r_tag_r);
+  assign br_tgt_jmp_o = tag_mem_data_lo.v & tag_mem_data_lo.jmp;
+  assign br_tgt_o     = tag_mem_data_lo.tgt;
 
 
 endmodule

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -113,7 +113,7 @@ module bp_fe_pc_gen
   wire is_ret  = fetch_instr_v_i & scan_instr.ret;
 
   // BTB
-  wire btb_r_v_li = next_pc_yumi_i & ~ovr_taken & ~ovr_ret;
+  wire btb_r_v_li = next_pc_yumi_i;
   wire btb_w_v_li = (redirect_br_v_i & redirect_br_taken_i)
     | (redirect_br_v_i & redirect_br_nonbr_i & redirect_br_metadata_fwd.src_btb)
     | (attaboy_v_i & attaboy_taken_i & ~attaboy_br_metadata_fwd.src_btb);
@@ -151,7 +151,7 @@ module bp_fe_pc_gen
      );
 
   // BHT
-  wire bht_r_v_li = next_pc_yumi_i & ~ovr_taken & ~ovr_ret;
+  wire bht_r_v_li = next_pc_yumi_i;
   wire [vaddr_width_p-1:0] bht_r_addr_li = next_pc_o;
   wire [ghist_width_p-1:0] bht_r_ghist_li = pred_if1_n.ghist;
   wire bht_w_v_li =

--- a/bp_fe/syn/flist.vcs
+++ b/bp_fe/syn/flist.vcs
@@ -75,8 +75,6 @@ $BASEJUMP_STL_DIR/bsg_mem/bsg_cam_1r1w_sync.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_cam_1r1w_tag_array.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_one_hot.v
-$BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_sync.v
-$BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_sync_synth.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_synth.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
@@ -245,4 +243,6 @@ $BP_ME_DIR/src/v/network/bp_me_stream_fifo.sv
 $BP_COMMON_DIR/src/v/bsg_async_noc_link.sv
 $BP_COMMON_DIR/src/v/bsg_deff_reset.v
 $BP_COMMON_DIR/src/v/bsg_dff_sync_read.v
+$BP_COMMON_DIR/src/v/bsg_mem_1r1w_sync.v
+$BP_COMMON_DIR/src/v/bsg_mem_1r1w_sync_synth.v
 

--- a/bp_me/syn/flist.vcs
+++ b/bp_me/syn/flist.vcs
@@ -78,8 +78,6 @@ $BASEJUMP_STL_DIR/bsg_mem/bsg_cam_1r1w_sync.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_cam_1r1w_tag_array.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_one_hot.v
-$BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_sync.v
-$BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_sync_synth.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_synth.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
@@ -198,3 +196,6 @@ $BP_ME_DIR/src/v/network/bp_me_xbar_burst.sv
 # BSG Staging area
 $BP_COMMON_DIR/src/v/bsg_async_noc_link.sv
 $BP_COMMON_DIR/src/v/bsg_dff_sync_read.v
+$BP_COMMON_DIR/src/v/bsg_mem_1r1w_sync.v
+$BP_COMMON_DIR/src/v/bsg_mem_1r1w_sync_synth.v
+

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -78,10 +78,6 @@ $BASEJUMP_STL_DIR/bsg_mem/bsg_cam_1r1w_sync.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_cam_1r1w_tag_array.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_one_hot.v
-$BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_sync.v
-$BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.v
-$BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_synth.v
-$BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_sync_synth.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_synth.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync.v
 $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
@@ -123,6 +119,7 @@ $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_en.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_en_bypass.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_dff_reset_set_clear.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_dlatch.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_edge_detect.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_encode_one_hot.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_expand_bitmask.v
@@ -330,5 +327,6 @@ $BP_COMMON_DIR/src/v/bsg_deff_reset.v
 $BP_COMMON_DIR/src/v/bsg_dff_sync_read.v
 $BP_COMMON_DIR/src/v/bsg_rom_param.v
 $BP_COMMON_DIR/src/v/bsg_crossbar_control_locking_o_by_i.v
-$BASEJUMP_STL_DIR/bsg_misc/bsg_dlatch.v
+$BP_COMMON_DIR/src/v/bsg_mem_1r1w_sync.v
+$BP_COMMON_DIR/src/v/bsg_mem_1r1w_sync_synth.v
 


### PR DESCRIPTION
- Fixes branch prediction bug causing unnecessary read disables #984 
- Reduces critical path from predictor to large memories by leveraging hardened rams