### PR TITLE
Support MULH

### DIFF
--- a/bp_be/src/include/bp_be_ctl_pkgdef.svh
+++ b/bp_be/src/include/bp_be_ctl_pkgdef.svh
@@ -140,6 +140,9 @@
     ,e_mul_op_divu      = 6'b000010
     ,e_mul_op_rem       = 6'b000011
     ,e_mul_op_remu      = 6'b000100
+    ,e_mul_op_mulh      = 6'b000101
+    ,e_mul_op_mulhsu    = 6'b000110
+    ,e_mul_op_mulhu     = 6'b000111
   } bp_be_mul_fu_op_e;
 
   typedef struct packed

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
@@ -56,6 +56,30 @@ module bp_be_pipe_long
   wire [dword_width_gp-1:0] op_a = decode.opw_v ? (rs1 << word_width_gp) : rs1;
   wire [dword_width_gp-1:0] op_b = decode.opw_v ? (rs2 << word_width_gp) : rs2;
 
+  wire signed_opA_li = decode.fu_op inside {e_mul_op_mulh, e_mul_op_mulhsu};
+  wire signed_opB_li = decode.fu_op inside {e_mul_op_mulh};
+
+  logic [dword_width_gp-1:0] imulh_result_lo;
+  logic imulh_ready_lo;
+  logic imulh_v_lo;
+  wire imulh_v_li = v_li & (decode.fu_op inside {e_mul_op_mulh, e_mul_op_mulhsu, e_mul_op_mulhu});
+  bsg_imul_iterative
+   #(.width_p(dword_width_gp))
+   imulh
+    (.clk_i(clk_i)
+    ,.reset_i(reset_i)
+    ,.v_i(imulh_v_li)
+    ,.ready_o(imulh_ready_lo)
+    ,.opA_i(op_a)
+	  ,.signed_opA_i(signed_opA_li)
+	  ,.opB_i(op_b)
+    ,.signed_opB_i(signed_opB_li)
+    ,.gets_high_part_i(1'b1)
+    ,.v_o(imulh_v_lo)
+	  ,.result_o(imulh_result_lo)
+    ,.yumi_i(imulh_v_lo & iwb_yumi_i)
+    );
+
   // We actual could exit early here
   logic [dword_width_gp-1:0] quotient_lo, remainder_lo;
   logic idiv_ready_and_lo;
@@ -150,19 +174,20 @@ module bp_be_pipe_long
      );
   assign fdivsqrt_result.tag = ops_v_r ? frm_r : e_fp_full;
 
-  logic idiv_done_v_r, fdiv_done_v_r, rd_w_v_r;
+  logic imulh_done_v_r, idiv_done_v_r, fdiv_done_v_r, rd_w_v_r;
   bsg_dff_reset_set_clear
-   #(.width_p(3))
+   #(.width_p(4))
    wb_v_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.set_i({idiv_v_lo, fdivsqrt_v_lo, v_li})
-     ,.clear_i({v_li, v_li, (iwb_yumi_i | fwb_yumi_i)})
-     ,.data_o({idiv_done_v_r, fdiv_done_v_r, rd_w_v_r})
+     ,.set_i({imulh_v_lo, idiv_v_lo, fdivsqrt_v_lo, v_li})
+     ,.clear_i({v_li, v_li, v_li, (iwb_yumi_i | fwb_yumi_i)})
+     ,.data_o({imulh_done_v_r, idiv_done_v_r, fdiv_done_v_r, rd_w_v_r})
      );
 
   logic [2:0] hazard_cnt;
+  wire imulh_safe = (hazard_cnt > 2);
   wire idiv_safe = (hazard_cnt > 2);
   wire fdiv_safe = (hazard_cnt > 3);
   bsg_counter_clear_up
@@ -178,7 +203,9 @@ module bp_be_pipe_long
 
   logic [dword_width_gp-1:0] rd_data_lo;
   always_comb
-    if (opw_v_r && fu_op_r inside {e_mul_op_div, e_mul_op_divu})
+    if (~opw_v_r && fu_op_r inside {e_mul_op_mulh, e_mul_op_mulhsu, e_mul_op_mulhu})
+      rd_data_lo = imulh_result_lo;
+    else if (opw_v_r && fu_op_r inside {e_mul_op_div, e_mul_op_divu})
       rd_data_lo = `BSG_SIGN_EXTEND(quotient_w_lo, dword_width_gp);
     else if (opw_v_r && fu_op_r inside {e_mul_op_rem, e_mul_op_remu})
       rd_data_lo = $signed(remainder_lo) >>> word_width_gp;
@@ -188,7 +215,7 @@ module bp_be_pipe_long
       rd_data_lo = remainder_lo;
 
   // Actually a busy signal
-  assign iready_o = idiv_ready_and_lo & ~rd_w_v_r & ~v_li;
+  assign iready_o = imulh_ready_lo & idiv_ready_and_lo & ~rd_w_v_r & ~v_li;
   assign fready_o = fdiv_ready_lo & ~rd_w_v_r & ~v_li;
 
   assign iwb_pkt.ird_w_v    = rd_w_v_r;
@@ -198,7 +225,7 @@ module bp_be_pipe_long
   assign iwb_pkt.rd_data    = rd_data_lo;
   assign iwb_pkt.fflags_w_v = 1'b0;
   assign iwb_pkt.fflags     = '0;
-  assign iwb_v_o = idiv_safe & idiv_done_v_r & rd_w_v_r;
+  assign iwb_v_o = ((imulh_safe & imulh_done_v_r) | (idiv_safe & idiv_done_v_r)) & rd_w_v_r;
 
   assign fwb_pkt.ird_w_v    = 1'b0;
   assign fwb_pkt.frd_w_v    = rd_w_v_r;

--- a/bp_be/src/v/bp_be_checker/bp_be_instr_decoder.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_instr_decoder.sv
@@ -76,7 +76,8 @@ module bp_be_instr_decoder
           begin
             if (instr inside {`RV64_MUL, `RV64_MULW})
               decode_cast_o.pipe_mul_v = 1'b1;
-            else if (instr inside {`RV64_DIV, `RV64_DIVU, `RV64_DIVW, `RV64_DIVUW
+            else if (instr inside {`RV64_MULH, `RV64_MULHSU, `RV64_MULHU,
+                                   `RV64_DIV, `RV64_DIVU, `RV64_DIVW, `RV64_DIVUW
                                    ,`RV64_REM, `RV64_REMU, `RV64_REMW, `RV64_REMUW
                                    })
               begin
@@ -102,6 +103,9 @@ module bp_be_instr_decoder
               `RV64_AND             : decode_cast_o.fu_op = e_int_op_and;
 
               `RV64_MUL, `RV64_MULW   : decode_cast_o.fu_op = e_fma_op_imul;
+              `RV64_MULH              : decode_cast_o.fu_op = e_mul_op_mulh;
+              `RV64_MULHSU            : decode_cast_o.fu_op = e_mul_op_mulhsu;
+              `RV64_MULHU             : decode_cast_o.fu_op = e_mul_op_mulhu;
               `RV64_DIV, `RV64_DIVW   : decode_cast_o.fu_op = e_mul_op_div;
               `RV64_DIVU, `RV64_DIVUW : decode_cast_o.fu_op = e_mul_op_divu;
               `RV64_REM, `RV64_REMW   : decode_cast_o.fu_op = e_mul_op_rem;

--- a/bp_be/src/v/bp_be_checker/bp_be_issue_queue.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_issue_queue.sv
@@ -162,6 +162,7 @@ module bp_be_issue_queue
       issue_pkt_li.long_v = instr inside {`RV64_DIV, `RV64_DIVU, `RV64_DIVW, `RV64_DIVUW
                                           ,`RV64_REM, `RV64_REMU, `RV64_REMW, `RV64_REMUW
                                           ,`RV64_FDIV_S, `RV64_FDIV_D, `RV64_FSQRT_S, `RV64_FSQRT_D
+                                          ,`RV64_MULH, `RV64_MULHU, `RV64_MULHSU
                                           };
 
       // Decide whether to read from integer regfile (saves power)

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -303,7 +303,7 @@
 
       ,fe_queue_fifo_els : 8
       ,fe_cmd_fifo_els   : 4
-      ,muldiv_support    : (1 << e_div) | (1 << e_mul)
+      ,muldiv_support    : (1 << e_div) | (1 << e_mul) | (1 << e_mulh)
       ,fpu_support       : 1
 
       ,async_coh_clk       : 0

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -128,6 +128,7 @@ $BASEJUMP_STL_DIR/bsg_misc/bsg_expand_bitmask.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_gray_to_binary.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_hash_bank.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_hash_bank_reverse.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_imul_iterative.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_idiv_iterative.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_idiv_iterative_controller.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_lfsr.v

--- a/bp_top/test/common/bp_nonsynth_if_verif.sv
+++ b/bp_top/test/common/bp_nonsynth_if_verif.sv
@@ -68,8 +68,6 @@ module bp_nonsynth_if_verif
     $error("Error: BlackParrot is only tested with 64-bit dword width");
 
   // Core or Features
-  if (muldiv_support_p[e_mulh])
-    $error("MULH is not currently supported in hardware");
   if (!muldiv_support_p[e_mul])
     $error("MUL is not currently support in emulation");
   if (!fpu_support_p)

--- a/bp_top/test/common/dromajo_cosim.cpp
+++ b/bp_top/test/common/dromajo_cosim.cpp
@@ -33,25 +33,27 @@ extern "C" void dromajo_init(char* cfg_f_name, int hartid, int ncpus, int memory
       sprintf(amo_str, "--enable_amo");
       char prog_str[50];
       sprintf(prog_str, "prog.elf");
+      char mulh_str[50];
+      sprintf(mulh_str, "--enable_mulh");
 
       if (checkpoint) {
         if (amo_en) {
-          char* argv[] = {dromajo_str, ncpus_str, memsize_str, mmio_str, amo_str, load_str, prog_str};
-          dromajo_pointer = dromajo_cosim_init(7, argv);
+          char* argv[] = {dromajo_str, ncpus_str, memsize_str, mmio_str, amo_str, load_str, prog_str, mulh_str};
+          dromajo_pointer = dromajo_cosim_init(8, argv);
         }
         else {
-          char* argv[] = {dromajo_str, ncpus_str, memsize_str, mmio_str, load_str, prog_str};
-          dromajo_pointer = dromajo_cosim_init(6, argv);
+          char* argv[] = {dromajo_str, ncpus_str, memsize_str, mmio_str, load_str, prog_str, mulh_str};
+          dromajo_pointer = dromajo_cosim_init(7, argv);
         }
       }
       else {
         if (amo_en) {
-          char* argv[] = {dromajo_str, ncpus_str, memsize_str, mmio_str, amo_str, prog_str};
-          dromajo_pointer = dromajo_cosim_init(6, argv);
+          char* argv[] = {dromajo_str, ncpus_str, memsize_str, mmio_str, amo_str, prog_str, mulh_str};
+          dromajo_pointer = dromajo_cosim_init(7, argv);
         }
         else {
-          char* argv[] = {dromajo_str, ncpus_str, memsize_str, mmio_str, prog_str};
-          dromajo_pointer = dromajo_cosim_init(5, argv);
+          char* argv[] = {dromajo_str, ncpus_str, memsize_str, mmio_str, prog_str, mulh_str};
+          dromajo_pointer = dromajo_cosim_init(6, argv);
         }
       }
     }


### PR DESCRIPTION
## Summary
This PR adds optional support for hardware mulh. We implement this as an iterative multiplier due to large hardware overheads for a rarely used feature.

## Issue Fixed
None, but general RISC-V compliance

## Area
Iterative multiplication pipe

## Reasoning (outdated, confusing, verbose, etc.)
Although this feature is rarely used, it's required for architectural compliance.

## Additional Changes Required (if any)
Other changes were already merged 

## Analysis
No impact for non-parameterized version. Unmeasured impact for iterative multiplier itself

## Verification
RISC-V mulh tests

## Additional Context
Supercedes https://github.com/black-parrot/black-parrot/pull/1061

