### PR TITLE
Update cache_req_yumi to cache_req_ready

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -63,7 +63,7 @@ module bp_be_calculator_top
 
   , output logic [dcache_req_width_lp-1:0]          cache_req_o
   , output logic                                    cache_req_v_o
-  , input                                           cache_req_yumi_i
+  , input                                           cache_req_ready_and_i
   , input                                           cache_req_busy_i
   , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
   , output logic                                    cache_req_metadata_v_o
@@ -298,7 +298,7 @@ module bp_be_calculator_top
 
      ,.cache_req_o(cache_req_o)
      ,.cache_req_v_o(cache_req_v_o)
-     ,.cache_req_yumi_i(cache_req_yumi_i)
+     ,.cache_req_ready_and_i(cache_req_ready_and_i)
      ,.cache_req_busy_i(cache_req_busy_i)
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -74,7 +74,7 @@ module bp_be_pipe_mem
    // signals to LCE
    , output logic [dcache_req_width_lp-1:0]          cache_req_o
    , output logic                                    cache_req_v_o
-   , input                                           cache_req_yumi_i
+   , input                                           cache_req_ready_and_i
    , input                                           cache_req_busy_i
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
@@ -318,7 +318,7 @@ module bp_be_pipe_mem
       // D$-LCE Interface
       ,.cache_req_o(cache_req_cast_o)
       ,.cache_req_v_o(cache_req_v_o)
-      ,.cache_req_yumi_i(cache_req_yumi_i)
+      ,.cache_req_ready_and_i(cache_req_ready_and_i)
       ,.cache_req_busy_i(cache_req_busy_i)
       ,.cache_req_metadata_o(cache_req_metadata_o)
       ,.cache_req_metadata_v_o(cache_req_metadata_v_o)

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -39,7 +39,7 @@ module bp_be_top
    // signals to LCE
    , output logic [dcache_req_width_lp-1:0]          cache_req_o
    , output logic                                    cache_req_v_o
-   , input                                           cache_req_yumi_i
+   , input                                           cache_req_ready_and_i
    , input                                           cache_req_busy_i
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
@@ -204,7 +204,7 @@ module bp_be_top
      ,.cache_req_o(cache_req_o)
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_v_o(cache_req_v_o)
-     ,.cache_req_yumi_i(cache_req_yumi_i)
+     ,.cache_req_ready_and_i(cache_req_ready_and_i)
      ,.cache_req_busy_i(cache_req_busy_i)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
      ,.cache_req_critical_tag_i(cache_req_critical_tag_i)

--- a/bp_be/test/common/bp_be_nonsynth_dcache_tracer.sv
+++ b/bp_be/test/common/bp_be_nonsynth_dcache_tracer.sv
@@ -37,7 +37,7 @@ module bp_be_nonsynth_dcache_tracer
 
    , input [cache_req_width_lp-1:0]                       cache_req_o
    , input                                                cache_req_v_o
-   , input                                                cache_req_yumi_i
+   , input                                                cache_req_ready_and_i
    , input                                                cache_req_busy_i
    , input [cache_req_metadata_width_lp-1:0]              cache_req_metadata_o
    , input                                                cache_req_metadata_v_o
@@ -166,7 +166,7 @@ module bp_be_nonsynth_dcache_tracer
       if (wbuf_yumi_li)
         $fwrite(acc_file, "%12t | wbuf: %p\n", $time, wbuf_entry_out_cast);
 
-      if (cache_req_yumi_i)
+      if (cache_req_ready_and_i & cache_req_v_o)
         $fwrite(eng_file, "%12t | cache_req: %p\n", $time, cache_req_cast_o);
       if (cache_req_metadata_v_o)
         $fwrite(eng_file, "%12t | cache_req_metadata: %p\n", $time, cache_req_metadata_cast_o);

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -73,7 +73,7 @@ module wrapper
   // D$ - LCE Interface signals
   // Miss, Management Interfaces
   logic [num_caches_p-1:0] cache_req_v_lo, cache_req_metadata_v_lo;
-  logic [num_caches_p-1:0] cache_req_yumi_lo, cache_req_busy_lo;
+  logic [num_caches_p-1:0] cache_req_ready_and_lo, cache_req_busy_lo;
   logic [num_caches_p-1:0] cache_req_complete_lo, cache_req_critical_tag_lo, cache_req_critical_data_lo;
   logic [num_caches_p-1:0][dcache_req_width_lp-1:0] cache_req_lo;
   logic [num_caches_p-1:0][dcache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
@@ -231,7 +231,7 @@ module wrapper
       ,.cache_req_o(cache_req_lo[i])
       ,.cache_req_metadata_o(cache_req_metadata_lo[i])
       ,.cache_req_metadata_v_o(cache_req_metadata_v_lo[i])
-      ,.cache_req_yumi_i(cache_req_yumi_lo[i])
+      ,.cache_req_ready_and_i(cache_req_ready_and_lo[i])
       ,.cache_req_busy_i(cache_req_busy_lo[i])
       ,.cache_req_complete_i(cache_req_complete_lo[i])
       ,.cache_req_critical_tag_i(cache_req_critical_tag_lo[i])
@@ -280,7 +280,7 @@ module wrapper
 
              ,.cache_req_i(cache_req_lo[i])
              ,.cache_req_v_i(cache_req_v_lo[i])
-             ,.cache_req_yumi_o(cache_req_yumi_lo[i])
+             ,.cache_req_ready_and_o(cache_req_ready_and_lo[i])
              ,.cache_req_busy_o(cache_req_busy_lo[i])
              ,.cache_req_metadata_i(cache_req_metadata_lo[i])
              ,.cache_req_metadata_v_i(cache_req_metadata_v_lo[i])
@@ -372,7 +372,7 @@ module wrapper
 
             ,.cache_req_i(cache_req_lo)
             ,.cache_req_v_i(cache_req_v_lo)
-            ,.cache_req_yumi_o(cache_req_yumi_lo)
+            ,.cache_req_ready_and_o(cache_req_ready_and_lo)
             ,.cache_req_busy_o(cache_req_busy_lo)
             ,.cache_req_metadata_i(cache_req_metadata_lo)
             ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -31,7 +31,7 @@ module bp_fe_top
 
    , output logic [icache_req_width_lp-1:0]           cache_req_o
    , output logic                                     cache_req_v_o
-   , input                                            cache_req_yumi_i
+   , input                                            cache_req_ready_and_i
    , input                                            cache_req_busy_i
    , output logic [icache_req_metadata_width_lp-1:0]  cache_req_metadata_o
    , output logic                                     cache_req_metadata_v_o
@@ -305,7 +305,7 @@ module bp_fe_top
 
      ,.cache_req_o(cache_req_o)
      ,.cache_req_v_o(cache_req_v_o)
-     ,.cache_req_yumi_i(cache_req_yumi_i)
+     ,.cache_req_ready_and_i(cache_req_ready_and_i)
      ,.cache_req_busy_i(cache_req_busy_i)
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)

--- a/bp_fe/test/common/bp_fe_nonsynth_icache_tracer.sv
+++ b/bp_fe/test/common/bp_fe_nonsynth_icache_tracer.sv
@@ -34,7 +34,7 @@ module bp_fe_nonsynth_icache_tracer
 
    , input [cache_req_width_lp-1:0]                       cache_req_o
    , input                                                cache_req_v_o
-   , input                                                cache_req_yumi_i
+   , input                                                cache_req_ready_and_i
    , input                                                cache_req_busy_i
    , input [cache_req_metadata_width_lp-1:0]              cache_req_metadata_o
    , input                                                cache_req_metadata_v_o
@@ -137,7 +137,7 @@ module bp_fe_nonsynth_icache_tracer
       if (miss_v_o)
         $fwrite(file, "%12t | spec miss: [%x]\n", $time, paddr_tv_r);
 
-      if (cache_req_yumi_i)
+      if (cache_req_ready_and_i & cache_req_v_o)
         $fwrite(file, "%12t | cache_req: %p\n", $time, cache_req_cast_o);
 
       if (cache_req_metadata_v_o)

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -57,7 +57,7 @@ module wrapper
 
   // I$-LCE Interface signals
   // Miss, Management Interfaces
-  logic cache_req_yumi_li, cache_req_busy_li;
+  logic cache_req_ready_and_li, cache_req_busy_li;
   logic [icache_req_width_lp-1:0] cache_req_lo;
   logic cache_req_v_lo;
   logic [icache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
@@ -185,7 +185,7 @@ module wrapper
 
      ,.cache_req_o(cache_req_lo)
      ,.cache_req_v_o(cache_req_v_lo)
-     ,.cache_req_yumi_i(cache_req_yumi_li)
+     ,.cache_req_ready_and_i(cache_req_ready_and_li)
      ,.cache_req_busy_i(cache_req_busy_li)
      ,.cache_req_metadata_o(cache_req_metadata_lo)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_lo)
@@ -263,7 +263,7 @@ module wrapper
 
        ,.cache_req_v_i(cache_req_v_lo)
        ,.cache_req_i(cache_req_lo)
-       ,.cache_req_yumi_o(cache_req_yumi_li)
+       ,.cache_req_ready_and_o(cache_req_ready_and_li)
        ,.cache_req_busy_o(cache_req_busy_li)
        ,.cache_req_metadata_i(cache_req_metadata_lo)
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
@@ -405,7 +405,7 @@ module wrapper
 
        ,.cache_req_i(cache_req_lo)
        ,.cache_req_v_i(cache_req_v_lo)
-       ,.cache_req_yumi_o(cache_req_yumi_li)
+       ,.cache_req_ready_and_o(cache_req_ready_and_li)
        ,.cache_req_busy_o(cache_req_busy_li)
        ,.cache_req_metadata_i(cache_req_metadata_lo)
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)

--- a/bp_me/src/v/cce/bp_uce.sv
+++ b/bp_me/src/v/cce/bp_uce.sv
@@ -32,7 +32,7 @@ module bp_uce
 
     , input [cache_req_width_lp-1:0]                 cache_req_i
     , input                                          cache_req_v_i
-    , output logic                                   cache_req_yumi_o
+    , output logic                                   cache_req_ready_and_o
     , output logic                                   cache_req_busy_o
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
@@ -149,7 +149,7 @@ module bp_uce
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.set_i(cache_req_yumi_o)
+     ,.set_i(cache_req_ready_and_o & cache_req_v_i)
      ,.clear_i(cache_req_done)
      ,.data_o(cache_req_v_r)
      );
@@ -161,7 +161,7 @@ module bp_uce
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.en_i(cache_req_yumi_o)
+     ,.en_i(cache_req_ready_and_o & cache_req_v_i)
      ,.data_i(cache_req_cast_i)
      ,.data_o(cache_req_r)
      );
@@ -431,7 +431,7 @@ module bp_uce
   assign cache_req_busy_o = is_reset | is_clear | cache_req_credits_full_o;
   always_comb
     begin
-      cache_req_yumi_o = '0;
+      cache_req_ready_and_o = '0;
 
       index_up = '0;
       way_up   = '0;
@@ -560,9 +560,9 @@ module bp_uce
               end
 
             // We can accept a new request as long as we send out an old one this cycle
-            cache_req_yumi_o = cache_req_v_i & (~cache_req_v_r | cache_req_done);
+            cache_req_ready_and_o = ~cache_req_v_r | cache_req_done;
 
-            state_n = cache_req_yumi_o
+            state_n = (cache_req_ready_and_o & cache_req_v_i)
                       ? flush_v_li
                         ? e_flush_read
                         : clear_v_li

--- a/bp_me/src/v/lce/bp_lce.sv
+++ b/bp_me/src/v/lce/bp_lce.sv
@@ -56,7 +56,7 @@ module bp_lce
     // can arrive, as indicated by the metadata_v_i signal
     , input [cache_req_width_lp-1:0]                 cache_req_i
     , input                                          cache_req_v_i
-    , output logic                                   cache_req_yumi_o
+    , output logic                                   cache_req_ready_and_o
     , output logic                                   cache_req_busy_o
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
@@ -157,7 +157,7 @@ module bp_lce
   `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
 
   // LCE Request Module
-  logic req_ready_lo;
+  logic req_busy_lo;
   logic uc_store_req_complete_lo;
   logic sync_done_lo;
   logic cache_init_done_lo;
@@ -180,11 +180,11 @@ module bp_lce
      ,.sync_done_i(sync_done_lo)
      ,.cache_init_done_i(cache_init_done_lo)
 
-     ,.ready_o(req_ready_lo)
+     ,.busy_o(req_busy_lo)
 
      ,.cache_req_i(cache_req_i)
      ,.cache_req_v_i(cache_req_v_i)
-     ,.cache_req_yumi_o(cache_req_yumi_o)
+     ,.cache_req_ready_and_o(cache_req_ready_and_o)
      ,.cache_req_metadata_i(cache_req_metadata_i)
      ,.cache_req_metadata_v_i(cache_req_metadata_v_i)
      ,.cache_req_complete_i(cache_req_complete_o)
@@ -380,8 +380,8 @@ module bp_lce
   // - LCE Request module is ready to accept a request (does not account for a free credit)
   // - timout signal is low, indicating LCE isn't blocked on using data/tag/stat mem
   // This signal acts as a hint to the cache that the LCE is not ready for a request.
-  // The cache_req_yumi_o signal actually controls whether the LCE accepts a request.
-  assign cache_req_busy_o = timeout | ~req_ready_lo;
+  // The cache_req_ready_and_o signal actually controls whether the LCE accepts a request.
+  assign cache_req_busy_o = timeout | req_busy_lo;
 
 endmodule
 

--- a/bp_me/src/v/lce/bp_lce_req.sv
+++ b/bp_me/src/v/lce/bp_lce_req.sv
@@ -53,16 +53,16 @@ module bp_lce_req
     , input                                          cache_init_done_i
     , input                                          sync_done_i
 
-    // LCE Req is able to sink any requests this cycle
-    , output logic                                   ready_o
+    // LCE Req is not able to accept requests
+    , output logic                                   busy_o
 
     // Cache-LCE Interface
-    // valid_i -> yumi_o handshake
+    // ready / valid handshake
     // metadata arrives in the same cycle as req, or any cycle after, but before the next request
     // can arrive, as indicated by the metadata_v_i signal
     , input [cache_req_width_lp-1:0]                 cache_req_i
     , input                                          cache_req_v_i
-    , output logic                                   cache_req_yumi_o
+    , output logic                                   cache_req_ready_and_o
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
 
@@ -107,7 +107,7 @@ module bp_lce_req
    cache_req_v_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
-     ,.set_i(cache_req_yumi_o)
+     ,.set_i(cache_req_ready_and_o & cache_req_v_i)
      ,.clear_i(req_sent)
      ,.data_o(cache_req_v_r)
      );
@@ -117,7 +117,7 @@ module bp_lce_req
    #(.width_p($bits(bp_cache_req_s)))
    req_reg
     (.clk_i(clk_i)
-     ,.en_i(cache_req_yumi_o)
+     ,.en_i(cache_req_ready_and_o & cache_req_v_i)
      ,.data_i(cache_req_i)
      ,.data_o(cache_req_r)
      );
@@ -180,23 +180,18 @@ module bp_lce_req
   assign req_sent = (lce_req_header_v_o & lce_req_header_ready_and_i & ~lce_req_has_data_o)
                     | (lce_req_data_v_o & lce_req_data_ready_and_i & lce_req_last_o);
 
-  // LCE is ready for a new request if not in reset and mode is uncached or cached with sync done
-  // ready_o being raised does not guarantee that this module will accept a valid cache request
-  // packet (refer to cache_req_yumi_o below).
-  assign ready_o = ~is_reset & (sync_done_i | (lce_mode_i == e_lce_mode_uncached));
+  // LCE should suppress messages if in reset or we are not synchronized with the CCE
+  // busy being lower does not guarantee that this module will accept a valid cache request
+  // packet (refer to cache_req_ready_and_o below).
+  assign busy_o = is_reset || (~sync_done_i && (lce_mode_i == e_lce_mode_normal));
 
-  // consume cache request if not in reset state, valid request on input, and
-  // the previous request has been issued or is being issued in the current cycle
-  assign cache_req_yumi_o = ~is_reset
-                            & cache_req_v_i
-                            & (~cache_req_v_r | (cache_req_v_r & req_sent));
+  // consume cache request if the previous request has been issued or is being issued in the current cycle
+  assign cache_req_ready_and_o = (~cache_req_v_r | (cache_req_v_r & req_sent));
 
   // atomic request subop determination
-  bp_cache_req_wr_subop_e cache_wr_subop;
   bp_bedrock_wr_subop_e req_subop;
-  always_comb  begin
-    cache_wr_subop = cache_req_r.subop;
-    unique case (cache_wr_subop)
+  always_comb
+    unique case (cache_req_r.subop)
       e_req_amolr  : req_subop = e_bedrock_amolr;
       e_req_amosc  : req_subop = e_bedrock_amosc;
       e_req_amoswap: req_subop = e_bedrock_amoswap;
@@ -210,7 +205,6 @@ module bp_lce_req
       e_req_amomaxu: req_subop = e_bedrock_amomaxu;
       default : req_subop = e_bedrock_store;
     endcase
-  end
 
   always_comb begin
     state_n = state_r;

--- a/bp_me/test/common/bp_me_nonsynth_cache.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cache.sv
@@ -65,7 +65,7 @@ module bp_me_nonsynth_cache
      // Cache-LCE interface
     , output logic [cache_req_width_lp-1:0]                 cache_req_o
     , output logic                                          cache_req_v_o
-    , input                                                 cache_req_yumi_i
+    , input                                                 cache_req_ready_and_i
     , input                                                 cache_req_busy_i
     , output logic [cache_req_metadata_width_lp-1:0]        cache_req_metadata_o
     , output logic                                          cache_req_metadata_v_o
@@ -489,7 +489,7 @@ module bp_me_nonsynth_cache
           cache_req_v_o = 1'b1;
           // metadata not used by LCE for uncached ops, but send it anyway
           cache_req_metadata_v_o = 1'b1;
-          state_n = cache_req_yumi_i
+          state_n = (cache_req_ready_and_i & cache_req_v_o)
                     ? tag_lookup_hit_lo
                       ? e_uc_hit_inv
                       : load_op
@@ -562,7 +562,7 @@ module bp_me_nonsynth_cache
         else begin
           cache_req_v_o = 1'b1;
           cache_req_metadata_v_o = 1'b1;
-          state_n = cache_req_yumi_i ? e_wait : state_r;
+          state_n = (cache_req_ready_and_i & cache_req_v_o) ? e_wait : state_r;
         end
       end // e_check_hit
 

--- a/bp_me/test/tb/bp_cce/testbench.sv
+++ b/bp_me/test/tb/bp_cce/testbench.sv
@@ -332,7 +332,7 @@ module testbench
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, cache);
 
   bp_cache_req_s [num_lce_p-1:0] cache_req_lo;
-  logic [num_lce_p-1:0] cache_req_v_lo, cache_req_yumi_li, cache_req_busy_li;
+  logic [num_lce_p-1:0] cache_req_v_lo, cache_req_ready_and_li, cache_req_busy_li;
   bp_cache_req_metadata_s [num_lce_p-1:0] cache_req_metadata_lo;
   logic [num_lce_p-1:0] cache_req_metadata_v_lo;
   logic [num_lce_p-1:0] cache_req_critical_tag_li, cache_req_critical_data_li, cache_req_complete_li;
@@ -420,7 +420,7 @@ module testbench
 
        ,.cache_req_o(cache_req_lo[i])
        ,.cache_req_v_o(cache_req_v_lo[i])
-       ,.cache_req_yumi_i(cache_req_yumi_li[i])
+       ,.cache_req_ready_and_i(cache_req_ready_and_li[i])
        ,.cache_req_busy_i(cache_req_busy_li[i])
        ,.cache_req_metadata_o(cache_req_metadata_lo[i])
        ,.cache_req_metadata_v_o(cache_req_metadata_v_lo[i])
@@ -471,7 +471,7 @@ module testbench
 
        ,.cache_req_i(cache_req_lo[i])
        ,.cache_req_v_i(cache_req_v_lo[i])
-       ,.cache_req_yumi_o(cache_req_yumi_li[i])
+       ,.cache_req_ready_and_o(cache_req_ready_and_li[i])
        ,.cache_req_busy_o(cache_req_busy_li[i])
        ,.cache_req_metadata_i(cache_req_metadata_lo[i])
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo[i])

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -140,7 +140,7 @@ module bp_cacc_vdp
   assign cfg_bus_cast_i.dcache_id = lce_id_i;
   assign cfg_bus_cast_i.dcache_mode = e_lce_mode_normal;
 
-  logic cache_req_v_o, cache_req_yumi_i, cache_req_busy_i, cache_req_metadata_v_o,
+  logic cache_req_v_o, cache_req_ready_and_i, cache_req_busy_i, cache_req_metadata_v_o,
   data_mem_pkt_v_i, data_mem_pkt_yumi_o,
   tag_mem_pkt_v_i, tag_mem_pkt_yumi_o,
   stat_mem_pkt_v_i, stat_mem_pkt_yumi_o,
@@ -209,7 +209,7 @@ module bp_cacc_vdp
      ,.cache_req_critical_data_i(cache_req_critical_data_lo)
      ,.cache_req_o(cache_req_cast_o)
      ,.cache_req_v_o(cache_req_v_o)
-     ,.cache_req_yumi_i(cache_req_yumi_i)
+     ,.cache_req_ready_and_i(cache_req_ready_and_i)
      ,.cache_req_busy_i(cache_req_busy_i)
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
@@ -249,7 +249,7 @@ module bp_cacc_vdp
 
      ,.cache_req_i(cache_req_cast_o)
      ,.cache_req_v_i(cache_req_v_o)
-     ,.cache_req_yumi_o(cache_req_yumi_i)
+     ,.cache_req_ready_and_o(cache_req_ready_and_i)
      ,.cache_req_busy_o(cache_req_busy_i)
      ,.cache_req_metadata_i(cache_req_metadata_o)
      ,.cache_req_metadata_v_i(cache_req_metadata_v_o)

--- a/bp_top/src/v/bp_core_lite.sv
+++ b/bp_top/src/v/bp_core_lite.sv
@@ -88,14 +88,14 @@ module bp_core_lite
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
   bp_icache_req_s icache_req_lo;
-  logic icache_req_v_lo, icache_req_yumi_li, icache_req_busy_li;
+  logic icache_req_v_lo, icache_req_ready_and_li, icache_req_busy_li;
   bp_icache_req_metadata_s icache_req_metadata_lo;
   logic icache_req_metadata_v_lo;
   logic icache_req_critical_tag_li, icache_req_critical_data_li, icache_req_complete_li;
   logic icache_req_credits_full_li, icache_req_credits_empty_li;
 
   bp_dcache_req_s dcache_req_lo;
-  logic dcache_req_v_lo, dcache_req_yumi_li, dcache_req_busy_li;
+  logic dcache_req_v_lo, dcache_req_ready_and_li, dcache_req_busy_li;
   bp_dcache_req_metadata_s dcache_req_metadata_lo;
   logic dcache_req_metadata_v_lo;
   logic dcache_req_critical_tag_li, dcache_req_critical_data_li, dcache_req_complete_li;
@@ -143,7 +143,7 @@ module bp_core_lite
 
      ,.icache_req_o(icache_req_lo)
      ,.icache_req_v_o(icache_req_v_lo)
-     ,.icache_req_yumi_i(icache_req_yumi_li)
+     ,.icache_req_ready_and_i(icache_req_ready_and_li)
      ,.icache_req_busy_i(icache_req_busy_li)
      ,.icache_req_metadata_o(icache_req_metadata_lo)
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
@@ -170,7 +170,7 @@ module bp_core_lite
 
      ,.dcache_req_o(dcache_req_lo)
      ,.dcache_req_v_o(dcache_req_v_lo)
-     ,.dcache_req_yumi_i(dcache_req_yumi_li)
+     ,.dcache_req_ready_and_i(dcache_req_ready_and_li)
      ,.dcache_req_busy_i(dcache_req_busy_li)
      ,.dcache_req_metadata_o(dcache_req_metadata_lo)
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
@@ -222,7 +222,7 @@ module bp_core_lite
 
      ,.cache_req_i(icache_req_lo)
      ,.cache_req_v_i(icache_req_v_lo)
-     ,.cache_req_yumi_o(icache_req_yumi_li)
+     ,.cache_req_ready_and_o(icache_req_ready_and_li)
      ,.cache_req_busy_o(icache_req_busy_li)
      ,.cache_req_metadata_i(icache_req_metadata_lo)
      ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
@@ -356,7 +356,7 @@ module bp_core_lite
 
      ,.cache_req_i(dcache_req_lo)
      ,.cache_req_v_i(dcache_req_v_lo)
-     ,.cache_req_yumi_o(dcache_req_yumi_li)
+     ,.cache_req_ready_and_o(dcache_req_ready_and_li)
      ,.cache_req_busy_o(dcache_req_busy_li)
      ,.cache_req_metadata_i(dcache_req_metadata_lo)
      ,.cache_req_metadata_v_i(dcache_req_metadata_v_lo)

--- a/bp_top/src/v/bp_core_minimal.sv
+++ b/bp_top/src/v/bp_core_minimal.sv
@@ -23,7 +23,7 @@ module bp_core_minimal
 
    , output logic [icache_req_width_lp-1:0]          icache_req_o
    , output logic                                    icache_req_v_o
-   , input                                           icache_req_yumi_i
+   , input                                           icache_req_ready_and_i
    , input                                           icache_req_busy_i
    , output logic [icache_req_metadata_width_lp-1:0] icache_req_metadata_o
    , output logic                                    icache_req_metadata_v_o
@@ -52,7 +52,7 @@ module bp_core_minimal
    //   a negative-edge cache engine and synchronized before getting to the memory system
    , output logic [dcache_req_width_lp-1:0]          dcache_req_o
    , output logic                                    dcache_req_v_o
-   , input                                           dcache_req_yumi_i
+   , input                                           dcache_req_ready_and_i
    , input                                           dcache_req_busy_i
    , output logic [dcache_req_metadata_width_lp-1:0] dcache_req_metadata_o
    , output logic                                    dcache_req_metadata_v_o
@@ -112,7 +112,7 @@ module bp_core_minimal
 
      ,.cache_req_o(icache_req_o)
      ,.cache_req_v_o(icache_req_v_o)
-     ,.cache_req_yumi_i(icache_req_yumi_i)
+     ,.cache_req_ready_and_i(icache_req_ready_and_i)
      ,.cache_req_busy_i(icache_req_busy_i)
      ,.cache_req_metadata_o(icache_req_metadata_o)
      ,.cache_req_metadata_v_o(icache_req_metadata_v_o)
@@ -156,7 +156,7 @@ module bp_core_minimal
 
      ,.cache_req_o(dcache_req_o)
      ,.cache_req_v_o(dcache_req_v_o)
-     ,.cache_req_yumi_i(dcache_req_yumi_i)
+     ,.cache_req_ready_and_i(dcache_req_ready_and_i)
      ,.cache_req_busy_i(dcache_req_busy_i)
      ,.cache_req_metadata_o(dcache_req_metadata_o)
      ,.cache_req_metadata_v_o(dcache_req_metadata_v_o)

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -47,7 +47,7 @@ module bp_unicore_lite
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
   bp_icache_req_s icache_req_lo;
-  logic icache_req_v_lo, icache_req_yumi_li, icache_req_busy_li, icache_req_metadata_v_lo;
+  logic icache_req_v_lo, icache_req_ready_and_li, icache_req_busy_li, icache_req_metadata_v_lo;
   bp_icache_req_metadata_s icache_req_metadata_lo;
   logic icache_req_critical_tag_li, icache_req_critical_data_li, icache_req_complete_li;
   logic icache_req_credits_full_li, icache_req_credits_empty_li;
@@ -63,7 +63,7 @@ module bp_unicore_lite
   bp_icache_stat_info_s icache_stat_mem_lo;
 
   bp_dcache_req_s dcache_req_lo;
-  logic dcache_req_v_lo, dcache_req_yumi_li, dcache_req_busy_li, dcache_req_metadata_v_lo;
+  logic dcache_req_v_lo, dcache_req_ready_and_li, dcache_req_busy_li, dcache_req_metadata_v_lo;
   bp_dcache_req_metadata_s dcache_req_metadata_lo;
   logic dcache_req_critical_tag_li, dcache_req_critical_data_li, dcache_req_complete_li;
   logic dcache_req_credits_full_li, dcache_req_credits_empty_li;
@@ -91,7 +91,7 @@ module bp_unicore_lite
 
      ,.icache_req_o(icache_req_lo)
      ,.icache_req_v_o(icache_req_v_lo)
-     ,.icache_req_yumi_i(icache_req_yumi_li)
+     ,.icache_req_ready_and_i(icache_req_ready_and_li)
      ,.icache_req_busy_i(icache_req_busy_li)
      ,.icache_req_metadata_o(icache_req_metadata_lo)
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
@@ -118,7 +118,7 @@ module bp_unicore_lite
 
      ,.dcache_req_o(dcache_req_lo)
      ,.dcache_req_v_o(dcache_req_v_lo)
-     ,.dcache_req_yumi_i(dcache_req_yumi_li)
+     ,.dcache_req_ready_and_i(dcache_req_ready_and_li)
      ,.dcache_req_busy_i(dcache_req_busy_li)
      ,.dcache_req_metadata_o(dcache_req_metadata_lo)
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
@@ -166,7 +166,7 @@ module bp_unicore_lite
 
      ,.cache_req_i(icache_req_lo)
      ,.cache_req_v_i(icache_req_v_lo)
-     ,.cache_req_yumi_o(icache_req_yumi_li)
+     ,.cache_req_ready_and_o(icache_req_ready_and_li)
      ,.cache_req_busy_o(icache_req_busy_li)
      ,.cache_req_metadata_i(icache_req_metadata_lo)
      ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
@@ -226,7 +226,7 @@ module bp_unicore_lite
 
      ,.cache_req_i(dcache_req_lo)
      ,.cache_req_v_i(dcache_req_v_lo)
-     ,.cache_req_yumi_o(dcache_req_yumi_li)
+     ,.cache_req_ready_and_o(dcache_req_ready_and_li)
      ,.cache_req_busy_o(dcache_req_busy_li)
      ,.cache_req_metadata_i(dcache_req_metadata_lo)
      ,.cache_req_metadata_v_i(dcache_req_metadata_v_lo)

--- a/bp_top/test/common/bp_nonsynth_cosim.sv
+++ b/bp_top/test/common/bp_nonsynth_cosim.sv
@@ -46,7 +46,8 @@ module bp_nonsynth_cosim
     , input [rv64_reg_addr_width_gp-1:0]      frd_addr_i
     , input [dpath_width_gp-1:0]              frd_data_i
 
-    , input                                   cache_req_yumi_i
+    , input                                   cache_req_v_i
+    , input                                   cache_req_ready_and_i
     , input                                   cache_req_complete_i
     , input                                   cache_req_nonblocking_i
 
@@ -91,7 +92,7 @@ module bp_nonsynth_cosim
 
   logic cache_req_complete_r, cache_req_v_r;
   // We filter out for ready so that the request only tracks once
-  wire cache_req_v_li = cache_req_yumi_i & ~cache_req_nonblocking_i;
+  wire cache_req_v_li = cache_req_ready_and_i & cache_req_v_i & ~cache_req_nonblocking_i;
   bsg_dff_chain
    #(.width_p(2), .num_stages_p(2))
    cache_req_reg

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -409,7 +409,8 @@ module testbench
            ,.frd_addr_i(scheduler.fwb_pkt_cast_i.rd_addr)
            ,.frd_data_i(scheduler.fwb_pkt_cast_i.rd_data)
 
-           ,.cache_req_yumi_i(calculator.pipe_mem.dcache.cache_req_yumi_i)
+           ,.cache_req_ready_and_i(calculator.pipe_mem.dcache.cache_req_ready_and_i)
+           ,.cache_req_v_i(calculator.pipe_mem.dcache.cache_req_v_o)
            ,.cache_req_complete_i(calculator.pipe_mem.dcache.cache_req_complete_i)
            ,.cache_req_nonblocking_i(calculator.pipe_mem.dcache.nonblocking_req)
 


### PR DESCRIPTION
## Summary
This PR updates cache_req_yumi to cache_req_ready. This simplifies the control scheme and allows the more critical cache paths to depend on future values of the ready signal.

## Issue Fixed
None

## Area
I$/D$/XCE

## Reasoning (outdated, confusing, verbose, etc.)
While not a critical path itself, relying on the cache_req_yumi signal generates circular paths that can influence the control signals of large SRAMs in blocking caches

## Additional Changes Required (if any)
None

## Analysis
This is a generally noncontroversial change which may decrease paths at the cost of a trivial number of AND gates

## Verification
Standard regressions

## Additional Context
None

