### PR TITLE
[WIP] Outputting true fetch PC from I$

### DIFF
--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -34,7 +34,8 @@ module bp_fe_pc_gen
 
    , output logic                                    ovr_o
 
-   , input [instr_width_gp-1:0]                      fetch_i
+   , input [instr_width_gp-1:0]                      fetch_instr_i
+   , input [vaddr_width_p-1:0]                       fetch_vaddr_i
    , input                                           fetch_instr_v_i
    , input                                           fetch_exception_v_i
    , output logic [branch_metadata_fwd_width_p-1:0]  fetch_br_metadata_fwd_o
@@ -264,7 +265,7 @@ module bp_fe_pc_gen
   bp_fe_instr_scan
    #(.bp_params_p(bp_params_p))
    instr_scan
-    (.instr_i(fetch_i)
+    (.instr_i(fetch_instr_i)
 
      ,.scan_o(scan_instr)
      );

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -179,6 +179,7 @@ module wrapper
      ,.ptag_dram_i(dram_r)
      ,.poison_tl_i(1'b0)
 
+     ,.vaddr_o()
      ,.data_o(data_o)
      ,.data_v_o(data_v_o)
      ,.miss_v_o()


### PR DESCRIPTION
This PR adds an aligned vaddr output to the I$. This is useful for determining what was actually fetched at the end of the pipeline (or after a stall for a stalling variant). It also explicitly aligns the input vaddr which is useful for fetch pipelines which send non-aligned addresses and then explicitly align the data.

Not sure if this will be useful, but putting it out here in case