### PR TITLE
Changes fe_queue_ready_o signal to ready_and interface

### DIFF
--- a/bp_be/src/v/bp_be_checker/bp_be_issue_queue.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_issue_queue.sv
@@ -21,7 +21,7 @@ module bp_be_issue_queue
 
    , input [fe_queue_width_lp-1:0]          fe_queue_i
    , input                                  fe_queue_v_i
-   , output logic                           fe_queue_ready_o
+   , output logic                           fe_queue_ready_and_o
 
    , output logic [fe_queue_width_lp-1:0]   fe_queue_o
    , output logic                           fe_queue_v_o
@@ -46,7 +46,7 @@ module bp_be_issue_queue
   logic cptr_jmp;
 
   // Operations
-  wire enq  = fe_queue_ready_o & fe_queue_v_i;
+  wire enq  = fe_queue_ready_and_o & fe_queue_v_i;
   wire deq  = deq_v_i;
   wire read = fe_queue_yumi_i;
   wire clr  = clr_v_i;
@@ -116,7 +116,7 @@ module bp_be_issue_queue
     ,.r_data_o(fe_queue_cast_o)
     );
   assign fe_queue_v_o     = ~roll & ~empty;
-  assign fe_queue_ready_o = ~clr & ~full;
+  assign fe_queue_ready_and_o = ~clr & ~full;
 
   rv64_instr_fmatype_s instr;
   assign instr = fe_queue_cast_i.instr;

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -47,7 +47,7 @@ module bp_be_scheduler
   // Fetch interface
   , input [fe_queue_width_lp-1:0]      fe_queue_i
   , input                              fe_queue_v_i
-  , output                             fe_queue_ready_o
+  , output                             fe_queue_ready_and_o
 
   // Dispatch interface
   , output [dispatch_pkt_width_lp-1:0] dispatch_pkt_o
@@ -88,7 +88,7 @@ module bp_be_scheduler
 
      ,.fe_queue_i(fe_queue_i)
      ,.fe_queue_v_i(fe_queue_v_i)
-     ,.fe_queue_ready_o(fe_queue_ready_o)
+     ,.fe_queue_ready_and_o(fe_queue_ready_and_o)
 
      ,.fe_queue_o(fe_queue_lo)
      ,.fe_queue_v_o(fe_queue_v_lo)

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -28,7 +28,7 @@ module bp_be_top
    // FE queue interface
    , input [fe_queue_width_lp-1:0]                   fe_queue_i
    , input                                           fe_queue_v_i
-   , output                                          fe_queue_ready_o
+   , output                                          fe_queue_ready_and_o
 
    // FE cmd interface
    , output [fe_cmd_width_lp-1:0]                    fe_cmd_o
@@ -169,7 +169,7 @@ module bp_be_top
 
      ,.fe_queue_i(fe_queue_i)
      ,.fe_queue_v_i(fe_queue_v_i)
-     ,.fe_queue_ready_o(fe_queue_ready_o)
+     ,.fe_queue_ready_and_o(fe_queue_ready_and_o)
 
      ,.dispatch_pkt_o(dispatch_pkt)
 

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -27,7 +27,7 @@ module bp_fe_top
 
    , output [fe_queue_width_lp-1:0]                   fe_queue_o
    , output                                           fe_queue_v_o
-   , input                                            fe_queue_ready_i
+   , input                                            fe_queue_ready_and_i
 
    , output logic [icache_req_width_lp-1:0]           cache_req_o
    , output logic                                     cache_req_v_o
@@ -271,9 +271,9 @@ module bp_fe_top
      ,.stat_mem_o(stat_mem_o)
      );
   wire icache_v_lo = icache_data_v_lo | icache_spec_v_lo | icache_fence_v_lo;
-  wire icache_data_yumi_li = fe_queue_ready_i & icache_data_v_lo;
-  wire icache_spec_yumi_li = fe_queue_ready_i & icache_spec_v_lo;
-  wire icache_fence_yumi_li = fe_queue_ready_i & icache_fence_v_lo;
+  wire icache_data_yumi_li = fe_queue_ready_and_i & icache_data_v_lo;
+  wire icache_spec_yumi_li = fe_queue_ready_and_i & icache_spec_v_lo;
+  wire icache_fence_yumi_li = fe_queue_ready_and_i & icache_fence_v_lo;
   assign icache_yumi_li = icache_data_yumi_li | icache_spec_yumi_li | icache_fence_yumi_li;
 
   // This tracks the I$ valid. Could move inside entirely, but we're trying to separate
@@ -335,8 +335,8 @@ module bp_fe_top
   wire fe_exception_v = (instr_access_fault_r | instr_page_fault_r | itlb_miss_r | icache_spec_v_lo);
   wire fe_instr_v     = fetch_instr_v_lo;
 
-  assign fetch_instr_yumi_li     = fe_queue_ready_i & fe_queue_v_o & fe_instr_v;
-  assign fetch_exception_yumi_li = fe_queue_ready_i & fe_queue_v_o & fe_exception_v;
+  assign fetch_instr_yumi_li     = fe_queue_ready_and_i & fe_queue_v_o & fe_instr_v;
+  assign fetch_exception_yumi_li = fe_queue_ready_and_i & fe_queue_v_o & fe_exception_v;
 
   assign fe_queue_v_o = (fe_instr_v | fe_exception_v);
   always_comb

--- a/bp_top/src/v/bp_core_minimal.sv
+++ b/bp_top/src/v/bp_core_minimal.sv
@@ -90,7 +90,7 @@ module bp_core_minimal
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
   bp_fe_queue_s fe_queue_li, fe_queue_lo;
-  logic fe_queue_v_li, fe_queue_ready_lo;
+  logic fe_queue_v_li, fe_queue_ready_and_lo;
   bp_fe_cmd_s fe_cmd_lo;
   logic fe_cmd_v_lo, fe_cmd_yumi_li;
 
@@ -104,7 +104,7 @@ module bp_core_minimal
 
      ,.fe_queue_o(fe_queue_li)
      ,.fe_queue_v_o(fe_queue_v_li)
-     ,.fe_queue_ready_i(fe_queue_ready_lo)
+     ,.fe_queue_ready_and_i(fe_queue_ready_and_lo)
 
      ,.fe_cmd_i(fe_cmd_lo)
      ,.fe_cmd_v_i(fe_cmd_v_lo)
@@ -148,7 +148,7 @@ module bp_core_minimal
 
      ,.fe_queue_i(fe_queue_li)
      ,.fe_queue_v_i(fe_queue_v_li)
-     ,.fe_queue_ready_o(fe_queue_ready_lo)
+     ,.fe_queue_ready_and_o(fe_queue_ready_and_lo)
 
      ,.fe_cmd_o(fe_cmd_lo)
      ,.fe_cmd_v_o(fe_cmd_v_lo)

--- a/bp_top/test/common/bp_nonsynth_core_profiler.sv
+++ b/bp_top/test/common/bp_nonsynth_core_profiler.sv
@@ -90,7 +90,7 @@ module bp_nonsynth_core_profiler
     , input [`BSG_SAFE_CLOG2(num_core_p)-1:0] mhartid_i
 
     // FE events
-    , input fe_queue_ready_i
+    , input fe_queue_ready_and_i
 
     , input br_ovr_i
     , input ret_ovr_i

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -481,7 +481,7 @@ module testbench
 
           ,.mhartid_i(be.calculator.pipe_sys.csr.cfg_bus_cast_i.core_id)
 
-          ,.fe_queue_ready_i(fe.fe_queue_ready_i)
+          ,.fe_queue_ready_and_i(fe.fe_queue_ready_and_i)
      
           ,.br_ovr_i(fe.pc_gen.ovr_btaken | fe.pc_gen.ovr_jmp)
           ,.ret_ovr_i(fe.pc_gen.ovr_ret)
@@ -568,7 +568,7 @@ module testbench
            ,.if2_pc_i(pc_gen.pc_if2_r)
            ,.if2_v_i(icache_v_lo)
 
-           ,.fetch_v_i(fe_queue_ready_i & fe_queue_v_o)
+           ,.fetch_v_i(fe_queue_ready_and_i & fe_queue_v_o)
            ,.fetch_pc_i(fetch_pc_lo)
            ,.fetch_instr_i(fetch_instr_lo)
            ,.fetch_partial_i(fetch_partial_lo)


### PR DESCRIPTION
## Summary
Renames fe_queue_ready_o signal to fe_queue_ready_and_o as the signal is used in a way consistent with the rv->& interface.

## Issue Fixed
None

## Area
BE, FE, Top

## Reasoning (outdated, confusing, verbose, etc.)
Clarifies usage of the ready signal from bp_be_issue_queue and makes the interface more consistent with the style guide.

## Verification
Built with Verilator with no issue, no functional changes so only linting required.

## Additional Context
We see that it is rv->& from its [usage within the bp_be_issue_queue module](https://github.com/black-parrot/black-parrot/blob/master/bp_be/src/v/bp_be_checker/bp_be_issue_queue.sv#L49) as well as the [generation of the ready signal](https://github.com/black-parrot/black-parrot/blob/master/bp_be/src/v/bp_be_checker/bp_be_issue_queue.sv#L119). It can be noted that clr is directed from a signal labelled as valid, but it does not represent a transaction of data, and is more in line with a halting signal which is [generated here](https://github.com/black-parrot/black-parrot/blob/master/bp_be/src/v/bp_be_checker/bp_be_director.sv#L139).

