### PR TITLE
Fixes ready handshake naming for bp_be_dcache

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -161,7 +161,7 @@ module bp_be_pipe_mem
   logic                     dcache_ptag_v;
   logic                     dcache_ptag_uncached;
   logic                     dcache_ptag_dram;
-  logic                     dcache_ready_lo;
+  logic                     dcache_ready_and_lo;
 
   logic load_access_fault_v, store_access_fault_v;
   logic load_page_fault_v, store_page_fault_v;
@@ -279,7 +279,7 @@ module bp_be_pipe_mem
      ,.dcache_pkt_o(ptw_dcache_pkt)
      ,.dcache_ptag_o(ptw_dcache_ptag)
      ,.dcache_ptag_v_o(ptw_dcache_ptag_v)
-     ,.dcache_ready_i(dcache_ready_lo)
+     ,.dcache_ready_i(dcache_ready_and_lo)
 
      ,.dcache_early_hit_v_i(dcache_early_hit_v)
      ,.dcache_early_data_i(dcache_early_data)
@@ -295,7 +295,7 @@ module bp_be_pipe_mem
 
       ,.dcache_pkt_i(dcache_pkt)
       ,.v_i(dcache_pkt_v)
-      ,.ready_o(dcache_ready_lo)
+      ,.ready_and_o(dcache_ready_and_lo)
       ,.poison_req_i(flush_i)
 
       ,.ptag_i(dcache_ptag)
@@ -403,7 +403,7 @@ module bp_be_pipe_mem
   assign fencei_clean_v_o       = early_v_r &  dcache_early_fencei &  dcache_early_hit_v;
   assign fencei_dirty_v_o       = early_v_r &  dcache_early_fencei & ~dcache_early_hit_v;
 
-  assign ready_o                = dcache_ready_lo;
+  assign ready_o                = dcache_ready_and_lo;
   assign ptw_busy_o             = ptw_busy;
   assign early_data_o           = dcache_early_data;
   assign early_fflags_o         = dcache_early_fflags;

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -128,7 +128,7 @@ module bp_be_dcache
    // New D$ packet comes in
    , input [dcache_pkt_width_lp-1:0]                 dcache_pkt_i
    , input                                           v_i
-   , output logic                                    ready_o
+   , output logic                                    ready_and_o
    , input                                           poison_req_i
 
    // Cycle 1: "Tag Lookup"
@@ -315,7 +315,7 @@ module bp_be_dcache
   logic [page_offset_width_gp-1:0] page_offset_tl_r;
   logic [dpath_width_gp-1:0] data_tl_r;
 
-  assign safe_tl_we = ready_o & v_i;
+  assign safe_tl_we = ready_and_o & v_i;
   assign tl_we = safe_tl_we & ~poison_req_i & ~flush_self;
   bsg_dff_reset
    #(.width_p(1))
@@ -982,7 +982,7 @@ module bp_be_dcache
     else
       state_r <= state_n;
 
-  assign ready_o = ~cache_req_busy_i & is_ready;
+  assign ready_and_o = ~cache_req_busy_i & is_ready;
 
   /////////////////////////////////////////////////////////////////////////////
   // SRAM Control

--- a/bp_be/test/common/bp_be_nonsynth_dcache_tracer.sv
+++ b/bp_be/test/common/bp_be_nonsynth_dcache_tracer.sv
@@ -27,7 +27,7 @@ module bp_be_nonsynth_dcache_tracer
 
    , input [dcache_pkt_width_lp-1:0]                      dcache_pkt_i
    , input                                                v_i
-   , input                                                ready_o
+   , input                                                ready_and_o
 
    , input [dpath_width_gp-1:0]                           early_data_o
    , input                                                early_hit_v_o
@@ -153,7 +153,7 @@ module bp_be_nonsynth_dcache_tracer
 
   always_ff @(posedge clk_i)
     begin
-      if (ready_o & v_i)
+      if (ready_and_o & v_i)
         $fwrite(acc_file, "%12t | access: %p\n", $time, dcache_pkt_cast_i);
       if (early_hit_v_o & decode_tv_r.load_op)
         $fwrite(acc_file, "%12t | early load: [%x]->%x\n", $time, paddr_tv_r, early_data_o);

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -63,7 +63,7 @@ module wrapper
   `declare_bp_be_dcache_pkt_s(vaddr_width_p);
 
   // Cache to Rolly FIFO signals
-  logic [num_caches_p-1:0] dcache_ready_lo;
+  logic [num_caches_p-1:0] dcache_ready_and_lo;
   logic [num_caches_p-1:0] rollback_li;
   logic [num_caches_p-1:0] rolly_uncached_lo;
   logic [num_caches_p-1:0] rolly_v_lo, rolly_yumi_li;
@@ -160,7 +160,7 @@ module wrapper
        ,.v_o(rolly_v_lo[i])
        ,.yumi_i(rolly_yumi_li[i])
        );
-      assign rolly_yumi_li[i] = rolly_v_lo[i] & dcache_ready_lo[i];
+      assign rolly_yumi_li[i] = rolly_v_lo[i] & dcache_ready_and_lo[i];
 
       bsg_dff_reset
        #(.width_p(1+ptag_width_p)
@@ -204,7 +204,7 @@ module wrapper
 
       ,.dcache_pkt_i(rolly_dcache_pkt_lo[i])
       ,.v_i(rolly_yumi_li[i])
-      ,.ready_o(dcache_ready_lo[i])
+      ,.ready_and_o(dcache_ready_and_lo[i])
 
       ,.early_data_o(early_data_lo[i])
       ,.early_hit_v_o(early_v_lo[i])

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -131,7 +131,7 @@ module bp_cacc_vdp
 
   `declare_bp_be_dcache_pkt_s(vaddr_width_p);
   bp_be_dcache_pkt_s        dcache_pkt;
-  logic                     dcache_ready, dcache_v;
+  logic                     dcache_ready_and, dcache_v;
   logic [dpath_width_gp-1:0] dcache_data;
   logic                     dcache_pkt_v;
 
@@ -180,7 +180,7 @@ module bp_cacc_vdp
 
      ,.dcache_pkt_i(dcache_pkt)
      ,.v_i(dcache_pkt_v)
-     ,.ready_o(dcache_ready)
+     ,.ready_and_o(dcache_ready_and)
      ,.poison_req_i(1'b0)
 
      ,.ptag_v_i(1'b1)
@@ -399,7 +399,7 @@ module bp_cacc_vdp
       second_operand = 0;
       dcache_pkt_v = 0;
 
-      state_n = state_r;
+  state_n = state_r;
       case (state_r)
         e_reset: begin
           state_n = reset_i ? e_reset : e_wait_start;
@@ -409,7 +409,7 @@ module bp_cacc_vdp
           state_n = start_cmd ? e_wait_fetch : e_wait_start;
         end
         e_wait_fetch: begin
-          state_n = dcache_ready ? e_fetch_vec1 : e_wait_fetch;
+          state_n = dcache_ready_and ? e_fetch_vec1 : e_wait_fetch;
         end
         e_fetch_vec1: begin
           dcache_pkt_v = '1;

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -494,7 +494,7 @@ module testbench
           ,.fe_queue_empty_i(~be.scheduler.fe_queue_fifo.fe_queue_v_o)
 
           ,.mispredict_i(be.director.npc_mismatch_v)
-          ,.dcache_miss_i(~be.calculator.pipe_mem.dcache.ready_o)
+          ,.dcache_miss_i(~be.calculator.pipe_mem.dcache.ready_and_o)
           ,.long_haz_i(be.detector.long_haz_v)
           ,.control_haz_i(be.detector.control_haz_v)
           ,.data_haz_i(be.detector.data_haz_v)


### PR DESCRIPTION
## Summary
bp_be_dcache ready_o operates via a ready_and handshake, and therefore this PR updates the signal to ready_and as per the style guide and modifies all instantiations of bp_be_dcache to use the updated naming convention.

## Issue Fixed
None

## Area
BE, Top

## Reasoning
Clarification of interface usage, more in line with existing style guide.

## Verification
Verilator successfully built, no functional differences

