### PR TITLE
Fixes for XSIM and NBF

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,28 +1,28 @@
 Thanks for contributing to BlackParrot! Check out the CONTRIBUTING guide, if this is your first
-time. A few details to check:
+time. Please provide a few details:
 
-## Summary
+### Summary
 Brief description of the change.
 
-## Issue Fixed
+### Issue Fixed
 Does this PR address a BlackParrot GitHub issue? Link it here:
 
-## Area
+### Area
 Module/tool/makefile/script in question.
 
-## Reasoning (outdated, confusing, verbose, etc.)
+### Reasoning (new feature, inefficient, verbose, etc.)
 Why is this change required?
 
-## Additional Changes Required (if any)
+### Additional Changes Required (if any)
 Next steps, downstream modules affected, etc.
 
-## Analysis
+### Analysis
 Potential impact of the change.
 
-## Verification
+### Verification
 Steps to taken to verify the change.
 
-## Additional Context
+### Additional Context
 Add any other context about the problem here.
 Logs, screenshots or videos that show the issue are very helpful.
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - dev_hotfix_xsim_fixes
   before_script:
       - git submodule update --init --checkout --recursive external/
       - cp -r $CI_RTL_INSTALL_DIR install/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - dev_hotfix_xsim_fixes
   before_script:
       - git submodule update --init --checkout --recursive external/
       - cp -r $CI_RTL_INSTALL_DIR install/

--- a/bp_be/src/v/bp_be_calculator/bp_be_nan_unbox.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_nan_unbox.sv
@@ -17,7 +17,10 @@ module bp_be_nan_unbox
  `bp_cast_o(bp_be_fp_reg_s, reg);
 
   wire invbox = unbox_i & (reg_cast_i.tag == e_fp_full);
-  assign reg_cast_o = invbox ? '{tag: unbox_i ? e_rne : e_fp_full, rec: dp_canonical_rec} : reg_i;
+  // Bug in XSIM 2019.2 causes SEGV when assigning to structs with a mux
+  bp_be_fp_reg_s invbox_nan;
+  assign invbox_nan = '{tag: unbox_i ? e_rne : e_fp_full, rec: dp_canonical_rec};
+  assign reg_cast_o = invbox ? invbox_nan : reg_i;
 
 endmodule
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_aux.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_aux.sv
@@ -186,9 +186,16 @@ module bp_be_pipe_aux
   assign f2i_result = decode.opw_v
                       ? {{word_width_gp{f2w_out[word_width_gp-1]}}, f2w_out}
                       : f2dw_out;
-  assign f2i_fflags = decode.opw_v
-                      ? '{nv: f2w_iflags.nv | f2w_iflags.of, nx: f2w_iflags.nx, default: '0}
-                      : '{nv: f2dw_iflags.nv | f2dw_iflags.of, nx: f2dw_iflags.nx, default: '0};
+
+  // Bug in XSIM 2019.2 causes SEGV when assigning to structs with a mux
+  // assign f2i_fflags = decode.opw_v
+  //                     ? '{nv: f2w_iflags.nv | f2w_iflags.of, nx: f2w_iflags.nx, default: '0}
+  //                     : '{nv: f2dw_iflags.nv | f2dw_iflags.of, nx: f2dw_iflags.nx, default: '0};
+  rv64_fflags_s word_fflags;
+  rv64_fflags_s dword_fflags;
+  assign word_fflags = '{nv: f2w_iflags.nv | f2w_iflags.of, nx: f2w_iflags.nx, default: '0};
+  assign dword_fflags = '{nv: f2dw_iflags.nv | f2dw_iflags.of, nx: f2dw_iflags.nx, default: '0};
+  assign f2i_fflags = decode.opw_v ? word_fflags : dword_fflags;
 
   //
   // FCLASS

--- a/bp_common/software/py/nbf.py
+++ b/bp_common/software/py/nbf.py
@@ -45,7 +45,6 @@ import subprocess
 ##  localparam cfg_reg_host_did_gp        = (dev_addr_width_gp)'('h0_0018);
 ##  // Used until PMP are setup properly
 ##  localparam cfg_reg_hio_mask_gp        = (dev_addr_width_gp)'('h0_001c);
-##  localparam cfg_reg_npc_gp        = (dev_addr_width_gp)'('h0_0020);
 ##  localparam cfg_reg_icache_id_gp       = (dev_addr_width_gp)'('h0_0200);
 ##  localparam cfg_reg_icache_mode_gp     = (dev_addr_width_gp)'('h0_0204);
 ##  localparam cfg_reg_dcache_id_gp       = (dev_addr_width_gp)'('h0_0400);
@@ -227,14 +226,14 @@ class NBF:
   def dump(self):
 
     # Freeze set
-    self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_freeze, 1)
+    self.print_nbf_allcores(2, cfg_base_addr + cfg_reg_freeze, 1)
     # Boot PC set
     if self.boot_pc:
-      self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_npc, int(self.boot_pc, 16))
+      self.print_nbf_allcores(2, cfg_base_addr + cfg_reg_npc, int(self.boot_pc, 16))
     if self.debug:
-      self.print_nbf_allcores(3, clint_base_addr + clint_reg_debug, 1)
+      self.print_nbf_allcores(2, clint_base_addr + clint_reg_debug, 1)
       self.print_fence()
-      self.print_nbf_allcores(3, clint_base_addr + clint_reg_debug, 0)
+      self.print_nbf_allcores(2, clint_base_addr + clint_reg_debug, 0)
 
     # For regular execution, the CCE ucode and cache/CCE modes are loaded by the bootrom
     if self.config:
@@ -246,9 +245,9 @@ class NBF:
             self.print_nbf(3, full_addr, self.ucode[i])
 
       # Write I$, D$, and CCE modes
-      self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_cce_mode, 1)
-      self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_icache_mode, 1)
-      self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_dcache_mode, 1)
+      self.print_nbf_allcores(2, cfg_base_addr + cfg_reg_cce_mode, 1)
+      self.print_nbf_allcores(2, cfg_base_addr + cfg_reg_icache_mode, 1)
+      self.print_nbf_allcores(2, cfg_base_addr + cfg_reg_dcache_mode, 1)
 
       if self.verify:
         # Read back I$, D$ and CCE modes for verification
@@ -257,7 +256,7 @@ class NBF:
         self.print_nbf(0x12, cfg_base_addr + cfg_reg_cce_mode, 1)
 
     # Write RTC
-    self.print_nbf_allcores(3, clint_base_addr + clint_reg_mtimesel, 1)
+    self.print_nbf_allcores(2, clint_base_addr + clint_reg_mtimesel, 1)
 
     self.print_fence()
 
@@ -275,7 +274,7 @@ class NBF:
     self.print_fence()
 
     # Freeze clear
-    self.print_nbf_allcores(3, cfg_base_addr + cfg_reg_freeze, 0)
+    self.print_nbf_allcores(2, cfg_base_addr + cfg_reg_freeze, 0)
     # EOF
     self.print_fence()
     self.print_finish()

--- a/bp_common/software/py/nbf.py
+++ b/bp_common/software/py/nbf.py
@@ -79,13 +79,14 @@ cfg_core_offset = 24
 class NBF:
 
   # constructor
-  def __init__(self, ncpus, ucode_file, mem_file, checkpoint_file, config, skip_zeros, addr_width,
+  def __init__(self, ncpus, ucode_file, mem_file, mem_size, checkpoint_file, config, skip_zeros, addr_width,
           data_width, boot_pc, debug, verify):
 
     # input parameters
     self.ncpus = ncpus
     self.ucode_file = ucode_file
     self.mem_file = mem_file
+    self.mem_size = mem_size
     self.config = config
     self.checkpoint_file = checkpoint_file
     self.skip_zeros = skip_zeros
@@ -204,6 +205,9 @@ class NBF:
 
   # initialize dram
   def init_dram(self):
+    if not(self.skip_zeros):
+      for k in xrange(self.mem_size*1024*1024/8):
+        self.print_nbf(3, 0x80000000 + k*8, 0)
     for k in sorted(self.dram_data.keys()):
       addr = k
       opcode = self.get_size(addr)
@@ -288,6 +292,7 @@ if __name__ == "__main__":
   parser.add_argument('--ncpus', type=int, default=1, help='number of BlackParrot cores')
   parser.add_argument('--ucode', dest='ucode_file', metavar='ucode.mem', help='CCE ucode file')
   parser.add_argument("--mem", dest='mem_file', metavar='prog.mem', help='DRAM verilog file')
+  parser.add_argument("--mem_size", type=int, default=16, help='DRAM size in MiB')
   parser.add_argument("--config", dest='config', action='store_true', help='Do config over nbf')
   parser.add_argument("--checkpoint", dest='checkpoint_file', metavar='sample.nbf',help='checkpoint nbf file')
   parser.add_argument('--skip_zeros', dest='skip_zeros', action='store_true', help='skip zero DRAM entries')
@@ -299,6 +304,6 @@ if __name__ == "__main__":
 
   args = parser.parse_args()
 
-  converter = NBF(args.ncpus, args.ucode_file, args.mem_file, args.checkpoint_file, args.config,
+  converter = NBF(args.ncpus, args.ucode_file, args.mem_file, args.mem_size, args.checkpoint_file, args.config,
           args.skip_zeros, args.addr_width, args.data_width, args.boot_pc, args.debug, args.verify)
   converter.dump()

--- a/bp_fe/src/v/bp_fe_btb.sv
+++ b/bp_fe/src/v/bp_fe_btb.sv
@@ -96,7 +96,10 @@ module bp_fe_btb
   wire rw_same_addr = r_v_i & w_v_i & (r_idx_li == w_idx_i);
   wire                          tag_mem_w_v_li = is_clear | (w_v_i & ~rw_same_addr);
   wire [btb_idx_width_p-1:0] tag_mem_w_addr_li = is_clear ? init_cnt : w_idx_i;
-  assign tag_mem_data_li = (is_clear | (w_v_i & w_clr_i)) ? '0 : '{v: 1'b1, jmp: w_jmp_i, tag: w_tag_i, tgt: br_tgt_i};
+  // Bug in XSIM 2019.2 causes SEGV when assigning to structs with a mux
+  bp_btb_entry_s new_btb;
+  assign new_btb = '{v: 1'b1, jmp: w_jmp_i, tag: w_tag_i, tgt: br_tgt_i};
+  assign tag_mem_data_li = (is_clear | (w_v_i & w_clr_i)) ? '0 : new_btb;
 
   bp_btb_entry_s tag_mem_data_lo;
   wire                           tag_mem_r_v_li = r_v_i;

--- a/bp_top/test/common/bp_nonsynth_cosim.sv
+++ b/bp_top/test/common/bp_nonsynth_cosim.sv
@@ -245,7 +245,7 @@ module bp_nonsynth_cosim
 
   always_ff @(negedge reset_i)
     if (cosim_en_i)
-      dromajo_init(config_file_i, mhartid_i, num_core_i, memsize_i, checkpoint_i, amo_en_i);
+      dromajo_init(string'(config_file_i), mhartid_i, num_core_i, memsize_i, checkpoint_i, amo_en_i);
 
   always_ff @(posedge cosim_clk_i)
     if (cosim_en_i & commit_fifo_yumi_li & trap_v_r)

--- a/bp_top/test/tb/bp_tethered/Makefile.params
+++ b/bp_top/test/tb/bp_tethered/Makefile.params
@@ -17,6 +17,8 @@ export NBF_CONFIG_P   ?= 1
 export DEV_TRACE_P    ?= 0
 
 export PRELOAD_MEM_P  ?= 0
+export NBF_SKIP_ZEROS ?= 1
+export NBF_MEM_SIZE   ?= 16
 
 export NO_BIND_P ?= 0
 

--- a/bp_top/test/tb/bp_tethered/Makefile.vcs
+++ b/bp_top/test/tb/bp_tethered/Makefile.vcs
@@ -79,7 +79,10 @@ else ifeq ($(NBF_CONFIG_P), 1)
 NBF_INPUTS += --config
 endif
 ifeq ($(PRELOAD_MEM_P), 0)
-NBF_INPUTS += --mem=prog.mem --skip_zeros
+NBF_INPUTS += --mem=prog.mem --mem_size=$(NBF_MEM_SIZE)
+ifeq ($(NBF_SKIP_ZEROS), 1)
+NBF_INPUTS += --skip_zeros
+endif
 endif
 NBF_INPUTS += --addr_width=$(PADDR_WIDTH)
 NBF_INPUTS += --debug

--- a/bp_top/test/tb/bp_tethered/Makefile.verilator
+++ b/bp_top/test/tb/bp_tethered/Makefile.verilator
@@ -56,7 +56,10 @@ NBF_INPUTS += --config --ucode=cce_ucode.mem
 else ifeq ($(NBF_CONFIG_P), 1)
 NBF_INPUTS += --config
 endif
-NBF_INPUTS += --mem=prog.mem --skip_zeros
+NBF_INPUTS += --mem=prog.mem --mem_size=$(NBF_MEM_SIZE)
+ifeq ($(NBF_SKIP_ZEROS), 1)
+NBF_INPUTS += --skip_zeros
+endif
 NBF_INPUTS += --addr_width=$(PADDR_WIDTH)
 NBF_INPUTS += --debug
 


### PR DESCRIPTION
Thanks for contributing to BlackParrot! Check out the CONTRIBUTING guide, if this is your first
time. A few details to check:

## Summary
This PR addresses issues identified while bringing up an alternate FPGA setup using vivado+xsim.

## Issue Fixed
None

## Area
NBF generation, and code in the BP backend

## Reasoning (outdated, confusing, verbose, etc.)
- XSIM cannot handle inferred struct muxing
- NBF may be required to clear zeros from memory in some setups
- NBF should use 32b requests for 32b config registers within BP for alignment purposes (Ucode is still 64b aligned)

## Additional Changes Required (if any)
None

## Analysis
No PPA impact

## Verification
Build with XSIM and run standard regression on VCS (XSIM still doesn't fully simulate due to DPI calls)

## Additional Context
None
