### PR TITLE
Fixing misaligned instruction handling (should be in backend)

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -31,9 +31,6 @@ module bp_be_calculator_top
    , localparam ptw_fill_pkt_width_lp   = `bp_be_ptw_fill_pkt_width(vaddr_width_p, paddr_width_p)
    , localparam wb_pkt_width_lp         = `bp_be_wb_pkt_width(vaddr_width_p)
    , localparam decode_info_width_lp    = `bp_be_decode_info_width
-
-   // From BP BE specifications
-   , localparam pipe_stage_els_lp = 5
    )
  (input                                             clk_i
   , input                                           reset_i
@@ -101,8 +98,9 @@ module bp_be_calculator_top
 
 
   // Pipeline stage registers
-  bp_be_exc_stage_s      [pipe_stage_els_lp  :0] exc_stage_n;
-  bp_be_exc_stage_s      [pipe_stage_els_lp-1:0] exc_stage_r;
+  localparam pipe_stage_els_lp = 5;
+  bp_be_exc_stage_s [pipe_stage_els_lp  :0] exc_stage_n;
+  bp_be_exc_stage_s [pipe_stage_els_lp-1:0] exc_stage_r;
 
   bp_be_wb_pkt_s [pipe_stage_els_lp  :0] comp_stage_n;
   bp_be_wb_pkt_s [pipe_stage_els_lp-1:0] comp_stage_r;
@@ -112,6 +110,8 @@ module bp_be_calculator_top
   rv64_frm_e           frm_dyn_lo;
 
   bp_be_wb_pkt_s long_iwb_pkt, long_fwb_pkt;
+
+  logic pipe_ctl_instr_misaligned_lo;
 
   logic pipe_mem_dtlb_store_miss_lo;
   logic pipe_mem_dtlb_load_miss_lo;
@@ -204,6 +204,7 @@ module bp_be_calculator_top
      ,.data_o(pipe_ctl_data_lo)
      ,.br_pkt_o(br_pkt_o)
      ,.v_o(pipe_ctl_data_lo_v)
+     ,.instr_misaligned_v_o(pipe_ctl_instr_misaligned_lo)
      );
 
   // Computation pipelines
@@ -477,6 +478,8 @@ module bp_be_calculator_top
 
           exc_stage_n[1].exc.illegal_instr      |= pipe_sys_illegal_instr_lo;
           exc_stage_n[1].spec.csrw              |= pipe_sys_csrw_lo;
+
+          exc_stage_n[1].exc.instr_misaligned   |= pipe_ctl_instr_misaligned_lo;
 
           exc_stage_n[1].exc.dtlb_store_miss    |= pipe_mem_dtlb_store_miss_lo;
           exc_stage_n[1].exc.dtlb_load_miss     |= pipe_mem_dtlb_load_miss_lo;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_ctl.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_ctl.sv
@@ -71,7 +71,7 @@ module bp_be_pipe_ctl
 
   wire [vaddr_width_p-1:0] baddr = decode.baddr_sel ? rs1 : pc;
   wire [vaddr_width_p-1:0] taken_raw = baddr + imm;
-  wire [vaddr_width_p-1:0] taken_tgt = {taken_tgt[vaddr_width_p-1:1], 1'b0};
+  wire [vaddr_width_p-1:0] taken_tgt = {taken_raw[vaddr_width_p-1:1], 1'b0};
   wire [vaddr_width_p-1:0] ntaken_tgt = pc + 4'd4;
 
   assign data_o   = vaddr_width_p'($signed(ntaken_tgt));

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_ctl.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_ctl.sv
@@ -21,15 +21,16 @@ module bp_be_pipe_ctl
    , localparam dispatch_pkt_width_lp = `bp_be_dispatch_pkt_width(vaddr_width_p)
    , localparam branch_pkt_width_lp = `bp_be_branch_pkt_width(vaddr_width_p)
    )
-  (input                               clk_i
-   , input                             reset_i
+  (input                                    clk_i
+   , input                                  reset_i
 
-   , input [dispatch_pkt_width_lp-1:0] reservation_i
-   , input                             flush_i
+   , input [dispatch_pkt_width_lp-1:0]      reservation_i
+   , input                                  flush_i
 
-   , output [dpath_width_gp-1:0]        data_o
-   , output [branch_pkt_width_lp-1:0]  br_pkt_o
-   , output                            v_o
+   , output logic [dpath_width_gp-1:0]      data_o
+   , output logic [branch_pkt_width_lp-1:0] br_pkt_o
+   , output logic                           v_o
+   , output logic                           instr_misaligned_v_o
    );
 
   // Suppress unused signal warning
@@ -69,16 +70,18 @@ module bp_be_pipe_ctl
       end
 
   wire [vaddr_width_p-1:0] baddr = decode.baddr_sel ? rs1 : pc;
-  wire [vaddr_width_p-1:0] taken_tgt = baddr + imm;
+  wire [vaddr_width_p-1:0] taken_raw = baddr + imm;
+  wire [vaddr_width_p-1:0] taken_tgt = {taken_tgt[vaddr_width_p-1:1], 1'b0};
   wire [vaddr_width_p-1:0] ntaken_tgt = pc + 4'd4;
 
   assign data_o   = vaddr_width_p'($signed(ntaken_tgt));
   assign v_o      = reservation.v & reservation.decode.pipe_ctl_v;
+  assign instr_misaligned_v_o = btaken & (taken_tgt[1:0] != 2'b00);
 
   assign br_pkt.v         = reservation.v & reservation.queue_v & ~flush_i;
   assign br_pkt.branch    = br_pkt.v & reservation.decode.pipe_ctl_v;
   assign br_pkt.btaken    = br_pkt.v & reservation.decode.pipe_ctl_v & btaken;
-  assign br_pkt.npc       = btaken ? {taken_tgt[vaddr_width_p-1:1], 1'b0} : ntaken_tgt;
+  assign br_pkt.npc       = btaken ? taken_tgt : ntaken_tgt;
 
 endmodule
 

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -212,8 +212,6 @@ module bp_be_scheduler
       dispatch_pkt.exception.instr_access_fault |=
         fe_exc_not_instr_li & fe_queue_lo.msg.exception.exception_code inside {e_instr_access_fault};
       dispatch_pkt.exception.instr_misaligned   |=
-        fe_exc_not_instr_li & fe_queue_lo.msg.exception.exception_code inside {e_instr_misaligned};
-      dispatch_pkt.exception.instr_page_fault   |=
         fe_exc_not_instr_li & fe_queue_lo.msg.exception.exception_code inside {e_instr_page_fault};
       dispatch_pkt.exception.itlb_miss          |=
         fe_exc_not_instr_li & fe_queue_lo.msg.exception.exception_code inside {e_itlb_miss};

--- a/bp_common/src/include/bp_common_core_pkgdef.svh
+++ b/bp_common/src/include/bp_common_core_pkgdef.svh
@@ -61,19 +61,18 @@
   } bp_fe_misprediction_reason_e;
 
   /*
-   * The exception code types. e_itlb_miss is when the instruction has a miss in
-   * the iTLB. ITLB misses can cause the instruction misaligned. Thus the frontend
-   * detects the instruction miss first and then detect whether there is an ITLB
-   * miss. e_instruction_access_fault is when the access control is violated.
-   * e_instr_page_fault is when the instruction page is accessed with insufficent privilege
+   * The exception code types.
+   * e_itlb_miss is for an ITLB miss
+   * e_instr_page_fault is for an access page fault
+   * e_instr_access_fault is when the physical address is not allowed for the access type
+   * e_icache_miss is for a nonspeculative I$ miss which needs to be confirmed by the backend
    */
   typedef enum logic [2:0]
   {
     e_itlb_miss           = 0
-    ,e_icache_miss        = 1
-    ,e_instr_misaligned   = 2
-    ,e_instr_access_fault = 3
-    ,e_instr_page_fault   = 4
+    ,e_instr_page_fault   = 1
+    ,e_instr_access_fault = 2
+    ,e_icache_miss        = 3
   } bp_fe_exception_code_e;
 
   /*


### PR DESCRIPTION
## Summary
This PR fixes the handling of misaligned instructions. Originally, we would raise a misaligned exception upon fetching a misaligned instruction. However, the correct spec behavior is to actually raise the exception on the instruction which causes the misalignment (i.e. the branch).

## Issue Fixed
#216 

## Area
FE-BE interface (danger zone), and exception pipelines.

## Reasoning (outdated, confusing, verbose, etc.)

To comply with the privileged spec:
<img width="686" alt="image" src="https://user-images.githubusercontent.com/2322266/179336552-8682e7b7-28a1-464a-8d0c-f1e0e2a6fde4.png">

## Additional Changes Required (if any)
When we implement compressed instructions this check must be disabled entirely

## Analysis
No PPA impact, higher compliance.

## Verification
Run with: https://github.com/black-parrot-sdk/bp-tests/pull/32 to verify that trap is taken as expected


