### PR TITLE
Fixing timing loop and clarifying vaddr injection

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -250,7 +250,7 @@ module bp_be_pipe_mem
     '{instr_miss_v  : commit_pkt.itlb_miss
       ,store_miss_v : commit_pkt.dtlb_store_miss
       ,load_miss_v  : commit_pkt.dtlb_load_miss
-      ,vaddr        : commit_pkt.itlb_miss ? commit_pkt.pc : commit_pkt.vaddr
+      ,vaddr        : commit_pkt.vaddr
       ,mstatus_mxr  : trans_info.mstatus_mxr
       ,mstatus_sum  : trans_info.mstatus_sum
       ,base_ppn     : trans_info.base_ppn

--- a/bp_be/src/v/bp_be_checker/bp_be_instr_decoder.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_instr_decoder.sv
@@ -610,26 +610,28 @@ module bp_be_instr_decoder
             end
           default : illegal_instr_o = 1'b1;
         endcase
-
-        // Immediate extraction
-        unique casez (instr.opcode)
-          `RV64_LUI_OP, `RV64_AUIPC_OP:
-            imm_o = `rv64_signext_u_imm(instr);
-          `RV64_JAL_OP:
-            imm_o = `rv64_signext_j_imm(instr);
-          `RV64_BRANCH_OP:
-            imm_o = `rv64_signext_b_imm(instr);
-          `RV64_STORE_OP, `RV64_FSTORE_OP:
-            imm_o = `rv64_signext_s_imm(instr);
-          `RV64_JALR_OP, `RV64_LOAD_OP, `RV64_OP_IMM_OP, `RV64_OP_IMM_32_OP, `RV64_FLOAD_OP:
-            imm_o = `rv64_signext_i_imm(instr);
-          `RV64_SYSTEM_OP:
-            imm_o = `rv64_signext_c_imm(instr);
-          //`RV64_AMO_OP:
-          default: imm_o = '0;
-        endcase
       end
 
+      // Immediate extraction
+      // This may be overwritten by exception injection
+      unique casez (instr.opcode)
+        `RV64_LUI_OP, `RV64_AUIPC_OP:
+          imm_o = `rv64_signext_u_imm(instr);
+        `RV64_JAL_OP:
+          imm_o = `rv64_signext_j_imm(instr);
+        `RV64_BRANCH_OP:
+          imm_o = `rv64_signext_b_imm(instr);
+        `RV64_STORE_OP, `RV64_FSTORE_OP:
+          imm_o = `rv64_signext_s_imm(instr);
+        `RV64_JALR_OP, `RV64_LOAD_OP, `RV64_OP_IMM_OP, `RV64_OP_IMM_32_OP, `RV64_FLOAD_OP:
+          imm_o = `rv64_signext_i_imm(instr);
+        `RV64_SYSTEM_OP:
+          imm_o = `rv64_signext_c_imm(instr);
+        //`RV64_AMO_OP:
+        default: imm_o = '0;
+      endcase
+
+      // Zero decode on illegal instruction to prevent unnecessary toggling
       if (illegal_instr_o)
         decode_cast_o = '0;
     end


### PR DESCRIPTION
## Summary
This PR fixes a timing loop in the instruction scheduler and clarifies vaddr injection by gathering it from the instruction decoder and system pipe and putting it in the scheduler.

## Issue Fixed
None

## Area
Scheduler and instruction decoder

## Reasoning (outdated, confusing, verbose, etc.)
Fixes timing loop caused by #1105 

## Additional Changes Required (if any)
None

## Analysis
Minimal PPA. Moves multiplexer in retirement to scheduler

## Verification
Standard regression as well as check_loops and check_design

## Additional Context
None

