### PR TITLE
Fix unfreeze under reset sequence

### DIFF
--- a/bp_be/src/v/bp_be_checker/bp_be_director.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.sv
@@ -115,6 +115,7 @@ module bp_be_director
   wire fe_cmd_nonattaboy_v = fe_cmd_v_li & (fe_cmd_li.opcode != e_op_attaboy);
 
   // Boot logic
+  wire freeze_li = cfg_bus_cast_i.freeze | reset_i;
   always_comb
     begin
       unique casez (state_r)
@@ -122,7 +123,7 @@ module bp_be_director
         e_run   : state_n = commit_pkt_cast_i.wfi ? e_wait : fe_cmd_nonattaboy_v ? e_fence : e_run;
         e_fence : state_n = cmd_empty_n_o ? e_run : e_fence;
         // e_freeze:
-        default : state_n = cfg_bus_cast_i.freeze ? e_freeze : e_wait;
+        default : state_n = freeze_li ? e_freeze : e_wait;
       endcase
     end
 
@@ -136,7 +137,7 @@ module bp_be_director
       end
 
   assign suppress_iss_o  = (state_r != e_run);
-  assign unfreeze_o      = ~cfg_bus_cast_i.freeze & (state_r == e_freeze);
+  assign unfreeze_o      = (state_r == e_freeze) & (state_n != e_freeze);
 
   always_comb
     begin


### PR DESCRIPTION
This is a minor fix to the reset sequencing. Currently, when unfreezing under reset, there can be x-propagation as the dispatch packet / pipeline has not been cleared yet and the unfreeze packet expects the pipeline to be clear. This fix allows this sequence and freeze/reset can be asserted either way