### PR TITLE
Crossbar Control Locking Bug

### DIFF
--- a/bp_common/src/v/bsg_crossbar_control_locking_o_by_i.v
+++ b/bp_common/src/v/bsg_crossbar_control_locking_o_by_i.v
@@ -62,6 +62,7 @@ module bsg_crossbar_control_locking_o_by_i
   for (genvar i = 0 ; i < o_els_p; i++) begin: rr
 
     logic [i_els_p-1:0] not_req_mask_r, req_mask_r;
+    logic [i_els_p-1:0] reqs_li;
 
     bsg_dff_reset_en #( .width_p(i_els_p) )
       req_words_reg
@@ -74,7 +75,9 @@ module bsg_crossbar_control_locking_o_by_i
 
     assign req_mask_r = ~not_req_mask_r;
 
-    assign valid_o[i] = |o_select_t[i];
+    assign reqs_li[i] = o_select_t[i] & req_mask_r;
+    // Every port should have a valid request and a valid grant to progress
+    assign valid_o[i] = |reqs_li;
     assign rr_yumi_li[i] = valid_o[i] & ready_and_i[i];
 
     bsg_arb_round_robin #(
@@ -83,7 +86,7 @@ module bsg_crossbar_control_locking_o_by_i
       .clk_i(clk_i)
       ,.reset_i(reset_i)
     
-      ,.reqs_i(o_select_t[i] & req_mask_r)
+      ,.reqs_i(reqs_li)
       ,.grants_o(grants_oi_one_hot_o[i])
       ,.yumi_i(rr_yumi_li[i])
     );

--- a/bp_common/src/v/bsg_crossbar_control_locking_o_by_i.v
+++ b/bp_common/src/v/bsg_crossbar_control_locking_o_by_i.v
@@ -75,7 +75,7 @@ module bsg_crossbar_control_locking_o_by_i
 
     assign req_mask_r = ~not_req_mask_r;
 
-    assign reqs_li[i] = o_select_t[i] & req_mask_r;
+    assign reqs_li = o_select_t[i] & req_mask_r;
     // Every port should have a valid request and a valid grant to progress
     assign valid_o[i] = |reqs_li;
     assign rr_yumi_li[i] = valid_o[i] & ready_and_i[i];


### PR DESCRIPTION
This PR fixes a bug in the locking crossbar control module.

## Summary
The locking crossbar control module locks an input port for an output port if the input port is granted access to the output port until the input port completes streaming data through to that output port. The valid signal for every output port currently contains information if the output port has valid requestors from any of the input ports but does not contain any information about which input port has locked arbitration. It is possible that this creates a situation where input ports that haven't locked the arbiter can access the output port. The PR attempts to correct this.

The fix is to AND the output request mask with the information about which input has locked the arbiter.

## Issue Fixed
There is no active issue that this PR addresses

## Area
bp_common/src/v/bsg_crossbar_control_locking_o_by_i.sv

## Reasoning (outdated, confusing, verbose, etc.)
This change is required for current functionality.

## Additional Changes Required (if any)


## Analysis
By using the flopped grant signal (i.e., req_mask_r), we ensure the RR arbiter does not come into the critical path. This needs to be confirmed with a synthesis and/or APR run.

## Verification
Only the hello_world test was run on the BP tile bench in the manycore-BP tapeout directory. Regression testing might be required.

## Additional Context

