### PR TITLE
Introduce compressed_support_p config parameter

### DIFF
--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -307,7 +307,7 @@
       ,fe_cmd_fifo_els   : 4
       ,muldiv_support    : (1 << e_div) | (1 << e_mul)
       ,fpu_support       : 1
-      ,compressed_support: 0
+      ,compressed_support: 1
 
       ,async_coh_clk       : 0
       ,coh_noc_flit_width  : 128

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -188,6 +188,8 @@
     // Whether to emulate FPU
     //   bit 0: fpu enabled
     integer unsigned fpu_support;
+    // Whether to enable the "c" extension.
+    integer unsigned compressed_support;
 
     // Whether the coherence network is on the core clock or on its own clock
     integer unsigned async_coh_clk;
@@ -305,6 +307,7 @@
       ,fe_cmd_fifo_els   : 4
       ,muldiv_support    : (1 << e_div) | (1 << e_mul)
       ,fpu_support       : 1
+      ,compressed_support: 0
 
       ,async_coh_clk       : 0
       ,coh_noc_flit_width  : 128
@@ -359,6 +362,7 @@
       ,`bp_aviary_define_override(fe_cmd_fifo_els, BP_FE_CMD_WIDTH, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(muldiv_support, BP_MULDIV_SUPPORT, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(fpu_support, BP_FPU_SUPPORT, `BP_CUSTOM_BASE_CFG)
+      ,`bp_aviary_define_override(compressed_support, BP_COMPRESSED_SUPPORT, `BP_CUSTOM_BASE_CFG)
 
       ,`bp_aviary_define_override(branch_metadata_fwd_width, BRANCH_METADATA_FWD_WIDTH, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(btb_tag_width, BP_BTB_TAG_WIDTH, `BP_CUSTOM_BASE_CFG)

--- a/bp_common/src/include/bp_common_aviary_defines.svh
+++ b/bp_common/src/include/bp_common_aviary_defines.svh
@@ -103,10 +103,11 @@
     , localparam l2_block_size_in_words_p = l2_block_width_p / l2_data_width_p                     \
     , localparam l2_block_size_in_fill_p  = l2_block_width_p / l2_fill_width_p                     \
                                                                                                    \
-    , localparam fe_queue_fifo_els_p = proc_param_lp.fe_queue_fifo_els                             \
-    , localparam fe_cmd_fifo_els_p   = proc_param_lp.fe_cmd_fifo_els                               \
-    , localparam muldiv_support_p    = proc_param_lp.muldiv_support                                \
-    , localparam fpu_support_p       = proc_param_lp.fpu_support                                   \
+    , localparam fe_queue_fifo_els_p  = proc_param_lp.fe_queue_fifo_els                            \
+    , localparam fe_cmd_fifo_els_p    = proc_param_lp.fe_cmd_fifo_els                              \
+    , localparam muldiv_support_p     = proc_param_lp.muldiv_support                               \
+    , localparam fpu_support_p        = proc_param_lp.fpu_support                                  \
+    , localparam compressed_support_p = proc_param_lp.compressed_support                           \
                                                                                                    \
     , localparam async_coh_clk_p        = proc_param_lp.async_coh_clk                              \
     , localparam coh_noc_max_credits_p  = proc_param_lp.coh_noc_max_credits                        \
@@ -200,6 +201,7 @@
           ,`bp_aviary_parameter_override(fe_cmd_fifo_els, override_cfg_mp, default_cfg_mp)         \
           ,`bp_aviary_parameter_override(muldiv_support, override_cfg_mp, default_cfg_mp)          \
           ,`bp_aviary_parameter_override(fpu_support, override_cfg_mp, default_cfg_mp)             \
+          ,`bp_aviary_parameter_override(compressed_support, override_cfg_mp, default_cfg_mp)      \
                                                                                                    \
           ,`bp_aviary_parameter_override(branch_metadata_fwd_width, override_cfg_mp, default_cfg_mp) \
           ,`bp_aviary_parameter_override(btb_tag_width, override_cfg_mp, default_cfg_mp)           \


### PR DESCRIPTION
Currently unused and defaults to disabled.

Looking for this to go in before the main PR.

Precursor to #1098.