### PR TITLE
Fix accidental wbuf delay, causing data mem hazards

### DIFF
--- a/bp_be/src/include/bp_be_ctl_pkgdef.svh
+++ b/bp_be/src/include/bp_be_ctl_pkgdef.svh
@@ -191,8 +191,6 @@
 
   typedef struct packed
   {
-    logic                             v;
-
     logic                             pipe_ctl_v;
     logic                             pipe_int_v;
     logic                             pipe_mem_early_v;

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache_wbuf.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache_wbuf.sv
@@ -64,11 +64,11 @@ module bp_be_dcache_wbuf
   always_comb begin
     unique case (num_els_r)
       2'd0: begin
-        v_o = 1'b0;
+        v_o = v_i;
         el0_valid = 1'b0;
         el1_valid = 1'b0;
         el0_enable = 1'b0;
-        el1_enable = v_i;
+        el1_enable = v_i & ~yumi_i;
         mux0_sel = 1'b0;
         mux1_sel = 1'b0;
       end


### PR DESCRIPTION
## Summary
This PR lets the wbuf entry in the D$ flow through, rather than be delayed.

## Issue Fixed
None

## Area
dcache wbuf

## Reasoning (outdated, confusing, verbose, etc.)
This was a performance regression introduced by #940, where the wbuf would wait for a cycle to sync up to the posedge. Since we moved the wbuf to the negedge, this was causing a full-cycle delay where there was only a half-cycle delay before.

## Additional Changes Required (if any)
None

## Analysis
No PPA impact, since we had data path signals flowing through, even though control signals were stifled.

## Verification
Looking at specific ST-ST-LD patterns on coremark waveform

## Additional Context
None

