### PR TITLE
Minor bugfixes and cleanup for pc_gen

### DIFF
--- a/bp_fe/src/include/bp_fe_defines.svh
+++ b/bp_fe/src/include/bp_fe_defines.svh
@@ -10,60 +10,24 @@
 `define BP_FE_DEFINES_SVH
 
   `include "bsg_defines.v"
-  `include "bp_common_core_if.svh"
   `include "bp_fe_icache_defines.svh"
-
-  /*
-   * bp_fe_instr_scan_s specifies metadata about the instruction, including FE-special opcodes
-   *   and the calculated branch target
-   */
-  `define declare_bp_fe_instr_scan_s(vaddr_width_mp) \
-    typedef struct packed                    \
-    {                                        \
-      logic branch;                          \
-      logic jal;                             \
-      logic jalr;                            \
-      logic call;                            \
-      logic ret;                             \
-      logic [vaddr_width_mp-1:0] imm;        \
-    }  bp_fe_instr_scan_s;
 
   `define declare_bp_fe_branch_metadata_fwd_s(btb_tag_width_mp, btb_idx_width_mp, bht_idx_width_mp, ghist_width_mp, bht_row_width_mp) \
     typedef struct packed                                                                         \
     {                                                                                             \
-      logic                           is_br;                                                      \
-      logic                           is_jal;                                                     \
-      logic                           is_jalr;                                                    \
-      logic                           is_call;                                                    \
-      logic                           is_ret;                                                     \
+      logic                           site_br;                                                     \
+      logic                           site_jal;                                                    \
+      logic                           site_jalr;                                                   \
+      logic                           site_call;                                                   \
+      logic                           site_return;                                                    \
+      logic                           src_ras;                                                    \
       logic                           src_btb;                                                    \
-      logic                           src_ret;                                                    \
       logic [btb_tag_width_mp-1:0]    btb_tag;                                                    \
       logic [btb_idx_width_mp-1:0]    btb_idx;                                                    \
       logic [bht_idx_width_mp-1:0]    bht_idx;                                                    \
       logic [bht_row_width_mp-1:0]    bht_row;                                                    \
       logic [ghist_width_mp-1:0]      ghist;                                                      \
     }  bp_fe_branch_metadata_fwd_s;
-
-  `define declare_bp_fe_pc_gen_stage_s(vaddr_width_mp, ghist_width_mp, bht_row_width_mp) \
-    typedef struct packed                   \
-    {                                       \
-      logic pred;                           \
-      logic taken;                          \
-      logic redir;                          \
-      logic ret;                            \
-      logic btb;                            \
-      logic [bht_row_width_mp-1:0] bht_row; \
-      logic [ghist_width_mp-1:0] ghist;     \
-    }  bp_fe_pred_s
-
-  `define bp_fe_instr_scan_width(vaddr_width_mp) \
-    (5 + vaddr_width_mp)
-
-  `define bp_fe_pred_width(vaddr_width_mp, ghist_width_mp, bht_row_width_mp) \
-    (5 + bht_row_width_mp + ghist_width_mp)
-
-  `include "bp_fe_icache_pkgdef.svh"
 
 `endif
 

--- a/bp_fe/src/include/bp_fe_pc_gen_pkgdef.svh
+++ b/bp_fe/src/include/bp_fe_pc_gen_pkgdef.svh
@@ -1,0 +1,21 @@
+
+`ifndef BP_FE_PC_GEN_PKGDEF_SVH
+`define BP_FE_PC_GEN_PKGDEF_SVH
+
+  import bp_common_pkg::*;
+
+  /*
+   * bp_fe_instr_scan_s specifies metadata about the instruction, including FE-special opcodes
+   *   and the calculated branch target
+   */
+    typedef struct packed
+    {
+      logic branch;
+      logic jal;
+      logic jalr;
+      logic call;
+      logic _return;
+    }  bp_fe_instr_scan_s;
+
+`endif
+

--- a/bp_fe/src/include/bp_fe_pkg.sv
+++ b/bp_fe/src/include/bp_fe_pkg.sv
@@ -1,5 +1,8 @@
 
 package bp_fe_pkg;
 
+  `include "bp_fe_icache_pkgdef.svh"
+  `include "bp_fe_pc_gen_pkgdef.svh"
+
 endpackage
 

--- a/bp_fe/src/v/bp_fe_instr_scan.sv
+++ b/bp_fe/src/v/bp_fe_instr_scan.sv
@@ -14,41 +14,37 @@ module bp_fe_instr_scan
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
 
-   , localparam instr_scan_width_lp = `bp_fe_instr_scan_width(vaddr_width_p)
+   , localparam instr_scan_width_lp = $bits(bp_fe_instr_scan_s)
    )
-  (input [instr_width_gp-1:0]          instr_i
+  (input [instr_width_gp-1:0]               instr_i
 
-   , output [instr_scan_width_lp-1:0] scan_o
-  );
+   , output logic [instr_scan_width_lp-1:0] scan_o
+   , output logic [vaddr_width_p-1:0]       imm_o
+   );
 
-`declare_bp_fe_instr_scan_s(vaddr_width_p);
-
-rv64_instr_rtype_s instr_cast_i;
-bp_fe_instr_scan_s scan_cast_o;
-
-assign instr_cast_i = instr_i;
-assign scan_o = scan_cast_o;
-
-wire dest_link   = (instr_cast_i.rd_addr inside {32'h1, 32'h5});
-wire src_link    = (instr_cast_i.rs1_addr inside {32'h1, 32'h5});
-wire dest_src_eq = (instr_cast_i.rd_addr == instr_cast_i.rs1_addr);
-
-always_comb
-  begin
-    scan_cast_o = '0;
-
-    scan_cast_o.branch = (instr_cast_i.opcode == `RV64_BRANCH_OP);
-    scan_cast_o.jal    = (instr_cast_i.opcode == `RV64_JAL_OP);
-    scan_cast_o.jalr   = (instr_cast_i.opcode == `RV64_JALR_OP);
-    scan_cast_o.call   = (instr_cast_i.opcode inside {`RV64_JAL_OP, `RV64_JALR_OP}) && dest_link;
-    scan_cast_o.ret    = (instr_cast_i.opcode == `RV64_JALR_OP) && src_link && !dest_src_eq;
-
-    unique casez (instr_cast_i.opcode)
-      `RV64_BRANCH_OP: scan_cast_o.imm = `rv64_signext_b_imm(instr_i);
-      `RV64_JAL_OP   : scan_cast_o.imm = `rv64_signext_j_imm(instr_i);
-      default        : scan_cast_o.imm = '0;
-    endcase
-  end
+  `bp_cast_i(rv64_instr_rtype_s, instr);
+  `bp_cast_o(bp_fe_instr_scan_s, scan);
+  
+  wire dest_link   = (instr_cast_i.rd_addr inside {32'h1, 32'h5});
+  wire src_link    = (instr_cast_i.rs1_addr inside {32'h1, 32'h5});
+  wire dest_src_eq = (instr_cast_i.rd_addr == instr_cast_i.rs1_addr);
+  
+  always_comb
+    begin
+      scan_cast_o = '0;
+  
+      scan_cast_o.branch = (instr_cast_i.opcode == `RV64_BRANCH_OP);
+      scan_cast_o.jal    = (instr_cast_i.opcode == `RV64_JAL_OP);
+      scan_cast_o.jalr   = (instr_cast_i.opcode == `RV64_JALR_OP);
+      scan_cast_o.call   = (instr_cast_i.opcode inside {`RV64_JAL_OP, `RV64_JALR_OP}) && dest_link;
+      scan_cast_o._return = (instr_cast_i.opcode == `RV64_JALR_OP) && src_link && !dest_src_eq;
+  
+      unique casez (instr_cast_i.opcode)
+        `RV64_BRANCH_OP: imm_o = `rv64_signext_b_imm(instr_i);
+        `RV64_JAL_OP   : imm_o = `rv64_signext_j_imm(instr_i);
+        default        : imm_o = '0;
+      endcase
+    end
 
 endmodule
 

--- a/bp_fe/src/v/bp_fe_ras.sv
+++ b/bp_fe/src/v/bp_fe_ras.sv
@@ -1,0 +1,53 @@
+/*
+ * bp_fe_ras.sv
+ *
+ * TODO: Implement repair of stack
+ */
+
+`include "bp_common_defines.svh"
+`include "bp_fe_defines.svh"
+
+module bp_fe_ras
+ import bp_common_pkg::*;
+ import bp_fe_pkg::*;
+ #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+   `declare_bp_proc_params(bp_params_p)
+   )
+  (input                              clk_i
+   , input                            reset_i
+
+   , input                            call_i
+   , input                            return_i
+
+   , input [vaddr_width_p-1:0]        addr_i
+   , output logic [vaddr_width_p-1:0] tgt_o
+   , output logic                     v_o
+   );
+
+  logic [vaddr_width_p-1:0] addr_r;
+  bsg_dff_reset_en
+   #(.width_p(vaddr_width_p))
+   addr_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.en_i(call_i)
+
+     ,.data_i(addr_i)
+     ,.data_o(addr_r)
+     );
+  assign tgt_o = addr_r;
+
+  logic v_r;
+  bsg_dff_reset_set_clear
+   #(.width_p(1))
+   v_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.set_i(call_i)
+     ,.clear_i(return_i)
+     ,.data_o(v_r)
+     );
+  assign v_o = v_r;
+
+endmodule
+

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -226,6 +226,7 @@ $BP_BE_DIR/src/v/bp_be_dcache/bp_be_dcache.sv
 $BP_BE_DIR/src/v/bp_be_dcache/bp_be_dcache_decoder.sv
 $BP_BE_DIR/src/v/bp_be_dcache/bp_be_dcache_wbuf.sv
 ## FE files
+$BP_FE_DIR/src/v/bp_fe_ras.sv
 $BP_FE_DIR/src/v/bp_fe_bht.sv
 $BP_FE_DIR/src/v/bp_fe_btb.sv
 $BP_FE_DIR/src/v/bp_fe_icache.sv

--- a/bp_top/test/common/bp_nonsynth_branch_profiler.sv
+++ b/bp_top/test/common/bp_nonsynth_branch_profiler.sv
@@ -78,13 +78,13 @@ module bp_nonsynth_branch_profiler
         redirect_cnt <= redirect_cnt + pc_redirect_v;
         if (attaboy_v)
           begin
-            br_cnt      <= br_cnt + branch_metadata.is_br;
-            jal_cnt     <= jal_cnt + branch_metadata.is_jal;
-            jalr_cnt    <= jalr_cnt + branch_metadata.is_jalr;
+            br_cnt      <= br_cnt + branch_metadata.site_br;
+            jal_cnt     <= jal_cnt + branch_metadata.site_jal;
+            jalr_cnt    <= jalr_cnt + branch_metadata.site_jalr;
 
             btb_hit_cnt <= btb_hit_cnt + branch_metadata.src_btb;
-            ras_hit_cnt <= ras_hit_cnt + branch_metadata.src_ret;
-            bht_hit_cnt <= bht_hit_cnt + branch_metadata.is_br;
+            ras_hit_cnt <= ras_hit_cnt + branch_metadata.src_ras;
+            bht_hit_cnt <= bht_hit_cnt + branch_metadata.site_br;
 
             if (branch_histo.exists(fe_cmd.npc))
               begin
@@ -99,9 +99,9 @@ module bp_nonsynth_branch_profiler
           end
         else if (pc_redirect_v)
           begin
-            br_cnt   <= br_cnt + branch_metadata.is_br;
-            jal_cnt  <= jal_cnt + branch_metadata.is_jal;
-            jalr_cnt <= jalr_cnt + branch_metadata.is_jalr;
+            br_cnt   <= br_cnt + branch_metadata.site_br;
+            jal_cnt  <= jal_cnt + branch_metadata.site_jal;
+            jalr_cnt <= jalr_cnt + branch_metadata.site_jalr;
 
             if (branch_histo.exists(fe_cmd.npc))
               begin

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -486,7 +486,7 @@ module testbench
           ,.fe_icache_ready_i(fe.icache.ready_o)
      
           ,.if2_v_i(fe.v_if2_r)
-          ,.br_ovr_i(fe.pc_gen.ovr_taken)
+          ,.br_ovr_i(fe.pc_gen.ovr_btaken | fe.pc_gen.ovr_jmp)
           ,.ret_ovr_i(fe.pc_gen.ovr_ret)
           ,.icache_data_v_i(fe.icache.data_v_o)
 
@@ -563,7 +563,7 @@ module testbench
 
            ,.src_redirect_i        (pc_gen.redirect_v_i)
            ,.src_override_ras_i    (pc_gen.ovr_ret)
-           ,.src_override_branch_i (pc_gen.ovr_taken)
+           ,.src_override_branch_i (pc_gen.ovr_btaken | pc_gen.ovr_jmp)
            ,.src_btb_taken_branch_i(pc_gen.btb_taken)
 
            ,.if1_top_v_i           (v_if1_r)


### PR DESCRIPTION
## Summary
This PR cleans up the pc_gen module of the frontend. Specifically, we're correcting metadata propagation and clarifying the pipeline flow to that fewer mistakes can be make about what data comes from where

## Issues Fixed
#966  #987 #884 

## Area
pc_gen

## Reasoning (outdated, confusing, verbose, etc.)
The old pc_gen metadata scheme was an amalgamation of site and target information travelling along the pipeline. As we send metadata long with targets, it only makes sense to store that same metadata alongside of the target itself, rather than manually realigning in IF2. When reworking this new scheme, several performance bugs were discovered that caused incorrect behavior in degenerate cases. These bugs have also been fixed as part of this changeset. Lastly, the issues found by @WasabiFan are included as well.

The bugs revolved around losing the metadata associated to branches when redirecting the FE from the BE, I$ miss or fe_queue miss. Since the metadata now travels with the PC, it is much easier to keep track of and harder to lose.

## Additional Changes Required (if any)
None

## Analysis
This change is unlikely to have a large PPA impact. If there is, it should be a mild improvement as the total number of registers has decreased, and the critical pc_gen mux is now a tree of priority muxes rather than a flat priority mux.

## Verification
Profiled benchmarks to see little change. Coremark saw a 0.7% performance improvement, which is promising.

## Additional Context
None

