### PR TITLE
Fix nonsynth cache UC store hit bug

### DIFF
--- a/bp_me/test/common/bp_me_nonsynth_cache.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cache.sv
@@ -206,6 +206,7 @@ module bp_me_nonsynth_cache
     (.tag_set_i(tag_mem_data_lo)
      ,.tag_i(tr_tag)
      ,.w_i(store_op)
+     ,.uc_i(uc_op)
      ,.hit_o(tag_lookup_hit_lo)
      ,.dirty_o(tag_lookup_dirty_lo)
      ,.way_o(tag_lookup_hit_way_lo)

--- a/ci/me_regress.sh
+++ b/ci/me_regress.sh
@@ -22,10 +22,9 @@ protos=(
     "mesi"
     "mesi-nonspec"
     "moesif"
+    "msi"
+    "msi-nonspec"
     )
-# TODO: Reenable
-#    "msi"
-#    "msi-nonspec"
 
 # The base command to append the configuration to
 cmd_base="make -C bp_me/syn run_testlist.${SUFFIX}"


### PR DESCRIPTION
Fixes #1086 

Root cause was implementation of the nonsynth cache used in the ME testbench. Uncached stores targeting valid cache blocks were not self-invalidating the block, causing the store to get lost if targeted by following cacheable load. Bug is only present in the ME testbench, not in a real BP system.