### PR TITLE
Testbench and config cleanup for ME/multicore

### DIFF
--- a/bp_common/src/include/bp_common_aviary_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_pkgdef.svh
@@ -195,7 +195,6 @@
       ,ic_y_dim             : 1
       ,icache_coherent      : 1
       ,l2_amo_support       : '0
-      ,l2_banks             : 1
       ,default : "inv"
       };
   `bp_aviary_derive_cfg(bp_multicore_1_cfg_p

--- a/bp_me/test/common/bp_me_nonsynth_cache.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cache.sv
@@ -414,7 +414,6 @@ module bp_me_nonsynth_cache
     state_n = state_r;
     // Trace Replay Interface
     tr_pkt_cast_o = tr_pkt_r;
-    tr_pkt_cast_o.cmd = bp_me_nonsynth_opcode_e'(0);
     tr_pkt_cast_o.data = '0;
     tr_pkt_v_o = 1'b0;
     // signal to lock LCE-Cache interface (data, stat, mem pkt from LCE)

--- a/bp_me/test/tb/bp_cce/test_gen.py
+++ b/bp_me/test/tb/bp_cce/test_gen.py
@@ -39,10 +39,10 @@ class TestGenerator(object):
         for (cmd,addr,size,uc,val) in ops[lce]:
           if cmd == 'store':
             lce_trace_file.write(self.tg.send_store(size=size, addr=addr, data=val, uc=uc))
-            lce_trace_file.write(self.tg.recv_data(addr=addr, data=0, uc=uc))
+            lce_trace_file.write(self.tg.recv_store(size=size, addr=addr, uc=uc))
           elif cmd == 'load':
             lce_trace_file.write(self.tg.send_load(signed=0, size=size, addr=addr, uc=uc))
-            lce_trace_file.write(self.tg.recv_data(addr=addr, data=val, uc=uc))
+            lce_trace_file.write(self.tg.recv_load(signed=0, size=size, addr=addr, data=val, uc=uc))
           elif cmd == 'wait':
             # addr is used as number of cycles
             lce_trace_file.write(self.tg.wait(addr))

--- a/bp_top/test/tb/bp_tethered/Makefile.cfgs
+++ b/bp_top/test/tb/bp_tethered/Makefile.cfgs
@@ -1,29 +1,10 @@
-e_bp_multicore_16_cce_ucode_cfg_cores   := 16
-e_bp_multicore_16_cfg_cores             := 16
-e_bp_multicore_12_cce_ucode_cfg_cores   := 12
-e_bp_multicore_12_cfg_cores             := 12
-e_bp_multicore_8_cce_ucode_cfg_cores    := 8
-e_bp_multicore_8_cfg_cores              := 8
-e_bp_multicore_6_cce_ucode_cfg_cores    := 6
-e_bp_multicore_6_cfg_cores              := 6
-e_bp_multicore_4_cce_ucode_cfg_cores    := 4
-e_bp_multicore_4_l2e_cfg_cores          := 6
-e_bp_multicore_4_cfg_cores              := 4
-e_bp_multicore_4_acc_loopback_cfg_cores := 4
-e_bp_multicore_4_acc_vdp_cfg_cores      := 4
-e_bp_multicore_3_cce_ucode_cfg_cores    := 3
-e_bp_multicore_3_cfg_cores              := 3
-e_bp_multicore_2_cce_ucode_cfg_cores    := 2
-e_bp_multicore_2_l2e_cfg_cores          := 4
-e_bp_multicore_2_cfg_cores              := 2
-e_bp_multicore_1_l2e_cfg_cores          := 2
-
-e_bp_default_cfg_cores                  := 1
-
-_NCPUS :=$($(CFG)_cores)
-ifeq ($(_NCPUS),)
+# compute number of cores from config
+_MULTICORE := $(findstring e_bp_multicore, $(CFG))
+ifeq ($(_MULTICORE),)
 	export NCPUS ?= 1
 else
+	# requires multicore configs to be named: e_bp_multicore_NCPUS_[*_]cfg
+	_NCPUS := $(strip $(word 4, $(subst _, ,$(CFG))))
 	export NCPUS ?= $(_NCPUS)
 endif
 

--- a/ci/multicore.sh
+++ b/ci/multicore.sh
@@ -47,6 +47,7 @@ progs=(
     "mc_sanity"
     "mc_rand_walk"
     "mc_work_share_sort"
+    "mc_lrsc_add"
     )
 
 # The base command to append the configuration to


### PR DESCRIPTION
This PR makes some small tweaks to testing and config related things for ME and multicore:
- refactor ME trace replay generation
- set L2 banks to 2 (default) for multicore configs up to 8 cores
- adds mc_lrsc_add test to multicore regressions
- refactors the NCPU computation in the top testbench to remove the need to keep the core per config list synchronized with the BP configs listing