### PR TITLE
 Support 32-bit instructions aligned to 16 bits (IALIGN=16), take two

### DIFF
--- a/bp_be/src/include/bp_be_ctl_pkgdef.svh
+++ b/bp_be/src/include/bp_be_ctl_pkgdef.svh
@@ -252,7 +252,7 @@
     logic cmd_full;
 
     // Metadata for instruction exceptions (instr_page_fault,instr_access_fault, itlb_miss, icache_miss)
-    logic instr_upper_not_lower_half;
+    logic upper_not_lower_half;
   }  bp_be_exception_s;
 
   typedef struct packed

--- a/bp_be/src/include/bp_be_ctl_pkgdef.svh
+++ b/bp_be/src/include/bp_be_ctl_pkgdef.svh
@@ -251,9 +251,6 @@
     logic dtlb_fill;
     logic _interrupt;
     logic cmd_full;
-
-    // Metadata for instruction exceptions (instr_page_fault,instr_access_fault, itlb_miss, icache_miss)
-    logic instr_partial_v;
   }  bp_be_exception_s;
 
   typedef struct packed

--- a/bp_be/src/include/bp_be_ctl_pkgdef.svh
+++ b/bp_be/src/include/bp_be_ctl_pkgdef.svh
@@ -253,7 +253,7 @@
     logic cmd_full;
 
     // Metadata for instruction exceptions (instr_page_fault,instr_access_fault, itlb_miss, icache_miss)
-    logic upper_not_lower_half;
+    logic instr_partial_v;
   }  bp_be_exception_s;
 
   typedef struct packed

--- a/bp_be/src/include/bp_be_ctl_pkgdef.svh
+++ b/bp_be/src/include/bp_be_ctl_pkgdef.svh
@@ -188,8 +188,6 @@
 
   typedef struct packed
   {
-    logic                             v;
-
     logic                             pipe_ctl_v;
     logic                             pipe_int_v;
     logic                             pipe_mem_early_v;

--- a/bp_be/src/include/bp_be_defines.svh
+++ b/bp_be/src/include/bp_be_defines.svh
@@ -142,7 +142,7 @@
       logic [rv64_priv_width_gp-1:0]  priv_n;                                                      \
       logic                           translation_en_n;                                            \
       logic                           exception;                                                   \
-      logic                           exception_instr_upper_not_lower_half;                        \
+      logic                           exception_instr_partial_v;                                   \
       logic                           _interrupt;                                                  \
       logic                           unfreeze;                                                    \
       logic                           eret;                                                        \
@@ -181,7 +181,7 @@
       logic                          instr_miss_v;                                                 \
       logic                          load_miss_v;                                                  \
       logic                          store_miss_v;                                                 \
-      logic                          instr_upper_not_lower_half;                                   \
+      logic                          instr_partial_v;                                              \
       logic [vaddr_width_mp-1:0]     vaddr;                                                        \
     }  bp_be_ptw_miss_pkt_s;                                                                       \
                                                                                                    \
@@ -193,7 +193,7 @@
       logic instr_page_fault_v;                                                                    \
       logic load_page_fault_v;                                                                     \
       logic store_page_fault_v;                                                                    \
-      logic instr_upper_not_lower_half;                                                            \
+      logic instr_partial_v;                                                                       \
       logic [vaddr_width_mp-1:0] vaddr;                                                            \
       bp_be_pte_leaf_s entry;                                                                      \
     }  bp_be_ptw_fill_pkt_s;                                                                       \
@@ -281,8 +281,8 @@
   `define bp_be_decode_info_width \
     (rv64_priv_width_gp+8)
 
-  `define bp_be_instr_half_address(base_pc_mp, upper_not_lower_half_mp) \
-    (base_pc_mp + (upper_not_lower_half_mp ? 2 : 0))
+  `define bp_be_instr_half_address(base_pc_mp, instr_partial_v_mp) \
+    (base_pc_mp + (instr_partial_v_mp ? 2 : 0))
 
 `endif
 

--- a/bp_be/src/include/bp_be_defines.svh
+++ b/bp_be/src/include/bp_be_defines.svh
@@ -39,6 +39,7 @@
       logic                                    v;                                                  \
       logic                                    queue_v;                                            \
       logic [vaddr_width_mp-1:0]               pc;                                                 \
+      logic                                    instr_v;                                            \
       rv64_instr_s                             instr;                                              \
       bp_be_decode_s                           decode;                                             \
                                                                                                    \
@@ -232,7 +233,7 @@
     (2                                                                                             \
      + vaddr_width_mp                                                                              \
      + rv64_instr_width_gp                                                                         \
-     + 3                                                                                           \
+     + 4                                                                                           \
      + 3 * dpath_width_gp                                                                          \
      + $bits(bp_be_decode_s)                                                                       \
      + $bits(bp_be_exception_s)                                                                    \

--- a/bp_be/src/include/bp_be_defines.svh
+++ b/bp_be/src/include/bp_be_defines.svh
@@ -49,6 +49,7 @@
       logic [dpath_width_gp-1:0]               rs2;                                                \
       logic                                    rs3_fp_v;                                           \
       logic [dpath_width_gp-1:0]               imm;                                                \
+      logic                                    instr_partial_v;                                    \
       bp_be_exception_s                        exception;                                          \
       bp_be_special_s                          special;                                            \
      } bp_be_dispatch_pkt_s;                                                                       \
@@ -113,6 +114,7 @@
       logic [vaddr_width_p-1:0]  vaddr;                                                            \
       logic [dpath_width_gp-1:0] data;                                                             \
       rv64_instr_s               instr;                                                            \
+      logic                      instr_partial_v;                                                  \
       bp_be_exception_s          exception;                                                        \
       bp_be_special_s            special;                                                          \
     }  bp_be_retire_pkt_s;                                                                         \
@@ -236,6 +238,7 @@
      + 4                                                                                           \
      + 3 * dpath_width_gp                                                                          \
      + $bits(bp_be_decode_s)                                                                       \
+     + 1                                                                                           \
      + $bits(bp_be_exception_s)                                                                    \
      + $bits(bp_be_special_s)                                                                      \
      )
@@ -250,7 +253,7 @@
     (3 + vaddr_width_mp)
 
   `define bp_be_retire_pkt_width(vaddr_width_mp) \
-    (3 + dpath_width_gp + 2*vaddr_width_mp + instr_width_gp + $bits(bp_be_exception_s) + $bits(bp_be_special_s))
+    (3 + dpath_width_gp + 2*vaddr_width_mp + instr_width_gp + 1 + $bits(bp_be_exception_s) + $bits(bp_be_special_s))
 
   `define bp_be_pte_leaf_width(paddr_width_mp) \
     (paddr_width_mp - page_offset_width_gp + 7)

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -141,11 +141,11 @@ module bp_be_calculator_top
   logic [pipe_stage_els_lp-1:0][dpath_width_gp-1:0] forward_data;
   for (genvar i = 0; i < pipe_stage_els_lp; i++)
     begin : forward_match
-      assign match_rs[0][i] = ((i < 4) & dispatch_pkt_cast_i.queue_v & ~dispatch_pkt_cast_i.rs1_fp_v & comp_stage_r[i].ird_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs1_addr == comp_stage_r[i].rd_addr))
-                              || ((i > 0) & dispatch_pkt_cast_i.queue_v & dispatch_pkt_cast_i.rs1_fp_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs1_addr == comp_stage_r[i].rd_addr));
-      assign match_rs[1][i] = ((i < 4) & dispatch_pkt_cast_i.queue_v & ~dispatch_pkt_cast_i.rs2_fp_v & comp_stage_r[i].ird_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs2_addr == comp_stage_r[i].rd_addr))
-                              || ((i > 0) & dispatch_pkt_cast_i.queue_v & dispatch_pkt_cast_i.rs2_fp_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs2_addr == comp_stage_r[i].rd_addr));
-      assign match_rs[2][i] = ((i > 0) & dispatch_pkt_cast_i.queue_v & dispatch_pkt_cast_i.rs3_fp_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs3_addr == comp_stage_r[i].rd_addr));
+      assign match_rs[0][i] = ((i < 4) & dispatch_pkt_cast_i.queue_v & dispatch_pkt_cast_i.instr_v & ~dispatch_pkt_cast_i.rs1_fp_v & comp_stage_r[i].ird_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs1_addr == comp_stage_r[i].rd_addr))
+                              || ((i > 0) & dispatch_pkt_cast_i.queue_v & dispatch_pkt_cast_i.instr_v & dispatch_pkt_cast_i.rs1_fp_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs1_addr == comp_stage_r[i].rd_addr));
+      assign match_rs[1][i] = ((i < 4) & dispatch_pkt_cast_i.queue_v & dispatch_pkt_cast_i.instr_v & ~dispatch_pkt_cast_i.rs2_fp_v & comp_stage_r[i].ird_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs2_addr == comp_stage_r[i].rd_addr))
+                              || ((i > 0) & dispatch_pkt_cast_i.queue_v & dispatch_pkt_cast_i.instr_v & dispatch_pkt_cast_i.rs2_fp_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs2_addr == comp_stage_r[i].rd_addr));
+      assign match_rs[2][i] = ((i > 0) & dispatch_pkt_cast_i.queue_v & dispatch_pkt_cast_i.instr_v & dispatch_pkt_cast_i.rs3_fp_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs3_addr == comp_stage_r[i].rd_addr));
 
       assign forward_data[i] = comp_stage_n[i+1].rd_data;
     end

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -682,7 +682,7 @@ module bp_be_csr
   assign commit_pkt_cast_o.priv_n           = priv_mode_n;
   assign commit_pkt_cast_o.translation_en_n = translation_en_n;
   assign commit_pkt_cast_o.exception        = exception_v_lo;
-  assign commit_pkt_cast_o.exception_instr_partial_v = retire_pkt_cast_i.exception.instr_partial_v;
+  assign commit_pkt_cast_o.exception_instr_partial_v = retire_pkt_cast_i.instr_partial_v;
   // Debug mode acts as a pseudo-interrupt
   assign commit_pkt_cast_o._interrupt       = interrupt_v_lo | enter_debug;
   assign commit_pkt_cast_o.fencei           = retire_pkt_cast_i.special.fencei_clean;

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -682,7 +682,7 @@ module bp_be_csr
   assign commit_pkt_cast_o.priv_n           = priv_mode_n;
   assign commit_pkt_cast_o.translation_en_n = translation_en_n;
   assign commit_pkt_cast_o.exception        = exception_v_lo;
-  assign commit_pkt_cast_o.exception_instr_upper_not_lower_half = retire_pkt_cast_i.exception.upper_not_lower_half;
+  assign commit_pkt_cast_o.exception_instr_partial_v = retire_pkt_cast_i.exception.instr_partial_v;
   // Debug mode acts as a pseudo-interrupt
   assign commit_pkt_cast_o._interrupt       = interrupt_v_lo | enter_debug;
   assign commit_pkt_cast_o.fencei           = retire_pkt_cast_i.special.fencei_clean;

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -682,7 +682,7 @@ module bp_be_csr
   assign commit_pkt_cast_o.priv_n           = priv_mode_n;
   assign commit_pkt_cast_o.translation_en_n = translation_en_n;
   assign commit_pkt_cast_o.exception        = exception_v_lo;
-  assign commit_pkt_cast_o.exception_instr_upper_not_lower_half = retire_pkt_cast_i.exception.instr_upper_not_lower_half;
+  assign commit_pkt_cast_o.exception_instr_upper_not_lower_half = retire_pkt_cast_i.exception.upper_not_lower_half;
   // Debug mode acts as a pseudo-interrupt
   assign commit_pkt_cast_o._interrupt       = interrupt_v_lo | enter_debug;
   assign commit_pkt_cast_o.fencei           = retire_pkt_cast_i.special.fencei_clean;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_ctl.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_ctl.sv
@@ -76,7 +76,7 @@ module bp_be_pipe_ctl
 
   assign data_o   = vaddr_width_p'($signed(ntaken_tgt));
   assign v_o      = reservation.v & reservation.decode.pipe_ctl_v;
-  assign instr_misaligned_v_o = btaken & (taken_tgt[1:0] != 2'b00) & !compressed_support_p;
+  assign instr_misaligned_v_o = btaken & (taken_tgt[1:0] != 2'b00);
 
   assign br_pkt.v         = reservation.v & reservation.queue_v & ~flush_i;
   assign br_pkt.branch    = br_pkt.v & reservation.decode.pipe_ctl_v;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_ctl.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_ctl.sv
@@ -76,7 +76,7 @@ module bp_be_pipe_ctl
 
   assign data_o   = vaddr_width_p'($signed(ntaken_tgt));
   assign v_o      = reservation.v & reservation.decode.pipe_ctl_v;
-  assign instr_misaligned_v_o = btaken & (taken_tgt[1:0] != 2'b00);
+  assign instr_misaligned_v_o = btaken & (taken_tgt[1:0] != 2'b00) & !compressed_support_p;
 
   assign br_pkt.v         = reservation.v & reservation.queue_v & ~flush_i;
   assign br_pkt.branch    = br_pkt.v & reservation.decode.pipe_ctl_v;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -250,7 +250,7 @@ module bp_be_pipe_mem
     '{instr_miss_v  : commit_pkt.itlb_miss
       ,store_miss_v : commit_pkt.dtlb_store_miss
       ,load_miss_v  : commit_pkt.dtlb_load_miss
-      ,instr_upper_not_lower_half: commit_pkt.exception_instr_upper_not_lower_half
+      ,instr_partial_v: commit_pkt.exception_instr_partial_v
       ,vaddr        : commit_pkt.vaddr
       ,mstatus_mxr  : trans_info.mstatus_mxr
       ,mstatus_sum  : trans_info.mstatus_sum

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
@@ -139,6 +139,7 @@ module bp_be_pipe_sys
   logic [vaddr_width_p-1:0] retire_npc_r, retire_pc_r;
   logic [vaddr_width_p-1:0] retire_nvaddr_r, retire_vaddr_r;
   logic [instr_width_gp-1:0] retire_ninstr_r, retire_instr_r;
+  logic retire_npartial_r, retire_partial_r;
   always_ff @(posedge clk_i)
     begin
       retire_npc_r <= reservation.pc;
@@ -149,6 +150,9 @@ module bp_be_pipe_sys
 
       retire_ninstr_r <= reservation.instr;
       retire_instr_r  <= retire_ninstr_r;
+
+      retire_npartial_r <= reservation.instr_partial_v;
+      retire_partial_r  <= retire_npartial_r;
     end
 
   wire instret_li = retire_v_i & ~|retire_exception_i;
@@ -160,6 +164,7 @@ module bp_be_pipe_sys
       ,vaddr     : retire_vaddr_r
       ,data      : retire_data_i
       ,instr     : retire_instr_r
+      ,instr_partial_v : retire_v_i & retire_partial_r
       // Could do a preemptive onehot decode here
       ,exception : retire_v_i ? retire_exception_i : '0
       ,special   : instret_li ? retire_special_i   : '0

--- a/bp_be/src/v/bp_be_calculator/bp_be_ptw.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_ptw.sv
@@ -141,7 +141,7 @@ module bp_be_ptw
   assign ptw_fill_pkt_cast_o.instr_page_fault_v = is_write & instr_page_fault;
   assign ptw_fill_pkt_cast_o.load_page_fault_v  = is_write & load_page_fault;
   assign ptw_fill_pkt_cast_o.store_page_fault_v = is_write & store_page_fault;
-  assign ptw_fill_pkt_cast_o.instr_upper_not_lower_half = is_write & ptw_miss_pkt_r.instr_upper_not_lower_half;
+  assign ptw_fill_pkt_cast_o.instr_partial_v    = is_write & ptw_miss_pkt_r.instr_partial_v;
   assign ptw_fill_pkt_cast_o.vaddr              = ptw_miss_pkt_r.vaddr;
   assign ptw_fill_pkt_cast_o.entry              = tlb_w_entry;
 

--- a/bp_be/src/v/bp_be_checker/bp_be_director.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.sv
@@ -148,7 +148,7 @@ module bp_be_director
       if (commit_pkt_cast_i.unfreeze)
         begin
           fe_cmd_li.opcode = e_op_state_reset;
-          fe_cmd_li.vaddr  = npc_r;
+          fe_cmd_li.pc     = npc_r;
 
           fe_cmd_pc_redirect_operands.priv           = commit_pkt_cast_i.priv_n;
           fe_cmd_pc_redirect_operands.translation_en = commit_pkt_cast_i.translation_en_n;
@@ -159,7 +159,7 @@ module bp_be_director
       else if (commit_pkt_cast_i.itlb_fill_v)
         begin
           fe_cmd_li.opcode                               = e_op_itlb_fill_response;
-          fe_cmd_li.vaddr                                = commit_pkt_cast_i.npc;
+          fe_cmd_li.pc                                   = commit_pkt_cast_i.npc;
           fe_cmd_li.operands.itlb_fill_response.pte_leaf = commit_pkt_cast_i.pte_leaf;
           fe_cmd_li.operands.itlb_fill_response.partial_instr   = commit_pkt_cast_i.instr;
           fe_cmd_li.operands.itlb_fill_response.partial_instr_v = commit_pkt_cast_i.exception_instr_upper_not_lower_half;
@@ -170,14 +170,14 @@ module bp_be_director
       else if (commit_pkt_cast_i.sfence)
         begin
           fe_cmd_li.opcode = e_op_itlb_fence;
-          fe_cmd_li.vaddr  = commit_pkt_cast_i.npc;
+          fe_cmd_li.pc     = commit_pkt_cast_i.npc;
 
           fe_cmd_v_li = fe_cmd_ready_lo;
         end
       else if (commit_pkt_cast_i.csrw)
         begin
           fe_cmd_li.opcode                            = e_op_pc_redirection;
-          fe_cmd_li.vaddr                             = commit_pkt_cast_i.npc;
+          fe_cmd_li.pc                                = commit_pkt_cast_i.npc;
           fe_cmd_pc_redirect_operands.subopcode       = e_subop_translation_switch;
           fe_cmd_pc_redirect_operands.translation_en  = commit_pkt_cast_i.translation_en_n;
           fe_cmd_li.operands.pc_redirect_operands     = fe_cmd_pc_redirect_operands;
@@ -187,21 +187,21 @@ module bp_be_director
       else if (commit_pkt_cast_i.wfi)
         begin
           fe_cmd_li.opcode = e_op_wait;
-          fe_cmd_li.vaddr  = commit_pkt_cast_i.npc;
+          fe_cmd_li.pc     = commit_pkt_cast_i.npc;
 
           fe_cmd_v_li = fe_cmd_ready_lo;
         end
       else if (commit_pkt_cast_i.fencei)
         begin
           fe_cmd_li.opcode = e_op_icache_fence;
-          fe_cmd_li.vaddr  = commit_pkt_cast_i.npc;
+          fe_cmd_li.pc     = commit_pkt_cast_i.npc;
 
           fe_cmd_v_li = fe_cmd_ready_lo;
         end
       else if (commit_pkt_cast_i.icache_miss)
         begin
           fe_cmd_li.opcode = e_op_icache_fill_response;
-          fe_cmd_li.vaddr  = commit_pkt_cast_i.npc;
+          fe_cmd_li.pc     = commit_pkt_cast_i.npc;
           fe_cmd_li.operands.icache_fill_response.partial_instr   = commit_pkt_cast_i.instr;
           fe_cmd_li.operands.icache_fill_response.partial_instr_v = commit_pkt_cast_i.exception_instr_upper_not_lower_half;
 
@@ -210,7 +210,7 @@ module bp_be_director
       else if (commit_pkt_cast_i.eret)
         begin
           fe_cmd_li.opcode                                 = e_op_pc_redirection;
-          fe_cmd_li.vaddr                                  = commit_pkt_cast_i.npc;
+          fe_cmd_li.pc                                     = commit_pkt_cast_i.npc;
           fe_cmd_pc_redirect_operands.subopcode            = e_subop_eret;
           fe_cmd_pc_redirect_operands.priv                 = commit_pkt_cast_i.priv_n;
           fe_cmd_pc_redirect_operands.translation_en       = commit_pkt_cast_i.translation_en_n;
@@ -221,7 +221,7 @@ module bp_be_director
       else if (commit_pkt_cast_i.exception | commit_pkt_cast_i._interrupt | (is_wait & irq_waiting_i))
         begin
           fe_cmd_li.opcode                                 = e_op_pc_redirection;
-          fe_cmd_li.vaddr                                  = commit_pkt_cast_i.npc;
+          fe_cmd_li.pc                                     = commit_pkt_cast_i.npc;
           fe_cmd_pc_redirect_operands.subopcode            = e_subop_trap;
           fe_cmd_pc_redirect_operands.priv                 = commit_pkt_cast_i.priv_n;
           fe_cmd_pc_redirect_operands.translation_en       = commit_pkt_cast_i.translation_en_n;
@@ -232,7 +232,7 @@ module bp_be_director
       else if (isd_status_cast_i.v & npc_mismatch_v)
         begin
           fe_cmd_li.opcode                                 = e_op_pc_redirection;
-          fe_cmd_li.vaddr                                  = expected_npc_o;
+          fe_cmd_li.pc                                     = expected_npc_o;
           fe_cmd_pc_redirect_operands.subopcode            = e_subop_branch_mispredict;
           fe_cmd_pc_redirect_operands.branch_metadata_fwd  = isd_status_cast_i.branch_metadata_fwd;
           fe_cmd_pc_redirect_operands.misprediction_reason = last_instr_was_branch
@@ -248,7 +248,7 @@ module bp_be_director
       else if (isd_status_cast_i.v & ~npc_mismatch_v & last_instr_was_branch)
         begin
           fe_cmd_li.opcode                               = e_op_attaboy;
-          fe_cmd_li.vaddr                                = expected_npc_o;
+          fe_cmd_li.pc                                   = expected_npc_o;
           fe_cmd_li.operands.attaboy.taken               = last_instr_was_btaken;
           fe_cmd_li.operands.attaboy.branch_metadata_fwd = isd_status_cast_i.branch_metadata_fwd;
 

--- a/bp_be/src/v/bp_be_checker/bp_be_director.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.sv
@@ -161,8 +161,8 @@ module bp_be_director
           fe_cmd_li.opcode                               = e_op_itlb_fill_response;
           fe_cmd_li.pc                                   = commit_pkt_cast_i.npc;
           fe_cmd_li.operands.itlb_fill_response.pte_leaf = commit_pkt_cast_i.pte_leaf;
-          fe_cmd_li.operands.itlb_fill_response.partial_instr   = commit_pkt_cast_i.instr;
-          fe_cmd_li.operands.itlb_fill_response.partial_instr_v = commit_pkt_cast_i.exception_instr_upper_not_lower_half;
+          fe_cmd_li.operands.itlb_fill_response.partial_instr   = compressed_support_p ? commit_pkt_cast_i.instr : '0;
+          fe_cmd_li.operands.itlb_fill_response.partial_instr_v = compressed_support_p & commit_pkt_cast_i.exception_instr_upper_not_lower_half;
           fe_cmd_li.operands.itlb_fill_response.fill_vaddr      = commit_pkt_cast_i.vaddr;
 
           fe_cmd_v_li = fe_cmd_ready_lo;
@@ -202,8 +202,8 @@ module bp_be_director
         begin
           fe_cmd_li.opcode = e_op_icache_fill_response;
           fe_cmd_li.pc     = commit_pkt_cast_i.npc;
-          fe_cmd_li.operands.icache_fill_response.partial_instr   = commit_pkt_cast_i.instr;
-          fe_cmd_li.operands.icache_fill_response.partial_instr_v = commit_pkt_cast_i.exception_instr_upper_not_lower_half;
+          fe_cmd_li.operands.icache_fill_response.partial_instr   = compressed_support_p ? commit_pkt_cast_i.instr : '0;
+          fe_cmd_li.operands.icache_fill_response.partial_instr_v = compressed_support_p & commit_pkt_cast_i.exception_instr_upper_not_lower_half;
 
           fe_cmd_v_li = fe_cmd_ready_lo;
         end

--- a/bp_be/src/v/bp_be_checker/bp_be_director.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.sv
@@ -162,7 +162,7 @@ module bp_be_director
           fe_cmd_li.npc                                  = commit_pkt_cast_i.npc;
           fe_cmd_li.operands.itlb_fill_response.pte_leaf = commit_pkt_cast_i.pte_leaf;
           fe_cmd_li.operands.itlb_fill_response.instr    = compressed_support_p ? commit_pkt_cast_i.instr : '0;
-          fe_cmd_li.operands.vtag                        = commit_pkt_cast_i.vaddr;
+          fe_cmd_li.operands.itlb_fill_response.vtag     = commit_pkt_cast_i.vaddr[vaddr_width_p-1-:vtag_width_p];
 
           fe_cmd_v_li = fe_cmd_ready_lo;
         end

--- a/bp_be/src/v/bp_be_checker/bp_be_director.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.sv
@@ -158,7 +158,7 @@ module bp_be_director
         end
       else if (commit_pkt_cast_i.itlb_fill_v)
         begin
-          fe_cmd_li.opcode                               = (compressed_support_p & commit_pkt_cast_i.exception_instr_upper_not_lower_half) ? e_op_itlb_fill_resume : e_op_itlb_fill_restart;
+          fe_cmd_li.opcode                               = (compressed_support_p & commit_pkt_cast_i.exception_instr_partial_v) ? e_op_itlb_fill_resume : e_op_itlb_fill_restart;
           fe_cmd_li.npc                                  = commit_pkt_cast_i.vaddr;
           fe_cmd_li.operands.itlb_fill_response.pte_leaf = commit_pkt_cast_i.pte_leaf;
           fe_cmd_li.operands.itlb_fill_response.instr    = compressed_support_p ? commit_pkt_cast_i.instr : '0;
@@ -199,7 +199,7 @@ module bp_be_director
         end
       else if (commit_pkt_cast_i.icache_miss)
         begin
-          fe_cmd_li.opcode = (compressed_support_p & commit_pkt_cast_i.exception_instr_upper_not_lower_half) ? e_op_icache_fill_resume : e_op_icache_fill_restart;
+          fe_cmd_li.opcode = (compressed_support_p & commit_pkt_cast_i.exception_instr_partial_v) ? e_op_icache_fill_resume : e_op_icache_fill_restart;
           fe_cmd_li.npc    = commit_pkt_cast_i.vaddr;
           fe_cmd_li.operands.icache_fill_response.instr = compressed_support_p ? commit_pkt_cast_i.instr : '0;
 

--- a/bp_be/src/v/bp_be_checker/bp_be_director.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.sv
@@ -159,10 +159,10 @@ module bp_be_director
       else if (commit_pkt_cast_i.itlb_fill_v)
         begin
           fe_cmd_li.opcode                               = (compressed_support_p & commit_pkt_cast_i.exception_instr_upper_not_lower_half) ? e_op_itlb_fill_resume : e_op_itlb_fill_restart;
-          fe_cmd_li.npc                                  = commit_pkt_cast_i.npc;
+          fe_cmd_li.npc                                  = commit_pkt_cast_i.vaddr;
           fe_cmd_li.operands.itlb_fill_response.pte_leaf = commit_pkt_cast_i.pte_leaf;
           fe_cmd_li.operands.itlb_fill_response.instr    = compressed_support_p ? commit_pkt_cast_i.instr : '0;
-          fe_cmd_li.operands.itlb_fill_response.vtag     = commit_pkt_cast_i.vaddr[vaddr_width_p-1-:vtag_width_p];
+          fe_cmd_li.operands.itlb_fill_response.vtag     = commit_pkt_cast_i.vaddr[vaddr_width_p-1-:vtag_width_p]; // TODO: dedupe?
 
           fe_cmd_v_li = fe_cmd_ready_lo;
         end
@@ -200,7 +200,7 @@ module bp_be_director
       else if (commit_pkt_cast_i.icache_miss)
         begin
           fe_cmd_li.opcode = (compressed_support_p & commit_pkt_cast_i.exception_instr_upper_not_lower_half) ? e_op_icache_fill_resume : e_op_icache_fill_restart;
-          fe_cmd_li.npc = commit_pkt_cast_i.npc;
+          fe_cmd_li.npc    = commit_pkt_cast_i.vaddr;
           fe_cmd_li.operands.icache_fill_response.instr = compressed_support_p ? commit_pkt_cast_i.instr : '0;
 
           fe_cmd_v_li = fe_cmd_ready_lo;

--- a/bp_be/src/v/bp_be_checker/bp_be_director.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.sv
@@ -162,7 +162,6 @@ module bp_be_director
           fe_cmd_li.npc                                  = commit_pkt_cast_i.vaddr;
           fe_cmd_li.operands.itlb_fill_response.pte_leaf = commit_pkt_cast_i.pte_leaf;
           fe_cmd_li.operands.itlb_fill_response.instr    = compressed_support_p ? commit_pkt_cast_i.instr : '0;
-          fe_cmd_li.operands.itlb_fill_response.vtag     = commit_pkt_cast_i.vaddr[vaddr_width_p-1-:vtag_width_p]; // TODO: dedupe?
 
           fe_cmd_v_li = fe_cmd_ready_lo;
         end

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -205,6 +205,7 @@ module bp_be_scheduler
       dispatch_pkt = '0;
       dispatch_pkt.v        = (fe_queue_yumi_li & ~poison_isd_i) || be_exc_not_instr_li;
       dispatch_pkt.queue_v  = fe_queue_yumi_li;
+      // TODO: instr_v could be restricted so that we don't need queue_v & instr_v in calculator_top
       dispatch_pkt.instr_v  = instr_v_li;
       dispatch_pkt.pc       = expected_npc_i;
       dispatch_pkt.instr    = fe_queue_lo.instr;

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -223,7 +223,7 @@ module bp_be_scheduler
         fe_exc_not_instr_li & fe_queue_lo.msg.exception.exception_code inside {e_itlb_miss};
       dispatch_pkt.exception.icache_miss        |=
         fe_exc_not_instr_li & fe_queue_lo.msg.exception.exception_code inside {e_icache_miss};
-      dispatch_pkt.exception.instr_upper_not_lower_half |=
+      dispatch_pkt.exception.upper_not_lower_half |=
         fe_exc_not_instr_li & fe_queue_lo.msg.exception.upper_not_lower_half;
 
       dispatch_pkt.exception.instr_page_fault |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.instr_page_fault_v;
@@ -231,7 +231,7 @@ module bp_be_scheduler
       dispatch_pkt.exception.store_page_fault |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.store_page_fault_v;
       dispatch_pkt.exception.itlb_fill        |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.itlb_fill_v;
       dispatch_pkt.exception.dtlb_fill        |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.dtlb_fill_v;
-      dispatch_pkt.exception.instr_upper_not_lower_half |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.instr_upper_not_lower_half;
+      dispatch_pkt.exception.upper_not_lower_half |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.instr_upper_not_lower_half;
       dispatch_pkt.exception._interrupt       |= be_exc_not_instr_li & interrupt_v_i & ~unfreeze_i;
       dispatch_pkt.exception.unfreeze         |= be_exc_not_instr_li & unfreeze_i;
 

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -218,6 +218,9 @@ module bp_be_scheduler
       dispatch_pkt.imm      = (fe_exc_not_instr_li | be_exc_not_instr_li) ? '0 : issue_pkt.frs3_v ? frf_rs3 : decoded_imm_lo;
       dispatch_pkt.decode   = instr_decoded;
 
+      dispatch_pkt.instr_partial_v = (be_exc_not_instr_li & ptw_fill_pkt_cast_i.instr_partial_v)
+                                   | (fe_exc_not_instr_li & fe_queue_lo.partial_v);
+
       dispatch_pkt.exception.instr_access_fault |=
         fe_exc_not_instr_li & fe_queue_lo.msg_type inside {e_instr_access_fault};
       dispatch_pkt.exception.instr_page_fault   |=
@@ -226,15 +229,12 @@ module bp_be_scheduler
         fe_exc_not_instr_li & fe_queue_lo.msg_type inside {e_itlb_miss};
       dispatch_pkt.exception.icache_miss        |=
         fe_exc_not_instr_li & fe_queue_lo.msg_type inside {e_icache_miss};
-      dispatch_pkt.exception.instr_partial_v |=
-        fe_exc_not_instr_li & fe_queue_lo.partial_v;
 
       dispatch_pkt.exception.instr_page_fault |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.instr_page_fault_v;
       dispatch_pkt.exception.load_page_fault  |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.load_page_fault_v;
       dispatch_pkt.exception.store_page_fault |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.store_page_fault_v;
       dispatch_pkt.exception.itlb_fill        |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.itlb_fill_v;
       dispatch_pkt.exception.dtlb_fill        |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.dtlb_fill_v;
-      dispatch_pkt.exception.instr_partial_v  |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.instr_partial_v;
       dispatch_pkt.exception._interrupt       |= be_exc_not_instr_li & interrupt_v_i & ~unfreeze_i;
       dispatch_pkt.exception.unfreeze         |= be_exc_not_instr_li & unfreeze_i;
 

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -164,7 +164,6 @@ module bp_be_scheduler
 
   wire fe_exc_not_instr_li = fe_queue_yumi_li & (fe_queue_lo.msg_type == e_fe_exception);
   wire [vaddr_width_p-1:0] fe_exc_pc_li = fe_queue_lo.msg.exception.pc;
-  // For now, the FE exception is always affiliated with the PC address (aligned)
   wire [vaddr_width_p-1:0] fe_exc_vaddr_li =  `bp_be_instr_half_address(fe_exc_pc_li, fe_queue_lo.msg.exception.upper_not_lower_half);
   wire be_exc_not_instr_li = ptw_fill_pkt_cast_i.v | interrupt_v_i | unfreeze_i;
   wire [vaddr_width_p-1:0] be_exc_vaddr_li = ptw_fill_pkt_cast_i.vaddr;

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -225,7 +225,7 @@ module bp_be_scheduler
         fe_exc_not_instr_li & fe_queue_lo.msg_type inside {e_itlb_miss};
       dispatch_pkt.exception.icache_miss        |=
         fe_exc_not_instr_li & fe_queue_lo.msg_type inside {e_icache_miss};
-      dispatch_pkt.exception.upper_not_lower_half |=
+      dispatch_pkt.exception.instr_partial_v |=
         fe_exc_not_instr_li & fe_queue_lo.partial_v;
 
       dispatch_pkt.exception.instr_page_fault |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.instr_page_fault_v;
@@ -233,7 +233,7 @@ module bp_be_scheduler
       dispatch_pkt.exception.store_page_fault |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.store_page_fault_v;
       dispatch_pkt.exception.itlb_fill        |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.itlb_fill_v;
       dispatch_pkt.exception.dtlb_fill        |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.dtlb_fill_v;
-      dispatch_pkt.exception.upper_not_lower_half |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.instr_upper_not_lower_half;
+      dispatch_pkt.exception.instr_partial_v  |= be_exc_not_instr_li & ptw_fill_pkt_cast_i.instr_partial_v;
       dispatch_pkt.exception._interrupt       |= be_exc_not_instr_li & interrupt_v_i & ~unfreeze_i;
       dispatch_pkt.exception.unfreeze         |= be_exc_not_instr_li & unfreeze_i;
 

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -197,8 +197,8 @@ module bp_be_scheduler
       isd_status_cast_o.frs3_v   = fe_queue_v_lo & issue_pkt.frs3_v;
       isd_status_cast_o.rs3_addr = fe_queue_lo.msg.fetch.instr.t.fmatype.rs3_addr;
       isd_status_cast_o.rd_addr  = fe_queue_lo.msg.fetch.instr.t.fmatype.rd_addr;
-      isd_status_cast_o.iwb_v    = fe_instr_not_exc_li & instr_decoded.irf_w_v;
-      isd_status_cast_o.fwb_v    = fe_instr_not_exc_li & instr_decoded.frf_w_v;
+      isd_status_cast_o.iwb_v    = instr_decoded.irf_w_v;
+      isd_status_cast_o.fwb_v    = instr_decoded.frf_w_v;
 
       // Form dispatch packet
       dispatch_pkt = '0;

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -205,6 +205,7 @@ module bp_be_scheduler
       dispatch_pkt = '0;
       dispatch_pkt.v        = (fe_queue_yumi_li & ~poison_isd_i) || be_exc_not_instr_li;
       dispatch_pkt.queue_v  = fe_queue_yumi_li;
+      dispatch_pkt.instr_v  = instr_v_li;
       dispatch_pkt.pc       = expected_npc_i;
       dispatch_pkt.instr    = fe_queue_lo.instr;
       // If register injection is critical, can be done after bypass

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -188,6 +188,9 @@
     // Whether to emulate FPU
     //   bit 0: fpu enabled
     integer unsigned fpu_support;
+    // Whether to enable the "c" extension.
+    // Currently, this only enables support for misaligned 32-bit instructions; full "C" support is not yet implemented.
+    integer unsigned compressed_support;
 
     // Whether the coherence network is on the core clock or on its own clock
     integer unsigned async_coh_clk;
@@ -305,6 +308,7 @@
       ,fe_cmd_fifo_els   : 4
       ,muldiv_support    : (1 << e_div) | (1 << e_mul)
       ,fpu_support       : 1
+      ,compressed_support: 1
 
       ,async_coh_clk       : 0
       ,coh_noc_flit_width  : 128
@@ -359,6 +363,7 @@
       ,`bp_aviary_define_override(fe_cmd_fifo_els, BP_FE_CMD_WIDTH, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(muldiv_support, BP_MULDIV_SUPPORT, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(fpu_support, BP_FPU_SUPPORT, `BP_CUSTOM_BASE_CFG)
+      ,`bp_aviary_define_override(compressed_support, BP_COMPRESSED_SUPPORT, `BP_CUSTOM_BASE_CFG)
 
       ,`bp_aviary_define_override(branch_metadata_fwd_width, BRANCH_METADATA_FWD_WIDTH, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(btb_tag_width, BP_BTB_TAG_WIDTH, `BP_CUSTOM_BASE_CFG)

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -188,9 +188,6 @@
     // Whether to emulate FPU
     //   bit 0: fpu enabled
     integer unsigned fpu_support;
-    // Whether to enable the "c" extension.
-    // Currently, this only enables support for misaligned 32-bit instructions; full "C" support is not yet implemented.
-    integer unsigned compressed_support;
 
     // Whether the coherence network is on the core clock or on its own clock
     integer unsigned async_coh_clk;
@@ -308,7 +305,6 @@
       ,fe_cmd_fifo_els   : 4
       ,muldiv_support    : (1 << e_div) | (1 << e_mul)
       ,fpu_support       : 1
-      ,compressed_support: 1
 
       ,async_coh_clk       : 0
       ,coh_noc_flit_width  : 128
@@ -363,7 +359,6 @@
       ,`bp_aviary_define_override(fe_cmd_fifo_els, BP_FE_CMD_WIDTH, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(muldiv_support, BP_MULDIV_SUPPORT, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(fpu_support, BP_FPU_SUPPORT, `BP_CUSTOM_BASE_CFG)
-      ,`bp_aviary_define_override(compressed_support, BP_COMPRESSED_SUPPORT, `BP_CUSTOM_BASE_CFG)
 
       ,`bp_aviary_define_override(branch_metadata_fwd_width, BRANCH_METADATA_FWD_WIDTH, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(btb_tag_width, BP_BTB_TAG_WIDTH, `BP_CUSTOM_BASE_CFG)

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -189,7 +189,7 @@
     //   bit 0: fpu enabled
     integer unsigned fpu_support;
     // Whether to enable the "c" extension.
-    // Currently, this only enables support for misaligned 32-bit instructions; full "C" support is not currently implemented.
+    // Currently, this only enables support for misaligned 32-bit instructions; full "C" support is not yet implemented.
     integer unsigned compressed_support;
 
     // Whether the coherence network is on the core clock or on its own clock

--- a/bp_common/src/include/bp_common_aviary_defines.svh
+++ b/bp_common/src/include/bp_common_aviary_defines.svh
@@ -45,8 +45,10 @@
     , localparam hio_width_p     = paddr_width_p - daddr_width_p                                   \
                                                                                                    \
     , localparam branch_metadata_fwd_width_p = proc_param_lp.branch_metadata_fwd_width             \
+    , localparam btb_ignored_bits_p          = proc_param_lp.compressed_support ? 1 : 2            \
     , localparam btb_tag_width_p             = proc_param_lp.btb_tag_width                         \
     , localparam btb_idx_width_p             = proc_param_lp.btb_idx_width                         \
+    , localparam bht_ignored_bits_p          = proc_param_lp.compressed_support ? 1 : 2            \
     , localparam bht_idx_width_p             = proc_param_lp.bht_idx_width                         \
     , localparam bht_row_els_p               = proc_param_lp.bht_row_els                           \
     , localparam ghist_width_p               = proc_param_lp.ghist_width                           \

--- a/bp_common/src/include/bp_common_aviary_defines.svh
+++ b/bp_common/src/include/bp_common_aviary_defines.svh
@@ -107,7 +107,6 @@
     , localparam fe_cmd_fifo_els_p    = proc_param_lp.fe_cmd_fifo_els                              \
     , localparam muldiv_support_p     = proc_param_lp.muldiv_support                               \
     , localparam fpu_support_p        = proc_param_lp.fpu_support                                  \
-    , localparam compressed_support_p = proc_param_lp.compressed_support                           \
                                                                                                    \
     , localparam async_coh_clk_p        = proc_param_lp.async_coh_clk                              \
     , localparam coh_noc_max_credits_p  = proc_param_lp.coh_noc_max_credits                        \
@@ -201,7 +200,6 @@
           ,`bp_aviary_parameter_override(fe_cmd_fifo_els, override_cfg_mp, default_cfg_mp)         \
           ,`bp_aviary_parameter_override(muldiv_support, override_cfg_mp, default_cfg_mp)          \
           ,`bp_aviary_parameter_override(fpu_support, override_cfg_mp, default_cfg_mp)             \
-          ,`bp_aviary_parameter_override(compressed_support, override_cfg_mp, default_cfg_mp)      \
                                                                                                    \
           ,`bp_aviary_parameter_override(branch_metadata_fwd_width, override_cfg_mp, default_cfg_mp) \
           ,`bp_aviary_parameter_override(btb_tag_width, override_cfg_mp, default_cfg_mp)           \

--- a/bp_common/src/include/bp_common_aviary_defines.svh
+++ b/bp_common/src/include/bp_common_aviary_defines.svh
@@ -107,6 +107,7 @@
     , localparam fe_cmd_fifo_els_p    = proc_param_lp.fe_cmd_fifo_els                              \
     , localparam muldiv_support_p     = proc_param_lp.muldiv_support                               \
     , localparam fpu_support_p        = proc_param_lp.fpu_support                                  \
+    , localparam compressed_support_p = proc_param_lp.compressed_support                           \
                                                                                                    \
     , localparam async_coh_clk_p        = proc_param_lp.async_coh_clk                              \
     , localparam coh_noc_max_credits_p  = proc_param_lp.coh_noc_max_credits                        \
@@ -200,6 +201,7 @@
           ,`bp_aviary_parameter_override(fe_cmd_fifo_els, override_cfg_mp, default_cfg_mp)         \
           ,`bp_aviary_parameter_override(muldiv_support, override_cfg_mp, default_cfg_mp)          \
           ,`bp_aviary_parameter_override(fpu_support, override_cfg_mp, default_cfg_mp)             \
+          ,`bp_aviary_parameter_override(compressed_support, override_cfg_mp, default_cfg_mp)      \
                                                                                                    \
           ,`bp_aviary_parameter_override(branch_metadata_fwd_width, override_cfg_mp, default_cfg_mp) \
           ,`bp_aviary_parameter_override(btb_tag_width, override_cfg_mp, default_cfg_mp)           \

--- a/bp_common/src/include/bp_common_core_if.svh
+++ b/bp_common/src/include/bp_common_core_if.svh
@@ -278,9 +278,9 @@
   `define bp_fe_cmd_operands_u_width(vaddr_width_mp, paddr_width_mp, asid_width_mp, branch_metadata_fwd_width_mp) \
     (1+`BSG_MAX(`bp_fe_cmd_pc_redirect_operands_width_no_padding(branch_metadata_fwd_width_mp)     \
                 ,`BSG_MAX(`bp_fe_cmd_attaboy_width_no_padding(branch_metadata_fwd_width_mp)        \
-                          ,`BSG_MAX(`bp_fe_cmd_itlb_map_width_no_padding(vaddr_width_mp, paddr_width_mp)           \
+                          ,`BSG_MAX(`bp_fe_cmd_itlb_map_width_no_padding(vaddr_width_mp, paddr_width_mp) \
                                     ,`BSG_MAX(`bp_fe_cmd_itlb_fence_width_no_padding(asid_width_mp)\
-                                             ,`bp_fe_cmd_icache_fill_width_no_padding \
+                                             ,`bp_fe_cmd_icache_fill_width_no_padding              \
                                              )                                                     \
                                     )                                                              \
                           )                                                                        \

--- a/bp_common/src/include/bp_common_core_if.svh
+++ b/bp_common/src/include/bp_common_core_if.svh
@@ -106,8 +106,6 @@
     typedef struct packed                                                                          \
     {                                                                                              \
       bp_pte_leaf_s              pte_leaf;                                                         \
-      logic [vaddr_width_mp-page_offset_width_gp-1:0]                                              \
-                                 vtag;                                                             \
       logic [instr_width_gp-1:0] instr;                                                            \
       logic [`bp_fe_cmd_itlb_map_padding_width(vaddr_width_mp, paddr_width_mp, asid_width_mp, branch_metadata_fwd_width_mp)-1:0] \
                                  padding;                                                          \
@@ -211,7 +209,7 @@
     (        1+branch_metadata_fwd_width_mp)
 
   `define bp_fe_cmd_itlb_map_width_no_padding(vaddr_width_mp, paddr_width_mp) \
-    (`bp_pte_leaf_width(paddr_width_mp)+vaddr_width_mp-page_offset_width_gp+instr_width_gp)
+    (`bp_pte_leaf_width(paddr_width_mp)+instr_width_gp)
 
   `define bp_fe_cmd_icache_fill_width_no_padding \
     (instr_width_gp)

--- a/bp_common/src/include/bp_common_core_if.svh
+++ b/bp_common/src/include/bp_common_core_if.svh
@@ -180,7 +180,7 @@
      */                                                                                            \
     typedef struct packed                                                                          \
     {                                                                                              \
-      logic [vaddr_width_mp-1:0]          vaddr;         /* TODO: rename to pc */                  \
+      logic [vaddr_width_mp-1:0]          pc;                                                      \
       bp_fe_command_queue_opcodes_e       opcode;                                                  \
       union packed                                                                                 \
       {                                                                                            \

--- a/bp_common/src/include/bp_common_rv64_csr_defines.svh
+++ b/bp_common/src/include/bp_common_rv64_csr_defines.svh
@@ -740,7 +740,7 @@
   `define bp_sepc_width ($bits(bp_sepc_s))
 
   `define compress_sepc_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) \
-    bp_sepc_s'(data_cast_mp.word_addr)
+    bp_sepc_s'(data_cast_mp.word_addr & ({ {62{1'b1}}, compressed_support_p != 0 }))
 
   `define decompress_sepc_s(data_comp_mp) \
     '{word_addr: `BSG_SIGN_EXTEND(data_comp_mp.word_addr, 63) \

--- a/bp_common/syn/Makefile.vcs
+++ b/bp_common/syn/Makefile.vcs
@@ -72,7 +72,7 @@ $(BUILD_DIR)/simv: | $(BUILD_COLLATERAL)
 	-@tail -n3 $(BUILD_LOG) > $(BUILD_REPORT)
 	-@test -s $(BUILD_ERROR) && echo "FAILED" >> $(BUILD_REPORT) || rm $(BUILD_ERROR)
 
-build_dump.v: VCS_BUILD_OPTS += -debug_all
+build_dump.v: VCS_BUILD_OPTS += -debug_pp
 build_dump.v: VCS_BUILD_OPTS += +vcs+vcdpluson
 build_dump.v: VCS_BUILD_OPTS += +vcs+vcdplusautoflushon
 build_dump.v: build.v

--- a/bp_fe/src/include/bp_fe_defines.svh
+++ b/bp_fe/src/include/bp_fe_defines.svh
@@ -32,15 +32,5 @@
   `define bp_addr_is_aligned(addr_mp, num_bytes_mp) \
     (!(|{ addr_mp[$clog2(num_bytes_mp)-1:0] }))
 
-  `define bp_align_addr_down(addr_mp, num_bytes_mp) \
-    ({addr_mp[$bits(addr_mp)-1:$clog2(num_bytes_mp)], {$clog2(num_bytes_mp){1'b0}}}) 
-
-  `define bp_align_addr_up(addr_mp, num_bytes_mp)                                            \
-    (                                                                                        \
-      `bp_addr_is_aligned(addr_mp, num_bytes_mp)                                             \
-      ? addr_mp                                                                              \
-      : ({addr_mp[$bits(addr_mp)-1:$clog2(num_bytes_mp)] + 1, {$clog2(num_bytes_mp){1'b0}}}) \
-    )
-
 `endif
 

--- a/bp_fe/src/v/bp_fe_bht.sv
+++ b/bp_fe/src/v/bp_fe_bht.sv
@@ -91,7 +91,7 @@ module bp_fe_bht
 
   // GSELECT
   wire                            r_v_li = r_v_i;
-  wire [idx_width_lp-1:0]       r_idx_li = {r_addr_i[2+:bht_idx_width_p], r_ghist_i};
+  wire [idx_width_lp-1:0]       r_idx_li = {r_addr_i[bht_ignored_bits_p+:bht_idx_width_p], r_ghist_i};
   logic [bht_row_width_p-1:0] r_data_lo;
 
   assign rw_same_addr = r_v_i & w_v_i & (r_idx_li == w_idx_li);
@@ -116,7 +116,7 @@ module bp_fe_bht
   if (bht_row_els_p > 1)
     begin : fold
       wire [`BSG_SAFE_CLOG2(bht_row_width_p)-1:0] pred_idx_n =
-        1'b1 + (r_addr_i[2+bht_idx_width_p+:`BSG_SAFE_CLOG2(bht_row_els_p)] << 1'b1);
+        1'b1 + (r_addr_i[bht_ignored_bits_p+bht_idx_width_p+:`BSG_SAFE_CLOG2(bht_row_els_p)] << 1'b1);
       bsg_dff
        #(.width_p(`BSG_SAFE_CLOG2(bht_row_width_p)))
        pred_idx_reg

--- a/bp_fe/src/v/bp_fe_btb.sv
+++ b/bp_fe/src/v/bp_fe_btb.sv
@@ -89,8 +89,8 @@ module bp_fe_btb
     logic [vaddr_width_p-1:0]   tgt;
   }  bp_btb_entry_s;
 
-  wire [btb_idx_width_p-1:0] r_idx_li = r_addr_i[2+:btb_idx_width_p];
-  wire [btb_tag_width_p-1:0] r_tag_li = r_addr_i[2+btb_idx_width_p+:btb_tag_width_p];
+  wire [btb_idx_width_p-1:0] r_idx_li = r_addr_i[btb_ignored_bits_p+:btb_idx_width_p];
+  wire [btb_tag_width_p-1:0] r_tag_li = r_addr_i[btb_ignored_bits_p+btb_idx_width_p+:btb_tag_width_p];
 
   bp_btb_entry_s tag_mem_data_li;
   wire rw_same_addr = r_v_i & w_v_i & (r_idx_li == w_idx_i);

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -324,7 +324,7 @@ module bp_fe_pc_gen
         ,.fetch_data_i  (fetch_i)
         ,.fetch_data_v_i(fetch_v_i)
 
-        ,.poison_i                       (realigner_poison_if1_r & !ovr_half)
+        ,.poison_i                       ((redirect_v_i & ~redirect_restore_insn_lower_half_v_i) | !ovr_half & (ovr_ret | ovr_taken | (misaligned_fetch_nonbr & fetch_v_i)))
         ,.restore_lower_half_v_i         (redirect_restore_insn_lower_half_v_i)
         ,.restore_lower_half_i           (redirect_restore_insn_lower_half_i)
         ,.restore_lower_half_next_vaddr_i(redirect_pc_i)

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -15,7 +15,6 @@ module bp_fe_pc_gen
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_core_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
-   , localparam max_ovr_ntaken_count_nonsynth_lp = (2**30)-1
    )
   (input                                             clk_i
    , input                                           reset_i
@@ -364,20 +363,6 @@ module bp_fe_pc_gen
       assign fetch_instr_v_o = fetch_v_i;
       assign fetch_is_second_half_o = 0;
     end
-
-`ifndef SYNTHESIS
-  logic [`BSG_SAFE_CLOG2(max_ovr_ntaken_count_nonsynth_lp+1)-1:0] ovr_ntaken_count;
-  bsg_counter_clear_up
-    #(.max_val_p(max_ovr_ntaken_count_nonsynth_lp), .init_val_p(0))
-    ovr_ntaken_counter
-      (.clk_i(clk_i)
-      ,.reset_i(reset_i)
-
-      ,.clear_i(reset_i)
-      ,.up_i(ovr_ntaken & !redirect_v_i)
-      ,.count_o(ovr_ntaken_count)
-      );
-`endif
 
   // Global history
   ///////////////////////////

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -309,7 +309,7 @@ module bp_fe_pc_gen
         ,.fetch_data_i  (fetch_i)
         ,.fetch_data_v_i(fetch_v_i)
 
-        ,.poison_i              (realigner_poison_if1_r)
+        ,.poison_i              (realigner_poison_if1_r & !ovr_half)
         ,.restore_lower_half_v_i(redirect_restore_insn_lower_half_v_i)
         ,.restore_lower_half_i  (redirect_restore_insn_lower_half_i)
 

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -74,7 +74,6 @@ module bp_fe_pc_gen
   logic [ghist_width_p-1:0] ghistory_n, ghistory_r;
 
   logic [vaddr_width_p-1:0] next_pc;
-  logic next_pc_nonlinear;
   logic [bht_row_width_p-1:0] bht_row_lo;
   logic bht_pred_lo;
   logic [vaddr_width_p-1:0] btb_br_tgt_lo;
@@ -97,13 +96,11 @@ module bp_fe_pc_gen
 
   // Note: "if" chain duplicated in in bp_fe_nonsynth_pc_gen_tracer.sv
   always_comb begin
-    next_pc_nonlinear = 1'b1;
     if (redirect_v_i)
       begin
         next_pred  = redirect_br_taken_i;
         next_taken = redirect_br_taken_i;
         next_pc    = redirect_pc_i;
-        next_pc_nonlinear = !redirect_resume_v_i;
 
         next_metadata = redirect_br_metadata_fwd;
       end
@@ -111,7 +108,6 @@ module bp_fe_pc_gen
         next_pred  = '0;
         next_pc           = pc_plus4_if2;
         next_taken = '0;
-        next_pc_nonlinear = 1'b0;
     end else if (ovr_o)
       begin
         next_pred  = ovr_btaken;
@@ -130,7 +126,6 @@ module bp_fe_pc_gen
         next_pred  = bht_pred_lo;
         next_taken = btb_taken;
         next_pc    = btb_taken ? btb_br_tgt_lo : pc_plus4;
-        next_pc_nonlinear = btb_taken;
 
         next_metadata = '0;
         next_metadata.src_btb = btb_br_tgt_v_lo;

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -155,7 +155,7 @@ module bp_fe_pc_gen
 
      ,.init_done_o(btb_init_done_lo)
 
-     ,.r_addr_i(next_fetch_o)
+     ,.r_addr_i(next_pc)
      ,.r_v_i(btb_r_v_li)
      ,.br_tgt_o(btb_br_tgt_lo)
      ,.br_tgt_v_o(btb_br_tgt_v_lo)
@@ -172,7 +172,7 @@ module bp_fe_pc_gen
 
   // BHT
   wire bht_r_v_li = next_fetch_yumi_i;
-  wire [vaddr_width_p-1:0] bht_r_addr_li = next_fetch_o;
+  wire [vaddr_width_p-1:0] bht_r_addr_li = next_pc;
   wire [ghist_width_p-1:0] bht_r_ghist_li = pred_if1_n.ghist;
   wire bht_w_v_li =
     (redirect_br_v_i & redirect_br_metadata_fwd.is_br) | (attaboy_v_i & attaboy_br_metadata_fwd.is_br);
@@ -267,8 +267,6 @@ module bp_fe_pc_gen
   assign br_tgt_lo  = fetch_pc_o + scan_instr.imm;
   assign fetch_resume_pc_o = pc_if2_r;
 
-  wire [vaddr_width_p-1:0] branch_prediction_source_addr_if2 = `bp_align_addr_down(pc_if2_r, rv64_instr_width_bytes_gp);
-
   bp_fe_branch_metadata_fwd_s br_metadata_site;
   assign fetch_br_metadata_fwd_o = br_metadata_site;
   always_ff @(posedge clk_i)
@@ -278,9 +276,9 @@ module bp_fe_pc_gen
           ,src_ret : pred_if2_r.ret
           ,ghist   : pred_if2_r.ghist
           ,bht_row : pred_if2_r.bht_row
-          ,btb_tag : branch_prediction_source_addr_if2[2+btb_idx_width_p+:btb_tag_width_p]
-          ,btb_idx : branch_prediction_source_addr_if2[2+:btb_idx_width_p]
-          ,bht_idx : branch_prediction_source_addr_if2[2+:bht_idx_width_p]
+          ,btb_tag : pc_if2_r[2+btb_idx_width_p+:btb_tag_width_p]
+          ,btb_idx : pc_if2_r[2+:btb_idx_width_p]
+          ,bht_idx : pc_if2_r[2+:bht_idx_width_p]
           ,is_br   : is_br
           ,is_jal  : is_jal
           ,is_jalr : is_jalr

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -249,7 +249,7 @@ module bp_fe_pc_gen
 
   // TODO: mask all usages of BTB and BHT outputs if read was not performed last cycle
   assign btb_taken = btb_br_tgt_v_lo & (bht_pred_lo | btb_br_tgt_jmp_lo);
-  assign pc_plus4             = pc_if1_r + vaddr_width_p'(4);
+  assign pc_plus4  = pc_if1_r + vaddr_width_p'(4);
 
   assign btb_tag_if1 = pc_if1_r[btb_ignored_bits_p+btb_idx_width_p+:btb_tag_width_p];
   assign btb_idx_if1 = pc_if1_r[btb_ignored_bits_p+:btb_idx_width_p];

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -82,6 +82,7 @@ module bp_fe_pc_gen
   logic [vaddr_width_p-1:0] br_tgt_lo;
   logic [vaddr_width_p-1:0] if2_second_half_addr;
   wire [vaddr_width_p-1:0] pc_plus4  = pc_if1_r + vaddr_width_p'(4);
+  // TODO: clarify name redirect_pc_restore
   wire [vaddr_width_p-1:0] redirect_pc_restore = redirect_pc_i + (redirect_restore_insn_lower_half_v_i ? vaddr_width_p'(4) : '0);
   // Note: "if" chain duplicated in in bp_fe_nonsynth_pc_gen_tracer.sv
   always_comb begin
@@ -313,7 +314,7 @@ module bp_fe_pc_gen
         ,.poison_i               (realigner_poison_if1_r & !ovr_half)
         ,.restore_lower_half_v_i (redirect_restore_insn_lower_half_v_i)
         ,.restore_lower_half_i   (redirect_restore_insn_lower_half_i)
-        ,.restore_lower_half_pc_i(redirect_pc_restore)
+        ,.restore_lower_half_pc_i(redirect_pc_i)
 
         ,.fetch_instr_pc_o       (fetch_pc_o)
         ,.fetch_instr_o          (fetch_instr_o)

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -68,7 +68,7 @@ module bp_fe_pc_gen
   logic [vaddr_width_p-1:0] pc_if1_n, pc_if1_r;
   logic realigner_poison_if1_n, realigner_poison_if1_r;
   logic [vaddr_width_p-1:0] pc_if2_n, pc_if2_r;
-  logic realigner_poison_if2_n, realigner_poison_if2_r;
+  logic realigner_poison_if2_n;
 
   /////////////////
   // IF1
@@ -248,12 +248,12 @@ module bp_fe_pc_gen
   assign realigner_poison_if2_n = realigner_poison_if1_r;
 
   bsg_dff
-   #(.width_p($bits(bp_fe_pred_s)+vaddr_width_p+1))
+   #(.width_p($bits(bp_fe_pred_s)+vaddr_width_p))
    pred_if2_reg
     (.clk_i(clk_i)
 
-     ,.data_i({pred_if2_n, pc_if2_n, realigner_poison_if2_n})
-     ,.data_o({pred_if2_r, pc_if2_r, realigner_poison_if2_r})
+     ,.data_i({pred_if2_n, pc_if2_n})
+     ,.data_o({pred_if2_r, pc_if2_r})
      );
   assign return_addr_n = pc_if2_r + vaddr_width_p'(4);
 
@@ -305,9 +305,9 @@ module bp_fe_pc_gen
     ,.fetch_data_i  (fetch_i)
     ,.fetch_data_v_i(fetch_v_i)
 
-    ,.poison_i(realigner_poison_if1_r) // TODO: timing is wonky
+    ,.poison_i              (realigner_poison_if2_n)
     ,.restore_upper_half_v_i(redirect_restore_insn_upper_half_v_i)
-    ,.restore_upper_half_i(redirect_restore_insn_upper_half_i)
+    ,.restore_upper_half_i  (redirect_restore_insn_upper_half_i)
 
     ,.fetch_instr_o         (fetch_instr_o)
     ,.fetch_instr_v_o       (fetch_instr_v_o)

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -29,8 +29,8 @@ module bp_fe_pc_gen
    , input                                           redirect_br_taken_i
    , input                                           redirect_br_ntaken_i
    , input                                           redirect_br_nonbr_i
-   , input                                           redirect_restore_insn_lower_half_v_i
-   , input [instr_half_width_gp-1:0]                 redirect_restore_insn_lower_half_i
+   , input                                           redirect_resume_v_i
+   , input [instr_half_width_gp-1:0]                 redirect_resume_instr_i
 
 
    , output logic [vaddr_width_p-1:0]                next_fetch_o
@@ -103,7 +103,7 @@ module bp_fe_pc_gen
         next_pred  = redirect_br_taken_i;
         next_taken = redirect_br_taken_i;
         next_pc    = redirect_pc_i;
-        next_pc_nonlinear = !redirect_restore_insn_lower_half_v_i;
+        next_pc_nonlinear = !redirect_resume_v_i;
 
         next_metadata = redirect_br_metadata_fwd;
       end
@@ -348,10 +348,10 @@ module bp_fe_pc_gen
         ,.fetch_data_v_i(fetch_v_i)
 
         ,.store_v_i  (fetch_half_v)
-        ,.poison_v_i (redirect_v_i & ~redirect_restore_insn_lower_half_v_i)
+        ,.poison_v_i (redirect_v_i & ~redirect_resume_v_i)
 
-        ,.restore_lower_half_v_i         (redirect_restore_insn_lower_half_v_i)
-        ,.restore_lower_half_i           (redirect_restore_insn_lower_half_i)
+        ,.restore_lower_half_v_i         (redirect_resume_v_i)
+        ,.restore_lower_half_i           (redirect_resume_instr_i)
         ,.restore_lower_half_next_vaddr_i(redirect_pc_i)
 
         ,.fetch_instr_pc_o      (fetch_pc_o)

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -45,6 +45,7 @@ module bp_fe_pc_gen
    , output logic [branch_metadata_fwd_width_p-1:0]  fetch_br_metadata_fwd_o
    , output logic [vaddr_width_p-1:0]                fetch_pc_o
    , output                                          fetch_is_second_half_o
+   , output logic[vaddr_width_p-1:0]                 fetch_resume_pc_o
 
    , input [vaddr_width_p-1:0]                       attaboy_pc_i
    , input [branch_metadata_fwd_width_p-1:0]         attaboy_br_metadata_fwd_i
@@ -257,7 +258,7 @@ module bp_fe_pc_gen
   assign ovr_taken  = btb_miss_br & ((is_br & pred_if2_r.pred) | is_jal);
   assign ovr_o      = ovr_taken | ovr_ret;
   assign br_tgt_lo  = fetch_pc_o + scan_instr.imm;
-  // assign fetch_pc_o = pc_if2_r;
+  assign fetch_resume_pc_o = pc_if2_r;
 
   wire [vaddr_width_p-1:0] branch_prediction_source_addr_if2 = `bp_align_addr_down(fetch_pc_o, rv64_instr_width_bytes_gp);
 
@@ -313,7 +314,7 @@ module bp_fe_pc_gen
     end
   else
     begin : fetch_instr_generation
-      assign fetch_pc_o      = fetch_pc_i;
+      assign fetch_pc_o      = pc_if2_r;
       assign fetch_instr_o   = fetch_i;
       assign fetch_instr_v_o = fetch_v_i;
       assign fetch_is_second_half_o = 0;

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -313,7 +313,7 @@ module bp_fe_pc_gen
      );
 
   // Override calculations
-  wire nonlinear_fetch = pred_if1_r || ovr_btaken || ovr_jmp || ovr_ret;
+  wire nonlinear_fetch = taken_if1_r || ovr_btaken || ovr_jmp || ovr_ret;
   wire pc_if2_misaligned = !`bp_addr_is_aligned(pc_if2_r, rv64_instr_width_bytes_gp);
   wire btb_miss_ras = pc_if1_r != ras_tgt_lo;
   // TODO: a jump that skips only one instruction within misaligned code can erroneously pass this check

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -252,6 +252,7 @@ module bp_fe_pc_gen
       metadata_if1.site_return |= fetch_instr_return_v_li;
     end
 
+  // TODO: mask all usages of BTB and BHT outputs if read was not performed last cycle
   assign btb_taken = btb_br_tgt_v_lo & (bht_pred_lo | btb_br_tgt_jmp_lo);
   assign pc_plus4             = pc_if1_r + vaddr_width_p'(4);
 

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -82,6 +82,7 @@ module bp_fe_pc_gen
   logic [vaddr_width_p-1:0] br_tgt_lo;
   logic [vaddr_width_p-1:0] if2_second_half_addr;
   wire [vaddr_width_p-1:0] pc_plus4  = pc_if1_r + vaddr_width_p'(4);
+
   // Note: "if" chain duplicated in in bp_fe_nonsynth_pc_gen_tracer.sv
   always_comb begin
     next_fetch_linear = 1'b0;
@@ -234,7 +235,7 @@ module bp_fe_pc_gen
         pred_if2_n = pred_if1_r;
         pred_if2_n.pred    = bht_pred_lo;
         pred_if2_n.taken   = btb_taken;
-        pred_if2_n.btb     = btb_br_tgt_v_lo; // TODO: mask this? does it matter?
+        pred_if2_n.btb     = btb_br_tgt_v_lo;
         pred_if2_n.bht_row = bht_row_lo;
       end
     else
@@ -307,15 +308,15 @@ module bp_fe_pc_gen
         ,.fetch_data_i  (fetch_i)
         ,.fetch_data_v_i(fetch_v_i)
 
-        ,.poison_i               (realigner_poison_if1_r & !ovr_half)
-        ,.restore_lower_half_v_i (redirect_restore_insn_lower_half_v_i)
-        ,.restore_lower_half_i   (redirect_restore_insn_lower_half_i)
-        ,.restore_lower_half_pc_i(redirect_pc_i - vaddr_width_p'(2)) // TODO: reorg
+        ,.poison_i                       (realigner_poison_if1_r & !ovr_half)
+        ,.restore_lower_half_v_i         (redirect_restore_insn_lower_half_v_i)
+        ,.restore_lower_half_i           (redirect_restore_insn_lower_half_i)
+        ,.restore_lower_half_next_vaddr_i(redirect_pc_i)
 
-        ,.fetch_instr_pc_o       (fetch_pc_o)
-        ,.fetch_instr_o          (fetch_instr_o)
-        ,.fetch_instr_v_o        (fetch_instr_v_o)
-        ,.fetch_is_second_half_o (fetch_is_second_half_o)
+        ,.fetch_instr_pc_o      (fetch_pc_o)
+        ,.fetch_instr_o         (fetch_instr_o)
+        ,.fetch_instr_v_o       (fetch_instr_v_o)
+        ,.fetch_is_second_half_o(fetch_is_second_half_o)
         );
     end
   else

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -320,7 +320,7 @@ module bp_fe_pc_gen
   assign ovr_ret    = btb_miss_ras & taken_ret_if2;
   assign ovr_btaken = btb_miss_br & taken_br_if2;
   assign ovr_jmp    = btb_miss_br & fetch_instr_jal_v_li;
-  assign ovr_ntaken   = compressed_support_p
+  assign ovr_ntaken = compressed_support_p
                     & fetch_v_i
                     & taken_if1_r
                     & (  (!fetch_is_second_half_o && pc_if2_misaligned)
@@ -342,16 +342,15 @@ module bp_fe_pc_gen
         (.clk_i(clk_i)
         ,.reset_i(reset_i)
 
-        ,.fetch_pc_i    (pc_if2_r)
-        ,.fetch_data_i  (fetch_i)
-        ,.fetch_data_v_i(fetch_v_i)
+        ,.fetch_v_i      (fetch_v_i)
+        ,.fetch_store_v_i(fetch_half_v)
+        ,.fetch_pc_i     (pc_if2_r)
+        ,.fetch_data_i   (fetch_i)
 
-        ,.store_v_i  (fetch_half_v)
-        ,.poison_v_i (redirect_v_i & ~redirect_resume_v_i)
-
-        ,.restore_lower_half_v_i         (redirect_resume_v_i)
-        ,.restore_lower_half_i           (redirect_resume_instr_i)
-        ,.restore_lower_half_next_vaddr_i(redirect_pc_i)
+        ,.redirect_v_i      (redirect_v_i)
+        ,.redirect_resume_i (redirect_resume_v_i)
+        ,.redirect_partial_i(redirect_resume_instr_i)
+        ,.redirect_vaddr_i  (redirect_pc_i)
 
         ,.fetch_instr_pc_o      (fetch_pc_o)
         ,.fetch_instr_o         (fetch_instr_o)

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -87,9 +87,11 @@ module bp_fe_pc_gen
     next_fetch_linear = 1'b0;
   if (redirect_v_i)
         next_pc = redirect_pc_i;
-    else if (ovr_half)
+    else if (ovr_half) begin
         next_pc = if2_second_half_addr;
-    else if (ovr_ret)
+        // TODO: clean up linear logic
+        next_fetch_linear = 1'b1;
+    end else if (ovr_ret)
         next_pc = ras_tgt_lo;
     else if (ovr_taken)
         next_pc = br_tgt_lo;

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -82,11 +82,12 @@ module bp_fe_pc_gen
   logic [vaddr_width_p-1:0] br_tgt_lo;
   logic [vaddr_width_p-1:0] if2_second_half_addr;
   wire [vaddr_width_p-1:0] pc_plus4  = pc_if1_r + vaddr_width_p'(4);
+  wire [vaddr_width_p-1:0] redirect_pc_restore = redirect_pc_i + (redirect_restore_insn_lower_half_v_i ? vaddr_width_p'(4) : '0);
   // Note: "if" chain duplicated in in bp_fe_nonsynth_pc_gen_tracer.sv
   always_comb begin
     next_fetch_linear = 1'b0;
-  if (redirect_v_i)
-        next_pc = redirect_pc_i;
+    if (redirect_v_i)
+        next_pc = redirect_pc_restore;
     else if (ovr_half) begin
         next_pc = if2_second_half_addr;
         // TODO: clean up linear logic
@@ -309,14 +310,15 @@ module bp_fe_pc_gen
         ,.fetch_data_i  (fetch_i)
         ,.fetch_data_v_i(fetch_v_i)
 
-        ,.poison_i              (realigner_poison_if1_r & !ovr_half)
-        ,.restore_lower_half_v_i(redirect_restore_insn_lower_half_v_i)
-        ,.restore_lower_half_i  (redirect_restore_insn_lower_half_i)
+        ,.poison_i               (realigner_poison_if1_r & !ovr_half)
+        ,.restore_lower_half_v_i (redirect_restore_insn_lower_half_v_i)
+        ,.restore_lower_half_i   (redirect_restore_insn_lower_half_i)
+        ,.restore_lower_half_pc_i(redirect_pc_restore)
 
-        ,.fetch_instr_pc_o      (fetch_pc_o)
-        ,.fetch_instr_o         (fetch_instr_o)
-        ,.fetch_instr_v_o       (fetch_instr_v_o)
-        ,.fetch_is_second_half_o(fetch_is_second_half_o)
+        ,.fetch_instr_pc_o       (fetch_pc_o)
+        ,.fetch_instr_o          (fetch_instr_o)
+        ,.fetch_instr_v_o        (fetch_instr_v_o)
+        ,.fetch_is_second_half_o (fetch_is_second_half_o)
         );
     end
   else

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -104,9 +104,11 @@ module bp_fe_pc_gen
         next_fetch_linear = 1'b1;
     end
   end
+
   assign pc_if1_n = next_pc;
-  assign realigner_poison_if1_n = !next_fetch_linear & !redirect_restore_insn_lower_half_v_i;
   assign next_fetch_o = `bp_align_addr_down(next_pc, rv64_instr_width_bytes_gp);
+
+  assign realigner_poison_if1_n = !next_fetch_linear & !redirect_restore_insn_lower_half_v_i;
 
   always_comb
     begin

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -273,7 +273,7 @@ module bp_fe_pc_gen
 `ifndef SYNTHESIS
   logic [`BSG_SAFE_CLOG2(max_ovr_half_count_nonsynth_lp+1)-1:0] ovr_half_count;
   bsg_counter_clear_up
-    #(.max_val_p(max_ovr_half_count_nonsynth_lp), .init_val_p(max_ovr_half_count_nonsynth_lp'(0)))
+    #(.max_val_p(max_ovr_half_count_nonsynth_lp), .init_val_p(0))
     ovr_half_counter
       (.clk_i(clk_i)
       ,.reset_i(reset_i)

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -313,7 +313,7 @@ module bp_fe_pc_gen
      );
 
   // Override calculations
-  wire nonlinear_fetch = taken_if1_r || ovr_btaken || ovr_jmp || ovr_ret;
+  wire taken_jump_site_if2 = taken_if1_r || ovr_btaken || ovr_jmp || ovr_ret;
   wire pc_if2_misaligned = !`bp_addr_is_aligned(pc_if2_r, rv64_instr_width_bytes_gp);
   wire btb_miss_ras = pc_if1_r != ras_tgt_lo;
   // TODO: a jump that skips only one instruction within misaligned code can erroneously pass this check
@@ -325,10 +325,10 @@ module bp_fe_pc_gen
                     & fetch_v_i
                     & taken_if1_r
                     & (  (!fetch_is_second_half_o && pc_if2_misaligned)
-                      || ( fetch_is_second_half_o && !nonlinear_fetch )
+                      || ( fetch_is_second_half_o && !taken_jump_site_if2 )
                       || ( fetch_is_second_half_o && !fetch_instr_v_o ));
   wire fetch_half_v =    (!fetch_is_second_half_o && pc_if2_misaligned)
-                      || ( fetch_is_second_half_o && !nonlinear_fetch );
+                      || ( fetch_is_second_half_o && !taken_jump_site_if2 );
   assign ovr_o      = ovr_btaken | ovr_jmp | ovr_ret | ovr_half;
   assign br_tgt_lo  = fetch_pc_o + scan_imm;
 

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -295,7 +295,7 @@ module bp_fe_pc_gen
   // RAS
   ///////////////////////////
   logic ras_valid_lo;
-  wire [vaddr_width_p-1:0] return_addr_if2 = pc_if2_r + vaddr_width_p'(4);
+  wire [vaddr_width_p-1:0] return_addr_if2 = fetch_pc_o + vaddr_width_p'(4);
   bp_fe_ras
    #(.bp_params_p(bp_params_p))
    ras
@@ -311,12 +311,13 @@ module bp_fe_pc_gen
      );
 
   // Override calculations
-  // assign if2_second_half_addr = pc_if2_r + vaddr_width_p'(4);
+  assign if2_second_half_addr = pc_if2_r + vaddr_width_p'(4);
 
   wire is_br = pred_if1_r || ovr_btaken || ovr_jmp || ovr_ret;
 
   wire pc_if2_misaligned = !`bp_addr_is_aligned(pc_if2_r, rv64_instr_width_bytes_gp);
   wire btb_miss_ras = pc_if1_r != ras_tgt_lo;
+  // TODO: a jump that skips only one instruction within misaligned code can erroneously pass this check
   wire btb_miss_br  = pc_if1_r != br_tgt_lo;
   // wire misaligned_fetch_nonbr = pc_if1_r != if2_second_half_addr;
   assign ovr_ret    = btb_miss_ras & fetch_instr_return_v_li & ras_valid_lo;

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -68,7 +68,6 @@ module bp_fe_pc_gen
   logic [vaddr_width_p-1:0] pc_if1_n, pc_if1_r;
   logic realigner_poison_if1_n, realigner_poison_if1_r;
   logic [vaddr_width_p-1:0] pc_if2_n, pc_if2_r;
-  logic realigner_poison_if2_n;
 
   /////////////////
   // IF1
@@ -247,7 +246,6 @@ module bp_fe_pc_gen
         pred_if2_n = pred_if1_r;
       end
   assign pc_if2_n = pc_if1_r;
-  assign realigner_poison_if2_n = realigner_poison_if1_r;
 
   bsg_dff
    #(.width_p($bits(bp_fe_pred_s)+vaddr_width_p))
@@ -309,7 +307,7 @@ module bp_fe_pc_gen
         ,.fetch_data_i  (fetch_i)
         ,.fetch_data_v_i(fetch_v_i)
 
-        ,.poison_i              (realigner_poison_if2_n)
+        ,.poison_i              (realigner_poison_if1_r)
         ,.restore_lower_half_v_i(redirect_restore_insn_lower_half_v_i)
         ,.restore_lower_half_i  (redirect_restore_insn_lower_half_i)
 

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -297,8 +297,8 @@ module bp_fe_pc_gen
      ,.scan_o(scan_instr)
      );
 
-  generate
-    if (compressed_support_p)
+  if (compressed_support_p)
+    begin : fetch_instr_generation
       bp_fe_realigner
         #(.bp_params_p(bp_params_p))
         realigner
@@ -317,12 +317,13 @@ module bp_fe_pc_gen
         ,.fetch_instr_v_o       (fetch_instr_v_o)
         ,.fetch_is_second_half_o(fetch_is_second_half_o)
         );
-    else begin
+    end
+  else
+    begin : fetch_instr_generation
       assign fetch_instr_o   = fetch_i;
       assign fetch_instr_v_o = fetch_v_i;
       assign fetch_is_second_half_o = 0;
     end
-  endgenerate
 
   // Global history
   //

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -355,6 +355,11 @@ module bp_fe_pc_gen
         ,.fetch_is_second_half_o(fetch_is_second_half_o)
         ,.fetch_instr_yumi_i    (fetch_instr_yumi_i)
         );
+
+      // Debug signals for pc_gen_tracer
+      wire                           half_buffer_v_r  = realigner.half_buffer_v_r;
+      wire [vaddr_width_p-1:0]       fetch_instr_pc_r = realigner.fetch_instr_pc_r;
+      wire [instr_half_width_gp-1:0] half_buffer_r    = realigner.half_buffer_r;
     end
   else
     begin : fetch_instr_generation
@@ -362,6 +367,11 @@ module bp_fe_pc_gen
       assign fetch_instr_o   = fetch_i;
       assign fetch_instr_v_o = fetch_v_i;
       assign fetch_is_second_half_o = 0;
+
+      // Debug signals for pc_gen_tracer
+      wire                           half_buffer_v_r  = '0;
+      wire [vaddr_width_p-1:0]       fetch_instr_pc_r = '0;
+      wire [instr_half_width_gp-1:0] half_buffer_r    = '0;
     end
 
   // Global history

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -280,7 +280,7 @@ module bp_fe_pc_gen
   bp_fe_instr_scan
    #(.bp_params_p(bp_params_p))
    instr_scan
-    (.instr_i(fetch_i)
+    (.instr_i(fetch_instr_o)
      ,.scan_o(scan_instr)
      ,.imm_o(scan_imm)
      );
@@ -311,18 +311,18 @@ module bp_fe_pc_gen
      );
 
   // Override calculations
-  assign if2_second_half_addr = pc_if2_r + vaddr_width_p'(4);
+  // assign if2_second_half_addr = pc_if2_r + vaddr_width_p'(4);
 
-  wire is_br = pred_if1_r || ovr_btaken || ovr_ret;
+  wire is_br = pred_if1_r || ovr_btaken || ovr_jmp || ovr_ret;
 
   wire pc_if2_misaligned = !`bp_addr_is_aligned(pc_if2_r, rv64_instr_width_bytes_gp);
   wire btb_miss_ras = pc_if1_r != ras_tgt_lo;
   wire btb_miss_br  = pc_if1_r != br_tgt_lo;
-  wire misaligned_fetch_nonbr = pc_if1_r != if2_second_half_addr;
+  // wire misaligned_fetch_nonbr = pc_if1_r != if2_second_half_addr;
   assign ovr_ret    = btb_miss_ras & fetch_instr_return_v_li & ras_valid_lo;
   assign ovr_btaken = btb_miss_br & fetch_instr_br_v_li & pred_if1_r;
   assign ovr_jmp    = btb_miss_br & fetch_instr_jal_v_li;
-  assign ovr_half   = compressed_support_p & taken_if1_r & ( ((!fetch_is_second_half_o && pc_if2_misaligned) || (fetch_is_second_half_o && !is_br) || (fetch_is_second_half_o && !fetch_instr_v_o))); //misaligned_fetch_nonbr & pc_if2_misaligned & fetch_v_i & !fetch_instr_v_o;
+  assign ovr_half   = compressed_support_p & fetch_v_i & taken_if1_r & ( ((!fetch_is_second_half_o && pc_if2_misaligned) || (fetch_is_second_half_o && !is_br) || (fetch_is_second_half_o && !fetch_instr_v_o))); //misaligned_fetch_nonbr & pc_if2_misaligned & fetch_v_i & !fetch_instr_v_o;
   assign ovr_o      = ovr_btaken | ovr_jmp | ovr_ret | ovr_half;
   assign br_tgt_lo  = fetch_pc_o + scan_imm;
 

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -105,10 +105,10 @@ module bp_fe_pc_gen
   assign realigner_poison_if1_n = !next_fetch_linear & !redirect_restore_insn_upper_half_v_i;
 
   wire next_pc_misaligned = !`bp_addr_is_aligned(next_pc, rv64_instr_width_bytes_gp);
-  assign next_fetch_o = (next_pc_misaligned & !realigner_poison_if1_n)
-    ? `bp_align_addr_up(next_pc, rv64_instr_width_bytes_gp)
-    : `bp_align_addr_down(next_pc, rv64_instr_width_bytes_gp);
   assign incomplete_fetch_if1_n = next_pc_misaligned & realigner_poison_if1_n;
+  assign next_fetch_o = incomplete_fetch_if1_n
+    ? `bp_align_addr_down(next_pc, rv64_instr_width_bytes_gp)
+    : `bp_align_addr_up(next_pc, rv64_instr_width_bytes_gp);
 
   always_comb
     begin

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -28,8 +28,8 @@ module bp_fe_pc_gen
    , input                                           redirect_br_taken_i
    , input                                           redirect_br_ntaken_i
    , input                                           redirect_br_nonbr_i
-   , input                                           redirect_restore_insn_upper_half_v_i
-   , input [instr_half_width_gp-1:0]                 redirect_restore_insn_upper_half_i
+   , input                                           redirect_restore_insn_lower_half_v_i
+   , input [instr_half_width_gp-1:0]                 redirect_restore_insn_lower_half_i
 
 
    , output logic [vaddr_width_p-1:0]                next_fetch_o
@@ -102,7 +102,7 @@ module bp_fe_pc_gen
     end
   end
   assign pc_if1_n = next_pc;
-  assign realigner_poison_if1_n = !next_fetch_linear & !redirect_restore_insn_upper_half_v_i;
+  assign realigner_poison_if1_n = !next_fetch_linear & !redirect_restore_insn_lower_half_v_i;
 
   wire next_pc_misaligned = !`bp_addr_is_aligned(next_pc, rv64_instr_width_bytes_gp);
   assign incomplete_fetch_if1_n = next_pc_misaligned & realigner_poison_if1_n;
@@ -306,8 +306,8 @@ module bp_fe_pc_gen
     ,.fetch_data_v_i(fetch_v_i)
 
     ,.poison_i              (realigner_poison_if2_n)
-    ,.restore_upper_half_v_i(redirect_restore_insn_upper_half_v_i)
-    ,.restore_upper_half_i  (redirect_restore_insn_upper_half_i)
+    ,.restore_lower_half_v_i(redirect_restore_insn_lower_half_v_i)
+    ,.restore_lower_half_i  (redirect_restore_insn_lower_half_i)
 
     ,.fetch_instr_o         (fetch_instr_o)
     ,.fetch_instr_v_o       (fetch_instr_v_o)

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -251,9 +251,9 @@ module bp_fe_pc_gen
   assign btb_taken = btb_br_tgt_v_lo & (bht_pred_lo | btb_br_tgt_jmp_lo);
   assign pc_plus4             = pc_if1_r + vaddr_width_p'(4);
 
-  assign btb_tag_if1 = pc_if1_r[2+btb_idx_width_p+:btb_tag_width_p];
-  assign btb_idx_if1 = pc_if1_r[2+:btb_idx_width_p];
-  assign bht_idx_if1 = pc_if1_r[2+:bht_idx_width_p];
+  assign btb_tag_if1 = pc_if1_r[btb_ignored_bits_p+btb_idx_width_p+:btb_tag_width_p];
+  assign btb_idx_if1 = pc_if1_r[btb_ignored_bits_p+:btb_idx_width_p];
+  assign bht_idx_if1 = pc_if1_r[bht_ignored_bits_p+:bht_idx_width_p];
 
   /////////////////////////////////////////////////////////////////////////////////////
   // IF2

--- a/bp_fe/src/v/bp_fe_realigner.sv
+++ b/bp_fe/src/v/bp_fe_realigner.sv
@@ -43,7 +43,7 @@ module bp_fe_realigner
   wire icache_fetch_is_aligned  = `bp_addr_is_aligned(fetch_pc_i, rv64_instr_width_bytes_gp);
   wire buffered_pc_is_aligned   = `bp_addr_is_aligned(fetch_instr_pc_r, rv64_instr_width_bytes_gp);
 
-  assign fetch_instr_pc_n = restore_lower_half_v_i ? restore_lower_half_pc_i : half_buffer_v_r ? fetch_pc_i + vaddr_width_p'(2) : fetch_pc_i;
+  assign fetch_instr_pc_n = restore_lower_half_v_i ? restore_lower_half_pc_i : ((half_buffer_v_r & icache_fetch_is_aligned) ? (fetch_pc_i + vaddr_width_p'(2)) : fetch_pc_i);
   assign half_buffer_n    = restore_lower_half_v_i ? restore_lower_half_i    : icache_data_upper_half_li;
 
   bsg_dff_reset_en

--- a/bp_fe/src/v/bp_fe_realigner.sv
+++ b/bp_fe/src/v/bp_fe_realigner.sv
@@ -68,7 +68,8 @@ module bp_fe_realigner
 
   assign fetch_is_second_half_o = !icache_fetch_is_aligned && half_buffer_v_r;
 
-  assign fetch_instr_pc_o = icache_fetch_is_aligned ? fetch_pc_i       : fetch_instr_pc_r;
+  assign fetch_instr_pc_o = !fetch_is_second_half_o ? fetch_pc_i       : fetch_instr_pc_r;
+
   assign fetch_instr_v_o  = icache_fetch_is_aligned ? fetch_data_v_i   : buffered_insn_v;
   assign fetch_instr_o    = icache_fetch_is_aligned ? fetch_data_i     : { icache_data_lower_half_li, half_buffer_r };
 endmodule

--- a/bp_fe/src/v/bp_fe_realigner.sv
+++ b/bp_fe/src/v/bp_fe_realigner.sv
@@ -76,7 +76,4 @@ module bp_fe_realigner
   assign fetch_instr_pc_o = half_buffer_v_r ? fetch_instr_pc_r                             : fetch_pc_i;
   assign fetch_instr_o    = half_buffer_v_r ? { icache_data_lower_half_li, half_buffer_r } : fetch_data_i;
 
-  always @(negedge clk_i)
-    if(buffered_pc_is_aligned && half_buffer_v_r)
-      $error("bad");
 endmodule

--- a/bp_fe/src/v/bp_fe_realigner.sv
+++ b/bp_fe/src/v/bp_fe_realigner.sv
@@ -31,8 +31,8 @@ module bp_fe_realigner
    , output                      fetch_is_second_half_o
    );
 
-  wire [instr_half_width_gp-1:0] icache_data_lower_half_li = fetch_data_i[instr_half_width_gp-1:0];
-  wire [instr_half_width_gp-1:0] icache_data_upper_half_li = fetch_data_i[instr_width_gp-1     :instr_half_width_gp];
+  wire [instr_half_width_gp-1:0] icache_data_lower_half_li = fetch_data_i[0                  +:instr_half_width_gp];
+  wire [instr_half_width_gp-1:0] icache_data_upper_half_li = fetch_data_i[instr_half_width_gp+:instr_half_width_gp];
 
   logic [instr_half_width_gp-1:0] half_buffer_n, half_buffer_r;
   assign half_buffer_n   = restore_lower_half_v_i ? restore_lower_half_i : icache_data_upper_half_li;

--- a/bp_fe/src/v/bp_fe_realigner.sv
+++ b/bp_fe/src/v/bp_fe_realigner.sv
@@ -20,6 +20,7 @@ module bp_fe_realigner
    , input [instr_width_gp-1:0]  fetch_data_i
    , input                       fetch_data_v_i
 
+   , input store_v_i
     // poison_i takes precedence over fetch_data_v_i
     // restore_lower_half_v_i takes precedence over poison_i
    , input                           poison_i
@@ -31,6 +32,7 @@ module bp_fe_realigner
    , output [instr_width_gp-1:0] fetch_instr_o
    , output                      fetch_instr_v_o
    , output                      fetch_is_second_half_o
+   , input                       fetch_instr_yumi_i
    );
 
   wire [instr_half_width_gp-1:0] icache_data_lower_half_li = fetch_data_i[0                  +:instr_half_width_gp];
@@ -65,8 +67,8 @@ module bp_fe_realigner
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.set_i  ((fetch_data_v_i & ~poison_i & (half_buffer_v_r | !icache_fetch_is_aligned)) | restore_lower_half_v_i)
-     ,.clear_i(fetch_instr_v_o | poison_i) // set overrides clear
+     ,.set_i  (fetch_data_v_i & store_v_i)
+     ,.clear_i(poison_i | fetch_instr_yumi_i) // set overrides clear
      ,.data_o (half_buffer_v_r)
      );
 

--- a/bp_fe/src/v/bp_fe_realigner.sv
+++ b/bp_fe/src/v/bp_fe_realigner.sv
@@ -25,7 +25,7 @@ module bp_fe_realigner
    , input                           poison_i
    , input                           restore_lower_half_v_i
    , input [instr_half_width_gp-1:0] restore_lower_half_i
-   , input [vaddr_width_p-1:0]       restore_lower_half_pc_i
+   , input [vaddr_width_p-1:0]       restore_lower_half_next_vaddr_i
 
    , output [vaddr_width_p-1:0]  fetch_instr_pc_o
    , output [instr_width_gp-1:0] fetch_instr_o
@@ -43,7 +43,9 @@ module bp_fe_realigner
   wire icache_fetch_is_aligned  = `bp_addr_is_aligned(fetch_pc_i, rv64_instr_width_bytes_gp);
   wire buffered_pc_is_aligned   = `bp_addr_is_aligned(fetch_instr_pc_r, rv64_instr_width_bytes_gp);
 
-  assign fetch_instr_pc_n = restore_lower_half_v_i ? restore_lower_half_pc_i : ((half_buffer_v_r & icache_fetch_is_aligned) ? (fetch_pc_i + vaddr_width_p'(2)) : fetch_pc_i);
+  assign fetch_instr_pc_n = restore_lower_half_v_i                      ? (restore_lower_half_next_vaddr_i - vaddr_width_p'(2))
+                          : (half_buffer_v_r & icache_fetch_is_aligned) ? (fetch_pc_i                      + vaddr_width_p'(2))
+                          :                                                fetch_pc_i;
   assign half_buffer_n    = restore_lower_half_v_i ? restore_lower_half_i    : icache_data_upper_half_li;
 
   bsg_dff_reset_en
@@ -64,12 +66,9 @@ module bp_fe_realigner
      ,.reset_i(reset_i)
 
      ,.set_i  ((fetch_data_v_i & ~poison_i & (half_buffer_v_r | !icache_fetch_is_aligned)) | restore_lower_half_v_i)
-     // TODO: invalidate when PC is aligned? (outside the realigner)
      ,.clear_i(fetch_instr_v_o | poison_i) // set overrides clear
      ,.data_o (half_buffer_v_r)
      );
-
-  // wire buffered_insn_v          = fetch_data_v_i && half_buffer_v_r;
 
   assign fetch_is_second_half_o = half_buffer_v_r;
 

--- a/bp_fe/src/v/bp_fe_realigner.sv
+++ b/bp_fe/src/v/bp_fe_realigner.sv
@@ -46,7 +46,7 @@ module bp_fe_realigner
   assign fetch_instr_pc_n = restore_lower_half_v_i                      ? (restore_lower_half_next_vaddr_i - vaddr_width_p'(2))
                           : (half_buffer_v_r & icache_fetch_is_aligned) ? (fetch_pc_i                      + vaddr_width_p'(2))
                           :                                                fetch_pc_i;
-  assign half_buffer_n    = restore_lower_half_v_i ? restore_lower_half_i    : icache_data_upper_half_li;
+  assign half_buffer_n    = restore_lower_half_v_i ? restore_lower_half_i : icache_data_upper_half_li;
 
   bsg_dff_reset_en
    #(.width_p(vaddr_width_p+instr_half_width_gp))

--- a/bp_fe/src/v/bp_fe_realigner.sv
+++ b/bp_fe/src/v/bp_fe_realigner.sv
@@ -56,7 +56,7 @@ module bp_fe_realigner
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.en_i  (fetch_data_v_i | restore_lower_half_v_i)
+     ,.en_i  ((fetch_data_v_i & store_v_i) | restore_lower_half_v_i)
      ,.data_i({fetch_instr_pc_n, half_buffer_n})
      ,.data_o({fetch_instr_pc_r, half_buffer_r})
      );

--- a/bp_fe/src/v/bp_fe_realigner.sv
+++ b/bp_fe/src/v/bp_fe_realigner.sv
@@ -67,7 +67,7 @@ module bp_fe_realigner
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.set_i  (fetch_data_v_i & store_v_i)
+     ,.set_i  (~poison_i & fetch_data_v_i & store_v_i)
      ,.clear_i(poison_i | fetch_instr_yumi_i) // set overrides clear
      ,.data_o (half_buffer_v_r)
      );

--- a/bp_fe/src/v/bp_fe_realigner.sv
+++ b/bp_fe/src/v/bp_fe_realigner.sv
@@ -25,6 +25,7 @@ module bp_fe_realigner
    , input                           poison_i
    , input                           restore_lower_half_v_i
    , input [instr_half_width_gp-1:0] restore_lower_half_i
+   , input [vaddr_width_p-1:0]       restore_lower_half_pc_i
 
    , output [vaddr_width_p-1:0]  fetch_instr_pc_o
    , output [instr_width_gp-1:0] fetch_instr_o
@@ -37,8 +38,8 @@ module bp_fe_realigner
 
   logic [vaddr_width_p-1:0] fetch_instr_pc_n, fetch_instr_pc_r;
   logic [instr_half_width_gp-1:0] half_buffer_n, half_buffer_r;
-  assign fetch_instr_pc_n = fetch_pc_i;
-  assign half_buffer_n    = restore_lower_half_v_i ? restore_lower_half_i : icache_data_upper_half_li;
+  assign fetch_instr_pc_n = restore_lower_half_v_i ? restore_lower_half_pc_i : fetch_pc_i;
+  assign half_buffer_n    = restore_lower_half_v_i ? restore_lower_half_i    : icache_data_upper_half_li;
   bsg_dff_reset_en
    #(.width_p(vaddr_width_p+instr_half_width_gp))
    half_buffer_reg

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -237,7 +237,7 @@ module bp_fe_top
   logic [ptag_width_p-1:0] ptag_li;
 
   bp_pte_leaf_s w_tlb_entry_li;
-  wire [vtag_width_p-1:0] w_vtag_li = fe_cmd_cast_i.npc[vaddr_width_p-1-:vtag_width_p];
+  wire [vtag_width_p-1:0] w_vtag_li = fe_cmd_cast_i.operands.itlb_fill_response.vtag;
   assign w_tlb_entry_li = fe_cmd_cast_i.operands.itlb_fill_response.pte_leaf;
 
   wire [dword_width_gp-1:0] r_eaddr_li = `BSG_SIGN_EXTEND(next_fetch_lo, dword_width_gp);

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -203,9 +203,7 @@ module bp_fe_top
   assign insn_upper_half_resume_n   = itlb_fill_v ? fe_cmd_cast_i.operands.itlb_fill_response.partial_instr
                                                   : icache_fill_response_v
                                                     ? fe_cmd_cast_i.operands.icache_fill_response.partial_instr
-                                                    : (~cmd_nonattaboy_v      & fetch_is_second_half_lo)
-                                                      ? fetch_instr_lo[instr_half_width_gp-1:0]
-                                                      : 'X; // TODO: remove X, can also remove condition
+                                                    : fetch_instr_lo[instr_half_width_gp-1:0];
   bsg_dff_reset_en_bypass
    #(.width_p(4+$bits(bp_fe_branch_metadata_fwd_s)+vaddr_width_p+1+instr_half_width_gp))
    pc_resume_reg

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -135,7 +135,7 @@ module bp_fe_top
      ,.attaboy_yumi_o(attaboy_yumi_lo)
      );
 
-  wire [instr_half_width_gp-1:0] realigner_instr_stored_half_lo = fetch_instr_lo[instr_half_width_gp-1:0];
+  wire [instr_half_width_gp-1:0] realigner_instr_stored_half_lo = fetch_instr_lo[0+:instr_half_width_gp];
 
   wire state_reset_v          = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_state_reset);
   wire pc_redirect_v          = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_pc_redirection);

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -194,7 +194,6 @@ module bp_fe_top
   logic br_miss_r, br_miss_nonbr_r, br_miss_taken_r, br_miss_ntaken_r;
   logic [instr_half_width_gp-1:0] insn_upper_half_resume_n, insn_upper_half_resume_r;
   logic insn_upper_half_v_resume_n, insn_upper_half_v_resume_r;
-  wire unstall_fetch_v = is_stall & next_fetch_yumi_li;
   assign pc_resume_n = cmd_nonattaboy_v ? fe_cmd_cast_i.pc : fetch_pc_lo;
   assign br_metadata_fwd_resume_n = cmd_nonattaboy_v ? fe_cmd_cast_i.operands.pc_redirect_operands.branch_metadata_fwd : fetch_br_metadata_fwd_lo;
   assign insn_upper_half_v_resume_n = (itlb_fill_v            & fe_cmd_cast_i.operands.itlb_fill_response.partial_instr_v)
@@ -214,7 +213,7 @@ module bp_fe_top
      ,.data_i({br_miss_v, br_miss_nonbr, br_miss_taken, br_miss_ntaken, br_metadata_fwd_resume_n, pc_resume_n, insn_upper_half_v_resume_n, insn_upper_half_resume_n})
      ,.data_o({br_miss_r, br_miss_nonbr_r, br_miss_taken_r, br_miss_ntaken_r, br_metadata_fwd_resume_r, pc_resume_r, insn_upper_half_v_resume_r, insn_upper_half_resume_r})
      );
-  assign redirect_v_li               = unstall_fetch_v | cmd_immediate_v;
+  assign redirect_v_li               = (is_stall & next_fetch_yumi_li) | cmd_immediate_v;
   assign redirect_pc_li              = pc_resume_r;
   assign redirect_br_v_li            = redirect_v_li & br_miss_r;
   assign redirect_br_metadata_fwd_li = br_metadata_fwd_resume_r;

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -110,8 +110,8 @@ module bp_fe_top
      ,.redirect_br_taken_i(redirect_br_taken_li)
      ,.redirect_br_ntaken_i(redirect_br_ntaken_li)
      ,.redirect_br_nonbr_i(redirect_br_nonbr_li)
-     ,.redirect_restore_insn_lower_half_v_i(redirect_restore_insn_lower_half_v_li)
-     ,.redirect_restore_insn_lower_half_i(redirect_restore_insn_lower_half_li)
+     ,.redirect_resume_v_i(redirect_restore_insn_lower_half_v_li)
+     ,.redirect_resume_instr_i(redirect_restore_insn_lower_half_li)
 
      ,.next_fetch_o(next_fetch_lo)
      ,.next_fetch_yumi_i(next_fetch_yumi_li)

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -238,7 +238,7 @@ module bp_fe_top
   logic [ptag_width_p-1:0] ptag_li;
 
   bp_pte_leaf_s w_tlb_entry_li;
-  wire [vtag_width_p-1:0] w_vtag_li = fe_cmd_cast_i.operands.itlb_fill_response.vtag;
+  wire [vtag_width_p-1:0] w_vtag_li = fe_cmd_cast_i.npc[vaddr_width_p-1-:vtag_width_p];
   assign w_tlb_entry_li = fe_cmd_cast_i.operands.itlb_fill_response.pte_leaf;
 
   wire [dword_width_gp-1:0] r_eaddr_li = `BSG_SIGN_EXTEND(next_fetch_lo, dword_width_gp);

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -88,7 +88,7 @@ module bp_fe_top
   logic attaboy_v_li, attaboy_yumi_lo, attaboy_taken_li, attaboy_ntaken_li;
   logic [vaddr_width_p-1:0] attaboy_pc_li;
   logic [instr_width_gp-1:0] fetch_li, fetch_instr_lo;
-  logic [vaddr_width_p-1:0] fetch_pc_lo;
+  logic [vaddr_width_p-1:0] fetch_pc_lo, fetch_resume_pc_lo;
   logic fetch_v_li, fetch_exception_v_li, fetch_fail_v_li;
   logic fetch_instr_v_lo, fetch_is_second_half_lo, fetch_instr_yumi_li;
   bp_fe_branch_metadata_fwd_s fetch_br_metadata_fwd_lo;
@@ -126,6 +126,7 @@ module bp_fe_top
      ,.fetch_br_metadata_fwd_o(fetch_br_metadata_fwd_lo)
      ,.fetch_pc_o(fetch_pc_lo)
      ,.fetch_is_second_half_o(fetch_is_second_half_lo)
+     ,.fetch_resume_pc_o(fetch_resume_pc_lo)
 
      ,.attaboy_pc_i(attaboy_pc_li)
      ,.attaboy_br_metadata_fwd_i(attaboy_br_metadata_fwd_li)
@@ -196,7 +197,7 @@ module bp_fe_top
   logic br_miss_r, br_miss_nonbr_r, br_miss_taken_r, br_miss_ntaken_r;
   logic [instr_half_width_gp-1:0] insn_lower_half_resume_n, insn_lower_half_resume_r;
   logic insn_lower_half_v_resume_n, insn_lower_half_v_resume_r;
-  assign pc_resume_n = cmd_nonattaboy_v ? fe_cmd_cast_i.npc : fetch_pc_lo;
+  assign pc_resume_n = cmd_nonattaboy_v ? fe_cmd_cast_i.npc : fetch_resume_pc_lo;
   assign br_metadata_fwd_resume_n = cmd_nonattaboy_v ? fe_cmd_cast_i.operands.pc_redirect_operands.branch_metadata_fwd : fetch_br_metadata_fwd_lo;
   assign insn_lower_half_v_resume_n = (compressed_support_p & itlb_fill_v            & (fe_cmd_cast_i.opcode == e_op_itlb_fill_resume))
                                     | (compressed_support_p & icache_fill_response_v & (fe_cmd_cast_i.opcode == e_op_icache_fill_resume))

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -378,7 +378,7 @@ module bp_fe_top
      ,.data_o({v_if2_r, v_if1_r})
      );
 
-  wire icache_miss    = v_if2_r & ~icache_data_v_lo;
+  wire icache_miss    = v_if2_r & icache_miss_v_lo;
   wire queue_miss     = v_if2_r & ~fe_queue_ready_i;
   wire fe_exception_v = v_if2_r & (instr_access_fault_r | instr_page_fault_r | itlb_miss_r | icache_miss_v_lo);
   wire fe_instr_v     = v_if2_r & fetch_instr_v_lo;

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -195,7 +195,7 @@ module bp_fe_top
   logic [instr_half_width_gp-1:0] insn_upper_half_resume_n, insn_upper_half_resume_r;
   logic insn_upper_half_v_resume_n, insn_upper_half_v_resume_r;
   wire unstall_fetch_v = is_stall & next_fetch_yumi_li;
-  assign pc_resume_n = cmd_nonattaboy_v ? fe_cmd_cast_i.vaddr : fetch_pc_lo;
+  assign pc_resume_n = cmd_nonattaboy_v ? fe_cmd_cast_i.pc : fetch_pc_lo;
   assign br_metadata_fwd_resume_n = cmd_nonattaboy_v ? fe_cmd_cast_i.operands.pc_redirect_operands.branch_metadata_fwd : fetch_br_metadata_fwd_lo;
   assign insn_upper_half_v_resume_n = (itlb_fill_v            & fe_cmd_cast_i.operands.itlb_fill_response.partial_instr_v)
                                     | (icache_fill_response_v & fe_cmd_cast_i.operands.icache_fill_response.partial_instr_v)
@@ -228,7 +228,7 @@ module bp_fe_top
   assign attaboy_taken_li           = attaboy_v &  fe_cmd_cast_i.operands.attaboy.taken;
   assign attaboy_ntaken_li          = attaboy_v & ~fe_cmd_cast_i.operands.attaboy.taken;
   assign attaboy_v_li               = attaboy_v;
-  assign attaboy_pc_li              = fe_cmd_cast_i.vaddr;
+  assign attaboy_pc_li              = fe_cmd_cast_i.pc;
 
   logic instr_access_fault_v, instr_page_fault_v;
   logic ptag_v_li, ptag_uncached_li, ptag_nonidem_li, ptag_dram_li, ptag_miss_li;

--- a/bp_fe/test/common/bp_fe_nonsynth_pc_gen_tracer.sv
+++ b/bp_fe/test/common/bp_fe_nonsynth_pc_gen_tracer.sv
@@ -12,7 +12,7 @@ with:
   - The reason the above PC was fetched:
     - undefined: the simulation just started and nothing has propagated to IF2 yet 
     - redirect: either a BE->FE command or resuming after a stall
-    - override_half: a misaligned instruction required a second fetch for the same PC
+    - override_ntaken: a misaligned instruction required a second fetch for the same PC
     - override_ras: the RAS was used to predict a JALR (IF2)
     - override_branch: a jump instruction was discovered late (IF2) and caused a bubble
     - btb_taken_branch: the BTB and BHT predict a taken jump (IF1)
@@ -63,7 +63,7 @@ typedef enum logic [2:0]
 {
   e_pc_src_undefined = 3'd0
   ,e_pc_src_redirect
-  ,e_pc_src_override_half
+  ,e_pc_src_override_ntaken
   ,e_pc_src_override_ras
   ,e_pc_src_override_branch
   ,e_pc_src_btb_taken_branch
@@ -101,7 +101,7 @@ module bp_fe_nonsynth_pc_gen_tracer
 
    // IF0
    , input src_redirect_i
-   , input src_override_half_i
+   , input src_override_ntaken_i
    , input src_override_ras_i
    , input src_override_branch_i
    , input src_btb_taken_branch_i
@@ -151,8 +151,8 @@ module bp_fe_nonsynth_pc_gen_tracer
       // TODO: deduplicate "if" chain from bp_fe_pc_gen.sv
       if (src_redirect_i)
         pc_src_if1_n = e_pc_src_redirect;
-      else if (src_override_half_i)
-        pc_src_if1_n = e_pc_src_override_half;
+      else if (src_override_ntaken_i)
+        pc_src_if1_n = e_pc_src_override_ntaken;
       else if (src_override_ras_i)
         pc_src_if1_n = e_pc_src_override_ras;
       else if (src_override_branch_i)

--- a/bp_fe/test/common/bp_fe_nonsynth_pc_gen_tracer.sv
+++ b/bp_fe/test/common/bp_fe_nonsynth_pc_gen_tracer.sv
@@ -92,6 +92,7 @@ module bp_fe_nonsynth_pc_gen_tracer
    // FE state causes
    , input queue_miss_i
    , input icache_miss_i
+   , input icache_req_i
    , input access_fault_i
    , input page_fault_i
    , input itlb_miss_i
@@ -195,6 +196,8 @@ module bp_fe_nonsynth_pc_gen_tracer
         $fwrite(file, "queue miss; ");
       if (icache_miss_i)
         $fwrite(file, "i$ miss; ");
+      if (icache_req_i)
+        $fwrite(file, "outgoing i$ req; ");
       if (access_fault_i)
         $fwrite(file, "access fault; ");
       if (page_fault_i)

--- a/bp_top/test/common/bp_nonsynth_branch_profiler.sv
+++ b/bp_top/test/common/bp_nonsynth_branch_profiler.sv
@@ -86,15 +86,15 @@ module bp_nonsynth_branch_profiler
             ras_hit_cnt <= ras_hit_cnt + branch_metadata.src_ret;
             bht_hit_cnt <= bht_hit_cnt + branch_metadata.is_br;
 
-            if (branch_histo.exists(fe_cmd.vaddr))
+            if (branch_histo.exists(fe_cmd.pc))
               begin
-                branch_histo[fe_cmd.vaddr] <= branch_histo[fe_cmd.vaddr] + 1;
-                miss_histo[fe_cmd.vaddr] <= miss_histo[fe_cmd.vaddr] + 0;
+                branch_histo[fe_cmd.pc] <= branch_histo[fe_cmd.pc] + 1;
+                miss_histo[fe_cmd.pc] <= miss_histo[fe_cmd.pc] + 0;
               end
             else
               begin
-                branch_histo[fe_cmd.vaddr] <= 1;
-                miss_histo[fe_cmd.vaddr] <= 0;
+                branch_histo[fe_cmd.pc] <= 1;
+                miss_histo[fe_cmd.pc] <= 0;
               end
           end
         else if (pc_redirect_v)
@@ -103,15 +103,15 @@ module bp_nonsynth_branch_profiler
             jal_cnt  <= jal_cnt + branch_metadata.is_jal;
             jalr_cnt <= jalr_cnt + branch_metadata.is_jalr;
 
-            if (branch_histo.exists(fe_cmd.vaddr))
+            if (branch_histo.exists(fe_cmd.pc))
               begin
-                branch_histo[fe_cmd.vaddr] <= branch_histo[fe_cmd.vaddr] + 1;
-                miss_histo[fe_cmd.vaddr]   <= miss_histo[fe_cmd.vaddr] + 1;
+                branch_histo[fe_cmd.pc] <= branch_histo[fe_cmd.pc] + 1;
+                miss_histo[fe_cmd.pc]   <= miss_histo[fe_cmd.pc] + 1;
               end
             else
               begin
-                branch_histo[fe_cmd.vaddr] <= 1;
-                miss_histo[fe_cmd.vaddr]   <= 1;
+                branch_histo[fe_cmd.pc] <= 1;
+                miss_histo[fe_cmd.pc]   <= 1;
               end
           end
       end

--- a/bp_top/test/tb/bp_tethered/Makefile.testlist
+++ b/bp_top/test/tb/bp_tethered/Makefile.testlist
@@ -37,6 +37,13 @@ MISC_TESTS := \
 
 MISC_TESTLIST := $(addprefix bp-tests@, $(MISC_TESTS))
 
+MISALIGNED_TESTS := \
+  misaligned_instructions_basic_jumps \
+  misaligned_instructions_advanced_jumps \
+  misaligned_instructions_virtual_memory \
+
+MISALIGNED_TESTLIST := $(addprefix bp-tests@, $(MISALIGNED_TESTS))
+
 RV64_P_ISA_TESTS := \
   rv64ui-p-add     \
   rv64ui-p-addi    \

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -557,6 +557,7 @@ module testbench
 
            ,.queue_miss_i          (queue_miss)
            ,.icache_miss_i         (icache_miss)
+           ,.icache_req_i          (cache_req_v_o)
            ,.access_fault_i        (v_if2_r & instr_access_fault_r)
            ,.page_fault_i          (v_if2_r & instr_page_fault_r)
            ,.itlb_miss_i           (v_if2_r & itlb_miss_r)

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -563,7 +563,7 @@ module testbench
            ,.itlb_miss_i           (v_if2_r & itlb_miss_r)
 
            ,.src_redirect_i        (pc_gen.redirect_v_i)
-           ,.src_override_half_i   (pc_gen.ovr_half)
+           ,.src_override_ntaken_i (pc_gen.ovr_ntaken)
            ,.src_override_ras_i    (pc_gen.ovr_ret)
            ,.src_override_branch_i (pc_gen.ovr_btaken | pc_gen.ovr_jmp)
            ,.src_btb_taken_branch_i(pc_gen.btb_taken)

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -564,6 +564,7 @@ module testbench
            ,.src_redirect_i        (pc_gen.redirect_v_i)
            ,.src_override_ras_i    (pc_gen.ovr_ret)
            ,.src_override_branch_i (pc_gen.ovr_taken)
+           ,.src_incomplete_partial_fetch_i(pc_gen.incomplete_fetch_if1_r)
            ,.src_btb_taken_branch_i(pc_gen.btb_taken)
 
            ,.if1_top_v_i           (v_if1_r)

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -573,9 +573,9 @@ module testbench
 
            ,.if2_top_v_i           (v_if2_r)
            ,.if2_pc_i              (pc_gen.pc_if2_r)
-           ,.realigner_v_i         (pc_gen.fetch_instr_generation.realigner.half_buffer_v_r)
-           ,.realigner_pc_i        (pc_gen.fetch_instr_generation.realigner.fetch_instr_pc_r)
-           ,.realigner_instr_i     (pc_gen.fetch_instr_generation.realigner.half_buffer_r)
+           ,.realigner_v_i         (pc_gen.fetch_instr_generation.half_buffer_v_r)
+           ,.realigner_pc_i        (pc_gen.fetch_instr_generation.fetch_instr_pc_r)
+           ,.realigner_instr_i     (pc_gen.fetch_instr_generation.half_buffer_r)
            );
 
       bind bp_be_top

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -573,6 +573,9 @@ module testbench
 
            ,.if2_top_v_i           (v_if2_r)
            ,.if2_pc_i              (pc_gen.pc_if2_r)
+           ,.realigner_v_i         (pc_gen.fetch_instr_generation.realigner.half_buffer_v_r)
+           ,.realigner_pc_i        (pc_gen.fetch_instr_generation.realigner.fetch_instr_pc_r)
+           ,.realigner_instr_i     (pc_gen.fetch_instr_generation.realigner.half_buffer_r)
            );
 
       bind bp_be_top

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -563,9 +563,9 @@ module testbench
            ,.itlb_miss_i           (v_if2_r & itlb_miss_r)
 
            ,.src_redirect_i        (pc_gen.redirect_v_i)
+           ,.src_override_half_i   (pc_gen.ovr_half)
            ,.src_override_ras_i    (pc_gen.ovr_ret)
            ,.src_override_branch_i (pc_gen.ovr_taken)
-           ,.src_incomplete_partial_fetch_i(pc_gen.incomplete_fetch_if1_r)
            ,.src_btb_taken_branch_i(pc_gen.btb_taken)
 
            ,.if1_top_v_i           (v_if1_r)


### PR DESCRIPTION
## Summary

This PR is the new revision of #986. It introduces support for executing 32-bit instructions aligned to an arbitrary 16-bit boundary. It does not widen or otherwise alter the instruction cache output; rather, it performs successive fetches and synthesizes the results via a new "realigner" component.

The key changes from the previous PR are as follows:
- Branch prediction metadata is now indexed by the aligned address of the second (upper) half of an instruction rather than the first (lower) half
  - As a result, I've removed a bunch of state previously used to carry over this information
- Modified and narrowed the I/O interface between the PC gen module and the overall frontend

  Note: Dan and I had previously discussed moving the realigner out of `pc_gen`. I took a deep dive on this approach and found that the interface between the realigner and `pc_gen`/`fe_top` would not be improved as we had hoped; the interaction is somewhat involved and there are a few signals that need to be routed regardless of where the module is housed. Moving it out of pc_gen increased the number of needed signals by one (two, now that I've added one more for ITLB fill handling). I am fairly happy with the middle ground I've arrived at but am happy to discuss if there are concerns.
- Support for exceptions and virtual memory is now fleshed out. This includes supporting instructions which span two pages. See the new tests in https://github.com/black-parrot-sdk/bp-tests/pull/32 for a demonstration.
  - Exception issue packets now include a new bit, indicating whether the exception is specific to the upper half of the instruction
  - Page table walks, ITLB fills and I$ fills are now performed using the appropriate half of the instruction
  - `{m,s}tval` now correctly indicate the portion of the instruction that failed (either the same as the faulting pc or 2 bytes beyond it)
  - `{m,s}epc` now reflects the true pc alignment and doesn't have its second-to-lowest bit masked

## Issue Fixed

IALIGN is now 16

## Area

Mostly frontend, but propagation of half-instruction faults includes backend changes too.

## Reasoning (outdated, confusing, verbose, etc.)
Why is this change required?

## Additional Changes Required (if any)

Test programs: https://github.com/black-parrot-sdk/bp-tests/pull/32

I also intend to do some updating and porting work for #988 but haven't done so yet.

## Analysis

Test suite does its best to cover relevant cases. Test plan from #986 still applies. But of course, it could have any unknown side-effects.

## Verification

Test suite does its best to cover relevant cases. Test plan from #986 still applies. See tests in https://github.com/black-parrot-sdk/bp-tests/pull/32.

## Additional Context

Previous version of this PR is: #986

