### PR TITLE
Refactor FE for non-replay I$

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - fe_dev_feature_ferefactor
   before_script:
       - git submodule update --init --checkout --recursive external/
       - cp -r $CI_RTL_INSTALL_DIR install/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,6 +71,7 @@ surelog:
 # Some licensing issue as of 02/10/21
 synth-vivado:
   <<: *job_definition
+  when: manual
   stage: check
   allow_failure: true
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - fe_dev_feature_ferefactor
   before_script:
       - git submodule update --init --checkout --recursive external/
       - cp -r $CI_RTL_INSTALL_DIR install/

--- a/bp_be/src/include/bp_be_defines.svh
+++ b/bp_be/src/include/bp_be_defines.svh
@@ -49,7 +49,7 @@
       logic [dpath_width_gp-1:0]               rs2;                                                \
       logic                                    rs3_fp_v;                                           \
       logic [dpath_width_gp-1:0]               imm;                                                \
-      logic                                    instr_partial_v;                                    \
+      logic                                    partial;                                            \
       bp_be_exception_s                        exception;                                          \
       bp_be_special_s                          special;                                            \
      } bp_be_dispatch_pkt_s;                                                                       \
@@ -114,7 +114,7 @@
       logic [vaddr_width_p-1:0]  vaddr;                                                            \
       logic [dpath_width_gp-1:0] data;                                                             \
       rv64_instr_s               instr;                                                            \
-      logic                      instr_partial_v;                                                  \
+      logic                      partial;                                                          \
       bp_be_exception_s          exception;                                                        \
       bp_be_special_s            special;                                                          \
     }  bp_be_retire_pkt_s;                                                                         \
@@ -144,7 +144,7 @@
       logic [rv64_priv_width_gp-1:0]  priv_n;                                                      \
       logic                           translation_en_n;                                            \
       logic                           exception;                                                   \
-      logic                           exception_instr_partial_v;                                   \
+      logic                           partial;                                                     \
       logic                           _interrupt;                                                  \
       logic                           unfreeze;                                                    \
       logic                           eret;                                                        \
@@ -183,7 +183,7 @@
       logic                          instr_miss_v;                                                 \
       logic                          load_miss_v;                                                  \
       logic                          store_miss_v;                                                 \
-      logic                          instr_partial_v;                                              \
+      logic                          partial;                                                      \
       logic [vaddr_width_mp-1:0]     vaddr;                                                        \
     }  bp_be_ptw_miss_pkt_s;                                                                       \
                                                                                                    \
@@ -195,7 +195,7 @@
       logic instr_page_fault_v;                                                                    \
       logic load_page_fault_v;                                                                     \
       logic store_page_fault_v;                                                                    \
-      logic instr_partial_v;                                                                       \
+      logic partial;                                                                               \
       logic [vaddr_width_mp-1:0] vaddr;                                                            \
       bp_be_pte_leaf_s entry;                                                                      \
     }  bp_be_ptw_fill_pkt_s;                                                                       \
@@ -284,8 +284,8 @@
   `define bp_be_decode_info_width \
     (rv64_priv_width_gp+8)
 
-  `define bp_be_instr_half_address(base_pc_mp, instr_partial_v_mp) \
-    (base_pc_mp + (instr_partial_v_mp ? 2 : 0))
+  `define bp_be_instr_half_address(base_pc_mp, partial_mp) \
+    (base_pc_mp + (partial_mp ? 2 : 0))
 
 `endif
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -682,7 +682,7 @@ module bp_be_csr
   assign commit_pkt_cast_o.priv_n           = priv_mode_n;
   assign commit_pkt_cast_o.translation_en_n = translation_en_n;
   assign commit_pkt_cast_o.exception        = exception_v_lo;
-  assign commit_pkt_cast_o.exception_instr_partial_v = retire_pkt_cast_i.instr_partial_v;
+  assign commit_pkt_cast_o.partial          = retire_pkt_cast_i.partial;
   // Debug mode acts as a pseudo-interrupt
   assign commit_pkt_cast_o._interrupt       = interrupt_v_lo | enter_debug;
   assign commit_pkt_cast_o.fencei           = retire_pkt_cast_i.special.fencei_clean;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -138,6 +138,7 @@ module bp_be_pipe_mem
   /* Internal connections */
   /* TLB ports */
   logic                    dtlb_miss_v, dtlb_w_v, dtlb_r_v, dtlb_v_lo;
+  logic                    tlb_store_miss_v, tlb_load_miss_v;
   logic [vtag_width_p-1:0] dtlb_w_vtag;
   bp_pte_leaf_s            dtlb_w_entry;
 
@@ -229,8 +230,8 @@ module bp_be_pipe_mem
      ,.r_v_o(dtlb_v_lo)
      ,.r_ptag_o(dtlb_ptag_lo)
      ,.r_instr_miss_o()
-     ,.r_load_miss_o(tlb_load_miss_v_o)
-     ,.r_store_miss_o(tlb_store_miss_v_o)
+     ,.r_load_miss_o(tlb_load_miss_v)
+     ,.r_store_miss_o(tlb_store_miss_v)
      ,.r_uncached_o(dcache_ptag_uncached)
      ,.r_nonidem_o(/* All D$ misses are non-speculative */)
      ,.r_dram_o(dcache_ptag_dram)
@@ -364,6 +365,15 @@ module bp_be_pipe_mem
         dcache_ptag_v          = dtlb_v_lo & ~load_misaligned_v & ~store_misaligned_v;
       end
 
+  logic dtlb_r_v_r;
+  bsg_dff
+   #(.width_p(1))
+   tlb_v_reg
+    (.clk_i(~clk_i)
+     ,.data_i(dtlb_r_v)
+     ,.data_o(dtlb_r_v_r)
+     );
+
   logic early_v_r;
   bsg_dff_chain
    #(.width_p(1), .num_stages_p(2))
@@ -372,6 +382,9 @@ module bp_be_pipe_mem
      ,.data_i(is_req)
      ,.data_o(early_v_r)
      );
+
+  assign tlb_load_miss_v_o      = dtlb_r_v_r & tlb_load_miss_v;
+  assign tlb_store_miss_v_o     = dtlb_r_v_r & tlb_store_miss_v;
 
   assign cache_fail_v_o         = early_v_r & ~dcache_early_hit_v  & ~dcache_early_miss_v;
   assign cache_miss_v_o         = early_v_r & ~dcache_early_fencei &  dcache_early_miss_v;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -252,7 +252,7 @@ module bp_be_pipe_mem
     '{instr_miss_v  : commit_pkt.itlb_miss
       ,store_miss_v : commit_pkt.dtlb_store_miss
       ,load_miss_v  : commit_pkt.dtlb_load_miss
-      ,instr_partial_v: commit_pkt.exception_instr_partial_v
+      ,partial      : commit_pkt.partial
       ,vaddr        : commit_pkt.vaddr
       ,mstatus_mxr  : trans_info.mstatus_mxr
       ,mstatus_sum  : trans_info.mstatus_sum

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
@@ -151,7 +151,7 @@ module bp_be_pipe_sys
       retire_ninstr_r <= reservation.instr;
       retire_instr_r  <= retire_ninstr_r;
 
-      retire_npartial_r <= reservation.instr_partial_v;
+      retire_npartial_r <= reservation.partial;
       retire_partial_r  <= retire_npartial_r;
     end
 
@@ -164,7 +164,7 @@ module bp_be_pipe_sys
       ,vaddr     : retire_vaddr_r
       ,data      : retire_data_i
       ,instr     : retire_instr_r
-      ,instr_partial_v : retire_v_i & retire_partial_r
+      ,partial   : retire_v_i & retire_partial_r
       // Could do a preemptive onehot decode here
       ,exception : retire_v_i ? retire_exception_i : '0
       ,special   : instret_li ? retire_special_i   : '0

--- a/bp_be/src/v/bp_be_calculator/bp_be_ptw.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_ptw.sv
@@ -141,7 +141,7 @@ module bp_be_ptw
   assign ptw_fill_pkt_cast_o.instr_page_fault_v = is_write & instr_page_fault;
   assign ptw_fill_pkt_cast_o.load_page_fault_v  = is_write & load_page_fault;
   assign ptw_fill_pkt_cast_o.store_page_fault_v = is_write & store_page_fault;
-  assign ptw_fill_pkt_cast_o.instr_partial_v    = is_write & ptw_miss_pkt_r.instr_partial_v;
+  assign ptw_fill_pkt_cast_o.partial            = is_write & ptw_miss_pkt_r.partial;
   assign ptw_fill_pkt_cast_o.vaddr              = ptw_miss_pkt_r.vaddr;
   assign ptw_fill_pkt_cast_o.entry              = tlb_w_entry;
 

--- a/bp_be/src/v/bp_be_checker/bp_be_cmd_queue.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_cmd_queue.sv
@@ -15,7 +15,6 @@ module bp_be_cmd_queue
 
    , input [fe_cmd_width_lp-1:0]        fe_cmd_i
    , input                              fe_cmd_v_i
-   , output logic                       fe_cmd_ready_o
 
    , output logic [fe_cmd_width_lp-1:0] fe_cmd_o
    , output logic                       fe_cmd_v_o
@@ -29,7 +28,7 @@ module bp_be_cmd_queue
 
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 
-  wire enq = fe_cmd_ready_o & fe_cmd_v_i;
+  wire enq = fe_cmd_v_i;
   wire deq = fe_cmd_yumi_i;
 
   logic [ptr_width_lp-1:0] wptr_r, rptr_n, rptr_r;
@@ -62,7 +61,6 @@ module bp_be_cmd_queue
      ,.r_data_o(fe_cmd_o)
      );
 
-  assign fe_cmd_ready_o = ~full_lo;
   assign fe_cmd_v_o     = ~empty_lo;
 
   wire almost_full = (rptr_r == wptr_r+1'b1);

--- a/bp_be/src/v/bp_be_checker/bp_be_director.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.sv
@@ -65,7 +65,7 @@ module bp_be_director
 
   // Cast input and output ports
   bp_fe_cmd_s                      fe_cmd_li;
-  logic                            fe_cmd_v_li, fe_cmd_ready_lo;
+  logic                            fe_cmd_v_li;
   bp_fe_cmd_pc_redirect_operands_s fe_cmd_pc_redirect_operands;
 
   // Declare intermediate signals
@@ -123,7 +123,7 @@ module bp_be_director
         e_run   : state_n = commit_pkt_cast_i.wfi ? e_wait : fe_cmd_nonattaboy_v ? e_fence : e_run;
         e_fence : state_n = cmd_empty_n_o ? e_run : e_fence;
         // e_freeze:
-        default : state_n = freeze_li ? e_freeze : e_wait;
+        default : state_n = fe_cmd_v_li ? e_run : e_freeze;
       endcase
     end
 
@@ -154,7 +154,7 @@ module bp_be_director
           fe_cmd_pc_redirect_operands.translation_en = commit_pkt_cast_i.translation_en_n;
           fe_cmd_li.operands.pc_redirect_operands    = fe_cmd_pc_redirect_operands;
 
-          fe_cmd_v_li = fe_cmd_ready_lo;
+          fe_cmd_v_li = is_freeze;
         end
       else if (commit_pkt_cast_i.itlb_fill_v)
         begin
@@ -163,14 +163,14 @@ module bp_be_director
           fe_cmd_li.operands.itlb_fill_response.pte_leaf = commit_pkt_cast_i.pte_leaf;
           fe_cmd_li.operands.itlb_fill_response.instr    = compressed_support_p ? commit_pkt_cast_i.instr : '0;
 
-          fe_cmd_v_li = fe_cmd_ready_lo;
+          fe_cmd_v_li = is_run;
         end
       else if (commit_pkt_cast_i.sfence)
         begin
           fe_cmd_li.opcode = e_op_itlb_fence;
           fe_cmd_li.npc = commit_pkt_cast_i.npc;
 
-          fe_cmd_v_li = fe_cmd_ready_lo;
+          fe_cmd_v_li = is_run;
         end
       else if (commit_pkt_cast_i.csrw)
         begin
@@ -180,21 +180,21 @@ module bp_be_director
           fe_cmd_pc_redirect_operands.translation_en  = commit_pkt_cast_i.translation_en_n;
           fe_cmd_li.operands.pc_redirect_operands     = fe_cmd_pc_redirect_operands;
 
-          fe_cmd_v_li = fe_cmd_ready_lo;
+          fe_cmd_v_li = is_run;
         end
       else if (commit_pkt_cast_i.wfi)
         begin
           fe_cmd_li.opcode = e_op_wait;
           fe_cmd_li.npc = commit_pkt_cast_i.npc;
 
-          fe_cmd_v_li = fe_cmd_ready_lo;
+          fe_cmd_v_li = is_run;
         end
       else if (commit_pkt_cast_i.fencei)
         begin
           fe_cmd_li.opcode = e_op_icache_fence;
           fe_cmd_li.npc = commit_pkt_cast_i.npc;
 
-          fe_cmd_v_li = fe_cmd_ready_lo;
+          fe_cmd_v_li = is_run;
         end
       else if (commit_pkt_cast_i.icache_miss)
         begin
@@ -202,7 +202,7 @@ module bp_be_director
           fe_cmd_li.npc    = commit_pkt_cast_i.vaddr;
           fe_cmd_li.operands.icache_fill_response.instr = compressed_support_p ? commit_pkt_cast_i.instr : '0;
 
-          fe_cmd_v_li = fe_cmd_ready_lo;
+          fe_cmd_v_li = is_run;
         end
       else if (commit_pkt_cast_i.eret)
         begin
@@ -213,18 +213,18 @@ module bp_be_director
           fe_cmd_pc_redirect_operands.translation_en       = commit_pkt_cast_i.translation_en_n;
           fe_cmd_li.operands.pc_redirect_operands          = fe_cmd_pc_redirect_operands;
 
-          fe_cmd_v_li = fe_cmd_ready_lo;
+          fe_cmd_v_li = is_run;
         end
       else if (commit_pkt_cast_i.exception | commit_pkt_cast_i._interrupt | (is_wait & irq_waiting_i))
         begin
           fe_cmd_li.opcode                                 = e_op_pc_redirection;
           fe_cmd_li.npc                                    = commit_pkt_cast_i.npc;
-          fe_cmd_pc_redirect_operands.subopcode            = e_subop_trap;
+          fe_cmd_pc_redirect_operands.subopcode            = commit_pkt_cast_i.exception ? e_subop_trap : e_subop_interrupt;
           fe_cmd_pc_redirect_operands.priv                 = commit_pkt_cast_i.priv_n;
           fe_cmd_pc_redirect_operands.translation_en       = commit_pkt_cast_i.translation_en_n;
           fe_cmd_li.operands.pc_redirect_operands          = fe_cmd_pc_redirect_operands;
 
-          fe_cmd_v_li = fe_cmd_ready_lo;
+          fe_cmd_v_li = is_run || (is_wait && irq_waiting_i);
         end
       else if (isd_status_cast_i.v & npc_mismatch_v)
         begin
@@ -239,7 +239,7 @@ module bp_be_director
                                                              : e_not_a_branch;
           fe_cmd_li.operands.pc_redirect_operands          = fe_cmd_pc_redirect_operands;
 
-          fe_cmd_v_li = fe_cmd_ready_lo;
+          fe_cmd_v_li = is_run;
         end
       // Send an attaboy if there's a correct prediction
       else if (isd_status_cast_i.v & ~npc_mismatch_v & last_instr_was_branch)
@@ -249,7 +249,7 @@ module bp_be_director
           fe_cmd_li.operands.attaboy.taken               = last_instr_was_btaken;
           fe_cmd_li.operands.attaboy.branch_metadata_fwd = isd_status_cast_i.branch_metadata_fwd;
 
-          fe_cmd_v_li = fe_cmd_ready_lo;
+          fe_cmd_v_li = is_run;
         end
     end
 
@@ -261,7 +261,6 @@ module bp_be_director
 
      ,.fe_cmd_i(fe_cmd_li)
      ,.fe_cmd_v_i(fe_cmd_v_li)
-     ,.fe_cmd_ready_o(fe_cmd_ready_lo)
 
      ,.fe_cmd_o(fe_cmd_o)
      ,.fe_cmd_v_o(fe_cmd_v_o)

--- a/bp_be/src/v/bp_be_checker/bp_be_director.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.sv
@@ -164,7 +164,7 @@ module bp_be_director
         end
       else if (commit_pkt_cast_i.itlb_fill_v)
         begin
-          fe_cmd_li.opcode                               = (compressed_support_p & commit_pkt_cast_i.exception_instr_partial_v) ? e_op_itlb_fill_resume : e_op_itlb_fill_restart;
+          fe_cmd_li.opcode                               = (compressed_support_p & commit_pkt_cast_i.partial) ? e_op_itlb_fill_resume : e_op_itlb_fill_restart;
           fe_cmd_li.npc                                  = commit_pkt_cast_i.vaddr;
           fe_cmd_li.operands.itlb_fill_response.pte_leaf = commit_pkt_cast_i.pte_leaf;
           fe_cmd_li.operands.itlb_fill_response.instr    = compressed_support_p ? commit_pkt_cast_i.instr : '0;
@@ -204,7 +204,7 @@ module bp_be_director
         end
       else if (commit_pkt_cast_i.icache_miss)
         begin
-          fe_cmd_li.opcode = (compressed_support_p & commit_pkt_cast_i.exception_instr_partial_v) ? e_op_icache_fill_resume : e_op_icache_fill_restart;
+          fe_cmd_li.opcode = (compressed_support_p & commit_pkt_cast_i.partial) ? e_op_icache_fill_resume : e_op_icache_fill_restart;
           fe_cmd_li.npc    = commit_pkt_cast_i.vaddr;
           fe_cmd_li.operands.icache_fill_response.instr = compressed_support_p ? commit_pkt_cast_i.instr : '0;
 

--- a/bp_be/src/v/bp_be_checker/bp_be_issue_queue.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_issue_queue.sv
@@ -62,7 +62,7 @@ module bp_be_issue_queue
                     : enq
                        ? ((ptr_width_lp+1)'(1))
                        : ((ptr_width_lp+1)'(0));
-  assign cptr_jmp = deq_v_i;
+  assign cptr_jmp = deq;
 
   wire empty = (rptr_r[0+:ptr_width_lp] == wptr_r[0+:ptr_width_lp])
                & (rptr_r[ptr_width_lp] == wptr_r[ptr_width_lp]);

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -218,7 +218,7 @@ module bp_be_scheduler
       dispatch_pkt.imm      = (fe_exc_not_instr_li | be_exc_not_instr_li) ? '0 : issue_pkt.frs3_v ? frf_rs3 : decoded_imm_lo;
       dispatch_pkt.decode   = instr_decoded;
 
-      dispatch_pkt.instr_partial_v = (be_exc_not_instr_li & ptw_fill_pkt_cast_i.instr_partial_v)
+      dispatch_pkt.partial = (be_exc_not_instr_li & ptw_fill_pkt_cast_i.partial)
                                    | (fe_exc_not_instr_li & fe_queue_lo.partial_v);
 
       dispatch_pkt.exception.instr_access_fault |=

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -1058,10 +1058,10 @@ module bp_be_dcache
   // Data Mem Control
   ///////////////////////////
   logic [block_size_in_fill_lp-1:0][fill_size_in_bank_lp-1:0] data_mem_pkt_fill_mask_expanded;
-  for (genvar i = 0; i < block_size_in_fill_lp; i++)
-    begin : fill_mask
-      assign data_mem_pkt_fill_mask_expanded[i] = {fill_size_in_bank_lp{data_mem_pkt_cast_i.fill_index[i]}};
-    end
+  bsg_expand_bitmask
+   #(.in_width_p(block_size_in_fill_lp), .expand_p(fill_size_in_bank_lp))
+   fill_mask_expand
+    (.i(data_mem_pkt_cast_i.fill_index), .o(data_mem_pkt_fill_mask_expanded));
 
   logic [assoc_p-1:0] data_mem_write_bank_mask;
   wire [`BSG_SAFE_CLOG2(assoc_p)-1:0] write_mask_rot_li = data_mem_pkt_cast_i.way_id;

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -380,7 +380,7 @@ module bp_be_dcache
   // TV Stage
   /////////////////////////////////////////////////////////////////////////////
   localparam snoop_offset_width_lp = `BSG_SAFE_CLOG2(fill_width_p/dword_width_gp);
-  logic uncached_op_tv_r, cached_op_tv_r, dram_op_tv_r, fill_tv_r;
+  logic uncached_op_tv_r, dram_op_tv_r, fill_tv_r;
   logic [paddr_width_p-1:0] paddr_tv_r;
   logic [dword_width_gp-1:0] st_data_tv_r;
   rv64_fflags_s st_fflags_tv_r;
@@ -464,18 +464,18 @@ module bp_be_dcache
      );
 
   bsg_dff_en
-   #(.width_p(paddr_width_p+assoc_p+3+$bits(bp_be_dcache_decode_s)))
+   #(.width_p(paddr_width_p+assoc_p+2+$bits(bp_be_dcache_decode_s)))
    tv_stage_reg
     (.clk_i(negedge_clk)
      ,.en_i(tv_we)
      ,.data_i({paddr_tl
                ,bank_sel_one_hot_tl
-               ,uncached_op_tl, cached_op_tl, dram_op_tl
+               ,uncached_op_tl, dram_op_tl
                ,decode_tl_r
                })
      ,.data_o({paddr_tv_r
                ,bank_sel_one_hot_tv_r
-               ,uncached_op_tv_r, cached_op_tv_r, dram_op_tv_r
+               ,uncached_op_tv_r, dram_op_tv_r
                ,decode_tv_r
                })
      );
@@ -580,9 +580,9 @@ module bp_be_dcache
   // Fail if we have a store conditional without success
   wire sc_fail_tv = v_tv_r & decode_tv_r.sc_op & ~sc_success_tv;
 
-  wire store_miss_tv    = cached_op_tv_r & decode_tv_r.store_op & ~decode_tv_r.sc_op & ~store_hit_tv & (writethrough_p == 0);
-  wire lr_miss_tv       = cached_op_tv_r & decode_tv_r.lr_op & ~lr_hit_tv;
-  wire load_miss_tv     = cached_op_tv_r & decode_tv_r.load_op & ~decode_tv_r.sc_op & ~load_hit_tv;
+  wire store_miss_tv    = ~uncached_op_tv_r & decode_tv_r.store_op & ~decode_tv_r.sc_op & ~store_hit_tv & (writethrough_p == 0);
+  wire lr_miss_tv       = ~uncached_op_tv_r & decode_tv_r.lr_op & ~lr_hit_tv;
+  wire load_miss_tv     = ~uncached_op_tv_r & decode_tv_r.load_op & ~decode_tv_r.sc_op & ~load_hit_tv;
   wire fencei_miss_tv   = decode_tv_r.fencei_op & gdirty_r & (coherent_p == 0);
   wire uncached_miss_tv = uncached_op_tv_r & decode_tv_r.load_op & ~fill_tv_r;
   wire engine_miss_tv   = cache_req_v_o & ~cache_req_ready_and_i;
@@ -1170,7 +1170,7 @@ module bp_be_dcache
   // Stat Mem Control
   ///////////////////////////
   wire stat_mem_fast_read  = (early_miss_v_o | (v_tv_r & load_hit_tv & uncached_op_tv_r));
-  wire stat_mem_fast_write = (v_tv_r & ~any_miss_tv & cached_op_tv_r);
+  wire stat_mem_fast_write = (v_tv_r & ~any_miss_tv & ~uncached_op_tv_r);
   wire stat_mem_slow_write = stat_mem_pkt_yumi_o & (stat_mem_pkt_cast_i.opcode != e_cache_stat_mem_read);
   wire stat_mem_slow_read  = stat_mem_pkt_yumi_o & (stat_mem_pkt_cast_i.opcode == e_cache_stat_mem_read);
   assign stat_mem_v_li = stat_mem_fast_read | stat_mem_fast_write

--- a/bp_be/test/tb/bp_be_dcache/testbench.sv
+++ b/bp_be/test/tb/bp_be_dcache/testbench.sv
@@ -292,7 +292,6 @@ module testbench
    #(.bp_params_p(bp_params_p)
      ,.preload_mem_p(0)
      ,.dram_type_p(dram_type_p)
-     ,.mem_els_p(2**20)
      )
    mem
     (.clk_i(clk_i)

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -308,7 +308,7 @@
       ,fe_cmd_fifo_els   : 4
       ,muldiv_support    : (1 << e_div) | (1 << e_mul) | (1 << e_mulh)
       ,fpu_support       : 1
-      ,compressed_support: 1
+      ,compressed_support: 0
 
       ,async_coh_clk       : 0
       ,coh_noc_flit_width  : 128

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -308,7 +308,7 @@
       ,fe_cmd_fifo_els   : 4
       ,muldiv_support    : (1 << e_div) | (1 << e_mul) | (1 << e_mulh)
       ,fpu_support       : 1
-      ,compressed_support: 0
+      ,compressed_support: 1
 
       ,async_coh_clk       : 0
       ,coh_noc_flit_width  : 128

--- a/bp_common/src/include/bp_common_aviary_defines.svh
+++ b/bp_common/src/include/bp_common_aviary_defines.svh
@@ -45,10 +45,8 @@
     , localparam hio_width_p     = paddr_width_p - daddr_width_p                                   \
                                                                                                    \
     , localparam branch_metadata_fwd_width_p = proc_param_lp.branch_metadata_fwd_width             \
-    , localparam btb_ignored_bits_p          = proc_param_lp.compressed_support ? 1 : 2            \
     , localparam btb_tag_width_p             = proc_param_lp.btb_tag_width                         \
     , localparam btb_idx_width_p             = proc_param_lp.btb_idx_width                         \
-    , localparam bht_ignored_bits_p          = proc_param_lp.compressed_support ? 1 : 2            \
     , localparam bht_idx_width_p             = proc_param_lp.bht_idx_width                         \
     , localparam bht_row_els_p               = proc_param_lp.bht_row_els                           \
     , localparam ghist_width_p               = proc_param_lp.ghist_width                           \

--- a/bp_common/src/include/bp_common_rv64_csr_defines.svh
+++ b/bp_common/src/include/bp_common_rv64_csr_defines.svh
@@ -213,12 +213,14 @@
                                                                                            \
   typedef struct packed                                                                    \
   {                                                                                        \
-    logic [63:1] word_addr;                                                                \
+    logic [63:2] word_addr;                                                                \
+    logic [0:0]  align;                                                                    \
     logic [0:0]  zero;                                                                     \
   }  rv64_sepc_s;                                                                          \
   typedef struct packed                                                                    \
   {                                                                                        \
     logic [(`BSG_MAX(vaddr_width_mp, paddr_width_mp))-2:0] word_addr;                      \
+    logic [0:0]                                            align;                          \
   }  bp_sepc_s;                                                                            \
                                                                                            \
   typedef struct packed                                                                    \
@@ -513,12 +515,14 @@
                                                                                            \
   typedef struct packed                                                                    \
   {                                                                                        \
-    logic [63:1] word_addr;                                                                \
+    logic [63:2] word_addr;                                                                \
+    logic [0:0]  align;                                                                    \
     logic [0:0]  zero;                                                                     \
   }  rv64_mepc_s;                                                                          \
   typedef struct packed                                                                    \
   {                                                                                        \
     logic [`BSG_MAX(vaddr_width_mp, paddr_width_mp)-2:0] word_addr;                        \
+    logic [0:0]                                          align;                            \
   }  bp_mepc_s;                                                                            \
                                                                                            \
   typedef struct packed                                                                    \
@@ -740,10 +744,11 @@
   `define bp_sepc_width ($bits(bp_sepc_s))
 
   `define compress_sepc_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) \
-    bp_sepc_s'(data_cast_mp.word_addr & ({ {62{1'b1}}, compressed_support_p != 0 }))
+    '{word_addr: data_cast_mp.word_addr, align: data_cast_mp.align}
 
   `define decompress_sepc_s(data_comp_mp) \
     '{word_addr: `BSG_SIGN_EXTEND(data_comp_mp.word_addr, 63) \
+      ,align   : compressed_support_p && data_comp_mp.align   \
       ,zero    : 1'b0                                         \
       }
 
@@ -921,11 +926,12 @@
     `BSG_SIGN_EXTEND(data_comp_mp, 64)
 
   `define compress_mepc_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) \
-    bp_mepc_s'(data_cast_mp.word_addr)
+    '{word_addr: data_cast_mp.word_addr, align: data_cast_mp.align}
 
   `define decompress_mepc_s(data_comp_mp) \
-    '{word_addr: `BSG_SIGN_EXTEND(data_comp_mp.word_addr, 63) \
-      ,zero    : 1'b0                                        \
+    '{word_addr: `BSG_SIGN_EXTEND(data_comp_mp.word_addr, 62) \
+      ,align   : compressed_support_p && data_comp_mp.align   \
+      ,zero    : 1'b0                                         \
       }
 
   `define compress_pmpcfg_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) \

--- a/bp_common/src/v/bp_mmu.sv
+++ b/bp_common/src/v/bp_mmu.sv
@@ -57,31 +57,43 @@ module bp_mmu
 
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 
-  logic trans_en_r, r_v_r, r_instr_r, r_load_r, r_store_r, sum_r, mxr_r;
+  // This logic only works for 8-byte words max.
+  logic misaligned;
+  always_comb
+    case (r_size_i)
+      2'b01: misaligned = |r_eaddr_i[0+:1];
+      2'b10: misaligned = |r_eaddr_i[0+:2];
+      2'b11: misaligned = |r_eaddr_i[0+:3];
+      default: misaligned = '0;
+    endcase
+
+  logic trans_en_r, r_instr_r, r_load_r, r_store_r, sum_r, mxr_r, misaligned_r;
   logic [1:0] priv_mode_r;
-  bsg_dff_reset
+  bsg_dff_reset_en
    #(.width_p(9))
-   r_v_reg
+   read_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
-     ,.data_i({mxr_i, sum_i, priv_mode_i, trans_en_i, r_v_i, r_instr_i, r_load_i, r_store_i})
-     ,.data_o({mxr_r, sum_r, priv_mode_r, trans_en_r, r_v_r, r_instr_r, r_load_r, r_store_r})
+     ,.en_i(r_v_i)
+     ,.data_i({misaligned, mxr_i, sum_i, priv_mode_i, trans_en_i, r_instr_i, r_load_i, r_store_i})
+     ,.data_o({misaligned_r, mxr_r, sum_r, priv_mode_r, trans_en_r, r_instr_r, r_load_r, r_store_r})
      );
 
   logic [etag_width_p-1:0] r_etag_r;
   wire [etag_width_p-1:0] r_etag_li = r_eaddr_i[dword_width_gp-1-:etag_width_p];
-  bsg_dff_reset
+  bsg_dff_reset_en
    #(.width_p(etag_width_p))
    etag_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
+     ,.en_i(r_v_i)
 
      ,.data_i(r_etag_li)
      ,.data_o(r_etag_r)
      );
 
   logic tlb_bypass_r;
-  wire tlb_bypass = ~w_v_i & (r_etag_li[0+:vtag_width_p] == r_etag_r[0+:vtag_width_p]) & r_v_r & trans_en_r & trans_en_i;
+  wire tlb_bypass = ~flush_i & ~w_v_i & (r_etag_li[0+:vtag_width_p] == r_etag_r[0+:vtag_width_p]) & trans_en_r & trans_en_i;
   bsg_dff_reset
    #(.width_p(1))
    tlb_bypass_reg
@@ -124,7 +136,7 @@ module bp_mmu
   bp_pte_leaf_s passthrough_entry, tlb_entry_lo;
   assign passthrough_entry = '{ptag: r_etag_r[0+:ptag_width_p], default: '0};
   assign tlb_entry_lo      = trans_en_r ? tlb_r_entry_r : passthrough_entry;
-  wire tlb_v_lo            = trans_en_r ? tlb_r_v_r : r_v_r;
+  wire tlb_v_lo            = trans_en_r ? tlb_r_v_r : 1'b1;
 
   wire ptag_v_lo                  = tlb_v_lo;
   wire [ptag_width_p-1:0] ptag_lo = tlb_entry_lo.ptag;
@@ -172,35 +184,23 @@ module bp_mmu
   wire store_page_fault_v = trans_en_r & r_store_r & (data_priv_page_fault | data_write_page_fault | eaddr_fault_v);
   wire any_page_fault_v   = |{instr_page_fault_v, load_page_fault_v, store_page_fault_v};
 
-  // This logic only works for 8-byte words max.
-  logic r_misaligned_n, r_misaligned_r;
-  always_comb
-    case (r_size_i)
-      2'b01: r_misaligned_n = |r_eaddr_i[0+:1];
-      2'b10: r_misaligned_n = |r_eaddr_i[0+:2];
-      2'b11: r_misaligned_n = |r_eaddr_i[0+:3];
-      default: r_misaligned_n = '0;
-    endcase
-  always_ff @(posedge clk_i)
-    r_misaligned_r <= r_misaligned_n;
-
-  assign r_v_o                   = r_v_r &  tlb_v_lo & ~any_access_fault_v & ~any_page_fault_v;
+  assign r_v_o                   = tlb_v_lo & ~any_access_fault_v & ~any_page_fault_v;
   assign r_ptag_o                = ptag_lo;
-  assign r_instr_miss_o          = r_v_r & ~tlb_v_lo & r_instr_r & ~any_access_fault_v & ~any_page_fault_v;
-  assign r_load_miss_o           = r_v_r & ~tlb_v_lo & r_load_r  & ~any_access_fault_v & ~any_page_fault_v;
-  assign r_store_miss_o          = r_v_r & ~tlb_v_lo & r_store_r & ~any_access_fault_v & ~any_page_fault_v;
-  assign r_uncached_o            = r_v_r &  tlb_v_lo & ptag_uncached_lo;
-  assign r_nonidem_o             = r_v_r &  tlb_v_lo & ptag_nonidem_lo;
-  assign r_dram_o                = r_v_r &  tlb_v_lo & ptag_dram_lo;
-  assign r_instr_misaligned_o    = r_v_r & r_misaligned_r & r_instr_r;
-  assign r_load_misaligned_o     = r_v_r & r_misaligned_r & r_load_r;
-  assign r_store_misaligned_o    = r_v_r & r_misaligned_r & r_store_r;
-  assign r_instr_access_fault_o  = r_v_r & instr_access_fault_v;
-  assign r_load_access_fault_o   = r_v_r & load_access_fault_v;
-  assign r_store_access_fault_o  = r_v_r & store_access_fault_v;
-  assign r_instr_page_fault_o    = r_v_r & instr_page_fault_v;
-  assign r_load_page_fault_o     = r_v_r & load_page_fault_v;
-  assign r_store_page_fault_o    = r_v_r & store_page_fault_v;
+  assign r_instr_miss_o          = ~tlb_v_lo & r_instr_r & ~any_access_fault_v & ~any_page_fault_v;
+  assign r_load_miss_o           = ~tlb_v_lo & r_load_r  & ~any_access_fault_v & ~any_page_fault_v;
+  assign r_store_miss_o          = ~tlb_v_lo & r_store_r & ~any_access_fault_v & ~any_page_fault_v;
+  assign r_uncached_o            =  tlb_v_lo & ptag_uncached_lo;
+  assign r_nonidem_o             =  tlb_v_lo & ptag_nonidem_lo;
+  assign r_dram_o                =  tlb_v_lo & ptag_dram_lo;
+  assign r_instr_misaligned_o    = misaligned_r & r_instr_r;
+  assign r_load_misaligned_o     = misaligned_r & r_load_r;
+  assign r_store_misaligned_o    = misaligned_r & r_store_r;
+  assign r_instr_access_fault_o  = instr_access_fault_v;
+  assign r_load_access_fault_o   = load_access_fault_v;
+  assign r_store_access_fault_o  = store_access_fault_v;
+  assign r_instr_page_fault_o    = instr_page_fault_v;
+  assign r_load_page_fault_o     = load_page_fault_v;
+  assign r_store_page_fault_o    = store_page_fault_v;
 
 endmodule
 

--- a/bp_common/src/v/bp_tlb.sv
+++ b/bp_common/src/v/bp_tlb.sv
@@ -62,14 +62,14 @@ module bp_tlb
      );
 
   logic [vtag_width_p-1:0] vtag_r;
-  logic r_v_r;
-  bsg_dff_reset
-   #(.width_p(vtag_width_p+1))
-   r_v_reg
+  bsg_dff_reset_en
+   #(.width_p(vtag_width_p))
+   vtag_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
-     ,.data_i({vtag_i, r_v_li})
-     ,.data_o({vtag_r, r_v_r})
+     ,.en_i(v_i)
+     ,.data_i(vtag_i)
+     ,.data_o(vtag_r)
      );
   wire [r_entry_low_bits_lp-1:0] passthrough_low_bits = vtag_r[0+:r_entry_low_bits_lp];
 
@@ -91,7 +91,7 @@ module bp_tlb
      ,.w_tag_i(vtag_i)
      ,.w_empty_o(tag_empty_4k_lo)
 
-     ,.r_v_i(r_v_r)
+     ,.r_v_i(~|tag_4k_w_v_li)
      ,.r_tag_i(vtag_r)
      ,.r_match_o(tag_r_match_4k_lo)
      );
@@ -125,7 +125,7 @@ module bp_tlb
      ,.w_tag_i(vtag_i)
      ,.w_empty_o(tag_empty_1g_lo)
 
-     ,.r_v_i(r_v_r)
+     ,.r_v_i(~|tag_1g_w_v_li)
      ,.r_tag_i(vtag_r)
      ,.r_match_o(tag_r_match_1g_lo)
      );
@@ -205,8 +205,8 @@ module bp_tlb
      ,.o(entry_unshifted)
      );
 
-  assign entry_o    = entry_unshifted;
-  assign v_o        = r_v_r & r_v_lo;
+  assign entry_o = entry_unshifted;
+  assign v_o     = r_v_lo;
 
 endmodule
 

--- a/bp_fe/src/include/bp_fe_icache_defines.svh
+++ b/bp_fe/src/include/bp_fe_icache_defines.svh
@@ -6,10 +6,11 @@
     {                                     \
       logic [vaddr_width_mp-1:0] vaddr;   \
       bp_fe_icache_op_e          op;      \
+      logic                      spec;    \
     }  bp_fe_icache_pkt_s;
 
   `define bp_fe_icache_pkt_width(vaddr_width_mp) \
-    (vaddr_width_mp+$bits(bp_fe_icache_op_e))
+    (1+vaddr_width_mp+$bits(bp_fe_icache_op_e))
 
 `endif
 

--- a/bp_fe/src/include/bp_fe_icache_pkgdef.svh
+++ b/bp_fe/src/include/bp_fe_icache_pkgdef.svh
@@ -5,7 +5,6 @@
   {
     e_icache_fetch
     ,e_icache_fencei
-    ,e_icache_fill
   } bp_fe_icache_op_e;
 
 `endif

--- a/bp_fe/src/include/bp_fe_pc_gen_pkgdef.svh
+++ b/bp_fe/src/include/bp_fe_pc_gen_pkgdef.svh
@@ -15,6 +15,7 @@
       logic jalr;
       logic call;
       logic _return;
+      logic [rv64_imm20_width_gp-1:0] imm20;
     }  bp_fe_instr_scan_s;
 
 `endif

--- a/bp_fe/src/v/bp_fe_bht.sv
+++ b/bp_fe/src/v/bp_fe_bht.sv
@@ -91,7 +91,7 @@ module bp_fe_bht
 
   // GSELECT
   wire                            r_v_li = r_v_i;
-  wire [idx_width_lp-1:0]       r_idx_li = {r_addr_i[bht_ignored_bits_p+:bht_idx_width_p], r_ghist_i};
+  wire [idx_width_lp-1:0]       r_idx_li = {r_addr_i[2+:bht_idx_width_p], r_ghist_i};
   logic [bht_row_width_p-1:0] r_data_lo;
 
   assign rw_same_addr = r_v_i & w_v_i & (r_idx_li == w_idx_li);
@@ -116,14 +116,14 @@ module bp_fe_bht
   if (bht_row_els_p > 1)
     begin : fold
       wire [`BSG_SAFE_CLOG2(bht_row_width_p)-1:0] pred_idx_n =
-        1'b1 + (r_addr_i[bht_ignored_bits_p+bht_idx_width_p+:`BSG_SAFE_CLOG2(bht_row_els_p)] << 1'b1);
+        1'b1 + (r_addr_i[2+bht_idx_width_p+:`BSG_SAFE_CLOG2(bht_row_els_p)] << 1'b1);
       bsg_dff
        #(.width_p(`BSG_SAFE_CLOG2(bht_row_width_p)))
        pred_idx_reg
         (.clk_i(clk_i)
          ,.data_i(pred_idx_n)
-        ,.data_o(pred_idx_r)
-        );
+         ,.data_o(pred_idx_r)
+         );
    end
  else
    begin : no_fold

--- a/bp_fe/src/v/bp_fe_btb.sv
+++ b/bp_fe/src/v/bp_fe_btb.sv
@@ -89,8 +89,8 @@ module bp_fe_btb
     logic [vaddr_width_p-1:0]   tgt;
   }  bp_btb_entry_s;
 
-  wire [btb_idx_width_p-1:0] r_idx_li = r_addr_i[btb_ignored_bits_p+:btb_idx_width_p];
-  wire [btb_tag_width_p-1:0] r_tag_li = r_addr_i[btb_ignored_bits_p+btb_idx_width_p+:btb_tag_width_p];
+  wire [btb_idx_width_p-1:0] r_idx_li = r_addr_i[2+:btb_idx_width_p];
+  wire [btb_tag_width_p-1:0] r_tag_li = r_addr_i[2+btb_idx_width_p+:btb_tag_width_p];
 
   bp_btb_entry_s tag_mem_data_li;
   wire rw_same_addr = r_v_i & w_v_i & (r_idx_li == w_idx_i);

--- a/bp_fe/src/v/bp_fe_controller.sv
+++ b/bp_fe/src/v/bp_fe_controller.sv
@@ -172,7 +172,7 @@ module bp_fe_controller
           end
         e_wait, e_run:
           begin
-            icache_v_o = (is_run & ~cmd_complex_v) || (is_wait && cmd_immediate_v);
+            icache_v_o = (is_run & ~cmd_complex_v) || (is_wait && cmd_nonattaboy_v);
             if1_we_o = icache_yumi_i & ~cmd_complex_v;
             itlb_r_v_o = icache_yumi_i;
             itlb_w_v_o = itlb_fill_response_v;

--- a/bp_fe/src/v/bp_fe_controller.sv
+++ b/bp_fe/src/v/bp_fe_controller.sv
@@ -1,0 +1,218 @@
+/*
+ * bp_fe_controller.v
+ */
+
+`include "bp_common_defines.svh"
+`include "bp_fe_defines.svh"
+
+module bp_fe_controller
+ import bp_fe_pkg::*;
+ import bp_common_pkg::*;
+ import bp_be_pkg::*;
+ #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+   `declare_bp_proc_params(bp_params_p)
+   `declare_bp_core_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
+   `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache)
+
+   , localparam icache_pkt_width_lp = `bp_fe_icache_pkt_width(vaddr_width_p)
+   )
+  (input                                              clk_i
+   , input                                            reset_i
+
+   , input [fe_cmd_width_lp-1:0]                      fe_cmd_i
+   , input                                            fe_cmd_v_i
+   , output logic                                     fe_cmd_yumi_o
+
+   , output logic                                     redirect_v_o
+   , output logic [vaddr_width_p-1:0]                 redirect_pc_o
+   , output logic                                     redirect_br_v_o
+   , output logic                                     redirect_br_taken_o
+   , output logic                                     redirect_br_ntaken_o
+   , output logic                                     redirect_br_nonbr_o
+   , output logic [branch_metadata_fwd_width_p-1:0]   redirect_br_metadata_fwd_o
+   , output logic                                     redirect_resume_v_o
+   , output logic [instr_width_gp/2-1:0]                redirect_resume_instr_o
+
+   , output logic [vaddr_width_p-1:0]                 attaboy_pc_o
+   , output logic                                     attaboy_taken_o
+   , output logic                                     attaboy_ntaken_o
+   , output logic [branch_metadata_fwd_width_p-1:0]   attaboy_br_metadata_fwd_o
+   , output logic                                     attaboy_v_o
+   , input                                            attaboy_yumi_i
+
+   , input                                            pc_gen_init_done_i
+   , input [vaddr_width_p-1:0]                        next_pc_i
+   , input                                            ovr_i
+   , input                                            icache_tv_we_i
+   , output logic                                     if1_we_o
+   , output logic                                     if2_we_o
+   , output logic                                     poison_if1_o
+   , output logic                                     poison_if2_o
+
+   , output logic                                     itlb_r_v_o
+   , output logic                                     itlb_w_v_o
+   , output logic                                     itlb_flush_v_o
+   , output logic                                     icache_v_o
+   , output logic                                     icache_force_o
+   , output logic [icache_pkt_width_lp-1:0]           icache_pkt_o
+   , input                                            icache_yumi_i
+
+   , output logic                                     shadow_priv_w_o
+   , output logic [rv64_priv_width_gp-1:0]            shadow_priv_o
+
+   , output logic                                     shadow_translation_en_w_o
+   , output logic                                     shadow_translation_en_o
+
+   , input                                            fetch_instr_v_i
+   , input                                            fetch_exception_v_i
+   , input [instr_width_gp-1:0]                       fetch_instr_i
+   );
+
+  `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
+  `declare_bp_fe_icache_pkt_s(vaddr_width_p);
+  `bp_cast_i(bp_fe_cmd_s, fe_cmd);
+  `bp_cast_o(bp_fe_icache_pkt_s, icache_pkt);
+
+  // FSM
+  enum logic [2:0] {e_reset, e_wait, e_run, e_fence, e_resume} state_n, state_r;
+
+  // Decoded state signals
+  wire is_reset    = (state_r == e_reset);
+  wire is_wait     = (state_r == e_wait);
+  wire is_run      = (state_r == e_run);
+  wire is_fence    = (state_r == e_fence);
+  wire is_resume   = (state_r == e_resume);
+
+  wire state_reset_v          = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_state_reset);
+  wire pc_redirect_v          = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_pc_redirection);
+  wire icache_fill_response_v = fe_cmd_v_i & (fe_cmd_cast_i.opcode inside {e_op_icache_fill_restart, e_op_icache_fill_resume});
+  wire wait_v                 = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_wait);
+
+  wire itlb_fill_response_v   = fe_cmd_v_i & (fe_cmd_cast_i.opcode inside {e_op_itlb_fill_restart, e_op_itlb_fill_resume});
+  wire icache_fence_v         = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_icache_fence);
+  wire itlb_fence_v           = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_itlb_fence);
+
+  wire br_miss_v     = pc_redirect_v & (fe_cmd_cast_i.operands.pc_redirect_operands.subopcode == e_subop_branch_mispredict);
+  wire eret_v        = pc_redirect_v & (fe_cmd_cast_i.operands.pc_redirect_operands.subopcode == e_subop_eret);
+  wire interrupt_v   = pc_redirect_v & (fe_cmd_cast_i.operands.pc_redirect_operands.subopcode == e_subop_interrupt);
+  wire trap_v        = pc_redirect_v & (fe_cmd_cast_i.operands.pc_redirect_operands.subopcode == e_subop_trap);
+  wire translation_v = pc_redirect_v & (fe_cmd_cast_i.operands.pc_redirect_operands.subopcode == e_subop_translation_switch);
+  // Unsupported
+  //wire context_v     = pc_redirect_v & (fe_cmd_cast_i.operands.pc_redirect_operands.subopcode == e_subop_context_swi
+
+  wire br_miss_taken = br_miss_v
+    & (fe_cmd_cast_i.operands.pc_redirect_operands.misprediction_reason == e_incorrect_pred_taken);
+  wire br_miss_ntaken = br_miss_v
+    & (fe_cmd_cast_i.operands.pc_redirect_operands.misprediction_reason == e_incorrect_pred_ntaken);
+  wire br_miss_nonbr = br_miss_v
+    & (fe_cmd_cast_i.operands.pc_redirect_operands.misprediction_reason == e_not_a_branch);
+
+  wire attaboy_v = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_attaboy);
+
+  wire cmd_nonattaboy_v = fe_cmd_v_i & (fe_cmd_cast_i.opcode != e_op_attaboy);
+  wire cmd_immediate_v  = fe_cmd_v_i & (pc_redirect_v | icache_fill_response_v);
+  wire cmd_complex_v    = fe_cmd_v_i & ~cmd_immediate_v & cmd_nonattaboy_v;
+
+  assign redirect_v_o               = ~attaboy_v & fe_cmd_yumi_o;
+  assign redirect_pc_o              = fe_cmd_cast_i.npc;
+  assign redirect_br_v_o            = br_miss_v;
+  assign redirect_br_taken_o        = br_miss_taken;
+  assign redirect_br_ntaken_o       = br_miss_ntaken;
+  assign redirect_br_nonbr_o        = br_miss_nonbr;
+  assign redirect_br_metadata_fwd_o = fe_cmd_cast_i.operands.pc_redirect_operands.branch_metadata_fwd;
+
+  assign attaboy_v_o               = attaboy_v;
+  assign attaboy_pc_o              = fe_cmd_cast_i.npc;
+  assign attaboy_taken_o           = attaboy_v &  fe_cmd_cast_i.operands.attaboy.taken;
+  assign attaboy_ntaken_o          = attaboy_v & ~fe_cmd_cast_i.operands.attaboy.taken;
+  assign attaboy_br_metadata_fwd_o = fe_cmd_cast_i.operands.attaboy.branch_metadata_fwd;
+
+  assign fe_cmd_yumi_o = (cmd_nonattaboy_v & if1_we_o) || attaboy_yumi_i;
+
+  assign shadow_priv_w_o = state_reset_v | trap_v | interrupt_v | eret_v;
+  assign shadow_priv_o = fe_cmd_cast_i.operands.pc_redirect_operands.priv;
+
+  assign shadow_translation_en_w_o = state_reset_v | trap_v | interrupt_v | eret_v | translation_v;
+  assign shadow_translation_en_o = fe_cmd_cast_i.operands.pc_redirect_operands.translation_en;
+
+  assign icache_pkt_cast_o =
+    '{vaddr: next_pc_i
+      ,op  : is_fence ? e_icache_fencei : e_icache_fetch
+      ,spec: !icache_fill_response_v && !is_fence
+      };
+  assign icache_force_o = cmd_nonattaboy_v;
+  assign poison_if1_o = fetch_exception_v_i;
+  assign poison_if2_o = fetch_exception_v_i
+    | ovr_i
+    | cmd_immediate_v
+    | (~is_resume & cmd_complex_v);
+
+
+  assign redirect_resume_v_o = (compressed_support_p & itlb_fill_response_v & (fe_cmd_cast_i.opcode == e_op_itlb_fill_resume))
+                                    | (compressed_support_p & icache_fill_response_v & (fe_cmd_cast_i.opcode == e_op_icache_fill_resume));
+  assign redirect_resume_instr_o = !compressed_support_p   ? '0
+                                    : itlb_fill_response_v             ? fe_cmd_cast_i.operands.itlb_fill_response.instr
+                                    : fe_cmd_cast_i.operands.icache_fill_response.instr;
+
+
+  always_comb
+    begin
+      state_n = state_r;
+      if1_we_o = 1'b0;
+      if2_we_o = icache_tv_we_i;
+      icache_v_o = 1'b0;
+      itlb_r_v_o = 1'b0;
+      itlb_w_v_o = 1'b0;
+      itlb_flush_v_o = 1'b0;
+
+      case (state_r)
+        e_reset:
+          begin
+            state_n = (state_reset_v && pc_gen_init_done_i) ? e_resume : e_reset;
+          end
+        e_wait, e_run:
+          begin
+            icache_v_o = (is_run & ~cmd_complex_v) || (is_wait && cmd_immediate_v);
+            if1_we_o = icache_yumi_i & ~cmd_complex_v;
+            itlb_r_v_o = icache_yumi_i;
+            itlb_w_v_o = itlb_fill_response_v;
+            itlb_flush_v_o = itlb_fence_v;
+            state_n = wait_v
+                      ? e_wait
+                      : icache_fence_v
+                        ? e_fence
+                        : cmd_complex_v
+                          ? e_resume
+                          : fetch_exception_v_i
+                            ? e_wait
+                            : if1_we_o
+                              ? e_run
+                              : state_r;
+          end
+        e_resume:
+          begin
+            icache_v_o = fe_cmd_v_i;
+            if1_we_o = icache_yumi_i;
+            itlb_r_v_o = icache_yumi_i;
+            state_n = if1_we_o ? e_run : e_resume;
+          end
+        e_fence:
+          begin
+            icache_v_o = fe_cmd_v_i;
+            state_n = icache_yumi_i ? e_resume : e_fence;
+          end
+        default: begin end
+      endcase
+    end
+
+  // synopsys sync_set_reset "reset_i"
+  always_ff @(posedge clk_i)
+    if (reset_i)
+        state_r <= e_reset;
+    else
+      begin
+        state_r <= state_n;
+      end
+
+endmodule
+

--- a/bp_fe/src/v/bp_fe_controller.sv
+++ b/bp_fe/src/v/bp_fe_controller.sv
@@ -110,7 +110,7 @@ module bp_fe_controller
   wire attaboy_v = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_attaboy);
 
   wire cmd_nonattaboy_v = fe_cmd_v_i & (fe_cmd_cast_i.opcode != e_op_attaboy);
-  wire cmd_immediate_v  = fe_cmd_v_i & (pc_redirect_v | icache_fill_response_v);
+  wire cmd_immediate_v  = fe_cmd_v_i & (pc_redirect_v | icache_fill_response_v | wait_v);
   wire cmd_complex_v    = fe_cmd_v_i & ~cmd_immediate_v & cmd_nonattaboy_v;
 
   assign redirect_v_o               = ~attaboy_v & fe_cmd_yumi_o;

--- a/bp_fe/src/v/bp_fe_controller.sv
+++ b/bp_fe/src/v/bp_fe_controller.sv
@@ -109,6 +109,7 @@ module bp_fe_controller
 
   wire attaboy_v = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_attaboy);
 
+  wire cmd_nonreset_v   = fe_cmd_v_i & (fe_cmd_cast_i.opcode != e_op_state_reset);
   wire cmd_nonattaboy_v = fe_cmd_v_i & (fe_cmd_cast_i.opcode != e_op_attaboy);
   wire cmd_immediate_v  = fe_cmd_v_i & (pc_redirect_v | icache_fill_response_v | wait_v);
   wire cmd_complex_v    = fe_cmd_v_i & ~cmd_immediate_v & cmd_nonattaboy_v;
@@ -127,7 +128,7 @@ module bp_fe_controller
   assign attaboy_ntaken_o          = attaboy_v & ~fe_cmd_cast_i.operands.attaboy.taken;
   assign attaboy_br_metadata_fwd_o = fe_cmd_cast_i.operands.attaboy.branch_metadata_fwd;
 
-  assign fe_cmd_yumi_o = (cmd_nonattaboy_v & if1_we_o) || attaboy_yumi_i;
+  assign fe_cmd_yumi_o = (cmd_nonattaboy_v & if1_we_o) || attaboy_yumi_i || (is_reset && cmd_nonreset_v);
 
   assign shadow_priv_w_o = state_reset_v | trap_v | interrupt_v | eret_v;
   assign shadow_priv_o = fe_cmd_cast_i.operands.pc_redirect_operands.priv;

--- a/bp_fe/src/v/bp_fe_controller.sv
+++ b/bp_fe/src/v/bp_fe_controller.sv
@@ -25,13 +25,13 @@ module bp_fe_controller
 
    , output logic                                     redirect_v_o
    , output logic [vaddr_width_p-1:0]                 redirect_pc_o
+   , output logic [instr_half_width_gp-1:0]           redirect_instr_o
+   , output logic                                     redirect_resume_v_o
    , output logic                                     redirect_br_v_o
    , output logic                                     redirect_br_taken_o
    , output logic                                     redirect_br_ntaken_o
    , output logic                                     redirect_br_nonbr_o
    , output logic [branch_metadata_fwd_width_p-1:0]   redirect_br_metadata_fwd_o
-   , output logic                                     redirect_resume_v_o
-   , output logic [instr_half_width_gp-1:0]           redirect_resume_instr_o
 
    , output logic [vaddr_width_p-1:0]                 attaboy_pc_o
    , output logic                                     attaboy_taken_o
@@ -148,7 +148,7 @@ module bp_fe_controller
     | (~is_resume & cmd_complex_v);
 
   assign redirect_resume_v_o = itlb_fill_resume_v | icache_fill_resume_v;
-  assign redirect_resume_instr_o = itlb_fill_response_v ? fe_cmd_cast_i.operands.itlb_fill_response.instr : fe_cmd_cast_i.operands.icache_fill_response.instr;
+  assign redirect_instr_o = itlb_fill_response_v ? fe_cmd_cast_i.operands.itlb_fill_response.instr : fe_cmd_cast_i.operands.icache_fill_response.instr;
 
   always_comb
     begin

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -292,7 +292,7 @@ module bp_fe_icache
    #(.width_p(2*assoc_p), .els_p(2))
    hit_mux
     (.data_i({{2{tag_mem_pseudo_hit}}, {way_v_tl, hit_v_tl}})
-     ,.sel_i(cache_req_critical_tag_i)
+     ,.sel_i(cache_req_critical_tag_i | cache_req_complete_i)
      ,.data_o({way_v_tv_n, hit_v_tv_n})
      );
 

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -292,7 +292,7 @@ module bp_fe_icache
    #(.width_p(2*assoc_p), .els_p(2))
    hit_mux
     (.data_i({{2{tag_mem_pseudo_hit}}, {way_v_tl, hit_v_tl}})
-     ,.sel_i(cache_req_critical_tag_i)
+     ,.sel_i(cache_req_critical_data_i)
      ,.data_o({way_v_tv_n, hit_v_tv_n})
      );
 
@@ -301,7 +301,7 @@ module bp_fe_icache
    hit_tv_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
-     ,.en_i(tv_we | cache_req_critical_tag_i)
+     ,.en_i(tv_we | cache_req_critical_data_i)
      ,.data_i({way_v_tv_n, hit_v_tv_n})
      ,.data_o({way_v_tv_r, hit_v_tv_r})
      );

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -56,7 +56,9 @@ module bp_fe_icache
    // New I$ packet comes in for a fetch, fence or fill request.
    , input [icache_pkt_width_lp-1:0]                  icache_pkt_i
    , input                                            v_i
-   , output                                           ready_o
+   , input                                            force_i
+   , output                                           yumi_o
+   , input                                            poison_tl_i
 
    // Cycle 1: "Tag Lookup"
    // TLB and PMA information comes in this cycle
@@ -65,13 +67,16 @@ module bp_fe_icache
    , input                                            ptag_uncached_i
    , input                                            ptag_nonidem_i
    , input                                            ptag_dram_i
-   , input                                            poison_tl_i
+   , input                                            poison_tv_i
+   , output logic                                     tv_we_o
 
    // Cycle 2: "Tag Verify"
    // Data (or miss result) comes out of the cache
    , output logic [instr_width_gp-1:0]                data_o
    , output logic                                     data_v_o
-   , output logic                                     miss_v_o
+   , output logic                                     fence_v_o
+   , output logic                                     spec_v_o
+   , input                                            yumi_i
 
    // Cache Engine Interface
    // This is considered the "slow path", handling uncached requests
@@ -124,17 +129,14 @@ module bp_fe_icache
   localparam fill_size_in_bank_lp   = fill_width_p / bank_width_lp;
 
   // State machine declaration
-  enum logic [1:0] {e_ready, e_miss} state_n, state_r;
+  enum logic [1:0] {e_ready, e_miss, e_recover} state_n, state_r;
   wire is_ready   = (state_r == e_ready);
   wire is_miss    = (state_r == e_miss);
+  wire is_recover = (state_r == e_recover);
 
   // Feedback signals between stages
-  logic tl_we, tv_we;
-  logic v_tl_r, v_tv_r;
-
-  // Uncached storage
-  logic [dword_width_gp-1:0] uncached_data_r;
-  logic uncached_pending_r;
+  logic safe_tl_we, tl_we, safe_tv_we, tv_we;
+  logic v_tl_n, v_tl_r, v_tv_n, v_tv_r;
 
   /////////////////////////////////////////////////////////////////////////////
   // Decode stage
@@ -142,14 +144,15 @@ module bp_fe_icache
   `declare_bp_fe_icache_pkt_s(vaddr_width_p);
   `bp_cast_i(bp_fe_icache_pkt_s, icache_pkt);
 
-  wire is_fetch  = (icache_pkt_cast_i.op inside {e_icache_fetch, e_icache_fill});
-  wire is_fencei = (icache_pkt_cast_i.op inside {e_icache_fencei});
-  wire is_fill   = (icache_pkt_cast_i.op inside {e_icache_fill});
+  wire fetch_op  = (icache_pkt_cast_i.op inside {e_icache_fetch});
+  wire fencei_op = (icache_pkt_cast_i.op inside {e_icache_fencei});
 
   wire [vaddr_width_p-1:0]   vaddr       = icache_pkt_cast_i.vaddr;
   wire [vtag_width_p-1:0]    vaddr_vtag  = vaddr[block_offset_width_lp+sindex_width_lp+:vtag_width_p];
   wire [sindex_width_lp-1:0] vaddr_index = vaddr[block_offset_width_lp+:sindex_width_lp];
   wire [bindex_width_lp-1:0] vaddr_bank  = vaddr[byte_offset_width_lp+:bindex_width_lp];
+
+  wire spec = icache_pkt_cast_i.spec;
 
   ///////////////////////////
   // Tag Mem Storage
@@ -201,22 +204,23 @@ module bp_fe_icache
     end
 
   /////////////////////////////////////////////////////////////////////////////
-  // TL stage
+  // TL Stage
   /////////////////////////////////////////////////////////////////////////////
   logic [vaddr_width_p-1:0] vaddr_tl_r;
-  logic fill_op_tl_r, fetch_op_tl_r, fencei_op_tl_r;
+  logic spec_tl_r, fetch_op_tl_r, fencei_op_tl_r;
 
   // Valid when we accept new data, clear when we advance to tv
-  assign tl_we = ready_o & v_i;
-  bsg_dff_reset_set_clear
+  assign safe_tl_we = yumi_o;
+  assign tl_we = safe_tl_we | poison_tl_i;
+  assign v_tl_n = tl_we & ~poison_tl_i;
+  bsg_dff_reset_en
    #(.width_p(1))
    v_tl_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
+     ,.en_i(tl_we)
 
-     ,.set_i(tl_we & ~cache_req_v_o)
-     // We always advance in the non-stalling I$
-     ,.clear_i(1'b1)
+     ,.data_i(v_tl_n)
      ,.data_o(v_tl_r)
      );
 
@@ -227,8 +231,8 @@ module bp_fe_icache
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
      ,.en_i(tl_we)
-     ,.data_i({vaddr, is_fill, is_fetch, is_fencei})
-     ,.data_o({vaddr_tl_r, fill_op_tl_r, fetch_op_tl_r, fencei_op_tl_r})
+     ,.data_i({vaddr, spec, fetch_op, fencei_op})
+     ,.data_o({vaddr_tl_r, spec_tl_r, fetch_op_tl_r, fencei_op_tl_r})
      );
 
   wire [paddr_width_p-1:0]         paddr_tl = {ptag_i, vaddr_tl_r[0+:page_offset_width_gp]};
@@ -241,11 +245,9 @@ module bp_fe_icache
     assign way_v_tl[i] = (tag_mem_data_lo[i].state != e_COH_I);
     assign hit_v_tl[i] = (tag_mem_data_lo[i].tag == ptag_i) && way_v_tl[i];
   end
-  wire cached_hit_tl     = |hit_v_tl;
   wire fetch_uncached_tl = (fetch_op_tl_r &  ptag_uncached_i);
   wire fetch_cached_tl   = (fetch_op_tl_r & ~ptag_uncached_i);
-  wire fill_tl           = (fill_op_tl_r | ~ptag_nonidem_i);
-  wire dram_tl           = (fill_op_tl_r | fetch_op_tl_r) & ptag_dram_i;
+  wire spec_tl           = (spec_tl_r & ptag_nonidem_i);
 
   logic [assoc_p-1:0] bank_sel_one_hot_tl;
   bsg_decode
@@ -256,51 +258,97 @@ module bp_fe_icache
      );
 
   /////////////////////////////////////////////////////////////////////////////
-  // TV stage
+  // TV Stage
   /////////////////////////////////////////////////////////////////////////////
+  localparam snoop_offset_width_lp = `BSG_SAFE_CLOG2(fill_width_p/word_width_gp);
   logic [paddr_width_p-1:0]              paddr_tv_r;
   logic [assoc_p-1:0]                    bank_sel_one_hot_tv_r;
   logic [assoc_p-1:0]                    way_v_tv_r, hit_v_tv_r;
-  logic                                  cached_hit_tv_r;
-  logic                                  fill_tv_r, dram_tv_r, fencei_op_tv_r, uncached_op_tv_r, cached_op_tv_r;
+  logic                                  fencei_op_tv_r, uncached_op_tv_r, cached_op_tv_r;
+  logic                                  fill_tv_r;
   logic [assoc_p-1:0][bank_width_lp-1:0] ld_data_tv_r;
 
   // fence.i does not check tags
-  assign tv_we = v_tl_r & (ptag_v_i | fencei_op_tl_r);
-  bsg_dff_reset_set_clear
+  assign safe_tv_we = v_tl_r & (is_ready & ~v_tv_r || yumi_i);
+  assign tv_we = safe_tv_we | poison_tv_i;
+  assign v_tv_n = v_tl_r & (ptag_v_i | fencei_op_tl_r) & ~poison_tv_i;
+  bsg_dff_reset_en
    #(.width_p(1))
    v_tv_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
-     ,.set_i(tv_we & ~poison_tl_i & ~cache_req_v_o)
-     // We always advance in the non-stalling I$
-     ,.clear_i(1'b1)
+     ,.en_i(tv_we)
+     ,.data_i(v_tv_n)
      ,.data_o(v_tv_r)
      );
+  assign tv_we_o = tv_we;
+
+  // Mask valid signal when we are recovering from a cache miss
+  wire v_tv = is_ready & v_tv_r;
+
+  logic [assoc_p-1:0] way_v_tv_n, hit_v_tv_n;
+  wire [assoc_p-1:0] tag_mem_pseudo_hit = 1'b1 << tag_mem_pkt_cast_i.way_id;
+  bsg_mux
+   #(.width_p(2*assoc_p), .els_p(2))
+   hit_mux
+    (.data_i({{2{tag_mem_pseudo_hit}}, {way_v_tl, hit_v_tl}})
+     ,.sel_i(cache_req_critical_tag_i)
+     ,.data_o({way_v_tv_n, hit_v_tv_n})
+     );
+
+  wire fill_tv_n = cache_req_critical_tag_i || cache_req_complete_i || spec_tl || (fencei_op_tl_r & coherent_p);
+  bsg_dff_reset_en
+   #(.width_p(1+2*assoc_p))
+   hit_tv_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.en_i(tv_we | cache_req_critical_tag_i | cache_req_complete_i)
+     ,.data_i({fill_tv_n, way_v_tv_n, hit_v_tv_n})
+     ,.data_o({fill_tv_r, way_v_tv_r, hit_v_tv_r})
+     );
+
+  // Snoop logic
+  logic [word_width_gp-1:0] snoop_word;
+  wire [snoop_offset_width_lp-1:0] snoop_word_offset = paddr_tv_r[2+:snoop_offset_width_lp];
+  bsg_mux
+   #(.width_p(word_width_gp), .els_p(fill_width_p/word_width_gp))
+   snoop_mux
+    (.data_i(data_mem_pkt_cast_i.data)
+     ,.sel_i(snoop_word_offset)
+     ,.data_o(snoop_word)
+     );
+  wire [block_width_p-1:0] snoop_data_lo = {block_width_p/word_width_gp{snoop_word}};
 
   logic [block_width_p-1:0] ld_data_tv_n;
-  assign ld_data_tv_n = data_mem_data_lo;
+  bsg_mux
+   #(.width_p(block_width_p), .els_p(2))
+   ld_data_mux
+    (.data_i({snoop_data_lo, data_mem_data_lo})
+     ,.sel_i(cache_req_critical_data_i)
+     ,.data_o(ld_data_tv_n)
+     );
+
   bsg_dff_en
    #(.width_p(block_width_p))
    ld_data_tv_reg
     (.clk_i(clk_i)
-     ,.en_i(tv_we)
+     ,.en_i(tv_we | cache_req_critical_data_i)
      ,.data_i(ld_data_tv_n)
      ,.data_o(ld_data_tv_r)
      );
 
   bsg_dff_en
-   #(.width_p(paddr_width_p+3*assoc_p+6))
+   #(.width_p(paddr_width_p+assoc_p+3))
    tv_stage_reg
     (.clk_i(clk_i)
      ,.en_i(tv_we)
      ,.data_i({paddr_tl
-               ,bank_sel_one_hot_tl, way_v_tl, hit_v_tl, cached_hit_tl
-               ,fill_tl, dram_tl, fencei_op_tl_r, fetch_uncached_tl, fetch_cached_tl
+               ,bank_sel_one_hot_tl
+               ,fencei_op_tl_r, fetch_uncached_tl, fetch_cached_tl
                })
      ,.data_o({paddr_tv_r
-               ,bank_sel_one_hot_tv_r, way_v_tv_r, hit_v_tv_r, cached_hit_tv_r
-               ,fill_tv_r, dram_tv_r, fencei_op_tv_r, uncached_op_tv_r, cached_op_tv_r
+               ,bank_sel_one_hot_tv_r
+               ,fencei_op_tv_r, uncached_op_tv_r, cached_op_tv_r
                })
      );
 
@@ -319,12 +367,13 @@ module bp_fe_icache
   wire [lg_assoc_lp-1:0] lru_way_li = invalid_exist_tv ? invalid_way_tv : lru_encode;
 
   logic [lg_assoc_lp-1:0] hit_index_tv;
+  logic hit_v_tv;
   bsg_encode_one_hot
    #(.width_p(assoc_p), .lo_to_hi_p(1))
    hit_index_encoder
     (.i(hit_v_tv_r)
      ,.addr_o(hit_index_tv)
-     ,.v_o()
+     ,.v_o(hit_v_tv)
      );
 
   // One-hot data muxing
@@ -355,11 +404,10 @@ module bp_fe_icache
      ,.data_o(final_data)
      );
 
-  assign data_o = uncached_op_tv_r ? uncached_data_r : final_data;
-  assign data_v_o = v_tv_r & ((uncached_op_tv_r & uncached_pending_r)
-                              | (cached_op_tv_r & cached_hit_tv_r)
-                              );
-  assign miss_v_o = v_tv_r & ~fill_tv_r & ~data_v_o;
+  assign data_o = final_data;
+  assign fence_v_o = v_tv &  fencei_op_tv_r & fill_tv_r;
+  assign data_v_o  = v_tv & ~fencei_op_tv_r &  hit_v_tv;
+  assign spec_v_o  = v_tv & ~fencei_op_tv_r & ~hit_v_tv & fill_tv_r;
 
   ///////////////////////////
   // Stat Mem Storage
@@ -402,18 +450,18 @@ module bp_fe_icache
   localparam bp_cache_req_size_e block_req_size = bp_cache_req_size_e'(`BSG_SAFE_CLOG2(block_width_p/8));
   localparam bp_cache_req_size_e uncached_req_size = e_size_4B;
 
-  wire cached_req   = v_tv_r & cached_op_tv_r & fill_tv_r & ~cached_hit_tv_r;
-  wire uncached_req = v_tv_r & uncached_op_tv_r & fill_tv_r & ~uncached_pending_r;
-  wire fencei_req   = v_tv_r & fencei_op_tv_r & !coherent_p;
+  wire cached_req   = cached_op_tv_r & ~fill_tv_r & ~hit_v_tv;
+  wire uncached_req = uncached_op_tv_r & ~fill_tv_r & ~hit_v_tv;
+  wire fencei_req   = fencei_op_tv_r & ~fill_tv_r;
 
-  assign cache_req_v_o = |{uncached_req, cached_req, fencei_req};
+  assign cache_req_v_o = v_tv & ~fill_tv_r & |{uncached_req, cached_req, fencei_req};
   assign cache_req_cast_o =
    '{addr     : paddr_tv_r
      ,size    : cached_req ? block_req_size : uncached_req_size
      ,msg_type: cached_req ? e_miss_load : uncached_req ? e_uc_load : e_cache_clear
      ,subop   : e_req_amoswap
      ,data    : '0
-     ,hit     : cached_hit_tv_r
+     ,hit     : hit_v_tv
      };
 
   // The cache pipeline is designed to always send metadata a cycle after the request
@@ -431,9 +479,9 @@ module bp_fe_icache
   logic [lg_assoc_lp-1:0] metadata_hit_index_r;
   bsg_dff
    #(.width_p(1+lg_assoc_lp))
-   cached_hit_reg
+   hit_reg
     (.clk_i(clk_i)
-     ,.data_i({cached_hit_tv_r, hit_index_tv})
+     ,.data_i({hit_v_tv, hit_index_tv})
      ,.data_o({metadata_hit_r, metadata_hit_index_r})
      );
 
@@ -445,12 +493,14 @@ module bp_fe_icache
   // State machine
   //   e_ready  : Cache is ready to accept requests
   //   e_miss   : Cache is waiting for a cache request to be serviced
+  //   e_recover: Reread the SRAMs to recover the updated TL state
   /////////////////////////////////////////////////////////////////////////////
   always_comb
     case (state_r)
       e_ready  : state_n = (cache_req_ready_and_i & cache_req_v_o) ? e_miss : e_ready;
-      e_miss   : state_n = cache_req_complete_i ? e_ready : e_miss;
-      default: state_n = e_ready;
+      e_miss   : state_n = cache_req_complete_i ? e_recover: e_miss;
+      // e_recover:
+      default  : state_n = e_ready;
     endcase
 
   //synopsys sync_set_reset "reset_i"
@@ -460,7 +510,9 @@ module bp_fe_icache
     else
       state_r <= state_n;
 
-  assign ready_o = is_ready & ~cache_req_busy_i;
+  // Accept requests when we're in ready state and there's no blocked request in TL
+  // Also accept request when 'forced'
+  assign yumi_o = v_i & (~v_tl_r | tv_we | force_i) & ~cache_req_busy_i;
 
   /////////////////////////////////////////////////////////////////////////////
   // SRAM Control
@@ -475,18 +527,21 @@ module bp_fe_icache
    tag_mem_last_read_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
-     ,.set_i(tl_we)
+     ,.set_i(tag_mem_v_li)
      ,.clear_i(tag_mem_w_li)
      ,.data_o(tag_mem_last_read_r)
      );
 
   // Tag mem is bypassed if the index is the same on consecutive reads
   wire tag_mem_bypass = (vaddr_index == vaddr_index_tl) & tag_mem_last_read_r;
-  wire tag_mem_fast_read = (tl_we & ~tag_mem_bypass);
-  assign tag_mem_v_li = tag_mem_fast_read | tag_mem_pkt_yumi_o;
-  assign tag_mem_w_li = tag_mem_pkt_yumi_o & (tag_mem_pkt_cast_i.opcode != e_cache_tag_mem_read);
+  wire tag_mem_fast_read = safe_tl_we & ~tag_mem_bypass || is_recover;
+  wire tag_mem_fast_write = 1'b0;
+  wire tag_mem_slow_read = tag_mem_pkt_yumi_o & (tag_mem_pkt_cast_i.opcode == e_cache_tag_mem_read) ;
+  wire tag_mem_slow_write = tag_mem_pkt_yumi_o & (tag_mem_pkt_cast_i.opcode != e_cache_tag_mem_read);
+  assign tag_mem_v_li = tag_mem_fast_read | tag_mem_fast_write | tag_mem_slow_read | tag_mem_slow_write;
+  assign tag_mem_w_li = tag_mem_fast_write | tag_mem_slow_write;
   assign tag_mem_addr_li = tag_mem_fast_read
-    ? vaddr_index
+    ? is_recover ? vaddr_index_tl : vaddr_index
     : tag_mem_pkt_cast_i.index;
   assign tag_mem_pkt_yumi_o = tag_mem_pkt_v_i & ~tag_mem_fast_read;
 
@@ -586,16 +641,16 @@ module bp_fe_icache
   logic [assoc_p-1:0] data_mem_fast_read, data_mem_fast_write, data_mem_slow_read, data_mem_slow_write;
   for (genvar i = 0; i < assoc_p; i++)
     begin : data_mem_lines
-      assign data_mem_slow_read[i] = data_mem_pkt_yumi_o & (data_mem_pkt_cast_i.opcode == e_cache_data_mem_read);
+      assign data_mem_slow_read[i] = data_mem_pkt_yumi_o & (data_mem_pkt_cast_i.opcode == e_cache_data_mem_read) || is_recover;
       assign data_mem_slow_write[i] = data_mem_pkt_yumi_o & (data_mem_pkt_cast_i.opcode == e_cache_data_mem_write) & data_mem_write_bank_mask[i];
 
-      assign data_mem_fast_read[i] = tl_we & is_fetch & (~data_mem_bypass | data_mem_bypass_select[i]);
+      assign data_mem_fast_read[i] = safe_tl_we & fetch_op & (~data_mem_bypass | data_mem_bypass_select[i]) || is_recover;
 
       assign data_mem_v_li[i] = data_mem_fast_read[i] | data_mem_slow_read[i] | data_mem_slow_write[i];
       assign data_mem_w_li[i] = data_mem_slow_write[i];
       wire [bindex_width_lp-1:0] data_mem_pkt_offset = (bindex_width_lp'(i) - data_mem_pkt_cast_i.way_id);
       assign data_mem_addr_li[i] = data_mem_fast_read[i]
-        ? {vaddr_index, {(assoc_p > 1){vaddr_bank}}}
+        ? is_recover ? {vaddr_index_tl, {(assoc_p>1){vaddr_bank_tl}}} : {vaddr_index, {(assoc_p > 1){vaddr_bank}}}
         : {data_mem_pkt_cast_i.index, {(assoc_p > 1){data_mem_pkt_offset}}};
       assign data_mem_data_li[i] = data_mem_pkt_data_li[i];
     end
@@ -624,8 +679,8 @@ module bp_fe_icache
   ///////////////////////////
   // Stat Mem Control
   ///////////////////////////
-  wire stat_mem_fast_read = (v_tv_r & ~data_v_o & cached_op_tv_r);
-  wire stat_mem_fast_write = (v_tv_r & data_v_o & cached_op_tv_r);
+  wire stat_mem_fast_read = (v_tv & cache_req_v_o & cached_op_tv_r);
+  wire stat_mem_fast_write = (v_tv & data_v_o & cached_op_tv_r);
   wire stat_mem_slow_write = stat_mem_pkt_v_i & (stat_mem_pkt_cast_i.opcode != e_cache_stat_mem_read);
   assign stat_mem_pkt_yumi_o = stat_mem_pkt_v_i & ~stat_mem_fast_write & ~stat_mem_fast_read;
   assign stat_mem_v_li = stat_mem_fast_read | stat_mem_fast_write | stat_mem_pkt_yumi_o;
@@ -648,38 +703,9 @@ module bp_fe_icache
 
   assign stat_mem_o = stat_mem_data_lo;
 
-  ///////////////////////////
-  // Uncached Load Storage
-  ///////////////////////////
-  wire uncached_pending_set = cache_req_ready_and_i & cache_req_v_o & uncached_req;
-  // Invalidate uncached data if the cache when we successfully complete the request
-  wire uncached_pending_clear = poison_tl_i | data_v_o;
-  bsg_dff_reset_set_clear
-   #(.width_p(1), .clear_over_set_p(1))
-   uncached_pending_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.set_i(uncached_pending_set)
-     ,.clear_i(uncached_pending_clear)
-     ,.data_o(uncached_pending_r)
-     );
-
-  wire uncached_data_set = data_mem_pkt_yumi_o & (data_mem_pkt_cast_i.opcode == e_cache_data_mem_uncached);
-  bsg_dff_en
-   #(.width_p(dword_width_gp))
-   uncached_data_reg
-    (.clk_i(clk_i)
-     ,.en_i(uncached_data_set)
-
-     ,.data_i(data_mem_pkt_cast_i.data[0+:dword_width_gp])
-     ,.data_o(uncached_data_r)
-     );
-
-  //synopsys translate_off
   if (`BSG_SAFE_CLOG2(block_width_p*sets_p/8) != page_offset_width_gp) begin
     $error("Total cache size must be equal to 4kB * associativity");
   end
-  //synopsys translate_on
 
 endmodule
+

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -298,10 +298,10 @@ module bp_fe_pc_gen
   wire taken_br_if2 = fetch_scan.branch & pred_if1_r;
   wire taken_jmp_if2 = fetch_scan.jal;
 
-  assign ovr_ret    = btb_miss_ras & taken_ret_if2;
-  assign ovr_btaken = btb_miss_br & taken_br_if2;
-  assign ovr_jmp    = btb_miss_br & taken_jmp_if2;
-  assign ovr_ntaken = taken_if1_r & fetch_linear_i;
+  assign ovr_ret    = ~fetch_linear_i & btb_miss_ras & taken_ret_if2;
+  assign ovr_btaken = ~fetch_linear_i & btb_miss_br & taken_br_if2;
+  assign ovr_jmp    = ~fetch_linear_i & btb_miss_br & taken_jmp_if2;
+  assign ovr_ntaken =  fetch_linear_i & taken_if1_r;
   assign ovr_o      = ovr_btaken | ovr_jmp | ovr_ret | ovr_ntaken;
 
   assign br_tgt_lo     = fetch_pc_i + `BSG_SIGN_EXTEND(fetch_scan.imm20, vaddr_width_p);

--- a/bp_fe/src/v/bp_fe_ras.sv
+++ b/bp_fe/src/v/bp_fe_ras.sv
@@ -18,8 +18,8 @@ module bp_fe_ras
 
    , input                            call_i
    , input                            return_i
-
    , input [vaddr_width_p-1:0]        addr_i
+
    , output logic [vaddr_width_p-1:0] tgt_o
    , output logic                     v_o
    );

--- a/bp_fe/src/v/bp_fe_realigner.sv
+++ b/bp_fe/src/v/bp_fe_realigner.sv
@@ -47,8 +47,8 @@ module bp_fe_realigner
 
   wire if2_pc_is_aligned  = `bp_addr_is_aligned(if2_pc_i, rv64_instr_width_bytes_gp);
 
-  wire fetch_store_v = if2_yumi_i &
-    ((!fetch_partial_o && !if2_pc_is_aligned) || ( fetch_partial_o && !if2_taken_branch_site_i));
+  wire fetch_store_v = if2_v_i &
+    ((!fetch_partial_o && !if2_pc_is_aligned) || (fetch_partial_o && !if2_taken_branch_site_i));
 
   assign fetch_instr_pc_n = (redirect_v_i & redirect_resume_i)
                             ? (redirect_vaddr_i - vaddr_width_p'(2))
@@ -65,7 +65,7 @@ module bp_fe_realigner
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.en_i  (fetch_store_v | (redirect_v_i & redirect_resume_i))
+     ,.en_i  ((if2_yumi_i & fetch_store_v) | (redirect_v_i & redirect_resume_i))
      ,.data_i({fetch_instr_pc_n, partial_n})
      ,.data_o({fetch_instr_pc_r, partial_r})
      );
@@ -76,16 +76,17 @@ module bp_fe_realigner
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.set_i  (~poison_li & fetch_store_v)
+     ,.set_i(~poison_li & (if2_yumi_i & fetch_store_v))
      ,.clear_i((redirect_v_i & ~redirect_resume_i) | fetch_instr_yumi_i) // set overrides clear
      ,.data_o (partial_v_r)
      );
 
   assign fetch_partial_o = partial_v_r;
 
-  assign fetch_instr_v_o  = (partial_v_r | if2_pc_is_aligned) & if2_v_i;
+  assign fetch_instr_v_o  = if2_v_i & (partial_v_r | if2_pc_is_aligned);
   assign fetch_instr_pc_o = partial_v_r ? fetch_instr_pc_r : if2_pc_i;
   assign fetch_instr_o    = partial_v_r ? { icache_data_lower_half_li, partial_r } : if2_data_i;
-  assign fetch_linear_o   = if2_v_i & fetch_store_v || (partial_v_r && !fetch_instr_v_o);
+  assign fetch_linear_o   = fetch_store_v;
 
 endmodule
+

--- a/bp_fe/src/v/bp_fe_realigner.sv
+++ b/bp_fe/src/v/bp_fe_realigner.sv
@@ -18,75 +18,92 @@ module bp_fe_realigner
 
    // Fetch PC and I$ data
    , input                       if2_v_i
-   , input                       if2_yumi_i
-   , input                       if2_taken_branch_site_i
    , input [vaddr_width_p-1:0]   if2_pc_i
    , input [instr_width_gp-1:0]  if2_data_i
+   , input                       if2_taken_branch_site_i
 
    // Redirection from backend
+   //   and whether to restore the instruction data
+   //   and PC to resume a fetch
    , input                           redirect_v_i
-   // Whether to restore the instruction data
-   , input                           redirect_resume_i
-   , input [instr_half_width_gp-1:0] redirect_partial_i
-   , input [vaddr_width_p-1:0]       redirect_vaddr_i
+   , input                           redirect_resume_v_i
+   , input [instr_half_width_gp-1:0] redirect_instr_i
+   , input [vaddr_width_p-1:0]       redirect_pc_i
 
-   , output [vaddr_width_p-1:0]  fetch_instr_pc_o
-   , output [instr_width_gp-1:0] fetch_instr_o
-   , output                      fetch_instr_v_o
-   , output                      fetch_partial_o
-   , output                      fetch_linear_o
-   , input                       fetch_instr_yumi_i
+   , output [vaddr_width_p-1:0]      fetch_pc_o
+   , output [instr_width_gp-1:0]     fetch_instr_o
+   , output                          fetch_instr_v_o
+   , output                          fetch_partial_o
+   , output                          fetch_linear_o
+   , input                           fetch_instr_yumi_i
    );
 
   wire [instr_half_width_gp-1:0] icache_data_lower_half_li = if2_data_i[0                  +:instr_half_width_gp];
   wire [instr_half_width_gp-1:0] icache_data_upper_half_li = if2_data_i[instr_half_width_gp+:instr_half_width_gp];
 
-  logic [vaddr_width_p-1:0] fetch_instr_pc_n, fetch_instr_pc_r;
-  logic [instr_half_width_gp-1:0] partial_n, partial_r;
+  logic [vaddr_width_p-1:0] partial_pc_n, partial_pc_r;
+  logic [instr_half_width_gp-1:0] partial_instr_n, partial_instr_r;
   logic partial_v_r;
 
   wire if2_pc_is_aligned  = `bp_addr_is_aligned(if2_pc_i, rv64_instr_width_bytes_gp);
-
-  wire fetch_store_v = if2_v_i &
-    ((!fetch_partial_o && !if2_pc_is_aligned) || (fetch_partial_o && !if2_taken_branch_site_i));
-
-  assign fetch_instr_pc_n = (redirect_v_i & redirect_resume_i)
-                            ? (redirect_vaddr_i - vaddr_width_p'(2))
-                            : (partial_v_r & if2_pc_is_aligned)
-                              ? (if2_pc_i + vaddr_width_p'(2))
-                              : if2_pc_i;
-  assign partial_n = redirect_resume_i ? redirect_partial_i : icache_data_upper_half_li;
-
-  wire poison_li = redirect_v_i & ~redirect_resume_i;
-
-  bsg_dff_reset_en
-   #(.width_p(vaddr_width_p+instr_half_width_gp))
-   partial_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.en_i  ((if2_yumi_i & fetch_store_v) | (redirect_v_i & redirect_resume_i))
-     ,.data_i({fetch_instr_pc_n, partial_n})
-     ,.data_o({fetch_instr_pc_r, partial_r})
+  wire if2_store_v = if2_v_i &
+    // Transition from aligned to misaligned
+    ((~partial_v_r & ~if2_pc_is_aligned)
+     // Continue misaligned to aligned/misaligned
+     || (partial_v_r & ~if2_taken_branch_site_i)
      );
 
-  bsg_dff_reset_set_clear
+  wire [vaddr_width_p-1:0] redirect_pc_adjusted = redirect_pc_i - 2'b10;
+  wire [vaddr_width_p-1:0] if2_pc_adjusted = (partial_v_r & if2_pc_is_aligned) ? (if2_pc_i + 2'b10) : if2_pc_i;
+  wire [instr_half_width_gp-1:0] if2_data_lower = if2_data_i[0+:instr_half_width_gp];
+  wire [instr_half_width_gp-1:0] if2_data_upper = if2_data_i[instr_half_width_gp+:instr_half_width_gp];
+  bsg_mux
+   #(.width_p(instr_half_width_gp+vaddr_width_p), .els_p(2))
+   partial_mux
+    (.data_i({{redirect_instr_i, redirect_pc_adjusted}, {if2_data_upper, if2_pc_adjusted}})
+     ,.sel_i(redirect_v_i)
+     ,.data_o({partial_instr_n, partial_pc_n})
+     );
+
+  wire partial_w_v = if2_store_v | redirect_v_i | fetch_instr_yumi_i;
+  wire partial_v_n = (if2_store_v & ~redirect_v_i) | (redirect_v_i & redirect_resume_v_i);
+  bsg_dff_reset_en
    #(.width_p(1))
    partial_v_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.set_i(~poison_li & (if2_yumi_i & fetch_store_v))
-     ,.clear_i((redirect_v_i & ~redirect_resume_i) | fetch_instr_yumi_i) // set overrides clear
-     ,.data_o (partial_v_r)
+     ,.en_i(partial_w_v)
+     ,.data_i(partial_v_n)
+     ,.data_o(partial_v_r)
      );
 
-  assign fetch_partial_o = partial_v_r;
+  bsg_dff_reset_en
+   #(.width_p(instr_half_width_gp+vaddr_width_p))
+   partial_instr_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
 
-  assign fetch_instr_v_o  = if2_v_i & (partial_v_r | if2_pc_is_aligned);
-  assign fetch_instr_pc_o = partial_v_r ? fetch_instr_pc_r : if2_pc_i;
-  assign fetch_instr_o    = partial_v_r ? { icache_data_lower_half_li, partial_r } : if2_data_i;
-  assign fetch_linear_o   = fetch_store_v;
+     ,.en_i(partial_w_v)
+     ,.data_i({partial_pc_n, partial_instr_n})
+     ,.data_o({partial_pc_r, partial_instr_r})
+     );
+
+  wire [instr_width_gp-1:0] instr_assembled = {if2_data_lower, partial_instr_r};
+  bsg_mux
+   #(.width_p(instr_width_gp+vaddr_width_p), .els_p(2))
+   fetch_mux
+    (.data_i({{instr_assembled, partial_pc_r}, {if2_data_i, if2_pc_i}})
+     ,.sel_i(partial_v_r)
+     ,.data_o({fetch_instr_o, fetch_pc_o})
+     );
+
+  // Either completing a partial instruction or fetching aligned instruction
+  assign fetch_instr_v_o = if2_v_i & (partial_v_r | if2_pc_is_aligned);
+  // Force a linear fetch if we're storing in the realigner (need to complete instruction)
+  //   or if we need to complete an instruction and are not currently completing an instruction
+  assign fetch_linear_o  = if2_store_v;
+  assign fetch_partial_o = partial_v_r;
 
 endmodule
 

--- a/bp_fe/src/v/bp_fe_realigner.sv
+++ b/bp_fe/src/v/bp_fe_realigner.sv
@@ -17,10 +17,11 @@ module bp_fe_realigner
    , input reset_i
 
    // Fetch PC and I$ data
-   , input                       fetch_v_i
-   , input                       fetch_store_v_i
-   , input [vaddr_width_p-1:0]   fetch_pc_i
-   , input [instr_width_gp-1:0]  fetch_data_i
+   , input                       if2_v_i
+   , input                       if2_yumi_i
+   , input                       if2_taken_branch_site_i
+   , input [vaddr_width_p-1:0]   if2_pc_i
+   , input [instr_width_gp-1:0]  if2_data_i
 
    // Redirection from backend
    , input                           redirect_v_i
@@ -32,52 +33,59 @@ module bp_fe_realigner
    , output [vaddr_width_p-1:0]  fetch_instr_pc_o
    , output [instr_width_gp-1:0] fetch_instr_o
    , output                      fetch_instr_v_o
-   , output                      fetch_is_second_half_o
+   , output                      fetch_partial_o
+   , output                      fetch_linear_o
    , input                       fetch_instr_yumi_i
    );
 
-  wire [instr_half_width_gp-1:0] icache_data_lower_half_li = fetch_data_i[0                  +:instr_half_width_gp];
-  wire [instr_half_width_gp-1:0] icache_data_upper_half_li = fetch_data_i[instr_half_width_gp+:instr_half_width_gp];
+  wire [instr_half_width_gp-1:0] icache_data_lower_half_li = if2_data_i[0                  +:instr_half_width_gp];
+  wire [instr_half_width_gp-1:0] icache_data_upper_half_li = if2_data_i[instr_half_width_gp+:instr_half_width_gp];
 
   logic [vaddr_width_p-1:0] fetch_instr_pc_n, fetch_instr_pc_r;
-  logic [instr_half_width_gp-1:0] half_buffer_n, half_buffer_r;
-  logic half_buffer_v_r;
+  logic [instr_half_width_gp-1:0] partial_n, partial_r;
+  logic partial_v_r;
 
-  wire fetch_pc_is_aligned  = `bp_addr_is_aligned(fetch_pc_i, rv64_instr_width_bytes_gp);
+  wire if2_pc_is_aligned  = `bp_addr_is_aligned(if2_pc_i, rv64_instr_width_bytes_gp);
 
-  assign fetch_instr_pc_n = redirect_resume_i                       ? (redirect_vaddr_i - vaddr_width_p'(2))
-                          : (half_buffer_v_r & fetch_pc_is_aligned) ? (fetch_pc_i       + vaddr_width_p'(2))
-                          :                                            fetch_pc_i;
-  assign half_buffer_n    = redirect_resume_i ? redirect_partial_i : icache_data_upper_half_li;
+  wire fetch_store_v = if2_yumi_i &
+    ((!fetch_partial_o && !if2_pc_is_aligned) || ( fetch_partial_o && !if2_taken_branch_site_i));
+
+  assign fetch_instr_pc_n = (redirect_v_i & redirect_resume_i)
+                            ? (redirect_vaddr_i - vaddr_width_p'(2))
+                            : (partial_v_r & if2_pc_is_aligned)
+                              ? (if2_pc_i + vaddr_width_p'(2))
+                              : if2_pc_i;
+  assign partial_n = redirect_resume_i ? redirect_partial_i : icache_data_upper_half_li;
 
   wire poison_li = redirect_v_i & ~redirect_resume_i;
 
   bsg_dff_reset_en
    #(.width_p(vaddr_width_p+instr_half_width_gp))
-   half_buffer_reg
+   partial_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.en_i  ((fetch_v_i & fetch_store_v_i) | redirect_resume_i)
-     ,.data_i({fetch_instr_pc_n, half_buffer_n})
-     ,.data_o({fetch_instr_pc_r, half_buffer_r})
+     ,.en_i  (fetch_store_v | (redirect_v_i & redirect_resume_i))
+     ,.data_i({fetch_instr_pc_n, partial_n})
+     ,.data_o({fetch_instr_pc_r, partial_r})
      );
 
   bsg_dff_reset_set_clear
    #(.width_p(1))
-   half_buffer_v_reg
+   partial_v_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.set_i  (~poison_li & (fetch_v_i & fetch_store_v_i) )
-     ,.clear_i(poison_li | fetch_instr_yumi_i) // set overrides clear
-     ,.data_o (half_buffer_v_r)
+     ,.set_i  (~poison_li & fetch_store_v)
+     ,.clear_i((redirect_v_i & ~redirect_resume_i) | fetch_instr_yumi_i) // set overrides clear
+     ,.data_o (partial_v_r)
      );
 
-  assign fetch_is_second_half_o = half_buffer_v_r;
+  assign fetch_partial_o = partial_v_r;
 
-  assign fetch_instr_v_o  = (half_buffer_v_r | fetch_pc_is_aligned) & fetch_v_i;
-  assign fetch_instr_pc_o = half_buffer_v_r ? fetch_instr_pc_r                             : fetch_pc_i;
-  assign fetch_instr_o    = half_buffer_v_r ? { icache_data_lower_half_li, half_buffer_r } : fetch_data_i;
+  assign fetch_instr_v_o  = (partial_v_r | if2_pc_is_aligned) & if2_v_i;
+  assign fetch_instr_pc_o = partial_v_r ? fetch_instr_pc_r : if2_pc_i;
+  assign fetch_instr_o    = partial_v_r ? { icache_data_lower_half_li, partial_r } : if2_data_i;
+  assign fetch_linear_o   = if2_v_i & fetch_store_v || (partial_v_r && !fetch_instr_v_o);
 
 endmodule

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -94,7 +94,7 @@ module bp_fe_top
   bp_fe_icache_pkt_s icache_pkt_li;
   logic [instr_width_gp-1:0] icache_data_lo;
   logic icache_v_li, icache_force_li, icache_yumi_lo;
-  logic icache_tv_we, icache_data_v_lo, icache_spec_v_lo, icache_fence_v_lo;
+  logic icache_tv_we, icache_data_v_lo, icache_spec_v_lo, icache_fence_v_lo, icache_yumi_li;
 
   logic redirect_v_li;
   logic [vaddr_width_p-1:0] redirect_pc_li;

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -60,24 +60,42 @@ module bp_fe_top
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
   `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_fe_branch_metadata_fwd_s(btb_tag_width_p, btb_idx_width_p, bht_idx_width_p, ghist_width_p, bht_row_width_p);
-  bp_fe_cmd_s fe_cmd_cast_i;
-  assign fe_cmd_cast_i = fe_cmd_i;
+  `bp_cast_o(bp_fe_queue_s, fe_queue);
+  `bp_cast_i(bp_cfg_bus_s, cfg_bus);
+  `bp_cast_i(bp_fe_cmd_s, fe_cmd);
 
-  bp_fe_queue_s fe_queue_cast_o;
-  assign fe_queue_o = fe_queue_cast_o;
+  logic [rv64_priv_width_gp-1:0] shadow_priv_n, shadow_priv_r;
+  logic shadow_priv_w;
+  bsg_dff_reset_en_bypass
+   #(.width_p(rv64_priv_width_gp))
+   shadow_priv_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.en_i(shadow_priv_w)
+     ,.data_i(shadow_priv_n)
+     ,.data_o(shadow_priv_r)
+     );
 
-  bp_cfg_bus_s cfg_bus_cast_i;
-  assign cfg_bus_cast_i = cfg_bus_i;
+  logic shadow_translation_en_n, shadow_translation_en_r;
+  logic shadow_translation_en_w;
+  bsg_dff_reset_en_bypass
+   #(.width_p(1))
+   shadow_translation_en_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.en_i(shadow_translation_en_w)
+     ,.data_i(shadow_translation_en_n)
+     ,.data_o(shadow_translation_en_r)
+     );
 
-  // FSM
-  enum logic [1:0] {e_wait=2'd0, e_run, e_stall} state_n, state_r;
 
-  // Decoded state signals
-  wire is_wait     = (state_r == e_wait);
-  wire is_run      = (state_r == e_run);
-  wire is_stall    = (state_r == e_stall);
+  // TEMP
+  `declare_bp_fe_icache_pkt_s(vaddr_width_p);
+  bp_fe_icache_pkt_s icache_pkt_li;
+  logic [instr_width_gp-1:0] icache_data_lo;
+  logic icache_v_li, icache_force_li, icache_yumi_lo;
+  logic icache_tv_we, icache_data_v_lo, icache_spec_v_lo, icache_fence_v_lo;
 
-  logic pc_gen_init_done_lo;
   logic redirect_v_li;
   logic [vaddr_width_p-1:0] redirect_pc_li;
   logic redirect_br_v_li, redirect_br_taken_li, redirect_br_ntaken_li, redirect_br_nonbr_li;
@@ -87,14 +105,15 @@ module bp_fe_top
   bp_fe_branch_metadata_fwd_s attaboy_br_metadata_fwd_li;
   logic attaboy_v_li, attaboy_yumi_lo, attaboy_taken_li, attaboy_ntaken_li;
   logic [vaddr_width_p-1:0] attaboy_pc_li;
-  logic [instr_width_gp-1:0] fetch_li, fetch_instr_lo;
-  logic [vaddr_width_p-1:0] fetch_pc_lo, fetch_resume_pc_lo;
-  logic fetch_v_li, fetch_exception_v_li, fetch_fail_v_li;
+  logic [instr_width_gp-1:0] fetch_instr_li, fetch_instr_lo;
+  logic [vaddr_width_p-1:0] fetch_pc_lo;
+  logic fetch_v_li, fetch_instr_v_li, fetch_exception_v_li;
   logic fetch_instr_v_lo, fetch_is_second_half_lo, fetch_instr_yumi_li;
   bp_fe_branch_metadata_fwd_s fetch_br_metadata_fwd_lo;
-  logic [vaddr_width_p-1:0] next_fetch_lo;
-  logic next_fetch_yumi_li;
-  logic ovr_lo;
+  logic [vaddr_width_p-1:0] next_pc_lo;
+  logic next_pc_v_li;
+  logic ovr_lo, if1_we, if2_we;
+  logic pc_gen_init_done_lo;
   bp_fe_pc_gen
    #(.bp_params_p(bp_params_p))
    pc_gen
@@ -113,20 +132,20 @@ module bp_fe_top
      ,.redirect_resume_v_i(redirect_restore_insn_lower_half_v_li)
      ,.redirect_resume_instr_i(redirect_restore_insn_lower_half_li)
 
-     ,.next_fetch_o(next_fetch_lo)
-     ,.next_fetch_yumi_i(next_fetch_yumi_li)
+     ,.next_pc_o(next_pc_lo)
+     ,.if1_we_i(if1_we)
 
      ,.ovr_o(ovr_lo)
+     ,.if2_we_i(if2_we)
 
-     ,.fetch_i(fetch_li)
-     ,.fetch_v_i(fetch_v_li)
+     ,.fetch_i(fetch_instr_li)
+     ,.fetch_v_i(icache_data_v_lo & icache_yumi_li)
      ,.fetch_instr_o(fetch_instr_lo)
      ,.fetch_instr_v_o(fetch_instr_v_lo)
-     ,.fetch_instr_yumi_i(fetch_instr_yumi_li)
+     ,.fetch_instr_yumi_i(fetch_instr_v_li)
      ,.fetch_br_metadata_fwd_o(fetch_br_metadata_fwd_lo)
      ,.fetch_pc_o(fetch_pc_lo)
      ,.fetch_is_second_half_o(fetch_is_second_half_lo)
-     ,.fetch_resume_pc_o(fetch_resume_pc_lo)
 
      ,.attaboy_pc_i(attaboy_pc_li)
      ,.attaboy_br_metadata_fwd_i(attaboy_br_metadata_fwd_li)
@@ -136,113 +155,24 @@ module bp_fe_top
      ,.attaboy_yumi_o(attaboy_yumi_lo)
      );
 
-  wire [instr_half_width_gp-1:0] realigner_instr_stored_half_lo = fetch_instr_lo[0+:instr_half_width_gp];
-
-  wire state_reset_v          = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_state_reset);
-  wire pc_redirect_v          = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_pc_redirection);
-  wire itlb_fill_v            = fe_cmd_v_i & (fe_cmd_cast_i.opcode inside {e_op_itlb_fill_restart, e_op_itlb_fill_resume});
-  wire icache_fence_v         = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_icache_fence);
-  wire icache_fill_response_v = fe_cmd_v_i & (fe_cmd_cast_i.opcode inside {e_op_icache_fill_restart, e_op_icache_fill_resume});
-  wire itlb_fence_v           = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_itlb_fence);
-  wire wait_v                 = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_wait);
-  wire attaboy_v              = fe_cmd_v_i & (fe_cmd_cast_i.opcode == e_op_attaboy);
-  wire cmd_nonattaboy_v       = fe_cmd_v_i & (fe_cmd_cast_i.opcode != e_op_attaboy);
-  wire cmd_complex_v          = (state_reset_v | itlb_fill_v | icache_fence_v | itlb_fence_v);
-  wire cmd_immediate_v        = (pc_redirect_v | icache_fill_response_v);
-
-  wire br_miss_v = pc_redirect_v
-    & (fe_cmd_cast_i.operands.pc_redirect_operands.subopcode == e_subop_branch_mispredict);
-  wire br_miss_taken = br_miss_v
-    & (fe_cmd_cast_i.operands.pc_redirect_operands.misprediction_reason == e_incorrect_pred_taken);
-  wire br_miss_ntaken = br_miss_v
-    & (fe_cmd_cast_i.operands.pc_redirect_operands.misprediction_reason == e_incorrect_pred_ntaken);
-  wire br_miss_nonbr = br_miss_v
-    & (fe_cmd_cast_i.operands.pc_redirect_operands.misprediction_reason == e_not_a_branch);
-
-  wire trap_v        = pc_redirect_v & (fe_cmd_cast_i.operands.pc_redirect_operands.subopcode == e_subop_trap);
-  wire eret_v        = pc_redirect_v & (fe_cmd_cast_i.operands.pc_redirect_operands.subopcode == e_subop_eret);
-  wire translation_v = pc_redirect_v & (fe_cmd_cast_i.operands.pc_redirect_operands.subopcode == e_subop_translation_switch);
-
-  logic [rv64_priv_width_gp-1:0] shadow_priv_n, shadow_priv_r;
-  wire shadow_priv_w = state_reset_v | trap_v | eret_v;
-  assign shadow_priv_n = fe_cmd_cast_i.operands.pc_redirect_operands.priv;
-  bsg_dff_reset_en_bypass
-   #(.width_p(rv64_priv_width_gp))
-   shadow_priv_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-     ,.en_i(shadow_priv_w)
-
-     ,.data_i(shadow_priv_n)
-     ,.data_o(shadow_priv_r)
-     );
-
-  logic shadow_translation_en_n, shadow_translation_en_r;
-  wire shadow_translation_en_w = state_reset_v | trap_v | eret_v | translation_v;
-  assign shadow_translation_en_n = fe_cmd_cast_i.operands.pc_redirect_operands.translation_en;
-  bsg_dff_reset_en_bypass
-   #(.width_p(1))
-   shadow_translation_en_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-     ,.en_i(shadow_translation_en_w)
-
-     ,.data_i(shadow_translation_en_n)
-     ,.data_o(shadow_translation_en_r)
-     );
-
-  // Change the resume pc on redirect command, else save the PC in IF2 while running
-  logic [vaddr_width_p-1:0] pc_resume_n, pc_resume_r;
-  bp_fe_branch_metadata_fwd_s br_metadata_fwd_resume_n, br_metadata_fwd_resume_r;
-  logic br_miss_r, br_miss_nonbr_r, br_miss_taken_r, br_miss_ntaken_r;
-  logic [instr_half_width_gp-1:0] insn_lower_half_resume_n, insn_lower_half_resume_r;
-  logic insn_lower_half_v_resume_n, insn_lower_half_v_resume_r;
-  assign pc_resume_n = cmd_nonattaboy_v ? fe_cmd_cast_i.npc : fetch_resume_pc_lo;
-  assign br_metadata_fwd_resume_n = cmd_nonattaboy_v ? fe_cmd_cast_i.operands.pc_redirect_operands.branch_metadata_fwd : fetch_br_metadata_fwd_lo;
-  assign insn_lower_half_v_resume_n = (compressed_support_p & itlb_fill_v            & (fe_cmd_cast_i.opcode == e_op_itlb_fill_resume))
-                                    | (compressed_support_p & icache_fill_response_v & (fe_cmd_cast_i.opcode == e_op_icache_fill_resume))
-                                    | (compressed_support_p & ~cmd_nonattaboy_v      & fetch_is_second_half_lo);
-  assign insn_lower_half_resume_n   = !compressed_support_p   ? '0
-                                    : itlb_fill_v             ? fe_cmd_cast_i.operands.itlb_fill_response.instr
-                                    : icache_fill_response_v  ? fe_cmd_cast_i.operands.icache_fill_response.instr
-                                    : realigner_instr_stored_half_lo;
-
-  bsg_dff_reset_en_bypass
-   #(.width_p(4+$bits(bp_fe_branch_metadata_fwd_s)+vaddr_width_p+1+instr_half_width_gp))
-   pc_resume_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-     ,.en_i(cmd_nonattaboy_v | is_run)
-
-     ,.data_i({br_miss_v, br_miss_nonbr, br_miss_taken, br_miss_ntaken, br_metadata_fwd_resume_n, pc_resume_n, insn_lower_half_v_resume_n, insn_lower_half_resume_n})
-     ,.data_o({br_miss_r, br_miss_nonbr_r, br_miss_taken_r, br_miss_ntaken_r, br_metadata_fwd_resume_r, pc_resume_r, insn_lower_half_v_resume_r, insn_lower_half_resume_r})
-     );
-  assign redirect_v_li               = (is_stall & next_fetch_yumi_li) | cmd_immediate_v;
-  assign redirect_pc_li              = pc_resume_r;
-  assign redirect_br_v_li            = redirect_v_li & br_miss_r;
-  assign redirect_br_metadata_fwd_li = br_metadata_fwd_resume_r;
-  assign redirect_br_taken_li        = br_miss_taken_r;
-  assign redirect_br_ntaken_li       = br_miss_ntaken_r;
-  assign redirect_br_nonbr_li        = br_miss_nonbr_r;
-  assign redirect_restore_insn_lower_half_v_li = redirect_v_li & insn_lower_half_v_resume_r;
-  assign redirect_restore_insn_lower_half_li   =                 insn_lower_half_resume_r;
-
-  assign attaboy_br_metadata_fwd_li = fe_cmd_cast_i.operands.attaboy.branch_metadata_fwd;
-  assign attaboy_taken_li           = attaboy_v &  fe_cmd_cast_i.operands.attaboy.taken;
-  assign attaboy_ntaken_li          = attaboy_v & ~fe_cmd_cast_i.operands.attaboy.taken;
-  assign attaboy_v_li               = attaboy_v;
-  assign attaboy_pc_li              = fe_cmd_cast_i.npc;
+  // TODO: Fix
+  //   ,.redirect_resume_v_i(redirect_restore_insn_lower_half_v_li)
+  // ,.redirect_resume_instr_i(redirect_restore_insn_lower_half_li)
 
   logic instr_access_fault_v, instr_page_fault_v;
   logic ptag_v_li, ptag_uncached_li, ptag_nonidem_li, ptag_dram_li, ptag_miss_li;
   logic [ptag_width_p-1:0] ptag_li;
+  logic poison_if1_lo, poison_if2_lo;
 
   bp_pte_leaf_s w_tlb_entry_li;
   wire [vtag_width_p-1:0] w_vtag_li = fe_cmd_cast_i.npc[vaddr_width_p-1-:vtag_width_p];
   assign w_tlb_entry_li = fe_cmd_cast_i.operands.itlb_fill_response.pte_leaf;
 
-  wire [dword_width_gp-1:0] r_eaddr_li = `BSG_SIGN_EXTEND(next_fetch_lo, dword_width_gp);
+  wire [dword_width_gp-1:0] r_eaddr_li = `BSG_SIGN_EXTEND(next_pc_lo, dword_width_gp);
   wire [1:0] r_size_li = 2'b10;
+  logic itlb_r_v_li, itlb_w_v_li, itlb_flush_v_li;
+  wire uncached_mode = (cfg_bus_cast_i.icache_mode == e_lce_mode_uncached);
+  wire nonspec_mode = (cfg_bus_cast_i.icache_mode == e_lce_mode_nonspec);
   bp_mmu
    #(.bp_params_p(bp_params_p)
      ,.tlb_els_4k_p(itlb_els_4k_p)
@@ -252,22 +182,22 @@ module bp_fe_top
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.flush_i(itlb_fence_v)
+     ,.flush_i(itlb_flush_v_li)
      ,.priv_mode_i(shadow_priv_r)
      ,.trans_en_i(shadow_translation_en_r)
      // Supervisor use of user memory is always disabled for immu
      ,.sum_i('0)
      // Immu does not handle dcache loads
      ,.mxr_i('0)
-     ,.uncached_mode_i((cfg_bus_cast_i.icache_mode == e_lce_mode_uncached))
-     ,.nonspec_mode_i((cfg_bus_cast_i.icache_mode == e_lce_mode_nonspec))
+     ,.uncached_mode_i(uncached_mode)
+     ,.nonspec_mode_i(nonspec_mode)
      ,.hio_mask_i(cfg_bus_cast_i.hio_mask)
 
-     ,.w_v_i(itlb_fill_v)
+     ,.w_v_i(itlb_w_v_li)
      ,.w_vtag_i(w_vtag_li)
      ,.w_entry_i(w_tlb_entry_li)
 
-     ,.r_v_i(next_fetch_yumi_li)
+     ,.r_v_i(itlb_r_v_li)
      ,.r_instr_i(1'b1)
      ,.r_load_i('0)
      ,.r_store_i('0)
@@ -293,16 +223,6 @@ module bp_fe_top
      ,.r_store_page_fault_o()
      );
 
-  `declare_bp_fe_icache_pkt_s(vaddr_width_p);
-  bp_fe_icache_pkt_s icache_pkt;
-  assign icache_pkt = '{vaddr: next_fetch_lo
-                        ,op  : icache_fence_v ? e_icache_fencei : icache_fill_response_v ? e_icache_fill : e_icache_fetch
-                        };
-  // TODO: Should only ack icache fence when icache_ready
-  wire icache_v_li = next_fetch_yumi_li | icache_fence_v;
-  logic [instr_width_gp-1:0] icache_data_lo;
-  logic icache_ready_lo, icache_data_v_lo, icache_miss_v_lo;
-  logic icache_poison_tl;
   bp_fe_icache
    #(.bp_params_p(bp_params_p))
    icache
@@ -311,20 +231,25 @@ module bp_fe_top
 
      ,.cfg_bus_i(cfg_bus_i)
 
-     ,.icache_pkt_i(icache_pkt)
+     ,.icache_pkt_i(icache_pkt_li)
      ,.v_i(icache_v_li)
-     ,.ready_o(icache_ready_lo)
+     ,.force_i(icache_force_li)
+     ,.yumi_o(icache_yumi_lo)
+     ,.poison_tl_i(poison_if1_lo)
 
      ,.ptag_i(ptag_li)
      ,.ptag_v_i(ptag_v_li)
      ,.ptag_uncached_i(ptag_uncached_li)
      ,.ptag_nonidem_i(ptag_nonidem_li)
      ,.ptag_dram_i(ptag_dram_li)
-     ,.poison_tl_i(icache_poison_tl)
+     ,.poison_tv_i(poison_if2_lo)
+     ,.tv_we_o(icache_tv_we)
 
      ,.data_o(icache_data_lo)
      ,.data_v_o(icache_data_v_lo)
-     ,.miss_v_o(icache_miss_v_lo)
+     ,.spec_v_o(icache_spec_v_lo)
+     ,.fence_v_o(icache_fence_v_lo)
+     ,.yumi_i(icache_yumi_li)
 
      ,.cache_req_o(cache_req_o)
      ,.cache_req_v_o(cache_req_v_o)
@@ -353,114 +278,103 @@ module bp_fe_top
      ,.stat_mem_pkt_yumi_o(stat_mem_pkt_yumi_o)
      ,.stat_mem_o(stat_mem_o)
      );
+  assign icache_yumi_li = fe_queue_ready_i & (icache_data_v_lo | icache_spec_v_lo) | icache_fence_v_lo;
 
+  // This tracks the I$ valid. Could move inside entirely, but we're trying to separate
+  //   those responsibilities
   logic itlb_miss_r, instr_access_fault_r, instr_page_fault_r;
-  bsg_dff_reset
-   #(.width_p(3))
+  bsg_dff_reset_set_clear
+   #(.width_p(3), .clear_over_set_p(1))
    fault_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
-
-     ,.data_i({ptag_miss_li, instr_access_fault_v, instr_page_fault_v})
+     ,.set_i({3{if2_we}} & {ptag_miss_li, instr_access_fault_v, instr_page_fault_v})
+     ,.clear_i({3{poison_if2_lo}})
      ,.data_o({itlb_miss_r, instr_access_fault_r, instr_page_fault_r})
      );
 
-  logic v_if1_r, v_if2_r;
-  wire v_if1_n = next_fetch_yumi_li;
-  wire v_if2_n = v_if1_r & ~icache_poison_tl & ~fetch_fail_v_li;
-  bsg_dff_reset
-   #(.width_p(2))
-   v_reg
+  wire fe_exception_v = (instr_access_fault_r | instr_page_fault_r | itlb_miss_r | icache_spec_v_lo);
+  wire fe_instr_v     = fetch_instr_v_lo;
+  assign fe_queue_v_o = (fe_instr_v | fe_exception_v);
+
+  assign fetch_instr_v_li     = fe_queue_ready_i & fe_queue_v_o & fe_instr_v;
+  assign fetch_exception_v_li = fe_queue_ready_i & fe_queue_v_o & fe_exception_v;
+  assign fetch_instr_li       = icache_data_lo;
+
+  bp_fe_controller
+   #(.bp_params_p(bp_params_p))
+   controller
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.data_i({v_if2_n, v_if1_n})
-     ,.data_o({v_if2_r, v_if1_r})
+     ,.fe_cmd_i(fe_cmd_cast_i)
+     ,.fe_cmd_v_i(fe_cmd_v_i)
+     ,.fe_cmd_yumi_o(fe_cmd_yumi_o)
+
+     ,.redirect_v_o(redirect_v_li)
+     ,.redirect_pc_o(redirect_pc_li)
+     ,.redirect_br_v_o(redirect_br_v_li)
+     ,.redirect_br_taken_o(redirect_br_taken_li)
+     ,.redirect_br_ntaken_o(redirect_br_ntaken_li)
+     ,.redirect_br_nonbr_o(redirect_br_nonbr_li)
+     ,.redirect_br_metadata_fwd_o(redirect_br_metadata_fwd_li)
+     ,.redirect_resume_v_o(redirect_restore_insn_lower_half_v_li)
+     ,.redirect_resume_instr_o(redirect_restore_insn_lower_half_li)
+
+     ,.attaboy_pc_o(attaboy_pc_li)
+     ,.attaboy_taken_o(attaboy_taken_li)
+     ,.attaboy_ntaken_o(attaboy_ntaken_li)
+     ,.attaboy_br_metadata_fwd_o(attaboy_br_metadata_fwd_li)
+     ,.attaboy_v_o(attaboy_v_li)
+     ,.attaboy_yumi_i(attaboy_yumi_lo)
+
+     ,.pc_gen_init_done_i(pc_gen_init_done_lo)
+     ,.next_pc_i(next_pc_lo)
+     ,.ovr_i(ovr_lo)
+     ,.icache_tv_we_i(icache_tv_we)
+     ,.if1_we_o(if1_we)
+     ,.if2_we_o(if2_we)
+     ,.poison_if1_o(poison_if1_lo)
+     ,.poison_if2_o(poison_if2_lo)
+
+     ,.itlb_r_v_o(itlb_r_v_li)
+     ,.itlb_w_v_o(itlb_w_v_li)
+     ,.itlb_flush_v_o(itlb_flush_v_li)
+     ,.icache_v_o(icache_v_li)
+     ,.icache_force_o(icache_force_li)
+     ,.icache_pkt_o(icache_pkt_li)
+     ,.icache_yumi_i(icache_yumi_lo)
+
+     ,.shadow_priv_w_o(shadow_priv_w)
+     ,.shadow_priv_o(shadow_priv_n)
+
+     ,.shadow_translation_en_w_o(shadow_translation_en_w)
+     ,.shadow_translation_en_o(shadow_translation_en_n)
+
+     ,.fetch_instr_v_i(fetch_instr_v_li)
+     ,.fetch_exception_v_i(fetch_exception_v_li)
+     ,.fetch_instr_i(fetch_instr_lo)
      );
 
-  wire icache_miss    = v_if2_r & icache_miss_v_lo;
-  wire queue_miss     = v_if2_r & ~fe_queue_ready_i;
-  wire fe_exception_v = v_if2_r & (instr_access_fault_r | instr_page_fault_r | itlb_miss_r | icache_miss_v_lo);
-  wire fe_instr_v     = v_if2_r & fetch_instr_v_lo;
-  wire fe_queue_exception_v = (fe_queue_ready_i & ~cmd_nonattaboy_v) & fe_exception_v;
-  wire fe_queue_instr_v     = (fe_queue_ready_i & ~cmd_nonattaboy_v) & fe_instr_v     & ~fe_queue_exception_v;
-  wire fe_instr_progress    = (fe_queue_ready_i & ~cmd_nonattaboy_v) & icache_data_v_lo;
-
-  assign fe_queue_v_o = fe_queue_exception_v | fe_queue_instr_v;
-  wire fe_progress    = fe_queue_exception_v | fe_instr_progress;
-
-  assign fetch_instr_yumi_li  = fe_queue_instr_v;
-
-  assign icache_poison_tl = ovr_lo | fe_exception_v | queue_miss | cmd_nonattaboy_v;
-
-  assign fe_cmd_yumi_o = pc_gen_init_done_lo & (cmd_nonattaboy_v | attaboy_yumi_lo);
-  assign next_fetch_yumi_li = (state_n == e_run);
-
-  assign fetch_exception_v_li = fe_queue_v_o & fe_exception_v;
-  assign fetch_fail_v_li      = v_if2_r & ~fe_progress;
-  assign fetch_li             = icache_data_lo;
-  assign fetch_v_li           = v_if2_r & icache_data_v_lo;
-
-  wire stall   = fetch_fail_v_li | cmd_nonattaboy_v;
-  wire unstall = icache_ready_lo & fe_queue_ready_i & ~cmd_nonattaboy_v;
   always_comb
-    if (fe_exception_v)
-      begin
-        fe_queue_cast_o = '0;
-        fe_queue_cast_o.pc        = fetch_pc_lo;
-        fe_queue_cast_o.msg_type  = itlb_miss_r
-                                    ? e_itlb_miss
-                                      : instr_page_fault_r
-                                        ? e_instr_page_fault
-                                        : instr_access_fault_r
-                                          ? e_instr_access_fault
-                                            : e_icache_miss;
-        fe_queue_cast_o.branch_metadata_fwd = fetch_br_metadata_fwd_lo;
-        // For now, we leave the upper half of the instr forward field zeroed. Once "C" support is
-        // finished this would contain the full realigner buffer.
-        fe_queue_cast_o.instr     = compressed_support_p ? { (instr_half_width_gp)'(0), realigner_instr_stored_half_lo } : '0;
-        fe_queue_cast_o.partial_v = compressed_support_p & fetch_is_second_half_lo;
-      end
-    else
-      begin
-        fe_queue_cast_o = '0;
-        fe_queue_cast_o.msg_type            = e_instr_fetch;
-        fe_queue_cast_o.pc                  = fetch_pc_lo;
-        fe_queue_cast_o.instr               = fetch_instr_lo;
-        fe_queue_cast_o.branch_metadata_fwd = fetch_br_metadata_fwd_lo;
-        // TODO: 16-bit instruction support
-        fe_queue_cast_o.partial_v = 1'b0;
-      end
-
-  // Controlling state machine
-  always_comb
-    case (state_r)
-      // Wait for FE cmd
-      e_wait : state_n = cmd_immediate_v ? e_run : cmd_nonattaboy_v ? e_stall : e_wait;
-      // Stall until we can start valid fetch
-      e_stall: state_n = unstall ? e_run : e_stall;
-      // Run state -- PCs are actually being fetched
-      // Stay in run if there's an incoming cmd, the next pc will automatically be valid
-      // Transition to wait if there's a TLB miss while we wait for fill
-      // Transition to stall if we don't successfully complete the fetch for whatever reason
-      e_run  : state_n = cmd_immediate_v
-                         ? e_run
-                         : (stall || cmd_complex_v)
-                           ? e_stall
-                           : fetch_exception_v_li
-                             ? e_wait
-                             : e_run;
-      default: state_n = e_wait;
-    endcase
-
-  // synopsys sync_set_reset "reset_i"
-  always_ff @(posedge clk_i)
-    if (reset_i)
-        state_r <= e_wait;
-    else
-      begin
-        state_r <= state_n;
-      end
+    begin
+      fe_queue_cast_o = '0;
+      fe_queue_cast_o.pc = fetch_pc_lo;
+      fe_queue_cast_o.msg_type = fe_instr_v
+                                 ? e_instr_fetch
+                                 : itlb_miss_r
+                                   ? e_itlb_miss
+                                     : instr_page_fault_r
+                                       ? e_instr_page_fault
+                                       : instr_access_fault_r
+                                         ? e_instr_access_fault
+                                         : icache_spec_v_lo
+                                           ? e_icache_miss
+                                           : e_instr_fetch;
+      fe_queue_cast_o.instr = fetch_instr_lo;
+      fe_queue_cast_o.branch_metadata_fwd = fetch_br_metadata_fwd_lo;
+      fe_queue_cast_o.partial_v = compressed_support_p & fetch_is_second_half_lo & fe_exception_v;
+    end
 
 endmodule
 

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -88,32 +88,23 @@ module bp_fe_top
      ,.data_o(shadow_translation_en_r)
      );
 
-
-  // TEMP
-  `declare_bp_fe_icache_pkt_s(vaddr_width_p);
-  bp_fe_icache_pkt_s icache_pkt_li;
-  logic [instr_width_gp-1:0] icache_data_lo;
-  logic icache_v_li, icache_force_li, icache_yumi_lo;
-  logic icache_tv_we, icache_data_v_lo, icache_spec_v_lo, icache_fence_v_lo, icache_yumi_li;
-
-  logic redirect_v_li;
+  logic redirect_v_li, redirect_resume_v_li;
   logic [vaddr_width_p-1:0] redirect_pc_li;
   logic redirect_br_v_li, redirect_br_taken_li, redirect_br_ntaken_li, redirect_br_nonbr_li;
-  logic redirect_restore_insn_lower_half_v_li;
-  logic [instr_half_width_gp-1:0] redirect_restore_insn_lower_half_li;
-  bp_fe_branch_metadata_fwd_s redirect_br_metadata_fwd_li;
-  bp_fe_branch_metadata_fwd_s attaboy_br_metadata_fwd_li;
+  logic [instr_half_width_gp-1:0] redirect_resume_instr_li;
+  bp_fe_branch_metadata_fwd_s redirect_br_metadata_fwd_li, attaboy_br_metadata_fwd_li;
   logic attaboy_v_li, attaboy_yumi_lo, attaboy_taken_li, attaboy_ntaken_li;
   logic [vaddr_width_p-1:0] attaboy_pc_li;
   logic [instr_width_gp-1:0] fetch_instr_li, fetch_instr_lo;
   logic [vaddr_width_p-1:0] fetch_pc_lo;
-  logic fetch_v_li, fetch_instr_v_li, fetch_exception_v_li;
-  logic fetch_instr_v_lo, fetch_is_second_half_lo, fetch_instr_yumi_li;
-  bp_fe_branch_metadata_fwd_s fetch_br_metadata_fwd_lo;
+  bp_fe_instr_scan_s fetch_scan;
+  logic fetch_v_li, fetch_instr_yumi_li, fetch_exception_yumi_li;
+  logic fetch_instr_v_lo, fetch_partial_lo, fetch_linear_lo;
+  bp_fe_branch_metadata_fwd_s if2_br_metadata_fwd_lo;
   logic [vaddr_width_p-1:0] next_pc_lo;
-  logic next_pc_v_li;
   logic ovr_lo, if1_we, if2_we;
-  logic pc_gen_init_done_lo;
+  logic [vaddr_width_p-1:0] if2_pc;
+  logic pc_gen_init_done_lo, if2_taken_branch_site_lo;
   bp_fe_pc_gen
    #(.bp_params_p(bp_params_p))
    pc_gen
@@ -129,8 +120,6 @@ module bp_fe_top
      ,.redirect_br_taken_i(redirect_br_taken_li)
      ,.redirect_br_ntaken_i(redirect_br_ntaken_li)
      ,.redirect_br_nonbr_i(redirect_br_nonbr_li)
-     ,.redirect_resume_v_i(redirect_restore_insn_lower_half_v_li)
-     ,.redirect_resume_instr_i(redirect_restore_insn_lower_half_li)
 
      ,.next_pc_o(next_pc_lo)
      ,.if1_we_i(if1_we)
@@ -138,14 +127,14 @@ module bp_fe_top
      ,.ovr_o(ovr_lo)
      ,.if2_we_i(if2_we)
 
-     ,.fetch_i(fetch_instr_li)
-     ,.fetch_v_i(icache_data_v_lo & icache_yumi_li)
-     ,.fetch_instr_o(fetch_instr_lo)
-     ,.fetch_instr_v_o(fetch_instr_v_lo)
-     ,.fetch_instr_yumi_i(fetch_instr_v_li)
-     ,.fetch_br_metadata_fwd_o(fetch_br_metadata_fwd_lo)
-     ,.fetch_pc_o(fetch_pc_lo)
-     ,.fetch_is_second_half_o(fetch_is_second_half_lo)
+     ,.if2_pc_o(if2_pc)
+     ,.if2_br_metadata_fwd_o(if2_br_metadata_fwd_lo)
+     ,.if2_taken_branch_site_o(if2_taken_branch_site_lo)
+
+     ,.fetch_pc_i(fetch_pc_lo)
+     ,.fetch_scan_i(fetch_scan)
+     ,.fetch_partial_i(fetch_partial_lo)
+     ,.fetch_linear_i(fetch_linear_lo)
 
      ,.attaboy_pc_i(attaboy_pc_li)
      ,.attaboy_br_metadata_fwd_i(attaboy_br_metadata_fwd_li)
@@ -155,22 +144,18 @@ module bp_fe_top
      ,.attaboy_yumi_o(attaboy_yumi_lo)
      );
 
-  // TODO: Fix
-  //   ,.redirect_resume_v_i(redirect_restore_insn_lower_half_v_li)
-  // ,.redirect_resume_instr_i(redirect_restore_insn_lower_half_li)
-
-  logic instr_access_fault_v, instr_page_fault_v;
-  logic ptag_v_li, ptag_uncached_li, ptag_nonidem_li, ptag_dram_li, ptag_miss_li;
-  logic [ptag_width_p-1:0] ptag_li;
-  logic poison_if1_lo, poison_if2_lo;
+  wire [dword_width_gp-1:0] r_eaddr_li = `BSG_SIGN_EXTEND(next_pc_lo, dword_width_gp);
+  wire [1:0] r_size_li = 2'b10;
+  logic itlb_r_v_li, itlb_w_v_li, itlb_flush_v_li;
 
   bp_pte_leaf_s w_tlb_entry_li;
   wire [vtag_width_p-1:0] w_vtag_li = fe_cmd_cast_i.npc[vaddr_width_p-1-:vtag_width_p];
   assign w_tlb_entry_li = fe_cmd_cast_i.operands.itlb_fill_response.pte_leaf;
 
-  wire [dword_width_gp-1:0] r_eaddr_li = `BSG_SIGN_EXTEND(next_pc_lo, dword_width_gp);
-  wire [1:0] r_size_li = 2'b10;
-  logic itlb_r_v_li, itlb_w_v_li, itlb_flush_v_li;
+  logic instr_access_fault_v, instr_page_fault_v;
+  logic ptag_v_li, ptag_uncached_li, ptag_nonidem_li, ptag_dram_li, ptag_miss_li;
+  logic [ptag_width_p-1:0] ptag_li;
+
   wire uncached_mode = (cfg_bus_cast_i.icache_mode == e_lce_mode_uncached);
   wire nonspec_mode = (cfg_bus_cast_i.icache_mode == e_lce_mode_nonspec);
   bp_mmu
@@ -223,6 +208,13 @@ module bp_fe_top
      ,.r_store_page_fault_o()
      );
 
+  `declare_bp_fe_icache_pkt_s(vaddr_width_p);
+  bp_fe_icache_pkt_s icache_pkt_li;
+  logic [instr_width_gp-1:0] icache_data_lo;
+  logic icache_v_li, icache_force_li, icache_yumi_lo;
+  logic icache_tv_we;
+  logic icache_data_v_lo, icache_spec_v_lo, icache_fence_v_lo, icache_yumi_li;
+  logic poison_if1_lo, poison_if2_lo;
   bp_fe_icache
    #(.bp_params_p(bp_params_p))
    icache
@@ -278,7 +270,11 @@ module bp_fe_top
      ,.stat_mem_pkt_yumi_o(stat_mem_pkt_yumi_o)
      ,.stat_mem_o(stat_mem_o)
      );
-  assign icache_yumi_li = fe_queue_ready_i & (icache_data_v_lo | icache_spec_v_lo) | icache_fence_v_lo;
+  wire icache_v_lo = icache_data_v_lo | icache_spec_v_lo | icache_fence_v_lo;
+  wire icache_data_yumi_li = fe_queue_ready_i & icache_data_v_lo;
+  wire icache_spec_yumi_li = fe_queue_ready_i & icache_spec_v_lo;
+  wire icache_fence_yumi_li = fe_queue_ready_i & icache_fence_v_lo;
+  assign icache_yumi_li = icache_data_yumi_li | icache_spec_yumi_li | icache_fence_yumi_li;
 
   // This tracks the I$ valid. Could move inside entirely, but we're trying to separate
   //   those responsibilities
@@ -293,69 +289,57 @@ module bp_fe_top
      ,.data_o({itlb_miss_r, instr_access_fault_r, instr_page_fault_r})
      );
 
-  wire fe_exception_v = (instr_access_fault_r | instr_page_fault_r | itlb_miss_r | icache_spec_v_lo);
-  wire fe_instr_v     = fetch_instr_v_lo;
-  assign fe_queue_v_o = (fe_instr_v | fe_exception_v);
+  if (compressed_support_p)
+    begin : realigner
+      bp_fe_realigner
+       #(.bp_params_p(bp_params_p))
+       realigner
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
 
-  assign fetch_instr_v_li     = fe_queue_ready_i & fe_queue_v_o & fe_instr_v;
-  assign fetch_exception_v_li = fe_queue_ready_i & fe_queue_v_o & fe_exception_v;
-  assign fetch_instr_li       = icache_data_lo;
+         ,.if2_v_i(icache_data_v_lo)
+         ,.if2_yumi_i(icache_data_yumi_li)
+         ,.if2_taken_branch_site_i(if2_taken_branch_site_lo)
+         ,.if2_pc_i(if2_pc)
+         ,.if2_data_i(icache_data_lo)
 
-  bp_fe_controller
+         ,.redirect_v_i(redirect_v_li)
+         ,.redirect_resume_i(redirect_resume_v_li)
+         ,.redirect_partial_i(redirect_resume_instr_li)
+         ,.redirect_vaddr_i(redirect_pc_li)
+
+         ,.fetch_instr_pc_o(fetch_pc_lo)
+         ,.fetch_instr_o(fetch_instr_lo)
+         ,.fetch_instr_v_o(fetch_instr_v_lo)
+         ,.fetch_partial_o(fetch_partial_lo)
+         ,.fetch_linear_o(fetch_linear_lo)
+         ,.fetch_instr_yumi_i(fetch_instr_yumi_li)
+         );
+    end
+  else
+    begin : realigner
+      assign fetch_pc_lo = if2_pc;
+      assign fetch_instr_lo = icache_data_lo;
+      assign fetch_instr_v_lo = icache_data_v_lo;
+      assign fetch_partial_lo = '0;
+      assign fetch_linear_lo = '0;
+    end
+  
+  bp_fe_instr_scan
    #(.bp_params_p(bp_params_p))
-   controller
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.fe_cmd_i(fe_cmd_cast_i)
-     ,.fe_cmd_v_i(fe_cmd_v_i)
-     ,.fe_cmd_yumi_o(fe_cmd_yumi_o)
-
-     ,.redirect_v_o(redirect_v_li)
-     ,.redirect_pc_o(redirect_pc_li)
-     ,.redirect_br_v_o(redirect_br_v_li)
-     ,.redirect_br_taken_o(redirect_br_taken_li)
-     ,.redirect_br_ntaken_o(redirect_br_ntaken_li)
-     ,.redirect_br_nonbr_o(redirect_br_nonbr_li)
-     ,.redirect_br_metadata_fwd_o(redirect_br_metadata_fwd_li)
-     ,.redirect_resume_v_o(redirect_restore_insn_lower_half_v_li)
-     ,.redirect_resume_instr_o(redirect_restore_insn_lower_half_li)
-
-     ,.attaboy_pc_o(attaboy_pc_li)
-     ,.attaboy_taken_o(attaboy_taken_li)
-     ,.attaboy_ntaken_o(attaboy_ntaken_li)
-     ,.attaboy_br_metadata_fwd_o(attaboy_br_metadata_fwd_li)
-     ,.attaboy_v_o(attaboy_v_li)
-     ,.attaboy_yumi_i(attaboy_yumi_lo)
-
-     ,.pc_gen_init_done_i(pc_gen_init_done_lo)
-     ,.next_pc_i(next_pc_lo)
-     ,.ovr_i(ovr_lo)
-     ,.icache_tv_we_i(icache_tv_we)
-     ,.if1_we_o(if1_we)
-     ,.if2_we_o(if2_we)
-     ,.poison_if1_o(poison_if1_lo)
-     ,.poison_if2_o(poison_if2_lo)
-
-     ,.itlb_r_v_o(itlb_r_v_li)
-     ,.itlb_w_v_o(itlb_w_v_li)
-     ,.itlb_flush_v_o(itlb_flush_v_li)
-     ,.icache_v_o(icache_v_li)
-     ,.icache_force_o(icache_force_li)
-     ,.icache_pkt_o(icache_pkt_li)
-     ,.icache_yumi_i(icache_yumi_lo)
-
-     ,.shadow_priv_w_o(shadow_priv_w)
-     ,.shadow_priv_o(shadow_priv_n)
-
-     ,.shadow_translation_en_w_o(shadow_translation_en_w)
-     ,.shadow_translation_en_o(shadow_translation_en_n)
-
-     ,.fetch_instr_v_i(fetch_instr_v_li)
-     ,.fetch_exception_v_i(fetch_exception_v_li)
-     ,.fetch_instr_i(fetch_instr_lo)
+   instr_scan
+    (.instr_i(fetch_instr_lo)
+     ,.instr_v_i(fetch_instr_yumi_li)
+     ,.scan_o(fetch_scan)
      );
 
+  wire fe_exception_v = (instr_access_fault_r | instr_page_fault_r | itlb_miss_r | icache_spec_v_lo);
+  wire fe_instr_v     = fetch_instr_v_lo;
+
+  assign fetch_instr_yumi_li     = fe_queue_ready_i & fe_queue_v_o & fe_instr_v;
+  assign fetch_exception_yumi_li = fe_queue_ready_i & fe_queue_v_o & fe_exception_v;
+
+  assign fe_queue_v_o = (fe_instr_v | fe_exception_v);
   always_comb
     begin
       fe_queue_cast_o = '0;
@@ -372,9 +356,63 @@ module bp_fe_top
                                            ? e_icache_miss
                                            : e_instr_fetch;
       fe_queue_cast_o.instr = fetch_instr_lo;
-      fe_queue_cast_o.branch_metadata_fwd = fetch_br_metadata_fwd_lo;
-      fe_queue_cast_o.partial_v = compressed_support_p & fetch_is_second_half_lo & fe_exception_v;
+      fe_queue_cast_o.branch_metadata_fwd = if2_br_metadata_fwd_lo;
+      fe_queue_cast_o.partial_v = compressed_support_p & fetch_partial_lo & fe_exception_v;
     end
+
+  bp_fe_controller
+   #(.bp_params_p(bp_params_p))
+   controller
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.fe_cmd_i(fe_cmd_cast_i)
+     ,.fe_cmd_v_i(fe_cmd_v_i)
+     ,.fe_cmd_yumi_o(fe_cmd_yumi_o)
+
+     ,.pc_gen_init_done_i(pc_gen_init_done_lo)
+
+     ,.redirect_v_o(redirect_v_li)
+     ,.redirect_pc_o(redirect_pc_li)
+     ,.redirect_br_v_o(redirect_br_v_li)
+     ,.redirect_br_taken_o(redirect_br_taken_li)
+     ,.redirect_br_ntaken_o(redirect_br_ntaken_li)
+     ,.redirect_br_nonbr_o(redirect_br_nonbr_li)
+     ,.redirect_br_metadata_fwd_o(redirect_br_metadata_fwd_li)
+     ,.redirect_resume_v_o(redirect_resume_v_li)
+     ,.redirect_resume_instr_o(redirect_resume_instr_li)
+
+     ,.attaboy_pc_o(attaboy_pc_li)
+     ,.attaboy_taken_o(attaboy_taken_li)
+     ,.attaboy_ntaken_o(attaboy_ntaken_li)
+     ,.attaboy_br_metadata_fwd_o(attaboy_br_metadata_fwd_li)
+     ,.attaboy_v_o(attaboy_v_li)
+     ,.attaboy_yumi_i(attaboy_yumi_lo)
+
+     ,.next_pc_i(next_pc_lo)
+
+     ,.ovr_i(ovr_lo)
+     ,.poison_if1_o(poison_if1_lo)
+     ,.if1_we_o(if1_we)
+
+     ,.icache_tv_we_i(icache_tv_we)
+     ,.poison_if2_o(poison_if2_lo)
+     ,.fetch_exception_yumi_i(fetch_exception_yumi_li)
+     ,.if2_we_o(if2_we)
+
+     ,.itlb_r_v_o(itlb_r_v_li)
+     ,.itlb_w_v_o(itlb_w_v_li)
+     ,.itlb_flush_v_o(itlb_flush_v_li)
+     ,.icache_v_o(icache_v_li)
+     ,.icache_force_o(icache_force_li)
+     ,.icache_pkt_o(icache_pkt_li)
+     ,.icache_yumi_i(icache_yumi_lo)
+
+     ,.shadow_priv_o(shadow_priv_n)
+     ,.shadow_priv_w_o(shadow_priv_w)
+     ,.shadow_translation_en_o(shadow_translation_en_n)
+     ,.shadow_translation_en_w_o(shadow_translation_en_w)
+     );
 
 endmodule
 

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -91,7 +91,7 @@ module bp_fe_top
   logic redirect_v_li, redirect_resume_v_li;
   logic [vaddr_width_p-1:0] redirect_pc_li;
   logic redirect_br_v_li, redirect_br_taken_li, redirect_br_ntaken_li, redirect_br_nonbr_li;
-  logic [instr_half_width_gp-1:0] redirect_resume_instr_li;
+  logic [instr_half_width_gp-1:0] redirect_instr_li;
   bp_fe_branch_metadata_fwd_s redirect_br_metadata_fwd_li, attaboy_br_metadata_fwd_li;
   logic attaboy_v_li, attaboy_yumi_lo, attaboy_taken_li, attaboy_ntaken_li;
   logic [vaddr_width_p-1:0] attaboy_pc_li;
@@ -298,19 +298,18 @@ module bp_fe_top
          ,.reset_i(reset_i)
 
          ,.if2_v_i(icache_data_v_lo)
-         ,.if2_yumi_i(icache_data_yumi_li)
-         ,.if2_taken_branch_site_i(if2_taken_branch_site_lo)
          ,.if2_pc_i(if2_pc)
          ,.if2_data_i(icache_data_lo)
+         ,.if2_taken_branch_site_i(if2_taken_branch_site_lo)
 
          ,.redirect_v_i(redirect_v_li)
-         ,.redirect_resume_i(redirect_resume_v_li)
-         ,.redirect_partial_i(redirect_resume_instr_li)
-         ,.redirect_vaddr_i(redirect_pc_li)
+         ,.redirect_resume_v_i(redirect_resume_v_li)
+         ,.redirect_pc_i(redirect_pc_li)
+         ,.redirect_instr_i(redirect_instr_li)
 
-         ,.fetch_instr_pc_o(fetch_pc_lo)
-         ,.fetch_instr_o(fetch_instr_lo)
          ,.fetch_instr_v_o(fetch_instr_v_lo)
+         ,.fetch_pc_o(fetch_pc_lo)
+         ,.fetch_instr_o(fetch_instr_lo)
          ,.fetch_partial_o(fetch_partial_lo)
          ,.fetch_linear_o(fetch_linear_lo)
          ,.fetch_instr_yumi_i(fetch_instr_yumi_li)
@@ -380,7 +379,7 @@ module bp_fe_top
      ,.redirect_br_nonbr_o(redirect_br_nonbr_li)
      ,.redirect_br_metadata_fwd_o(redirect_br_metadata_fwd_li)
      ,.redirect_resume_v_o(redirect_resume_v_li)
-     ,.redirect_resume_instr_o(redirect_resume_instr_li)
+     ,.redirect_instr_o(redirect_instr_li)
 
      ,.attaboy_pc_o(attaboy_pc_li)
      ,.attaboy_taken_o(attaboy_taken_li)

--- a/bp_fe/test/common/bp_fe_nonsynth_icache_tracer.sv
+++ b/bp_fe/test/common/bp_fe_nonsynth_icache_tracer.sv
@@ -26,11 +26,12 @@ module bp_fe_nonsynth_icache_tracer
 
    , input [icache_pkt_width_lp-1:0]                      icache_pkt_i
    , input                                                v_i
-   , input                                                ready_o
+   , input                                                force_i
+   , input                                                yumi_o
 
    , input [instr_width_gp-1:0]                           data_o
    , input                                                data_v_o
-   , input                                                miss_v_o
+   , input                                                spec_v_o
 
    , input [cache_req_width_lp-1:0]                       cache_req_o
    , input                                                cache_req_v_o
@@ -114,7 +115,7 @@ module bp_fe_nonsynth_icache_tracer
 
   always_ff @(posedge clk_i)
     begin
-      if (ready_o & v_i)
+      if (yumi_o)
         $fwrite(file, "%12t | access: %p\n", $time, icache_pkt_cast_i);
 
       if (data_mem_pkt_yumi_o)
@@ -134,7 +135,7 @@ module bp_fe_nonsynth_icache_tracer
 
       if (data_v_o)
         $fwrite(file, "%12t | fetch: [%x]->%x\n", $time, paddr_tv_r, data_o);
-      if (miss_v_o)
+      if (spec_v_o)
         $fwrite(file, "%12t | spec miss: [%x]\n", $time, paddr_tv_r);
 
       if (cache_req_ready_and_i & cache_req_v_o)

--- a/bp_fe/test/common/bp_fe_nonsynth_pc_gen_tracer.sv
+++ b/bp_fe/test/common/bp_fe_nonsynth_pc_gen_tracer.sv
@@ -1,243 +1,257 @@
-`include "bp_common_defines.svh"
-`include "bp_top_defines.svh"
-`include "bp_fe_defines.svh"
-
-/*
-Tracer which emits a log of every program counter/fetch address output by the pc_gen module. Every
-cycle has an associated log output line. Each line shows the simulation time and cycle count, along
-with:
-
-  - The PC currently in the IF2 stage. If it is enclosed in parentheses, this entry was
-    invalidated and won't be issued.
-  - The reason the above PC was fetched:
-    - undefined: the simulation just started and nothing has propagated to IF2 yet 
-    - redirect: either a BE->FE command or resuming after a stall
-    - override_ntaken: a misaligned instruction required a second fetch for the same PC
-    - override_ras: the RAS was used to predict a JALR (IF2)
-    - override_branch: a jump instruction was discovered late (IF2) and caused a bubble
-    - btb_taken_branch: the BTB and BHT predict a taken jump (IF1)
-    - last_fetch_plus_four: no special control flow, defaulted to a linear fetch
-  - The PC and partial instruction stored in the realigner (for misaligned and compressed instructions)
-  - The running count of "ntaken" overrides, i.e. predicted-taken jumps which were overridden to be not-taken
-  - Frontend state: either "run" or "stall". Note that, even when stalled, log entries are
-    emitted and PCs progress through the frontend. They will not be issued.
-  - Events: external status which may impact the next fetch. Faults, I$ and ITLB misses, and "queue"
-    misses (FE queue full) are indicated here.
-
-Although "stall" entries are generally uninteresting, a change in behavior while stalled may
-indicate a logic bug. This has been useful in the past.
-
-This tracer can be used to inspect the branch prediction flow for specific points in execution, or to
-textually diff the output before and after a change to identify its effects. This can be extremely
-valuable for tracking down regressions.
-
-Exmple trace ("cuts" introduced for brevity):
-
-        time |   cycle,       IF2 PC,           IF2 PC src, state, events
-    [============================ cut ===========================]
-    76356000 | 0022607, (0080000998), last_fetch_plus_four,   run, 
-    76357000 | 0022608,  0080000954 ,             redirect,   run, 
-    76358000 | 0022609, (0080000958), last_fetch_plus_four,   run, 
-    76359000 | 0022610,  00800007f8 ,      override_branch,   run, 
-    76360000 | 0022611,  00800007fc , last_fetch_plus_four,   run, 
-    76361000 | 0022612,  0080000800 , last_fetch_plus_four,   run, 
-    76362000 | 0022613,  0080000804 , last_fetch_plus_four,   run, 
-    76363000 | 0022614,  0080000808 , last_fetch_plus_four,   run, 
-    76364000 | 0022615,  008000080c , last_fetch_plus_four,   run, 
-    76365000 | 0022616,  0080000810 , last_fetch_plus_four,   run, 
-    76366000 | 0022617,  0080000814 , last_fetch_plus_four,   run, 
-    76367000 | 0022618,  0080000818 , last_fetch_plus_four,   run, 
-    76368000 | 0022619, (008000081c), last_fetch_plus_four,   run, 
-    76369000 | 0022620,  0080000710 ,      override_branch,   run, queue miss; i$ miss; 
-    76370000 | 0022621, (0080000714), last_fetch_plus_four, stall, 
-    76371000 | 0022622, (0080000718), last_fetch_plus_four, stall, 
-    [============================ cut ===========================]
-    76383000 | 0022634, (0080000748), last_fetch_plus_four, stall, 
-    76384000 | 0022635, (008000074c), last_fetch_plus_four, stall, 
-    76385000 | 0022636, (0080000750), last_fetch_plus_four,   run, 
-    76386000 | 0022637,  0080000710 ,             redirect,   run, 
-    76387000 | 0022638,  0080000714 , last_fetch_plus_four,   run, 
-    76388000 | 0022639,  0080000718 , last_fetch_plus_four,   run, 
-    76389000 | 0022640,  008000071c , last_fetch_plus_four,   run, 
-*/
-
-typedef enum logic [2:0]
-{
-  e_pc_src_undefined = 3'd0
-  ,e_pc_src_redirect
-  ,e_pc_src_override_ntaken
-  ,e_pc_src_override_ras
-  ,e_pc_src_override_branch
-  ,e_pc_src_btb_taken_branch
-  ,e_pc_src_last_fetch_plus_four
-} bp_fe_pc_gen_src_e;
-
-module bp_fe_nonsynth_pc_gen_tracer
-  import bp_common_pkg::*;
-  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
-    `declare_bp_proc_params(bp_params_p)
-
-    , parameter fe_trace_file_p = "pc_gen_trace"
-
-    , localparam pc_src_enum_name_prefix_length_lp = 9 // length of "e_pc_src_"
-    , localparam max_ovr_ntaken_count_nonsynth_lp = (2**30)-1
-    )
-   (input clk_i
-    , input reset_i
-    , input freeze_i 
-
-    , input [`BSG_SAFE_CLOG2(num_core_p)-1:0] mhartid_i
-
-   // FE state
-   , input state_stall_i
-   , input state_wait_i
-
-   // FE state causes
-   , input queue_miss_i
-   , input icache_miss_i
-   , input icache_req_i
-   , input access_fault_i
-   , input page_fault_i
-   , input itlb_miss_i
-
-   // TODO: I$ rollback, fence
-
-   // IF0
-   , input src_redirect_i
-   , input src_override_ntaken_i
-   , input src_override_ras_i
-   , input src_override_branch_i
-   , input src_btb_taken_branch_i
-
-   // IF1
-   , input                     if1_top_v_i
-   , input [vaddr_width_p-1:0] if1_pc_i
-
-    // IF2
-   , input                     if2_top_v_i
-   , input [vaddr_width_p-1:0] if2_pc_i
-   , input                     realigner_v_i
-   , input [vaddr_width_p-1:0] realigner_pc_i
-   , input [instr_half_width_gp-1:0] realigner_instr_i
-
-   // TODO: indicate output to FE queue
-    );
-
-  // Cycle counter
-  logic [29:0] cycle_cnt;
-  bsg_counter_clear_up
-   #(.max_val_p(2**30-1), .init_val_p(0))
-   cycle_counter
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i | freeze_i)
-
-     ,.clear_i(1'b0)
-     ,.up_i(1'b1)
-     ,.count_o(cycle_cnt)
-     );
-
-  bp_fe_pc_gen_src_e pc_src_if1_n, pc_src_if1_r;
-  bp_fe_pc_gen_src_e pc_src_if2_n, pc_src_if2_r;
-  bsg_dff_reset
-   #(.width_p($bits(bp_fe_pc_gen_src_e)*2))
-   pc_src_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i | freeze_i)
-
-     ,.data_i({pc_src_if1_n, pc_src_if2_n})
-     ,.data_o({pc_src_if1_r, pc_src_if2_r})
-    );
-  assign pc_src_if2_n = pc_src_if1_r;
-
-  logic [`BSG_SAFE_CLOG2(max_ovr_ntaken_count_nonsynth_lp+1)-1:0] ovr_ntaken_count;
-  bsg_counter_clear_up
-    #(.max_val_p(max_ovr_ntaken_count_nonsynth_lp), .init_val_p(0))
-    ovr_ntaken_counter
-      (.clk_i(clk_i)
-      ,.reset_i(reset_i)
-
-      ,.clear_i(reset_i)
-      ,.up_i(pc_src_if2_n == e_pc_src_override_ntaken)
-      ,.count_o(ovr_ntaken_count)
-      );
-
-  always_comb
-    begin
-      // TODO: deduplicate "if" chain from bp_fe_pc_gen.sv
-      if (src_redirect_i)
-        pc_src_if1_n = e_pc_src_redirect;
-      else if (src_override_ntaken_i)
-        pc_src_if1_n = e_pc_src_override_ntaken;
-      else if (src_override_ras_i)
-        pc_src_if1_n = e_pc_src_override_ras;
-      else if (src_override_branch_i)
-        pc_src_if1_n = e_pc_src_override_branch;
-      else if (src_btb_taken_branch_i)
-        pc_src_if1_n = e_pc_src_btb_taken_branch;
-      else
-        pc_src_if1_n = e_pc_src_last_fetch_plus_four;
-    end
-
-  function string render_addr_with_validity(logic [vaddr_width_p-1:0] addr, logic valid);
-    if (valid)
-      return $sformatf(" %x ", addr);
-    else
-      return $sformatf("(%x)", addr);
-  endfunction
-
-  function string render_half_instr_with_validity(logic [instr_half_width_gp-1:0] instr, logic valid);
-    if (valid)
-      return $sformatf("     %x ", instr);
-    else
-      return $sformatf("    (%x)", instr);
-  endfunction
-
-  integer file;
-  string file_name;
-  wire reset_li = reset_i | freeze_i;
-  always_ff @(negedge reset_li)
-    begin
-      file_name = $sformatf("%s_%x.trace", fe_trace_file_p, mhartid_i);
-      file      = $fopen(file_name, "w");
-      $fwrite(
-        file,
-        "%12s | %7s, %12s, %20s, %12s, %12s, %8s, %5s, %s\n",
-        "time", "cycle", "IF2 PC", "IF2 PC src", "partial PC", "partial insn", "# ntaken", "state", "events"
-      );
-    end
-
-  string trimmed_pc_src_if2_name;
-  always_ff @(negedge clk_i)
-    if (!reset_i && !freeze_i)
-    begin
-      trimmed_pc_src_if2_name = pc_src_if2_r.name().substr(pc_src_enum_name_prefix_length_lp, pc_src_if2_r.name().len()-1);
-
-      $fwrite
-        (file
-        ,"%12t | %07d, %12s, %20s, %12s, %12s, %8d, %5s, "
-        ,$time
-        ,cycle_cnt
-        ,render_addr_with_validity(if2_pc_i, if2_top_v_i)
-        ,trimmed_pc_src_if2_name
-        ,render_addr_with_validity(realigner_pc_i, realigner_v_i)
-        ,render_half_instr_with_validity(realigner_instr_i, realigner_v_i)
-        ,ovr_ntaken_count
-        ,state_stall_i ? "stall" : (state_wait_i ? "wait" : "run"));
-
-      if (queue_miss_i)
-        $fwrite(file, "queue miss; ");
-      if (icache_miss_i)
-        $fwrite(file, "i$ miss; ");
-      if (icache_req_i)
-        $fwrite(file, "outgoing i$ req; ");
-      if (access_fault_i)
-        $fwrite(file, "access fault; ");
-      if (page_fault_i)
-        $fwrite(file, "page fault; ");
-      if (itlb_miss_i)
-        $fwrite(file, "itlb miss; ");
-
-      $fwrite(file, "\n");
-    end
-
-endmodule
+//`include "bp_common_defines.svh"
+//`include "bp_top_defines.svh"
+//`include "bp_fe_defines.svh"
+//
+///*
+//Tracer which emits a log of every program counter/fetch address output by the pc_gen module. Every
+//cycle has an associated log output line. Each line shows the simulation time and cycle count, along
+//with:
+//
+//  - The PC currently in the IF2 stage. If it is enclosed in parentheses, this entry was
+//    invalidated and won't be issued.
+//  - The reason the above PC was fetched:
+//    - undefined: the simulation just started and nothing has propagated to IF2 yet 
+//    - redirect: either a BE->FE command or resuming after a stall
+//    - override_ntaken: a misaligned instruction required a second fetch for the same PC
+//    - override_ras: the RAS was used to predict a JALR (IF2)
+//    - override_branch: a jump instruction was discovered late (IF2) and caused a bubble
+//    - btb_taken_branch: the BTB and BHT predict a taken jump (IF1)
+//    - last_fetch_plus_four: no special control flow, defaulted to a linear fetch
+//  - The PC and partial instruction stored in the realigner (for misaligned and compressed instructions)
+//  - The running count of "ntaken" overrides, i.e. predicted-taken jumps which were overridden to be not-taken
+//  - Frontend state: either "run" or "stall". Note that, even when stalled, log entries are
+//    emitted and PCs progress through the frontend. They will not be issued.
+//  - Events: external status which may impact the next fetch. Faults, I$ and ITLB misses, and "queue"
+//    misses (FE queue full) are indicated here.
+//
+//Although "stall" entries are generally uninteresting, a change in behavior while stalled may
+//indicate a logic bug. This has been useful in the past.
+//
+//This tracer can be used to inspect the branch prediction flow for specific points in execution, or to
+//textually diff the output before and after a change to identify its effects. This can be extremely
+//valuable for tracking down regressions.
+//
+//Exmple trace ("cuts" introduced for brevity):
+//
+//        time |   cycle,       IF2 PC,           IF2 PC src, state, events
+//    [============================ cut ===========================]
+//    76356000 | 0022607, (0080000998), last_fetch_plus_four,   run, 
+//    76357000 | 0022608,  0080000954 ,             redirect,   run, 
+//    76358000 | 0022609, (0080000958), last_fetch_plus_four,   run, 
+//    76359000 | 0022610,  00800007f8 ,      override_branch,   run, 
+//    76360000 | 0022611,  00800007fc , last_fetch_plus_four,   run, 
+//    76361000 | 0022612,  0080000800 , last_fetch_plus_four,   run, 
+//    76362000 | 0022613,  0080000804 , last_fetch_plus_four,   run, 
+//    76363000 | 0022614,  0080000808 , last_fetch_plus_four,   run, 
+//    76364000 | 0022615,  008000080c , last_fetch_plus_four,   run, 
+//    76365000 | 0022616,  0080000810 , last_fetch_plus_four,   run, 
+//    76366000 | 0022617,  0080000814 , last_fetch_plus_four,   run, 
+//    76367000 | 0022618,  0080000818 , last_fetch_plus_four,   run, 
+//    76368000 | 0022619, (008000081c), last_fetch_plus_four,   run, 
+//    76369000 | 0022620,  0080000710 ,      override_branch,   run, queue miss; i$ miss; 
+//    76370000 | 0022621, (0080000714), last_fetch_plus_four, stall, 
+//    76371000 | 0022622, (0080000718), last_fetch_plus_four, stall, 
+//    [============================ cut ===========================]
+//    76383000 | 0022634, (0080000748), last_fetch_plus_four, stall, 
+//    76384000 | 0022635, (008000074c), last_fetch_plus_four, stall, 
+//    76385000 | 0022636, (0080000750), last_fetch_plus_four,   run, 
+//    76386000 | 0022637,  0080000710 ,             redirect,   run, 
+//    76387000 | 0022638,  0080000714 , last_fetch_plus_four,   run, 
+//    76388000 | 0022639,  0080000718 , last_fetch_plus_four,   run, 
+//    76389000 | 0022640,  008000071c , last_fetch_plus_four,   run, 
+//*/
+//
+//typedef enum logic [2:0]
+//{
+//  e_pc_src_undefined = 3'd0
+//  ,e_pc_src_redirect
+//  ,e_pc_src_override_ntaken
+//  ,e_pc_src_override_ras
+//  ,e_pc_src_override_branch
+//  ,e_pc_src_btb_taken_branch
+//  ,e_pc_src_last_fetch_plus_four
+//} bp_fe_pc_gen_src_e;
+//
+//module bp_fe_nonsynth_pc_gen_tracer
+//  import bp_common_pkg::*;
+//  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+//    `declare_bp_proc_params(bp_params_p)
+//
+//    , parameter fe_trace_file_p = "pc_gen_trace"
+//
+//    , localparam pc_src_enum_name_prefix_length_lp = 9 // length of "e_pc_src_"
+//    , localparam max_ovr_ntaken_count_nonsynth_lp = (2**30)-1
+//    )
+//   (input clk_i
+//    , input reset_i
+//    , input freeze_i 
+//
+//    , input [`BSG_SAFE_CLOG2(num_core_p)-1:0] mhartid_i
+//
+//   // FE state
+//   , input state_resume_i
+//   , input state_wait_i
+//
+//   // FE state causes
+//<<<<<<< HEAD
+//   , input queue_miss_i
+//   , input icache_miss_i
+//   , input icache_req_i
+//=======
+//   , input icache_spec_i
+//>>>>>>> Changes made, should break up and clean
+//   , input access_fault_i
+//   , input page_fault_i
+//   , input itlb_miss_i
+//
+//   // IF0
+//   , input src_redirect_i
+//   , input src_override_ntaken_i
+//   , input src_override_ras_i
+//   , input src_override_branch_i
+//   , input src_btb_taken_branch_i
+//
+//    // IF2
+//<<<<<<< HEAD
+//   , input                     if2_top_v_i
+//   , input [vaddr_width_p-1:0] if2_pc_i
+//   , input                     realigner_v_i
+//   , input [vaddr_width_p-1:0] realigner_pc_i
+//   , input [instr_half_width_gp-1:0] realigner_instr_i
+//=======
+//   , input                     fetch_v_i
+//   , input [vaddr_width_p-1:0] fetch_pc_i
+//>>>>>>> Changes made, should break up and clean
+//
+//   // TODO: indicate output to FE queue
+//    );
+//
+//  // Cycle counter
+//  logic [29:0] cycle_cnt;
+//  bsg_counter_clear_up
+//   #(.max_val_p(2**30-1), .init_val_p(0))
+//   cycle_counter
+//    (.clk_i(clk_i)
+//     ,.reset_i(reset_i | freeze_i)
+//
+//     ,.clear_i(1'b0)
+//     ,.up_i(1'b1)
+//     ,.count_o(cycle_cnt)
+//     );
+//
+//  bp_fe_pc_gen_src_e pc_src_next, pc_src_fetch;
+//  logic [$bits(bp_fe_pc_gen_src_e)-1:0] pc_src_fetch_r;
+//  bsg_dff_chain
+//   #(.width_p($bits(bp_fe_pc_gen_src_e)), .num_stages_p(2))
+//   pc_src_reg
+//    (.clk_i(clk_i)
+//
+//     ,.data_i(pc_src_next)
+//     ,.data_o(pc_src_fetch_r)
+//    );
+//  assign pc_src_fetch = bp_fe_pc_gen_src_e'(pc_src_fetch_r);
+//
+//  logic [`BSG_SAFE_CLOG2(max_ovr_ntaken_count_nonsynth_lp+1)-1:0] ovr_ntaken_count;
+//  bsg_counter_clear_up
+//    #(.max_val_p(max_ovr_ntaken_count_nonsynth_lp), .init_val_p(0))
+//    ovr_ntaken_counter
+//      (.clk_i(clk_i)
+//      ,.reset_i(reset_i)
+//
+//      ,.clear_i(reset_i)
+//      ,.up_i(pc_src_if2_n == e_pc_src_override_ntaken)
+//      ,.count_o(ovr_ntaken_count)
+//      );
+//
+//  always_comb
+//    begin
+//      // TODO: deduplicate "if" chain from bp_fe_pc_gen.sv
+//      if (src_redirect_i)
+//<<<<<<< HEAD
+//        pc_src_if1_n = e_pc_src_redirect;
+//      else if (src_override_ntaken_i)
+//        pc_src_if1_n = e_pc_src_override_ntaken;
+//=======
+//        pc_src_next = e_pc_src_redirect;
+//>>>>>>> Changes made, should break up and clean
+//      else if (src_override_ras_i)
+//        pc_src_next = e_pc_src_override_ras;
+//      else if (src_override_branch_i)
+//        pc_src_next = e_pc_src_override_branch;
+//      else if (src_btb_taken_branch_i)
+//        pc_src_next = e_pc_src_btb_taken_branch;
+//      else
+//        pc_src_next = e_pc_src_last_fetch_plus_four;
+//    end
+//
+//  function string render_addr_with_validity(logic [vaddr_width_p-1:0] addr, logic valid);
+//    if (valid)
+//      return $sformatf(" %x ", addr);
+//    else
+//      return $sformatf("(%x)", addr);
+//  endfunction
+//
+//  function string render_half_instr_with_validity(logic [instr_half_width_gp-1:0] instr, logic valid);
+//    if (valid)
+//      return $sformatf("     %x ", instr);
+//    else
+//      return $sformatf("    (%x)", instr);
+//  endfunction
+//
+//  integer file;
+//  string file_name;
+//  wire reset_li = reset_i | freeze_i;
+//  always_ff @(negedge reset_li)
+//    begin
+//      file_name = $sformatf("%s_%x.trace", fe_trace_file_p, mhartid_i);
+//      file      = $fopen(file_name, "w");
+//      $fwrite(
+//        file,
+//        "%12s | %7s, %12s, %20s, %12s, %12s, %8s, %5s, %s\n",
+//        "time", "cycle", "IF2 PC", "IF2 PC src", "partial PC", "partial insn", "# ntaken", "state", "events"
+//      );
+//    end
+//
+//  string trimmed_pc_src_fetch_name;
+//  always_ff @(negedge clk_i)
+//    if (!reset_i && !freeze_i)
+//    begin
+//      trimmed_pc_src_fetch_name = pc_src_fetch.name().substr(pc_src_enum_name_prefix_length_lp, pc_src_fetch.name().len()-1);
+//
+//      $fwrite
+//        (file
+//        ,"%12t | %07d, %12s, %20s, %12s, %12s, %8d, %5s, "
+//        ,$time
+//        ,cycle_cnt
+//<<<<<<< HEAD
+//        ,render_addr_with_validity(if2_pc_i, if2_top_v_i)
+//        ,trimmed_pc_src_if2_name
+//        ,render_addr_with_validity(realigner_pc_i, realigner_v_i)
+//        ,render_half_instr_with_validity(realigner_instr_i, realigner_v_i)
+//        ,ovr_ntaken_count
+//        ,state_stall_i ? "stall" : (state_wait_i ? "wait" : "run"));
+//=======
+//        ,render_addr_with_validity(fetch_pc_i, fetch_v_i)
+//        ,trimmed_pc_src_fetch_name
+//        ,state_resume_i ? "resume" : (state_wait_i ? "wait" : "run"));
+//>>>>>>> Changes made, should break up and clean
+//
+//      if (icache_spec_i & fetch_v_i)
+//        $fwrite(file, "i$ miss; ");
+//<<<<<<< HEAD
+//      if (icache_req_i)
+//        $fwrite(file, "outgoing i$ req; ");
+//      if (access_fault_i)
+//=======
+//      if (access_fault_i & fetch_v_i)
+//>>>>>>> Changes made, should break up and clean
+//        $fwrite(file, "access fault; ");
+//      if (page_fault_i & fetch_v_i)
+//        $fwrite(file, "page fault; ");
+//      if (itlb_miss_i & fetch_v_i)
+//        $fwrite(file, "itlb miss; ");
+//
+//      $fwrite(file, "\n");
+//    end
+//
+//endmodule

--- a/bp_fe/test/common/bp_fe_nonsynth_pc_gen_tracer.sv
+++ b/bp_fe/test/common/bp_fe_nonsynth_pc_gen_tracer.sv
@@ -1,257 +1,230 @@
-//`include "bp_common_defines.svh"
-//`include "bp_top_defines.svh"
-//`include "bp_fe_defines.svh"
-//
-///*
-//Tracer which emits a log of every program counter/fetch address output by the pc_gen module. Every
-//cycle has an associated log output line. Each line shows the simulation time and cycle count, along
-//with:
-//
-//  - The PC currently in the IF2 stage. If it is enclosed in parentheses, this entry was
-//    invalidated and won't be issued.
-//  - The reason the above PC was fetched:
-//    - undefined: the simulation just started and nothing has propagated to IF2 yet 
-//    - redirect: either a BE->FE command or resuming after a stall
-//    - override_ntaken: a misaligned instruction required a second fetch for the same PC
-//    - override_ras: the RAS was used to predict a JALR (IF2)
-//    - override_branch: a jump instruction was discovered late (IF2) and caused a bubble
-//    - btb_taken_branch: the BTB and BHT predict a taken jump (IF1)
-//    - last_fetch_plus_four: no special control flow, defaulted to a linear fetch
-//  - The PC and partial instruction stored in the realigner (for misaligned and compressed instructions)
-//  - The running count of "ntaken" overrides, i.e. predicted-taken jumps which were overridden to be not-taken
-//  - Frontend state: either "run" or "stall". Note that, even when stalled, log entries are
-//    emitted and PCs progress through the frontend. They will not be issued.
-//  - Events: external status which may impact the next fetch. Faults, I$ and ITLB misses, and "queue"
-//    misses (FE queue full) are indicated here.
-//
-//Although "stall" entries are generally uninteresting, a change in behavior while stalled may
-//indicate a logic bug. This has been useful in the past.
-//
-//This tracer can be used to inspect the branch prediction flow for specific points in execution, or to
-//textually diff the output before and after a change to identify its effects. This can be extremely
-//valuable for tracking down regressions.
-//
-//Exmple trace ("cuts" introduced for brevity):
-//
-//        time |   cycle,       IF2 PC,           IF2 PC src, state, events
-//    [============================ cut ===========================]
-//    76356000 | 0022607, (0080000998), last_fetch_plus_four,   run, 
-//    76357000 | 0022608,  0080000954 ,             redirect,   run, 
-//    76358000 | 0022609, (0080000958), last_fetch_plus_four,   run, 
-//    76359000 | 0022610,  00800007f8 ,      override_branch,   run, 
-//    76360000 | 0022611,  00800007fc , last_fetch_plus_four,   run, 
-//    76361000 | 0022612,  0080000800 , last_fetch_plus_four,   run, 
-//    76362000 | 0022613,  0080000804 , last_fetch_plus_four,   run, 
-//    76363000 | 0022614,  0080000808 , last_fetch_plus_four,   run, 
-//    76364000 | 0022615,  008000080c , last_fetch_plus_four,   run, 
-//    76365000 | 0022616,  0080000810 , last_fetch_plus_four,   run, 
-//    76366000 | 0022617,  0080000814 , last_fetch_plus_four,   run, 
-//    76367000 | 0022618,  0080000818 , last_fetch_plus_four,   run, 
-//    76368000 | 0022619, (008000081c), last_fetch_plus_four,   run, 
-//    76369000 | 0022620,  0080000710 ,      override_branch,   run, queue miss; i$ miss; 
-//    76370000 | 0022621, (0080000714), last_fetch_plus_four, stall, 
-//    76371000 | 0022622, (0080000718), last_fetch_plus_four, stall, 
-//    [============================ cut ===========================]
-//    76383000 | 0022634, (0080000748), last_fetch_plus_four, stall, 
-//    76384000 | 0022635, (008000074c), last_fetch_plus_four, stall, 
-//    76385000 | 0022636, (0080000750), last_fetch_plus_four,   run, 
-//    76386000 | 0022637,  0080000710 ,             redirect,   run, 
-//    76387000 | 0022638,  0080000714 , last_fetch_plus_four,   run, 
-//    76388000 | 0022639,  0080000718 , last_fetch_plus_four,   run, 
-//    76389000 | 0022640,  008000071c , last_fetch_plus_four,   run, 
-//*/
-//
-//typedef enum logic [2:0]
-//{
-//  e_pc_src_undefined = 3'd0
-//  ,e_pc_src_redirect
-//  ,e_pc_src_override_ntaken
-//  ,e_pc_src_override_ras
-//  ,e_pc_src_override_branch
-//  ,e_pc_src_btb_taken_branch
-//  ,e_pc_src_last_fetch_plus_four
-//} bp_fe_pc_gen_src_e;
-//
-//module bp_fe_nonsynth_pc_gen_tracer
-//  import bp_common_pkg::*;
-//  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
-//    `declare_bp_proc_params(bp_params_p)
-//
-//    , parameter fe_trace_file_p = "pc_gen_trace"
-//
-//    , localparam pc_src_enum_name_prefix_length_lp = 9 // length of "e_pc_src_"
-//    , localparam max_ovr_ntaken_count_nonsynth_lp = (2**30)-1
-//    )
-//   (input clk_i
-//    , input reset_i
-//    , input freeze_i 
-//
-//    , input [`BSG_SAFE_CLOG2(num_core_p)-1:0] mhartid_i
-//
-//   // FE state
-//   , input state_resume_i
-//   , input state_wait_i
-//
-//   // FE state causes
-//<<<<<<< HEAD
-//   , input queue_miss_i
-//   , input icache_miss_i
-//   , input icache_req_i
-//=======
-//   , input icache_spec_i
-//>>>>>>> Changes made, should break up and clean
-//   , input access_fault_i
-//   , input page_fault_i
-//   , input itlb_miss_i
-//
-//   // IF0
-//   , input src_redirect_i
-//   , input src_override_ntaken_i
-//   , input src_override_ras_i
-//   , input src_override_branch_i
-//   , input src_btb_taken_branch_i
-//
-//    // IF2
-//<<<<<<< HEAD
-//   , input                     if2_top_v_i
-//   , input [vaddr_width_p-1:0] if2_pc_i
-//   , input                     realigner_v_i
-//   , input [vaddr_width_p-1:0] realigner_pc_i
-//   , input [instr_half_width_gp-1:0] realigner_instr_i
-//=======
-//   , input                     fetch_v_i
-//   , input [vaddr_width_p-1:0] fetch_pc_i
-//>>>>>>> Changes made, should break up and clean
-//
-//   // TODO: indicate output to FE queue
-//    );
-//
-//  // Cycle counter
-//  logic [29:0] cycle_cnt;
-//  bsg_counter_clear_up
-//   #(.max_val_p(2**30-1), .init_val_p(0))
-//   cycle_counter
-//    (.clk_i(clk_i)
-//     ,.reset_i(reset_i | freeze_i)
-//
-//     ,.clear_i(1'b0)
-//     ,.up_i(1'b1)
-//     ,.count_o(cycle_cnt)
-//     );
-//
-//  bp_fe_pc_gen_src_e pc_src_next, pc_src_fetch;
-//  logic [$bits(bp_fe_pc_gen_src_e)-1:0] pc_src_fetch_r;
-//  bsg_dff_chain
-//   #(.width_p($bits(bp_fe_pc_gen_src_e)), .num_stages_p(2))
-//   pc_src_reg
-//    (.clk_i(clk_i)
-//
-//     ,.data_i(pc_src_next)
-//     ,.data_o(pc_src_fetch_r)
-//    );
-//  assign pc_src_fetch = bp_fe_pc_gen_src_e'(pc_src_fetch_r);
-//
-//  logic [`BSG_SAFE_CLOG2(max_ovr_ntaken_count_nonsynth_lp+1)-1:0] ovr_ntaken_count;
-//  bsg_counter_clear_up
-//    #(.max_val_p(max_ovr_ntaken_count_nonsynth_lp), .init_val_p(0))
-//    ovr_ntaken_counter
-//      (.clk_i(clk_i)
-//      ,.reset_i(reset_i)
-//
-//      ,.clear_i(reset_i)
-//      ,.up_i(pc_src_if2_n == e_pc_src_override_ntaken)
-//      ,.count_o(ovr_ntaken_count)
-//      );
-//
-//  always_comb
-//    begin
-//      // TODO: deduplicate "if" chain from bp_fe_pc_gen.sv
-//      if (src_redirect_i)
-//<<<<<<< HEAD
-//        pc_src_if1_n = e_pc_src_redirect;
-//      else if (src_override_ntaken_i)
-//        pc_src_if1_n = e_pc_src_override_ntaken;
-//=======
-//        pc_src_next = e_pc_src_redirect;
-//>>>>>>> Changes made, should break up and clean
-//      else if (src_override_ras_i)
-//        pc_src_next = e_pc_src_override_ras;
-//      else if (src_override_branch_i)
-//        pc_src_next = e_pc_src_override_branch;
-//      else if (src_btb_taken_branch_i)
-//        pc_src_next = e_pc_src_btb_taken_branch;
-//      else
-//        pc_src_next = e_pc_src_last_fetch_plus_four;
-//    end
-//
-//  function string render_addr_with_validity(logic [vaddr_width_p-1:0] addr, logic valid);
-//    if (valid)
-//      return $sformatf(" %x ", addr);
-//    else
-//      return $sformatf("(%x)", addr);
-//  endfunction
-//
-//  function string render_half_instr_with_validity(logic [instr_half_width_gp-1:0] instr, logic valid);
-//    if (valid)
-//      return $sformatf("     %x ", instr);
-//    else
-//      return $sformatf("    (%x)", instr);
-//  endfunction
-//
-//  integer file;
-//  string file_name;
-//  wire reset_li = reset_i | freeze_i;
-//  always_ff @(negedge reset_li)
-//    begin
-//      file_name = $sformatf("%s_%x.trace", fe_trace_file_p, mhartid_i);
-//      file      = $fopen(file_name, "w");
-//      $fwrite(
-//        file,
-//        "%12s | %7s, %12s, %20s, %12s, %12s, %8s, %5s, %s\n",
-//        "time", "cycle", "IF2 PC", "IF2 PC src", "partial PC", "partial insn", "# ntaken", "state", "events"
-//      );
-//    end
-//
-//  string trimmed_pc_src_fetch_name;
-//  always_ff @(negedge clk_i)
-//    if (!reset_i && !freeze_i)
-//    begin
-//      trimmed_pc_src_fetch_name = pc_src_fetch.name().substr(pc_src_enum_name_prefix_length_lp, pc_src_fetch.name().len()-1);
-//
-//      $fwrite
-//        (file
-//        ,"%12t | %07d, %12s, %20s, %12s, %12s, %8d, %5s, "
-//        ,$time
-//        ,cycle_cnt
-//<<<<<<< HEAD
-//        ,render_addr_with_validity(if2_pc_i, if2_top_v_i)
-//        ,trimmed_pc_src_if2_name
-//        ,render_addr_with_validity(realigner_pc_i, realigner_v_i)
-//        ,render_half_instr_with_validity(realigner_instr_i, realigner_v_i)
-//        ,ovr_ntaken_count
-//        ,state_stall_i ? "stall" : (state_wait_i ? "wait" : "run"));
-//=======
-//        ,render_addr_with_validity(fetch_pc_i, fetch_v_i)
-//        ,trimmed_pc_src_fetch_name
-//        ,state_resume_i ? "resume" : (state_wait_i ? "wait" : "run"));
-//>>>>>>> Changes made, should break up and clean
-//
-//      if (icache_spec_i & fetch_v_i)
-//        $fwrite(file, "i$ miss; ");
-//<<<<<<< HEAD
-//      if (icache_req_i)
-//        $fwrite(file, "outgoing i$ req; ");
-//      if (access_fault_i)
-//=======
-//      if (access_fault_i & fetch_v_i)
-//>>>>>>> Changes made, should break up and clean
-//        $fwrite(file, "access fault; ");
-//      if (page_fault_i & fetch_v_i)
-//        $fwrite(file, "page fault; ");
-//      if (itlb_miss_i & fetch_v_i)
-//        $fwrite(file, "itlb miss; ");
-//
-//      $fwrite(file, "\n");
-//    end
-//
-//endmodule
+`include "bp_common_defines.svh"
+`include "bp_top_defines.svh"
+`include "bp_fe_defines.svh"
+
+/*
+Tracer which emits a log of every program counter/fetch address output by the pc_gen module. Every
+cycle has an associated log output line. Each line shows the simulation time and cycle count, along
+with:
+
+  - The PC currently in the IF2 stage. If it is enclosed in parentheses, this entry was
+    invalidated and won't be issued.
+  - The reason the above PC was fetched:
+    - undefined: the simulation just started and nothing has propagated to IF2 yet 
+    - redirect: either a BE->FE command or resuming after a stall
+    - override_ntaken: a misaligned instruction required a second fetch for the same PC
+    - override_ras: the RAS was used to predict a JALR (IF2)
+    - override_branch: a jump instruction was discovered late (IF2) and caused a bubble
+    - btb_taken_branch: the BTB and BHT predict a taken jump (IF1)
+    - last_fetch_plus_four: no special control flow, defaulted to a linear fetch
+  - The PC and partial instruction stored in the fetch (for misaligned and compressed instructions)
+  - The running count of "ntaken" overrides, i.e. predicted-taken jumps which were overridden to be not-taken
+  - Frontend state: either "run" or "stall". Note that, even when stalled, log entries are
+    emitted and PCs progress through the frontend. They will not be issued.
+  - Events: external status which may impact the next fetch. Faults, I$ and ITLB misses, and "queue"
+    misses (FE queue full) are indicated here.
+
+Although "stall" entries are generally uninteresting, a change in behavior while stalled may
+indicate a logic bug. This has been useful in the past.
+
+This tracer can be used to inspect the branch prediction flow for specific points in execution, or to
+textually diff the output before and after a change to identify its effects. This can be extremely
+valuable for tracking down regressions.
+
+Exmple trace ("cuts" introduced for brevity):
+
+        time |   cycle,       IF2 PC,           IF2 PC src, state, events
+    [============================ cut ===========================]
+    76356000 | 0022607, (0080000998), last_fetch_plus_four,   run, 
+    76357000 | 0022608,  0080000954 ,             redirect,   run, 
+    76358000 | 0022609, (0080000958), last_fetch_plus_four,   run, 
+    76359000 | 0022610,  00800007f8 ,      override_branch,   run, 
+    76360000 | 0022611,  00800007fc , last_fetch_plus_four,   run, 
+    76361000 | 0022612,  0080000800 , last_fetch_plus_four,   run, 
+    76362000 | 0022613,  0080000804 , last_fetch_plus_four,   run, 
+    76363000 | 0022614,  0080000808 , last_fetch_plus_four,   run, 
+    76364000 | 0022615,  008000080c , last_fetch_plus_four,   run, 
+    76365000 | 0022616,  0080000810 , last_fetch_plus_four,   run, 
+    76366000 | 0022617,  0080000814 , last_fetch_plus_four,   run, 
+    76367000 | 0022618,  0080000818 , last_fetch_plus_four,   run, 
+    76368000 | 0022619, (008000081c), last_fetch_plus_four,   run, 
+    76369000 | 0022620,  0080000710 ,      override_branch,   run, queue miss; i$ miss; 
+    76370000 | 0022621, (0080000714), last_fetch_plus_four, stall, 
+    76371000 | 0022622, (0080000718), last_fetch_plus_four, stall, 
+    [============================ cut ===========================]
+    76383000 | 0022634, (0080000748), last_fetch_plus_four, stall, 
+    76384000 | 0022635, (008000074c), last_fetch_plus_four, stall, 
+    76385000 | 0022636, (0080000750), last_fetch_plus_four,   run, 
+    76386000 | 0022637,  0080000710 ,             redirect,   run, 
+    76387000 | 0022638,  0080000714 , last_fetch_plus_four,   run, 
+    76388000 | 0022639,  0080000718 , last_fetch_plus_four,   run, 
+    76389000 | 0022640,  008000071c , last_fetch_plus_four,   run, 
+*/
+
+typedef enum logic [2:0]
+{
+  e_pc_src_undefined = 3'd0
+  ,e_pc_src_redirect
+  ,e_pc_src_override_ntaken
+  ,e_pc_src_override_ras
+  ,e_pc_src_override_branch
+  ,e_pc_src_btb_taken_branch
+  ,e_pc_src_last_fetch_plus_four
+} bp_fe_pc_gen_src_e;
+
+module bp_fe_nonsynth_pc_gen_tracer
+ import bp_common_pkg::*;
+ #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+   `declare_bp_proc_params(bp_params_p)
+
+   , parameter fe_trace_file_p = "pc_gen_trace"
+
+   , localparam pc_src_enum_name_prefix_length_lp = 9 // length of "e_pc_src_"
+   , localparam max_ovr_ntaken_count_nonsynth_lp = (2**30)-1
+   )
+  (input clk_i
+   , input reset_i
+   , input freeze_i 
+
+   , input [`BSG_SAFE_CLOG2(num_core_p)-1:0] mhartid_i
+
+   // FE state
+   , input state_resume_i
+   , input state_wait_i
+
+   // FE state causes
+   , input icache_spec_i
+   , input access_fault_i
+   , input page_fault_i
+   , input itlb_miss_i
+
+   // IF0
+   , input src_redirect_i
+   , input src_override_ntaken_i
+   , input src_override_ras_i
+   , input src_override_branch_i
+   , input src_btb_taken_branch_i
+
+    // IF2
+   , input [vaddr_width_p-1:0] if2_pc_i
+   , input                     if2_v_i
+   , input                     fetch_v_i
+   , input                     fetch_partial_i
+   , input [vaddr_width_p-1:0] fetch_pc_i
+   , input [instr_width_gp-1:0] fetch_instr_i
+   );
+
+  // Cycle counter
+  logic [29:0] cycle_cnt;
+  bsg_counter_clear_up
+   #(.max_val_p(2**30-1), .init_val_p(0))
+   cycle_counter
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i | freeze_i)
+
+     ,.clear_i(1'b0)
+     ,.up_i(1'b1)
+     ,.count_o(cycle_cnt)
+     );
+
+  bp_fe_pc_gen_src_e pc_src_next, pc_src_fetch;
+  logic [$bits(bp_fe_pc_gen_src_e)-1:0] pc_src_fetch_r;
+  bsg_dff_chain
+   #(.width_p($bits(bp_fe_pc_gen_src_e)), .num_stages_p(2))
+   pc_src_reg
+    (.clk_i(clk_i)
+
+     ,.data_i(pc_src_next)
+     ,.data_o(pc_src_fetch_r)
+    );
+  assign pc_src_fetch = bp_fe_pc_gen_src_e'(pc_src_fetch_r);
+
+  logic [`BSG_SAFE_CLOG2(max_ovr_ntaken_count_nonsynth_lp+1)-1:0] ovr_ntaken_count;
+  bsg_counter_clear_up
+    #(.max_val_p(max_ovr_ntaken_count_nonsynth_lp), .init_val_p(0))
+    ovr_ntaken_counter
+      (.clk_i(clk_i)
+      ,.reset_i(reset_i)
+
+      ,.clear_i(reset_i)
+      ,.up_i(pc_src_next == e_pc_src_override_ntaken)
+      ,.count_o(ovr_ntaken_count)
+      );
+
+  always_comb
+    begin
+      // TODO: deduplicate "if" chain from bp_fe_pc_gen.sv
+      if (src_redirect_i)
+        pc_src_next = e_pc_src_redirect;
+      else if (src_override_ntaken_i)
+        pc_src_next = e_pc_src_override_ntaken;
+      else if (src_override_ras_i)
+        pc_src_next = e_pc_src_override_ras;
+      else if (src_override_branch_i)
+        pc_src_next = e_pc_src_override_branch;
+      else if (src_btb_taken_branch_i)
+        pc_src_next = e_pc_src_btb_taken_branch;
+      else
+        pc_src_next = e_pc_src_last_fetch_plus_four;
+    end
+
+  function string render_addr_with_validity(logic [vaddr_width_p-1:0] addr, logic valid);
+    if (valid)
+      return $sformatf(" %x ", addr);
+    else
+      return $sformatf("(%x)", addr);
+  endfunction
+
+  function string render_half_instr_with_validity(logic [instr_half_width_gp-1:0] instr, logic valid);
+    if (valid)
+      return $sformatf("     %x ", instr);
+    else
+      return $sformatf("    (%x)", instr);
+  endfunction
+
+  integer file;
+  string file_name;
+  wire reset_li = reset_i | freeze_i;
+  always_ff @(negedge reset_li)
+    begin
+      file_name = $sformatf("%s_%x.trace", fe_trace_file_p, mhartid_i);
+      file      = $fopen(file_name, "w");
+      $fwrite(
+        file,
+        "%12s | %7s, %12s, %20s, %12s, %12s, %8s, %5s, %s\n",
+        "time", "cycle", "IF2 PC", "IF2 PC src", "partial PC", "partial insn", "# ntaken", "state", "events"
+      );
+    end
+
+  string trimmed_pc_src_fetch_name;
+  always_ff @(negedge clk_i)
+    if (!reset_i && !freeze_i)
+    begin
+      trimmed_pc_src_fetch_name = pc_src_fetch.name().substr(pc_src_enum_name_prefix_length_lp, pc_src_fetch.name().len()-1);
+
+      $fwrite
+        (file
+        ,"%12t | %07d, %12s, %20s, %12s, %12s, %8d, %5s, "
+        ,$time
+        ,cycle_cnt
+        ,render_addr_with_validity(if2_pc_i, if2_v_i)
+        ,trimmed_pc_src_fetch_name
+        ,render_addr_with_validity(fetch_pc_i, fetch_partial_i)
+        ,render_half_instr_with_validity(fetch_instr_i, fetch_partial_i)
+        ,ovr_ntaken_count
+        ,state_resume_i ? "resume" : (state_wait_i ? "wait" : "run"));
+
+      if (icache_spec_i & fetch_v_i)
+        $fwrite(file, "i$ miss; ");
+      if (access_fault_i & fetch_v_i)
+        $fwrite(file, "access fault; ");
+      if (page_fault_i & fetch_v_i)
+        $fwrite(file, "page fault; ");
+      if (itlb_miss_i & fetch_v_i)
+        $fwrite(file, "itlb miss; ");
+
+      $fwrite(file, "\n");
+    end
+
+endmodule
+

--- a/bp_fe/test/tb/bp_fe_icache/testbench.sv
+++ b/bp_fe/test/tb/bp_fe_icache/testbench.sv
@@ -124,7 +124,6 @@ module testbench
   assign vaddr_li      = trace_data_lo[ptag_width_p+:vaddr_width_p];
   wire uncached_li     = trace_data_lo[(ptag_width_p+vaddr_width_p)+:1];
   wire nonidem_li      = '0;
-  wire trace_yumi_li   = trace_v_lo & dut_ready_lo;
 
   // Trace replay
   logic test_done_lo;
@@ -222,16 +221,16 @@ module testbench
      ,.cfg_bus_i(cfg_bus_li)
 
      ,.vaddr_i(vaddr_li)
-     ,.vaddr_v_i(trace_v_lo)
-     ,.vaddr_ready_o(dut_ready_lo)
-
      ,.ptag_i(ptag_li)
-     ,.ptag_v_i(trace_v_lo)
      ,.ptag_uncached_i(uncached_li)
      ,.ptag_nonidem_i(nonidem_li)
      ,.ptag_dram_i(~uncached_li)
+     ,.v_i(trace_v_lo)
+     ,.yumi_o(trace_yumi_li)
+
      ,.data_o(icache_data_lo)
      ,.data_v_o(icache_data_v_lo)
+     ,.ready_i(icache_ready_li)
 
      ,.mem_fwd_header_o(mem_fwd_header_lo)
      ,.mem_fwd_data_o(mem_fwd_data_lo)
@@ -251,7 +250,6 @@ module testbench
    #(.bp_params_p(bp_params_p)
      ,.preload_mem_p(1)
      ,.dram_type_p(dram_type_p)
-     ,.mem_els_p(2**20)
      )
     mem
     (.clk_i(clk_i)

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -122,6 +122,7 @@ module wrapper
      ,.data_o(data_o)
      ,.data_v_o(data_v_o)
      ,.spec_v_o()
+     ,.fence_v_o()
      ,.yumi_i(ready_i & data_v_o)
 
      ,.cache_req_o(cache_req_lo)

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -16,24 +16,22 @@ module wrapper
 
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
    )
-  (input                                     clk_i
-   , input                                   reset_i
+  (input                                         clk_i
+   , input                                       reset_i
 
-   , input [cfg_bus_width_lp-1:0]            cfg_bus_i
+   , input [cfg_bus_width_lp-1:0]                cfg_bus_i
 
-   , input [vaddr_width_p-1:0]               vaddr_i
-   , input                                   vaddr_v_i
-   , output                                  vaddr_ready_o
+   , input [vaddr_width_p-1:0]                   vaddr_i
+   , input [ptag_width_p-1:0]                    ptag_i
+   , input                                       ptag_uncached_i
+   , input                                       ptag_nonidem_i
+   , input                                       ptag_dram_i
+   , input                                       v_i
+   , output                                      yumi_o
 
-   , input [ptag_width_p-1:0]                ptag_i
-   , input                                   ptag_v_i
-
-   , input                                   ptag_uncached_i
-   , input                                   ptag_nonidem_i
-   , input                                   ptag_dram_i
-
-   , output [instr_width_gp-1:0]             data_o
-   , output                                  data_v_o
+   , output [instr_width_gp-1:0]                 data_o
+   , output                                      data_v_o
+   , input                                       ready_i
 
    , output logic [mem_fwd_header_width_lp-1:0]  mem_fwd_header_o
    , output logic [l2_data_width_p-1:0]          mem_fwd_data_o
@@ -49,8 +47,7 @@ module wrapper
    );
 
   `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
-  bp_cfg_bus_s cfg_bus_cast_i;
-  assign cfg_bus_cast_i = cfg_bus_i;
+  `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
   `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
@@ -75,84 +72,24 @@ module wrapper
   logic [icache_tag_info_width_lp-1:0] tag_mem_lo;
   logic [icache_stat_info_width_lp-1:0] stat_mem_lo;
 
-  // Rolly fifo signals
-  logic [ptag_width_p-1:0] rolly_ptag_lo;
-  logic [vaddr_width_p-1:0] rolly_vaddr_lo;
-  logic rolly_nonidem_lo;
-  logic rolly_uncached_lo;
-  logic rolly_dram_lo;
-  logic rolly_v_lo;
-  logic rolly_yumi_li;
-  logic icache_ready_lo;
-  assign rolly_yumi_li = rolly_v_lo & icache_ready_lo;
-
-  logic rollback_li, rolly_yumi_rr;
-
-  bsg_fifo_1r1w_rolly
-   #(.width_p(vaddr_width_p+ptag_width_p+3), .els_p(8))
-   rolly_icache
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.clr_v_i(1'b0)
-     ,.deq_v_i(data_v_o)
-     ,.roll_v_i(rollback_li)
-
-     ,.data_i({ptag_dram_i, ptag_nonidem_i, ptag_uncached_i, vaddr_i, ptag_i})
-     ,.v_i(vaddr_v_i)
-     ,.ready_o(vaddr_ready_o)
-
-     ,.data_o({rolly_dram_lo, rolly_nonidem_lo, rolly_uncached_lo, rolly_vaddr_lo, rolly_ptag_lo})
-     ,.v_o(rolly_v_lo)
-     ,.yumi_i(rolly_yumi_li)
-     );
-
-  bsg_dff_chain
-   #(.width_p(1), .num_stages_p(2))
-   rolly_yumi_reg
-    (.clk_i(clk_i)
-     ,.data_i(rolly_yumi_li)
-     ,.data_o(rolly_yumi_rr)
-     );
-
-  assign rollback_li = rolly_yumi_rr & ~data_v_o;
-
-  logic [ptag_width_p-1:0] rolly_ptag_r;
-  bsg_dff_reset
-   #(.width_p(ptag_width_p))
+  logic ptag_dram_r, ptag_nonidem_r, ptag_uncached_r;
+  logic [vaddr_width_p-1:0] vaddr_r;
+  logic [ptag_width_p-1:0] ptag_r;
+  bsg_dff_reset_en
+   #(.width_p(3+vaddr_width_p+ptag_width_p))
    ptag_dff
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
+     ,.en_i(yumi_o)
 
-     ,.data_i(rolly_ptag_lo)
-     ,.data_o(rolly_ptag_r)
+     ,.data_i({ptag_dram_i, ptag_nonidem_i, ptag_uncached_i, vaddr_i, ptag_i})
+     ,.data_o({ptag_dram_r, ptag_nonidem_r, ptag_uncached_r, vaddr_r, ptag_r})
      );
 
-  logic ptag_v_r, dram_r, uncached_r, nonidem_r;
-  bsg_dff_reset
-   #(.width_p(4))
-   ptag_v_dff
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.data_i({rolly_dram_lo, rolly_nonidem_lo, rolly_uncached_lo, rolly_v_lo})
-     ,.data_o({dram_r, nonidem_r, uncached_r, ptag_v_r})
-     );
-
-   logic icache_v_rr, poison_li;
-   bsg_dff_chain
-    #(.width_p(1), .num_stages_p(2))
-    icache_v_reg
-     (.clk_i(clk_i)
-      ,.data_i(rolly_yumi_li)
-      ,.data_o(icache_v_rr)
-      );
-
-   assign poison_li = icache_v_rr & ~data_v_o;
 
   `declare_bp_fe_icache_pkt_s(vaddr_width_p);
   bp_fe_icache_pkt_s icache_pkt;
-  assign icache_pkt = '{vaddr: rolly_vaddr_lo, op: e_icache_fill};
+  assign icache_pkt = '{vaddr: vaddr_i, op: e_icache_fetch, spec: 1'b0};
 
   // I-Cache
   bp_fe_icache
@@ -169,19 +106,23 @@ module wrapper
      ,.cfg_bus_i(cfg_bus_i)
 
      ,.icache_pkt_i(icache_pkt)
-     ,.v_i(rolly_yumi_li)
-     ,.ready_o(icache_ready_lo)
-
-     ,.ptag_i(rolly_ptag_r)
-     ,.ptag_v_i(ptag_v_r)
-     ,.ptag_uncached_i(uncached_r)
-     ,.ptag_nonidem_i(nonidem_r)
-     ,.ptag_dram_i(dram_r)
+     ,.v_i(v_i)
+     ,.yumi_o(yumi_o)
+     ,.force_i(1'b0)
      ,.poison_tl_i(1'b0)
+
+     ,.ptag_i(ptag_r)
+     ,.ptag_v_i(1'b1)
+     ,.ptag_uncached_i(ptag_uncached_r)
+     ,.ptag_nonidem_i(ptag_nonidem_r)
+     ,.ptag_dram_i(ptag_dram_r)
+     ,.poison_tv_i(1'b0)
+     ,.tv_we_o()
 
      ,.data_o(data_o)
      ,.data_v_o(data_v_o)
-     ,.miss_v_o()
+     ,.spec_v_o()
+     ,.yumi_i(ready_i & data_v_o)
 
      ,.cache_req_o(cache_req_lo)
      ,.cache_req_v_o(cache_req_v_lo)

--- a/bp_me/src/v/lce/bp_lce_req.sv
+++ b/bp_me/src/v/lce/bp_lce_req.sv
@@ -37,8 +37,6 @@ module bp_lce_req
    // byte offset bits required per bedrock data channel beat
    , localparam bedrock_byte_offset_lp = `BSG_SAFE_CLOG2(fill_width_p/8)
    , localparam bit [paddr_width_p-1:0] req_addr_mask = {paddr_width_p{1'b1}} << bedrock_byte_offset_lp
-   // coherence request size for cached requests
-   , localparam bp_bedrock_msg_size_e req_block_size_lp = bp_bedrock_msg_size_e'(`BSG_SAFE_CLOG2(block_width_p/8))
 
    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache)
@@ -262,7 +260,7 @@ module bp_lce_req
           end
           e_miss_load: begin
             lce_req_header_v_o = cache_req_v_with_credit;
-            lce_req_header_cast_o.size = req_block_size_lp;
+            lce_req_header_cast_o.size = bp_bedrock_msg_size_e'(cache_req_r.size);
             // align address to data width and send address of critical beat
             lce_req_header_cast_o.addr = critical_req_addr;
             lce_req_header_cast_o.msg_type.req = e_bedrock_req_rd_miss;
@@ -274,7 +272,7 @@ module bp_lce_req
           end
           e_miss_store: begin
             lce_req_header_v_o = cache_req_v_with_credit;
-            lce_req_header_cast_o.size = req_block_size_lp;
+            lce_req_header_cast_o.size = bp_bedrock_msg_size_e'(cache_req_r.size);
             // align address to data width and send address of critical beat
             lce_req_header_cast_o.addr = critical_req_addr;
             lce_req_header_cast_o.msg_type.req = e_bedrock_req_wr_miss;

--- a/bp_me/test/common/bp_me_nonsynth_cache.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cache.sv
@@ -94,6 +94,8 @@ module bp_me_nonsynth_cache
 
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache);
 
+    localparam bp_cache_req_size_e block_req_size = bp_cache_req_size_e'(`BSG_SAFE_CLOG2(block_width_p/8));
+
   // Trace Replay Interface
   `declare_bp_me_nonsynth_tr_pkt_s(paddr_width_p, dword_width_gp);
   `bp_cast_i(bp_me_nonsynth_tr_pkt_s, tr_pkt);
@@ -422,13 +424,15 @@ module bp_me_nonsynth_cache
     cache_req_cast_o = '0;
     cache_req_cast_o.hit = 1'b0; // unused by LCE
     cache_req_cast_o.data = tr_pkt_r.data;
-    cache_req_cast_o.size = double_op
-                            ? e_size_8B
-                            : word_op
-                              ? e_size_4B
-                              : half_op
-                                ? e_size_2B
-                                : e_size_1B;
+    cache_req_cast_o.size = uc_op
+                            ? double_op
+                              ? e_size_8B
+                              : word_op
+                                ? e_size_4B
+                                : half_op
+                                  ? e_size_2B
+                                  : e_size_1B
+                            : block_req_size;
     cache_req_cast_o.addr = tr_pkt_r.paddr;
     // AMO, flush, clear, and wt_store not supported
     cache_req_cast_o.msg_type = uc_op ? store_op ? e_uc_store : e_uc_load

--- a/bp_me/test/tb/bp_cce/testbench.sv
+++ b/bp_me/test/tb/bp_cce/testbench.sv
@@ -688,7 +688,6 @@ module testbench
    #(.bp_params_p(bp_params_p)
      ,.preload_mem_p(0)
      ,.dram_type_p(dram_type_p)
-     ,.mem_els_p(2**20)
      )
    mem
     (.clk_i(clk_i)

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -230,6 +230,7 @@ $BP_BE_DIR/src/v/bp_be_dcache/bp_be_dcache_wbuf.sv
 $BP_FE_DIR/src/v/bp_fe_ras.sv
 $BP_FE_DIR/src/v/bp_fe_bht.sv
 $BP_FE_DIR/src/v/bp_fe_btb.sv
+$BP_FE_DIR/src/v/bp_fe_controller.sv
 $BP_FE_DIR/src/v/bp_fe_icache.sv
 $BP_FE_DIR/src/v/bp_fe_instr_scan.sv
 $BP_FE_DIR/src/v/bp_fe_pc_gen.sv

--- a/bp_top/test/common/bp_nonsynth_core_profiler.sv
+++ b/bp_top/test/common/bp_nonsynth_core_profiler.sv
@@ -91,12 +91,12 @@ module bp_nonsynth_core_profiler
 
     // FE events
     , input fe_queue_ready_i
-    , input fe_icache_ready_i
 
-    , input if2_v_i
     , input br_ovr_i
     , input ret_ovr_i
     , input icache_data_v_i
+    , input icache_v_i
+    , input icache_yumi_i
 
     // Backwards ISS events
     // TODO: Differentiate between different FE cmds
@@ -171,19 +171,18 @@ module bp_nonsynth_core_profiler
       // IF0
       stall_stage_n[0]                    = '0;
       stall_stage_n[0].fe_cmd            |= fe_cmd_nonattaboy_i;
-      stall_stage_n[0].icache_miss       |= (~fe_icache_ready_i | (if2_v_i & ~icache_data_v_i));
+      stall_stage_n[0].icache_miss       |= icache_v_i & ~icache_yumi_i;
 
       // IF1
       stall_stage_n[1]                    = stall_stage_r[0];
       stall_stage_n[1].fe_cmd            |= fe_cmd_nonattaboy_i;
-      stall_stage_n[1].icache_miss       |= if2_v_i & ~icache_data_v_i;
       stall_stage_n[1].branch_override   |= br_ovr_i;
       stall_stage_n[1].ret_override      |= ret_ovr_i;
 
       // IF2
       stall_stage_n[2]                    = stall_stage_r[1];
       stall_stage_n[2].fe_cmd            |= fe_cmd_nonattaboy_i;
-      stall_stage_n[2].icache_miss       |= if2_v_i & ~icache_data_v_i;
+      stall_stage_n[2].icache_miss       |= ~icache_data_v_i;
 
       // ISD
       // Dispatch stalls

--- a/bp_top/test/tb/bp_tethered/Makefile.testlist
+++ b/bp_top/test/tb/bp_tethered/Makefile.testlist
@@ -9,6 +9,7 @@
 #  unhandled_trap
 #  These tests dont work on all configs
 #  aviary_rom
+#  This test fails spuriously because it assumes IALIGN=32
 #  epc
 MISC_TESTS := \
   hello_world           \

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -541,53 +541,38 @@ module testbench
           ,.commit_pkt_i(be.calculator.pipe_sys.commit_pkt)
           );
 
-//      bind bp_fe_top
-//        bp_fe_nonsynth_pc_gen_tracer
-//         #(.bp_params_p(bp_params_p))
-//         pc_gen_tracer
-//          (.clk_i                  (clk_i & testbench.pc_gen_trace_en_lo)
-//           ,.reset_i               (reset_i)
-//           ,.freeze_i              (cfg_bus_cast_i.freeze)
-//
-//           ,.mhartid_i             (cfg_bus_cast_i.core_id)
-//
-//           ,.state_resume_i        (controller.is_resume)
-//           ,.state_wait_i          (controller.is_wait)
-//
-//<<<<<<< HEAD
-//           ,.queue_miss_i          (queue_miss)
-//           ,.icache_miss_i         (icache_miss)
-//           ,.icache_req_i          (cache_req_v_o)
-//           ,.access_fault_i        (v_if2_r & instr_access_fault_r)
-//           ,.page_fault_i          (v_if2_r & instr_page_fault_r)
-//           ,.itlb_miss_i           (v_if2_r & itlb_miss_r)
-//=======
-//           ,.icache_spec_i         (icache_spec_v_lo)
-//           ,.access_fault_i        (instr_access_fault_r)
-//           ,.page_fault_i          (instr_page_fault_r)
-//           ,.itlb_miss_i           (itlb_miss_r)
-//>>>>>>> Changes made, should break up and clean
-//
-//           ,.src_redirect_i        (pc_gen.redirect_v_i)
-//           ,.src_override_ntaken_i (pc_gen.ovr_ntaken)
-//           ,.src_override_ras_i    (pc_gen.ovr_ret)
-//           ,.src_override_branch_i (pc_gen.ovr_btaken | pc_gen.ovr_jmp)
-//           ,.src_btb_taken_branch_i(pc_gen.btb_taken)
-//
-//<<<<<<< HEAD
-//           ,.if1_top_v_i           (v_if1_r)
-//           ,.if1_pc_i              (pc_gen.pc_if1_r)
-//
-//           ,.if2_top_v_i           (v_if2_r)
-//           ,.if2_pc_i              (pc_gen.pc_if2_r)
-//           ,.realigner_v_i         (pc_gen.fetch_instr_generation.half_buffer_v_r)
-//           ,.realigner_pc_i        (pc_gen.fetch_instr_generation.fetch_instr_pc_r)
-//           ,.realigner_instr_i     (pc_gen.fetch_instr_generation.half_buffer_r)
-//=======
-//           ,.fetch_pc_i            (pc_gen.pc_if2_r)
-//           ,.fetch_v_i             (fe_queue_ready_i & fe_queue_v_o)
-//>>>>>>> Changes made, should break up and clean
-//           );
+      bind bp_fe_top
+        bp_fe_nonsynth_pc_gen_tracer
+         #(.bp_params_p(bp_params_p))
+         pc_gen_tracer
+          (.clk_i(clk_i & testbench.pc_gen_trace_en_lo)
+           ,.reset_i(reset_i)
+           ,.freeze_i(cfg_bus_cast_i.freeze)
+
+           ,.mhartid_i(cfg_bus_cast_i.core_id)
+
+           ,.state_resume_i(controller.is_resume)
+           ,.state_wait_i(controller.is_wait)
+
+           ,.icache_spec_i(icache_spec_v_lo)
+           ,.access_fault_i(instr_access_fault_r)
+           ,.page_fault_i(instr_page_fault_r)
+           ,.itlb_miss_i(itlb_miss_r)
+
+           ,.src_redirect_i(pc_gen.redirect_v_i)
+           ,.src_override_ntaken_i(pc_gen.ovr_ntaken)
+           ,.src_override_ras_i(pc_gen.ovr_ret)
+           ,.src_override_branch_i(pc_gen.ovr_btaken | pc_gen.ovr_jmp)
+           ,.src_btb_taken_branch_i(pc_gen.btb_taken)
+
+           ,.if2_pc_i(pc_gen.pc_if2_r)
+           ,.if2_v_i(icache_v_lo)
+
+           ,.fetch_v_i(fe_queue_ready_i & fe_queue_v_o)
+           ,.fetch_pc_i(fetch_pc_lo)
+           ,.fetch_instr_i(fetch_instr_lo)
+           ,.fetch_partial_i(fetch_partial_lo)
+           );
 
       bind bp_be_top
         bp_nonsynth_pc_profiler

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -249,8 +249,6 @@ module testbench
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     // TODO: Set appropriately for multicore
-
      ,.lce_id_i(io_lce_id_li)
      ,.did_i(host_did_li)
 
@@ -484,14 +482,14 @@ module testbench
           ,.mhartid_i(be.calculator.pipe_sys.csr.cfg_bus_cast_i.core_id)
 
           ,.fe_queue_ready_i(fe.fe_queue_ready_i)
-          ,.fe_icache_ready_i(fe.icache.ready_o)
      
-          ,.if2_v_i(fe.v_if2_r)
           ,.br_ovr_i(fe.pc_gen.ovr_btaken | fe.pc_gen.ovr_jmp)
           ,.ret_ovr_i(fe.pc_gen.ovr_ret)
           ,.icache_data_v_i(fe.icache.data_v_o)
+          ,.icache_v_i(fe.icache.v_i)
+          ,.icache_yumi_i(fe.icache.yumi_o)
 
-          ,.fe_cmd_nonattaboy_i(fe.fe_cmd_yumi_o & ~fe.attaboy_v) 
+          ,.fe_cmd_nonattaboy_i(fe.fe_cmd_yumi_o & ~fe.controller.attaboy_v)
           ,.fe_cmd_fence_i(be.director.is_fence)
           ,.fe_queue_empty_i(~be.scheduler.fe_queue_fifo.fe_queue_v_o)
 
@@ -543,41 +541,53 @@ module testbench
           ,.commit_pkt_i(be.calculator.pipe_sys.commit_pkt)
           );
 
-      bind bp_fe_top
-        bp_fe_nonsynth_pc_gen_tracer
-         #(.bp_params_p(bp_params_p))
-         pc_gen_tracer
-          (.clk_i                  (clk_i & testbench.pc_gen_trace_en_lo)
-           ,.reset_i               (reset_i)
-           ,.freeze_i              (cfg_bus_cast_i.freeze)
-
-           ,.mhartid_i             (cfg_bus_cast_i.core_id)
-
-           ,.state_stall_i         (is_stall)
-           ,.state_wait_i          (is_wait)
-
-           ,.queue_miss_i          (queue_miss)
-           ,.icache_miss_i         (icache_miss)
-           ,.icache_req_i          (cache_req_v_o)
-           ,.access_fault_i        (v_if2_r & instr_access_fault_r)
-           ,.page_fault_i          (v_if2_r & instr_page_fault_r)
-           ,.itlb_miss_i           (v_if2_r & itlb_miss_r)
-
-           ,.src_redirect_i        (pc_gen.redirect_v_i)
-           ,.src_override_ntaken_i (pc_gen.ovr_ntaken)
-           ,.src_override_ras_i    (pc_gen.ovr_ret)
-           ,.src_override_branch_i (pc_gen.ovr_btaken | pc_gen.ovr_jmp)
-           ,.src_btb_taken_branch_i(pc_gen.btb_taken)
-
-           ,.if1_top_v_i           (v_if1_r)
-           ,.if1_pc_i              (pc_gen.pc_if1_r)
-
-           ,.if2_top_v_i           (v_if2_r)
-           ,.if2_pc_i              (pc_gen.pc_if2_r)
-           ,.realigner_v_i         (pc_gen.fetch_instr_generation.half_buffer_v_r)
-           ,.realigner_pc_i        (pc_gen.fetch_instr_generation.fetch_instr_pc_r)
-           ,.realigner_instr_i     (pc_gen.fetch_instr_generation.half_buffer_r)
-           );
+//      bind bp_fe_top
+//        bp_fe_nonsynth_pc_gen_tracer
+//         #(.bp_params_p(bp_params_p))
+//         pc_gen_tracer
+//          (.clk_i                  (clk_i & testbench.pc_gen_trace_en_lo)
+//           ,.reset_i               (reset_i)
+//           ,.freeze_i              (cfg_bus_cast_i.freeze)
+//
+//           ,.mhartid_i             (cfg_bus_cast_i.core_id)
+//
+//           ,.state_resume_i        (controller.is_resume)
+//           ,.state_wait_i          (controller.is_wait)
+//
+//<<<<<<< HEAD
+//           ,.queue_miss_i          (queue_miss)
+//           ,.icache_miss_i         (icache_miss)
+//           ,.icache_req_i          (cache_req_v_o)
+//           ,.access_fault_i        (v_if2_r & instr_access_fault_r)
+//           ,.page_fault_i          (v_if2_r & instr_page_fault_r)
+//           ,.itlb_miss_i           (v_if2_r & itlb_miss_r)
+//=======
+//           ,.icache_spec_i         (icache_spec_v_lo)
+//           ,.access_fault_i        (instr_access_fault_r)
+//           ,.page_fault_i          (instr_page_fault_r)
+//           ,.itlb_miss_i           (itlb_miss_r)
+//>>>>>>> Changes made, should break up and clean
+//
+//           ,.src_redirect_i        (pc_gen.redirect_v_i)
+//           ,.src_override_ntaken_i (pc_gen.ovr_ntaken)
+//           ,.src_override_ras_i    (pc_gen.ovr_ret)
+//           ,.src_override_branch_i (pc_gen.ovr_btaken | pc_gen.ovr_jmp)
+//           ,.src_btb_taken_branch_i(pc_gen.btb_taken)
+//
+//<<<<<<< HEAD
+//           ,.if1_top_v_i           (v_if1_r)
+//           ,.if1_pc_i              (pc_gen.pc_if1_r)
+//
+//           ,.if2_top_v_i           (v_if2_r)
+//           ,.if2_pc_i              (pc_gen.pc_if2_r)
+//           ,.realigner_v_i         (pc_gen.fetch_instr_generation.half_buffer_v_r)
+//           ,.realigner_pc_i        (pc_gen.fetch_instr_generation.fetch_instr_pc_r)
+//           ,.realigner_instr_i     (pc_gen.fetch_instr_generation.half_buffer_r)
+//=======
+//           ,.fetch_pc_i            (pc_gen.pc_if2_r)
+//           ,.fetch_v_i             (fe_queue_ready_i & fe_queue_v_o)
+//>>>>>>> Changes made, should break up and clean
+//           );
 
       bind bp_be_top
         bp_nonsynth_pc_profiler


### PR DESCRIPTION
## Summary
This PR is a major refactor of the FE to fix a few architectural problems and leave room for future enhancements to the FE-BE interface.

## Issue Fixed
No issues

## Area
FE, some FE/BE interface changes

## Reasoning (outdated, confusing, verbose, etc.)
There are several problems with the current FE:
- Replaying I$ misses can cause non-idempotent regions to accidentally fetch twice
- Replaying I$ misses costs more power on re-reading
- Failing fe_queue ready condition causes an additional "replay" on the currently fetched instruction. This causes us to need another entry on the next_pc mux
- The culmination of these issues is in the x_resume registers which are unnecessary muxing and storage.

## Additional Changes Required (if any)
Impacts #1098, will rebase those changes on top of this once CI passes

## Analysis
This is a net decrease in flops, muxing and adders. There is additional control logic, but unlikely to be critical.

## Verification
Have verified that current performance is maintained or increased in three categories of benchmarks
- coremark (+0.01%)
- beebs (+1-5%)
- VM tests (+1-10%)* mostly from fixing a latency bug when redirects would happen after most TLB fills

## Additional Context


