### PR TITLE
[WIP] Compressed instruction support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,6 @@ stages:
     - master
     - dev
     - fe_dev
-    - be_dev
     - me_dev
     - top_dev
     - sw_dev

--- a/Makefile.common
+++ b/Makefile.common
@@ -19,9 +19,11 @@ export BP_RTL_LIB_DIR     := $(BP_RTL_INSTALL_DIR)/lib
 export BP_RTL_INCLUDE_DIR := $(BP_RTL_INSTALL_DIR)/include
 export BP_RTL_TOUCH_DIR   := $(BP_RTL_INSTALL_DIR)/touch
 
-export BP_TOOLS_DIR ?= $(TOP)/../black-parrot-tools
+#export BP_TOOLS_DIR ?= $(TOP)/../black-parrot-tools
+export BP_TOOLS_DIR ?= $(TOP)/../compressed-tools
 include $(BP_TOOLS_DIR)/Makefile.common
 
-export BP_SDK_DIR ?= $(TOP)/../black-parrot-sdk
+#export BP_SDK_DIR ?= $(TOP)/../black-parrot-sdk
+export BP_SDK_DIR ?= $(TOP)/../compressed-sdk
 include $(BP_SDK_DIR)/Makefile.common
 

--- a/bp_be/src/include/bp_be_defines.svh
+++ b/bp_be/src/include/bp_be_defines.svh
@@ -26,6 +26,7 @@
       logic                                    frs2_v;                                             \
       logic                                    frs3_v;                                             \
       rv64_instr_s                             instr;                                              \
+      logic                                    compressed;                                         \
     }  bp_be_preissue_pkt_s;                                                                       \
                                                                                                    \
     typedef struct packed                                                                          \
@@ -38,8 +39,9 @@
       logic                                    icache_miss_v;                                      \
       logic [vaddr_width_mp-1:0]               pc;                                                 \
       rv64_instr_s                             instr;                                              \
+      logic                                    partial;                                            \
+      logic                                    compressed;                                         \
       logic [branch_metadata_fwd_width_mp-1:0] branch_metadata_fwd;                                \
-      logic                                    partial_v;                                          \
       logic                                    csr_v;                                              \
       logic                                    mem_v;                                              \
       logic                                    fence_v;                                            \
@@ -57,8 +59,10 @@
     {                                                                                              \
       logic                                    v;                                                  \
       logic                                    queue_v;                                            \
-      logic [vaddr_width_mp-1:0]               pc;                                                 \
       logic                                    instr_v;                                            \
+      logic                                    compressed;                                         \
+      logic                                    partial;                                            \
+      logic [vaddr_width_mp-1:0]               pc;                                                 \
       rv64_instr_s                             instr;                                              \
       bp_be_decode_s                           decode;                                             \
                                                                                                    \
@@ -71,7 +75,6 @@
       logic [dpath_width_gp-1:0]               rs1;                                                \
       logic [dpath_width_gp-1:0]               rs2;                                                \
       logic [dpath_width_gp-1:0]               imm;                                                \
-      logic                                    partial;                                            \
       bp_be_exception_s                        exception;                                          \
       bp_be_special_s                          special;                                            \
     }  bp_be_dispatch_pkt_s;                                                                       \
@@ -113,6 +116,7 @@
       logic [dpath_width_gp-1:0] data;                                                             \
       rv64_instr_s               instr;                                                            \
       logic                      partial;                                                          \
+      logic                      compressed;                                                       \
       bp_be_exception_s          exception;                                                        \
       bp_be_special_s            special;                                                          \
     }  bp_be_retire_pkt_s;                                                                         \
@@ -134,6 +138,8 @@
       logic                           npc_w_v;                                                     \
       logic                           queue_v;                                                     \
       logic                           instret;                                                     \
+      logic                           partial;                                                     \
+      logic                           compressed;                                                  \
       logic [vaddr_width_p-1:0]       pc;                                                          \
       logic [vaddr_width_p-1:0]       npc;                                                         \
       logic [vaddr_width_p-1:0]       vaddr;                                                       \
@@ -142,7 +148,6 @@
       logic [rv64_priv_width_gp-1:0]  priv_n;                                                      \
       logic                           translation_en_n;                                            \
       logic                           exception;                                                   \
-      logic                           partial;                                                     \
       logic                           _interrupt;                                                  \
       logic                           unfreeze;                                                    \
       logic                           eret;                                                        \
@@ -228,13 +233,13 @@
    *   and an unfortunate, necessary consequence of parameterized structs.
    */
   `define bp_be_preissue_pkt_width \
-    (5+rv64_instr_width_gp)
+    (6+rv64_instr_width_gp)
 
   `define bp_be_issue_pkt_width(vaddr_width_mp, branch_metadata_fwd_width_mp) \
-    (6+vaddr_width_mp+instr_width_gp+branch_metadata_fwd_width_mp+12)
+    (7+vaddr_width_mp+instr_width_gp+branch_metadata_fwd_width_mp+12)
 
   `define bp_be_dispatch_pkt_width(vaddr_width_mp) \
-    (2                                                                                             \
+    (3                                                                                             \
      + vaddr_width_mp                                                                              \
      + rv64_instr_width_gp                                                                         \
      + 7                                                                                           \
@@ -252,13 +257,13 @@
     (3 + vaddr_width_mp)
 
   `define bp_be_retire_pkt_width(vaddr_width_mp) \
-    (3 + dpath_width_gp + 2*vaddr_width_mp + instr_width_gp + 1 + $bits(bp_be_exception_s) + $bits(bp_be_special_s))
+    (4 + dpath_width_gp + 2*vaddr_width_mp + instr_width_gp + 1 + $bits(bp_be_exception_s) + $bits(bp_be_special_s))
 
   `define bp_be_pte_leaf_width(paddr_width_mp) \
     (paddr_width_mp - page_offset_width_gp + 7)
 
   `define bp_be_commit_pkt_width(vaddr_width_mp, paddr_width_mp) \
-    (4 + `bp_be_pte_leaf_width(paddr_width_mp) +  3*vaddr_width_mp + instr_width_gp + rv64_priv_width_gp + 18)
+    (5 + `bp_be_pte_leaf_width(paddr_width_mp) +  3*vaddr_width_mp + instr_width_gp + rv64_priv_width_gp + 18)
 
   `define bp_be_wb_pkt_width(vaddr_width_mp) \
     (3                                                                                             \

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -673,6 +673,8 @@ module bp_be_csr
   assign commit_pkt_cast_o.npc_w_v           = |{retire_pkt_cast_i.special, retire_pkt_cast_i.exception};
   assign commit_pkt_cast_o.queue_v           = retire_pkt_cast_i.queue_v & ~|retire_pkt_cast_i.exception;
   assign commit_pkt_cast_o.instret           = retire_pkt_cast_i.instret;
+  assign commit_pkt_cast_o.partial           = retire_pkt_cast_i.partial;
+  assign commit_pkt_cast_o.compressed        = retire_pkt_cast_i.compressed;
   assign commit_pkt_cast_o.pc                = apc_r;
   assign commit_pkt_cast_o.npc               = apc_n;
   assign commit_pkt_cast_o.vaddr             = retire_pkt_cast_i.vaddr;
@@ -681,7 +683,6 @@ module bp_be_csr
   assign commit_pkt_cast_o.priv_n            = priv_mode_n;
   assign commit_pkt_cast_o.translation_en_n  = translation_en_n;
   assign commit_pkt_cast_o.exception         = exception_v_lo;
-  assign commit_pkt_cast_o.partial           = retire_pkt_cast_i.partial;
   // Debug mode acts as a pseudo-interrupt
   assign commit_pkt_cast_o._interrupt        = interrupt_v_lo | enter_debug;
   assign commit_pkt_cast_o.fencei            = retire_pkt_cast_i.special.fencei_clean;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_ctl.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_ctl.sv
@@ -72,7 +72,7 @@ module bp_be_pipe_ctl
   wire [vaddr_width_p-1:0] baddr = decode.baddr_sel ? rs1 : pc;
   wire [vaddr_width_p-1:0] taken_raw = baddr + imm;
   wire [vaddr_width_p-1:0] taken_tgt = {taken_raw[vaddr_width_p-1:1], 1'b0};
-  wire [vaddr_width_p-1:0] ntaken_tgt = pc + 4'd4;
+  wire [vaddr_width_p-1:0] ntaken_tgt = pc + (reservation.compressed ? 4'd2 : 4'd4);
 
   assign data_o   = vaddr_width_p'($signed(ntaken_tgt));
   assign v_o      = reservation.v & reservation.decode.pipe_ctl_v;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
@@ -140,6 +140,7 @@ module bp_be_pipe_sys
   logic [vaddr_width_p-1:0] retire_nvaddr_r, retire_vaddr_r;
   logic [instr_width_gp-1:0] retire_ninstr_r, retire_instr_r;
   logic retire_npartial_r, retire_partial_r;
+  logic retire_ncompressed_r, retire_compressed_r;
   always_ff @(posedge clk_i)
     begin
       retire_npc_r <= reservation.pc;
@@ -153,21 +154,25 @@ module bp_be_pipe_sys
 
       retire_npartial_r <= reservation.partial;
       retire_partial_r  <= retire_npartial_r;
+
+      retire_ncompressed_r <= reservation.compressed;
+      retire_compressed_r  <= retire_ncompressed_r;
     end
 
   wire instret_li = retire_v_i & ~|retire_exception_i;
   assign retire_pkt =
-    '{v          : retire_v_i
-      ,queue_v   : retire_queue_v_i
-      ,instret   : instret_li
-      ,npc       : retire_npc_r
-      ,vaddr     : retire_vaddr_r
-      ,data      : retire_data_i
-      ,instr     : retire_instr_r
-      ,partial   : retire_v_i & retire_partial_r
+    '{v           : retire_v_i
+      ,queue_v    : retire_queue_v_i
+      ,instret    : instret_li
+      ,npc        : retire_npc_r
+      ,vaddr      : retire_vaddr_r
+      ,data       : retire_data_i
+      ,instr      : retire_instr_r
+      ,partial    : retire_partial_r
+      ,compressed : retire_compressed_r
       // Could do a preemptive onehot decode here
-      ,exception : retire_v_i ? retire_exception_i : '0
-      ,special   : instret_li ? retire_special_i   : '0
+      ,exception  : retire_v_i ? retire_exception_i : '0
+      ,special    : instret_li ? retire_special_i   : '0
       };
 
 endmodule

--- a/bp_be/src/v/bp_be_checker/bp_be_expander.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_expander.sv
@@ -1,0 +1,198 @@
+
+`include "bp_common_defines.svh"
+`include "bp_be_defines.svh"
+
+module bp_be_expander
+ import bp_common_pkg::*;
+ import bp_be_pkg::*;
+  (input [cinstr_width_gp-1:0]         cinstr_i
+
+   , output logic [instr_width_gp-1:0] instr_o
+   );
+
+  logic [rv64_reg_addr_width_gp-1:0] rs1, rs2, rd;
+  logic [dword_width_gp-1:0] imm;
+  wire [11:0] zero_imm = '0;
+
+  localparam rv64_zero_addr_gp = 5'd0;
+  localparam rv64_link_addr_gp = 5'd1;
+  localparam rv64_sp_addr_gp = 5'd2;
+
+  always_comb
+    begin
+      instr_o = cinstr_i;
+
+      // Different per quadrant
+      casez (cinstr_i)
+        `RV64_C2_INSTR, `RV64_CADDI, `RV64_CADDIW, `RV64_CLI, `RV64_CADDI16SP, `RV64_CLUI:
+          begin
+            rs1 = cinstr_i[11:7];
+            rs2 = cinstr_i[6:2];
+            rd  = cinstr_i[11:7];
+          end
+        `RV64_C1_INSTR:
+          begin
+            rs1 = {2'b01, cinstr_i[9:7]};
+            rs2 = {2'b01, cinstr_i[4:2]};
+            rd  = {2'b01, cinstr_i[9:7]};
+          end
+        // `RV64_C0_INSTR:
+        default:
+          begin
+            rs1 = {2'b01, cinstr_i[9:7]};
+            rs2 = {2'b01, cinstr_i[4:2]};
+            rd  = {2'b01, cinstr_i[4:2]};
+          end
+      endcase
+
+      casez (cinstr_i)
+        `RV64_CADDI16SP:
+          imm = dword_width_gp'($signed({cinstr_i[12], cinstr_i[4:3], cinstr_i[5], cinstr_i[2], cinstr_i[6], 4'b0000}));
+        `RV64_CADDI4SPN:
+          imm = dword_width_gp'($unsigned({cinstr_i[10:7], cinstr_i[12:11], cinstr_i[5], cinstr_i[6], 2'b00}));
+        `RV64_CLWSP:
+          imm = dword_width_gp'($unsigned({cinstr_i[3:2], cinstr_i[12], cinstr_i[6:4], 2'b00}));
+        `RV64_CFLDSP, `RV64_CLDSP:
+          imm = dword_width_gp'($unsigned({cinstr_i[4:2], cinstr_i[12], cinstr_i[6:5], 3'b000}));
+        `RV64_CSWSP:
+          imm = dword_width_gp'($unsigned({cinstr_i[8:7], cinstr_i[12:9], 2'b00}));
+        `RV64_CFSDSP, `RV64_CSDSP:
+          imm = dword_width_gp'($unsigned({cinstr_i[9:7], cinstr_i[12:10], 3'b000}));
+        `RV64_CLW, `RV64_CSW:
+          imm = dword_width_gp'($unsigned({cinstr_i[5], cinstr_i[12:10], cinstr_i[6], 2'b00}));
+        `RV64_CFLD, `RV64_CLD, `RV64_CFSD, `RV64_CSD:
+          imm = dword_width_gp'($unsigned({cinstr_i[6:5], cinstr_i[12:10], 3'b000}));
+        `RV64_CJ:
+          imm = dword_width_gp'($signed({cinstr_i[12], cinstr_i[8], cinstr_i[10:9], cinstr_i[6] ,cinstr_i[7], cinstr_i[2], cinstr_i[11], cinstr_i[5:3], 1'b0}));
+        `RV64_CBEQZ, `RV64_CBNEZ:
+          imm = dword_width_gp'($signed({cinstr_i[12], cinstr_i[6:5], cinstr_i[2], cinstr_i[11:10], cinstr_i[4:3], 1'b0}));
+        `RV64_CLUI:
+          imm = dword_width_gp'($signed({cinstr_i[12], cinstr_i[6:2], 12'b0}));
+        `RV64_CNOP, `RV64_CADDI, `RV64_CADDIW, `RV64_CLI, `RV64_CANDI:
+          imm = dword_width_gp'($signed({cinstr_i[12], cinstr_i[6:2]}));
+        `RV64_CSLLI, `RV64_CSRLI:
+          imm = dword_width_gp'($unsigned({6'b000000, cinstr_i[12], cinstr_i[6:2]}));
+        `RV64_CSRAI:
+          imm = dword_width_gp'($unsigned({6'b010000, cinstr_i[12], cinstr_i[6:2]}));
+        default: imm = '0;
+      endcase
+
+      casez (cinstr_i)
+        // C.ILL -> 0000_0000_0000_0000
+        `RV64_CILL: instr_o = '0;
+        // C.ADDI4SPN -> addi rd', x2, nzuimm[9:2]
+        `RV64_CADDI4SPN: instr_o =
+            `rv64_i_type_exp(`RV64_OP_IMM_OP, rd, 3'b000, rv64_sp_addr_gp, imm);
+        // C.ADDI16SP -> addi x2, x2, nzimm[9:4]
+        `RV64_CADDI16SP: instr_o =
+          `rv64_i_type_exp(`RV64_OP_IMM_OP, rv64_sp_addr_gp, 3'b000, rv64_sp_addr_gp, imm);
+        // C.EBREAK   -> ebreak
+        `RV64_CEBREAK: instr_o = `RV64_EBREAK;
+        // C.LWSP     -> lw rd, offset[7:2] (x2)
+        `RV64_CLWSP: instr_o =
+          `rv64_i_type_exp(`RV64_LOAD_OP, rd, 3'b010, rv64_sp_addr_gp, imm);
+        // C.LDSP     -> ld rd, offset[8:3] (x2)
+        `RV64_CLDSP: instr_o =
+          `rv64_i_type_exp(`RV64_LOAD_OP, rd, 3'b011, rv64_sp_addr_gp, imm);
+        // C.SWSP     -> sw rs2, offset[7:2] (x2)
+        `RV64_CSWSP: instr_o =
+          `rv64_s_type_exp(`RV64_STORE_OP, 3'b010, rv64_sp_addr_gp, rs2, imm);
+        // C.SDSP     -> sd rs2, offset[8:3] (x2)
+        `RV64_CSDSP: instr_o =
+          `rv64_s_type_exp(`RV64_STORE_OP, 3'b011, rv64_sp_addr_gp, rs2, imm);
+        // C.FLDSP -> fld rd, offset(x2)
+        `RV64_CFLDSP: instr_o =
+          `rv64_i_type_exp(`RV64_FLOAD_OP, rd, 3'b011, rv64_sp_addr_gp, imm);
+        // C.FSDSP -> fsd rs2, offset(x2)
+        `RV64_CFSDSP: instr_o =
+          `rv64_s_type_exp(`RV64_FSTORE_OP, 3'b011, rv64_sp_addr_gp, rs2, imm);
+        // C.LW       -> lw rd', offset[6:2] (rs1')
+        `RV64_CLW: instr_o =
+          `rv64_i_type_exp(`RV64_LOAD_OP, rd, 3'b010, rs1, imm);
+        // C.LD       -> ld rd', offset[7:3] (rs1')
+        `RV64_CLD: instr_o =
+          `rv64_i_type_exp(`RV64_LOAD_OP, rd, 3'b011, rs1, imm);
+        // C.SW       -> sw rs2', offset[6:2] (rs1')
+        `RV64_CSW: instr_o =
+          `rv64_s_type_exp(`RV64_STORE_OP, 3'b010, rs1, rs2, imm);
+        // C.SD       -> sd rs2', offset[7:3] (rs1')
+        `RV64_CSD: instr_o =
+          `rv64_s_type_exp(`RV64_STORE_OP, 3'b011, rs1, rs2, imm);
+        // C.FLD -> fld rd', offset(rs1')
+        `RV64_CFLD: instr_o =
+          `rv64_i_type_exp(`RV64_FLOAD_OP, rd, 3'b011, rs1, imm);
+        // C.FSD -> fsd rs2', offset(rs1')
+        `RV64_CFSD: instr_o =
+          `rv64_s_type_exp(`RV64_FSTORE_OP, 3'b011, rs1, rs2, imm);
+        // C.J        -> jal x0, offset[11:1]
+        `RV64_CJ: instr_o =
+          `rv64_j_type_exp(`RV64_JAL_OP, rv64_zero_addr_gp, imm);
+        // C.JR       -> jalr x0, 0(rs1)
+        `RV64_CJR: instr_o =
+          `rv64_i_type_exp(`RV64_JALR_OP, rv64_zero_addr_gp, 3'b000, rs1, zero_imm);
+        // C.JALR     -> jalr x1, 0(rs1)
+        `RV64_CJALR: instr_o =
+          `rv64_i_type_exp(`RV64_JALR_OP, rv64_link_addr_gp, 3'b000, rs1, zero_imm);
+        // C.BEQZ     -> beq rs1', x0, offset[8:1]
+        `RV64_CBEQZ: instr_o =
+          `rv64_b_type_exp(`RV64_BRANCH_OP, 3'b000, rs1, rv64_zero_addr_gp, imm);
+        // C.BNEZ     -> bne rs1', x0, offset[8:1]
+        `RV64_CBNEZ: instr_o =
+          `rv64_b_type_exp(`RV64_BRANCH_OP, 3'b001, rs1, rv64_zero_addr_gp, imm);
+        // C.LI       -> addi rd, x0, imm[5:0]
+        `RV64_CLI: instr_o =
+          `rv64_i_type_exp(`RV64_OP_IMM_OP, rd, 3'b000, rv64_zero_addr_gp, imm);
+        // C.LUI      -> lui rd, nzimm[17:12]
+        `RV64_CLUI: instr_o =
+          `rv64_u_type_exp(`RV64_LUI_OP, rd, imm);
+        // C.NOP      -> addi x0, x0, 0
+        `RV64_CNOP: instr_o =
+          `rv64_i_type_exp(`RV64_OP_IMM_OP, rv64_zero_addr_gp, 3'b000, rv64_zero_addr_gp, zero_imm);
+        // C.ADDI     -> addi rd, rd, nzimm[5:0]
+        `RV64_CADDI: instr_o =
+          `rv64_i_type_exp(`RV64_OP_IMM_OP, rd, 3'b000, rd, imm);
+        // C.ADDIW    -> addiw rd, rd, imm[5:0]
+        `RV64_CADDIW: instr_o =
+          `rv64_i_type_exp(`RV64_OP_IMM_32_OP, rd, 3'b000, rd, imm);
+        // C.SLLI     -> slli rd, rd, shamt[5:0]
+        `RV64_CSLLI: instr_o =
+          `rv64_i_type_exp(`RV64_OP_IMM_OP, rd, 3'b001, rd, imm);
+        // C.SRLI     -> srli rd', rd', shamt[5:0]
+        `RV64_CSRLI: instr_o =
+          `rv64_i_type_exp(`RV64_OP_IMM_OP, rd, 3'b101, rd, imm);
+        // C.SRAI     -> srai rd', rd', shamt[5:0]
+        `RV64_CSRAI: instr_o =
+          `rv64_i_type_exp(`RV64_OP_IMM_OP, rd, 3'b101, rd, imm);
+        // C.ANDI     -> andi rd', rd', imm[5:0]
+        `RV64_CANDI: instr_o =
+          `rv64_i_type_exp(`RV64_OP_IMM_OP, rd, 3'b111, rd, imm);
+        // C.MV       -> add rd, x0, rs2
+        `RV64_CMV: instr_o =
+          `rv64_r_type_exp(`RV64_OP_OP, rd, 3'b000, rv64_zero_addr_gp, rs2, 7'b0);
+        // C.ADD      -> add rd, rd, rs2
+        `RV64_CADD: instr_o =
+          `rv64_r_type_exp(`RV64_OP_OP, rd, 3'b000, rd, rs2, 7'b0);
+        // C.AND      -> and rd', rd', rs2'
+        `RV64_CAND: instr_o =
+          `rv64_r_type_exp(`RV64_OP_OP, rd, 3'b111, rd, rs2, 7'b0);
+        // C.OR       -> or rd', rd', rs2'
+        `RV64_COR: instr_o =
+          `rv64_r_type_exp(`RV64_OP_OP, rd, 3'b110, rd, rs2, 7'b0);
+        // C.XOR      -> xor rd', rd', rs2'
+        `RV64_CXOR: instr_o =
+          `rv64_r_type_exp(`RV64_OP_OP, rd, 3'b100, rd, rs2, 7'b0);
+        // C.SUB      -> sub rd', rd', rs2'
+        `RV64_CSUB: instr_o =
+          `rv64_r_type_exp(`RV64_OP_OP, rd, 3'b000, rd, rs2, 7'b010_0000);
+        // C.ADDW     -> addw rd', rd', rs2'
+        `RV64_CADDW: instr_o =
+          `rv64_r_type_exp(`RV64_OP_32_OP, rd, 3'b000, rd, rs2, 7'b0);
+        // C.SUBW     -> subw rd', rd', rs2'
+        `RV64_CSUBW: instr_o =
+          `rv64_r_type_exp(`RV64_OP_32_OP, rd, 3'b000, rd, rs2, 7'b010_0000);
+        default: begin end
+      endcase
+    end
+
+endmodule
+

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -75,7 +75,7 @@ module bp_be_scheduler
   bp_be_preissue_pkt_s preissue_pkt;
   bp_be_issue_queue
    #(.bp_params_p(bp_params_p))
-   fe_queue_fifo
+   issue_queue
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
@@ -167,11 +167,11 @@ module bp_be_scheduler
   wire be_exc_not_instr_li = fe_queue_inject_li;
 
   wire [vaddr_width_p-1:0] fe_exc_pc_li = issue_pkt_cast_o.pc;
-  wire [vaddr_width_p-1:0] fe_exc_vaddr_li = fe_exc_pc_li + (issue_pkt_cast_o.partial_v ? 2'b10 : 2'b00);
+  wire [vaddr_width_p-1:0] fe_exc_vaddr_li = fe_exc_pc_li + (issue_pkt_cast_o.partial ? 2'b10 : 2'b00);
   wire [vaddr_width_p-1:0] be_exc_vaddr_li = ptw_fill_pkt_cast_i.vaddr;
   wire [dpath_width_gp-1:0] be_exc_data_li = ptw_fill_pkt_cast_i.entry;
 
-  wire fe_partial = issue_pkt_cast_o.partial_v;
+  wire fe_partial = issue_pkt_cast_o.partial;
   wire be_partial = ptw_fill_pkt_cast_i.v & ptw_fill_pkt_cast_i.partial;
 
   wire ptw_fill_v  =  ptw_fill_pkt_cast_i.v;

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -68,8 +68,10 @@ module bp_be_scheduler
 
   wire fe_queue_clr_li  = suppress_iss_i;
   wire fe_queue_deq_li  = commit_pkt_cast_i.queue_v;
+  wire fe_queue_deq_skip_li = !commit_pkt_cast_i.compressed | commit_pkt_cast_i.partial;
   wire fe_queue_roll_li = commit_pkt_cast_i.npc_w_v;
   wire fe_queue_read_li = dispatch_v_i;
+  wire fe_queue_read_skip_li = !dispatch_pkt_cast_o.compressed | dispatch_pkt_cast_o.partial;
   wire fe_queue_inject_li = ptw_fill_pkt_cast_i.v | unfreeze_i | interrupt_v_i;
 
   bp_be_preissue_pkt_s preissue_pkt;
@@ -81,8 +83,10 @@ module bp_be_scheduler
 
      ,.clr_v_i(fe_queue_clr_li)
      ,.deq_v_i(fe_queue_deq_li)
+     ,.deq_skip_i(fe_queue_deq_skip_li)
      ,.roll_v_i(fe_queue_roll_li)
      ,.read_v_i(dispatch_v_i)
+     ,.read_skip_i(fe_queue_read_skip_li)
      ,.inject_v_i(fe_queue_inject_li)
 
      ,.fe_queue_i(fe_queue_i)
@@ -188,24 +192,25 @@ module bp_be_scheduler
     begin
       // Form dispatch packet
       dispatch_pkt_cast_o = '0;
-      dispatch_pkt_cast_o.v        = (dispatch_v_i & ~poison_isd_i) || be_exc_not_instr_li;
-      dispatch_pkt_cast_o.queue_v  = dispatch_v_i;
-      dispatch_pkt_cast_o.instr_v  = fe_instr_not_exc_li;
-      dispatch_pkt_cast_o.pc       = expected_npc_i;
-      dispatch_pkt_cast_o.instr    = issue_pkt_cast_o.instr;
+      dispatch_pkt_cast_o.v            = (dispatch_v_i & ~poison_isd_i) || be_exc_not_instr_li;
+      dispatch_pkt_cast_o.queue_v      = dispatch_v_i;
+      dispatch_pkt_cast_o.instr_v      = fe_instr_not_exc_li;
+      dispatch_pkt_cast_o.partial      = be_exc_not_instr_li ? be_partial : fe_partial;
+      dispatch_pkt_cast_o.compressed   = issue_pkt_cast_o.compressed;
+      dispatch_pkt_cast_o.pc           = expected_npc_i;
+      dispatch_pkt_cast_o.instr        = issue_pkt_cast_o.instr;
       // If register injection is critical, can be done after bypass
-      dispatch_pkt_cast_o.frs1_v   = issue_pkt_cast_o.frs1_v;
-      dispatch_pkt_cast_o.irs1_v   = issue_pkt_cast_o.irs1_v;
-      dispatch_pkt_cast_o.rs1      = be_exc_not_instr_li ? be_exc_vaddr_li : fe_exc_not_instr_li ? fe_exc_vaddr_li : issue_pkt_cast_o.frs1_v ? frf_rs1 : irf_rs1;
-      dispatch_pkt_cast_o.frs2_v   = issue_pkt_cast_o.frs2_v;
-      dispatch_pkt_cast_o.irs2_v   = issue_pkt_cast_o.irs2_v;
-      dispatch_pkt_cast_o.rs2      = be_exc_not_instr_li ? be_exc_data_li  : fe_exc_not_instr_li ? '0 : issue_pkt_cast_o.frs2_v ? frf_rs2 : irf_rs2;
-      dispatch_pkt_cast_o.frs3_v   = issue_pkt_cast_o.frs3_v;
-      dispatch_pkt_cast_o.irs3_v   = 1'b0;
-      dispatch_pkt_cast_o.imm      = (fe_exc_not_instr_li | be_exc_not_instr_li) ? '0 : issue_pkt_cast_o.frs3_v ? frf_rs3 : decoded_imm_lo;
-      dispatch_pkt_cast_o.decode   = (fe_exc_not_instr_li | be_exc_not_instr_li | illegal_instr_lo) ? '0 : decoded_instr_lo;
+      dispatch_pkt_cast_o.frs1_v       = issue_pkt_cast_o.frs1_v;
+      dispatch_pkt_cast_o.irs1_v       = issue_pkt_cast_o.irs1_v;
+      dispatch_pkt_cast_o.rs1          = be_exc_not_instr_li ? be_exc_vaddr_li : fe_exc_not_instr_li ? fe_exc_vaddr_li : issue_pkt_cast_o.frs1_v ? frf_rs1 : irf_rs1;
+      dispatch_pkt_cast_o.frs2_v       = issue_pkt_cast_o.frs2_v;
+      dispatch_pkt_cast_o.irs2_v       = issue_pkt_cast_o.irs2_v;
+      dispatch_pkt_cast_o.rs2          = be_exc_not_instr_li ? be_exc_data_li  : fe_exc_not_instr_li ? '0 : issue_pkt_cast_o.frs2_v ? frf_rs2 : irf_rs2;
+      dispatch_pkt_cast_o.frs3_v       = issue_pkt_cast_o.frs3_v;
+      dispatch_pkt_cast_o.irs3_v       = 1'b0;
+      dispatch_pkt_cast_o.imm          = (fe_exc_not_instr_li | be_exc_not_instr_li) ? '0 : issue_pkt_cast_o.frs3_v ? frf_rs3 : decoded_imm_lo;
+      dispatch_pkt_cast_o.decode       = (fe_exc_not_instr_li | be_exc_not_instr_li | illegal_instr_lo) ? '0 : decoded_instr_lo;
 
-      dispatch_pkt_cast_o.partial  = be_exc_not_instr_li ? be_partial : fe_partial;
 
       dispatch_pkt_cast_o.exception.instr_page_fault |= be_exc_not_instr_li & ptw_instr_page_fault_v;
       dispatch_pkt_cast_o.exception.load_page_fault  |= be_exc_not_instr_li & ptw_load_page_fault_v;

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -300,7 +300,7 @@
       ,fe_cmd_fifo_els   : 4
       ,muldiv_support    : (1 << e_div) | (1 << e_mul) | (1 << e_mulh)
       ,fpu_support       : 1
-      ,compressed_support: 0
+      ,compressed_support: 1
 
       ,async_coh_clk       : 0
       ,coh_noc_flit_width  : 128

--- a/bp_common/src/include/bp_common_aviary_defines.svh
+++ b/bp_common/src/include/bp_common_aviary_defines.svh
@@ -51,6 +51,8 @@
     , localparam bht_row_els_p               = proc_param_lp.bht_row_els                           \
     , localparam ghist_width_p               = proc_param_lp.ghist_width                           \
     , localparam bht_row_width_p             = 2*bht_row_els_p                                     \
+    , localparam bht_start_bit_p             = proc_param_lp.compressed_support ? 1 : 2            \
+    , localparam btb_start_bit_p             = proc_param_lp.compressed_support ? 1 : 2            \
                                                                                                    \
     , localparam itlb_els_4k_p              = proc_param_lp.itlb_els_4k                            \
     , localparam itlb_els_1g_p              = proc_param_lp.itlb_els_1g                            \

--- a/bp_common/src/include/bp_common_rv64_instr_defines.svh
+++ b/bp_common/src/include/bp_common_rv64_instr_defines.svh
@@ -34,18 +34,28 @@
   `define rv64_r_type(op, funct3, funct7) {``funct7``,{5{1'b?}},{5{1'b?}},``funct3``,{5{1'b?}},``op``}
   `define rv64_i_type(op, funct3)         {{12{1'b?}},{5{1'b?}},``funct3``,{5{1'b?}},``op``}
   `define rv64_s_type(op, funct3)         {{7{1'b?}},{5{1'b?}},{5{1'b?}},``funct3``,{5{1'b?}},``op``}
+  `define rv64_b_type(op, funct3)         {{7{1'b?}},{5{1'b?}},{5{1'b?}},``funct3``,{5{1'b?}},``op``}
   `define rv64_u_type(op)                 {{20{1'b?}},{5{1'b?}},``op``}
   `define rv64_fma_type(op, pr2)          {{5{1'b?}},``pr2``,{5{1'b?}},{5{1'b?}},{3{3'b?}},{5{1'b?}},``op``}
 
   // RV64 Immediate sign extension macros
   `define rv64_signext_i_imm(instr) {{53{``instr``[31]}},``instr``[30:20]}
   `define rv64_signext_s_imm(instr) {{53{``instr``[31]}},``instr[30:25],``instr``[11:7]}
-  `define rv64_signext_b_imm(instr) {{52{``instr``[31]}},``instr``[7],``instr``[30:25]  \
-                                         ,``instr``[11:8], {1'b0}}
+  `define rv64_signext_b_imm(instr) {{52{``instr``[31]}},``instr``[7],``instr``[30:25],``instr``[11:8], {1'b0}}
   `define rv64_signext_u_imm(instr) {{32{``instr``[31]}},``instr``[31:12], {12{1'b0}}}
-  `define rv64_signext_j_imm(instr) {{44{``instr``[31]}},``instr``[19:12],``instr``[20] \
-                                         ,``instr``[30:21], {1'b0}}
+  `define rv64_signext_j_imm(instr) {{44{``instr``[31]}},``instr``[19:12],``instr``[20],``instr``[30:21], {1'b0}}
   `define rv64_signext_c_imm(instr) {{59{1'b0}},``instr``[19:15]}
+
+  // Compressed quadrants
+  `define RV64_C0_OP  2'b00
+  `define RV64_C1_OP  2'b01
+  `define RV64_C2_OP  2'b10
+  `define RV64_32B_OP 2'b11
+
+  `define RV64_C0_INSTR   {14'b????_????_????_??,`RV64_C0_OP}
+  `define RV64_C1_INSTR   {14'b????_????_????_??,`RV64_C1_OP}
+  `define RV64_C2_INSTR   {14'b????_????_????_??,`RV64_C2_OP}
+  `define RV64_32B_INSTR  {30'b????_????_????_??,`RV32_32B_OP}
 
   // I extension
   `define RV64_LUI        `rv64_u_type(`RV64_LUI_OP)
@@ -219,6 +229,71 @@
   `define RV64_FCVT_DL    32'b1101001_00010_?????_???_?????_1010011
   `define RV64_FCVT_DLU   32'b1101001_00011_?????_???_?????_1010011
   `define RV64_FMV_DX     32'b1111001_00000_?????_000_?????_1010011
+
+  // C extension
+  // Instruction expansions
+  `define rv64_r_type_exp(op, rd, funct3, rs1, rs2, funct7) {``funct7``,``rs2``,``rs1``,``funct3``,``rd``,``op``}
+  `define rv64_i_type_exp(op, rd, funct3, rs1, imm) {``imm``[11:0],``rs1``,``funct3``,``rd``,``op``}
+  `define rv64_s_type_exp(op, funct3, rs1, rs2, imm) {``imm``[11:5],``rs2``,``rs1``,``funct3``,``imm``[4:0],``op``}
+  `define rv64_u_type_exp(op, rd, imm) {``imm``[31:12],``rd``,``op``}
+  `define rv64_b_type_exp(op, funct3, rs1, rs2, imm) {``imm``[12],``imm``[10:5],``rs2``,``rs1``,``funct3``,``imm``[4:1],``imm``[11],``op``}
+  `define rv64_j_type_exp(op, rd, imm) {``imm``[20],``imm``[10:1],``imm``[11],``imm``[19:12],``rd``,``op``}
+
+  // Instruction types
+  `define rv64_cr_type(op, funct4) {``funct4``,{5{1'b?}},{5{1'b?}},``op``}
+  `define rv64_ci_type(op, funct3) {``funct3``,{1{1'b?}},{5{1'b?}},{5{1'b?}},``op``}
+  `define rv64_css_type(op, funct3) {``funct3``,{6{1'b?}},{5{1'b?}},``op``}
+  `define rv64_ciw_type(op, funct3) {``funct3``,{8{1'b?}},{3{1'b?}},``op``}
+  `define rv64_cl_type(op, funct3) {``funct3``,{3{1'b?}},{3{1'b?}},{2{1'b?}},{3{1'b?}},``op``}
+  `define rv64_cs_type(op, funct3) {``funct3``,{3{1'b?}},{3{1'b?}},{2{1'b?}},{3{1'b?}},``op``}
+  `define rv64_ca_type(op, funct6, funct2) {``funct6``,{3{1'b?}},``funct2``,{3{1'b?}},``op``}
+  `define rv64_cb_type(op, funct3) {``funct3``,{3{1'b?}},{3{1'b?}},{5{1'b?}},``op``}
+  `define rv64_cb2_type(op, funct3, funct2) {``funct3``,{1{1'b?}},``funct2``,{3{1'b?}},{5{1'b?}},``op``}
+  `define rv64_cj_type(op, funct3) {``funct3``,{11{1'b?}},``op``}
+
+  `define RV64_CLWSP      `rv64_ci_type(`RV64_C2_OP,3'b010)
+  `define RV64_CLDSP      `rv64_ci_type(`RV64_C2_OP,3'b011)
+  `define RV64_CSWSP      `rv64_css_type(`RV64_C2_OP,3'b110)
+  `define RV64_CSDSP      `rv64_css_type(`RV64_C2_OP,3'b111)
+  `define RV64_CLW        `rv64_cl_type(`RV64_C0_OP,3'b010)
+  `define RV64_CLD        `rv64_cl_type(`RV64_C0_OP,3'b011)
+  `define RV64_CSW        `rv64_cs_type(`RV64_C0_OP,3'b110)
+  `define RV64_CSD        `rv64_cs_type(`RV64_C0_OP,3'b111)
+  `define RV64_CJ         `rv64_cj_type(`RV64_C1_OP,3'b101)
+  `define RV64_CJR        16'b1000_????_?000_0010
+  `define RV64_CJALR      16'b1001_????_?000_0010
+  `define RV64_CBEQZ      `rv64_cb_type(`RV64_C1_OP,3'b110)
+  `define RV64_CBNEZ      `rv64_cb_type(`RV64_C1_OP,3'b111)
+  `define RV64_CLI        `rv64_ci_type(`RV64_C1_OP,3'b010)
+  `define RV64_CLUI       `rv64_ci_type(`RV64_C1_OP,3'b011)
+
+  `define RV64_CADDI      `rv64_ci_type(`RV64_C1_OP,3'b000)
+  `define RV64_CADDIW     `rv64_ci_type(`RV64_C1_OP,3'b001)
+  `define RV64_CADDI16SP  16'b011?_0001_0???_??01
+                            
+  `define RV64_CADDI4SPN  `rv64_ciw_type(`RV64_C0_OP,3'b000)
+  `define RV64_CSLLI      `rv64_ci_type(`RV64_C2_OP,3'b000)
+  `define RV64_CSRLI      `rv64_cb2_type(`RV64_C1_OP,3'b100,2'b00)
+  `define RV64_CSRAI      `rv64_cb2_type(`RV64_C1_OP,3'b100,2'b01)
+  `define RV64_CANDI      `rv64_cb2_type(`RV64_C1_OP,3'b100,2'b10)
+  `define RV64_CMV        `rv64_cr_type(`RV64_C2_OP,4'b1000)
+  `define RV64_CADD       `rv64_cr_type(`RV64_C2_OP,4'b1001)
+  `define RV64_CAND       `rv64_ca_type(`RV64_C1_OP,6'b100011,2'b11)
+  `define RV64_COR        `rv64_ca_type(`RV64_C1_OP,6'b100011,2'b10)
+  `define RV64_CXOR       `rv64_ca_type(`RV64_C1_OP,6'b100011,2'b01)
+  `define RV64_CSUB       `rv64_ca_type(`RV64_C1_OP,6'b100011,2'b00)
+  `define RV64_CADDW      `rv64_ca_type(`RV64_C1_OP,6'b100111,2'b01)
+  `define RV64_CSUBW      `rv64_ca_type(`RV64_C1_OP,6'b100111,2'b00)
+  `define RV64_CILL       16'b0000_0000_0000_0000
+  `define RV64_CNOP       16'b0000_0000_0000_0001
+  `define RV64_CEBREAK    16'b1001_0000_0000_0010
+
+  `define RV64_CFLD       `rv64_cs_type(`RV64_C0_OP,3'b001)
+  `define RV64_CFSD       `rv64_cs_type(`RV64_C0_OP,3'b101)
+  `define RV64_CFLWSP     `rv64_css_type(`RV64_C2_OP,3'b011)
+  `define RV64_CFLDSP     `rv64_css_type(`RV64_C2_OP,3'b001)
+  `define RV64_CFSWSP     `rv64_cl_type(`RV64_C2_OP,3'b111)
+  `define RV64_CFSDSP     `rv64_cl_type(`RV64_C2_OP,3'b101)
 
 `endif
 

--- a/bp_common/src/include/bp_common_rv64_pkgdef.svh
+++ b/bp_common/src/include/bp_common_rv64_pkgdef.svh
@@ -1,36 +1,37 @@
 `ifndef BP_COMMON_RV64_PKGDEF_SVH
 `define BP_COMMON_RV64_PKGDEF_SVH
 
-  localparam dword_width_gp       = 64;
-  localparam word_width_gp        = 32;
-  localparam half_width_gp        = 16;
-  localparam byte_width_gp        = 8;
-  localparam hinstr_width_gp      = 16;
-  localparam instr_width_gp       = 32;
-  localparam csr_addr_width_gp    = 12;
-  localparam reg_addr_width_gp    = 5;
-  localparam page_offset_width_gp = 12;
+  localparam dword_width_gp          = 64;
+  localparam word_width_gp           = 32;
+  localparam half_width_gp           = 16;
+  localparam byte_width_gp           = 8;
+  localparam cinstr_width_gp         = 16;
+  localparam instr_width_gp          = 32;
+  localparam csr_addr_width_gp       = 12;
+  localparam reg_addr_width_gp       = 5;
+  localparam page_offset_width_gp    = 12;
 
-  localparam rv64_rf_els_gp         = 32;
-  localparam rv64_instr_width_gp    = 32;
-  localparam rv64_eaddr_width_gp    = 64;
-  localparam rv64_byte_width_gp     = 8;
-  localparam rv64_hword_width_gp    = 16;
-  localparam rv64_word_width_gp     = 32;
-  localparam rv64_dword_width_gp    = 64;
-  localparam rv64_reg_data_width_gp = 64;
-  localparam rv64_reg_addr_width_gp = 5;
-  localparam rv64_shamt_width_gp    = 6;
-  localparam rv64_shamtw_width_gp   = 5;
-  localparam rv64_opcode_width_gp   = 7;
-  localparam rv64_funct3_width_gp   = 3;
-  localparam rv64_funct7_width_gp   = 7;
-  localparam rv64_csr_addr_width_gp = 12;
-  localparam rv64_imm20_width_gp    = 20;
-  localparam rv64_imm12_width_gp    = 12;
-  localparam rv64_imm11to5_width_gp = 7;
-  localparam rv64_imm4to0_width_gp  = 5;
-  localparam rv64_priv_width_gp     = 2;
+  localparam rv64_rf_els_gp          = 32;
+  localparam rv64_instr_width_gp     = 32;
+  localparam rv64_eaddr_width_gp     = 64;
+  localparam rv64_byte_width_gp      = 8;
+  localparam rv64_hword_width_gp     = 16;
+  localparam rv64_word_width_gp      = 32;
+  localparam rv64_dword_width_gp     = 64;
+  localparam rv64_reg_data_width_gp  = 64;
+  localparam rv64_reg_addr_width_gp  = 5;
+  localparam rv64_creg_addr_width_gp = 3;
+  localparam rv64_shamt_width_gp     = 6;
+  localparam rv64_shamtw_width_gp    = 5;
+  localparam rv64_opcode_width_gp    = 7;
+  localparam rv64_copcode_width_gp   = 2;
+  localparam rv64_funct2_width_gp    = 2;
+  localparam rv64_funct3_width_gp    = 3;
+  localparam rv64_funct4_width_gp    = 4;
+  localparam rv64_funct6_width_gp    = 6;
+  localparam rv64_funct7_width_gp    = 7;
+  localparam rv64_csr_addr_width_gp  = 12;
+  localparam rv64_priv_width_gp      = 2;
 
   typedef struct packed
   {
@@ -65,7 +66,7 @@
 
   typedef struct packed
   {
-    logic [rv64_imm12_width_gp-1:0]    imm12;
+    logic [11:0]                       imm12;
     logic [rv64_reg_addr_width_gp-1:0] rs1;
     logic [rv64_funct3_width_gp-1:0]   funct3;
     logic [rv64_reg_addr_width_gp-1:0] rd_addr;
@@ -74,17 +75,17 @@
 
   typedef struct packed
   {
-    logic [rv64_imm11to5_width_gp-1:0] imm11to5;
+    logic [11:5]                       imm11to5;
     logic [rv64_reg_addr_width_gp-1:0] rs2;
     logic [rv64_reg_addr_width_gp-1:0] rs1;
     logic [rv64_funct3_width_gp-1:0]   funct3;
-    logic [rv64_imm4to0_width_gp-1:0]  imm4to0;
+    logic [4:0]                        imm4to0;
     logic [rv64_opcode_width_gp-1:0]   opcode;
   }  rv64_instr_stype_s;
 
   typedef struct packed
   {
-    logic [rv64_imm20_width_gp-1:0]    imm20;
+    logic [19:0]                       imm20;
     logic [rv64_reg_addr_width_gp-1:0] rd_addr;
     logic [rv64_opcode_width_gp-1:0]   opcode;
   }  rv64_instr_utype_s;
@@ -114,6 +115,100 @@
       rv64_instr_btype_s    btype;
     }  t;
   }  rv64_instr_s;
+
+  typedef struct packed
+  {
+    logic [rv64_funct4_width_gp-1:0]    funct4;
+    logic [rv64_reg_addr_width_gp-1:0]  rdrs1_addr;
+    logic [rv64_reg_addr_width_gp-1:0]  rs2_addr;
+    logic [rv64_copcode_width_gp-1:0]   opcode;
+  }  rv64_instr_crtype_s;
+
+  typedef struct packed
+  {
+    logic [rv64_funct3_width_gp-1:0]    funct3;
+    logic [5:5]                         imm5;
+    logic [rv64_reg_addr_width_gp-1:0]  rdrs1_addr;
+    logic [4:0]                         imm4to0;
+    logic [rv64_copcode_width_gp-1:0]   opcode;
+  }  rv64_instr_citype_s;
+
+  typedef struct packed
+  {
+    logic [rv64_funct3_width_gp-1:0]    funct3;
+    logic [5:0]                         imm6;
+    logic [rv64_reg_addr_width_gp-1:0]  rs2_addr;
+    logic [rv64_copcode_width_gp-1:0]   opcode;
+  }  rv64_instr_csstype_s;
+
+  typedef struct packed
+  {
+    logic [rv64_funct3_width_gp-1:0]     funct3;
+    logic [7:0]                          imm8;
+    logic [rv64_creg_addr_width_gp-1:0]  rdp_addr;
+    logic [rv64_copcode_width_gp-1:0]    opcode;
+  }  rv64_instr_ciwtype_s;
+
+  typedef struct packed
+  {
+    logic [rv64_funct3_width_gp-1:0]     funct3;
+    logic [4:2]                          imm4to2;
+    logic [rv64_creg_addr_width_gp-1:0]  rs1p_addr;
+    logic [1:0]                          imm1to0;
+    logic [rv64_creg_addr_width_gp-1:0]  rdp_addr;
+    logic [rv64_copcode_width_gp-1:0]    opcode;
+  }  rv64_instr_cltype_s;
+
+  typedef struct packed
+  {
+    logic [rv64_funct3_width_gp-1:0]     funct3;
+    logic [4:2]                          imm4to2;
+    logic [rv64_creg_addr_width_gp-1:0]  rs1p_addr;
+    logic [1:0]                          imm1to0;
+    logic [rv64_creg_addr_width_gp-1:0]  rs2p_addr;
+    logic [rv64_copcode_width_gp-1:0]    opcode;
+  }  rv64_instr_cstype_s;
+
+  typedef struct packed
+  {
+    logic [rv64_funct6_width_gp-1:0]     funct6;
+    logic [rv64_creg_addr_width_gp-1:0]  rdrs1p_addr;
+    logic [rv64_funct2_width_gp-1:0]     funct2;
+    logic [rv64_creg_addr_width_gp-1:0]  rs2p_addr;
+    logic [rv64_copcode_width_gp-1:0]    opcode;
+  }  rv64_instr_catype_s;
+
+  typedef struct packed
+  {
+    logic [rv64_funct3_width_gp-1:0]     funct3;
+    logic [7:5]                          offset7to5;
+    logic [rv64_creg_addr_width_gp-1:0]  rdrs1p_addr;
+    logic [4:0]                          offset4to0;
+    logic [rv64_copcode_width_gp-1:0]    opcode;
+  }  rv64_instr_cbtype_s;
+
+  typedef struct packed
+  {
+    logic [rv64_funct3_width_gp-1:0]  funct3;
+    logic [10:0]                      target;
+    logic [rv64_copcode_width_gp-1:0] opcode;
+  }  rv64_instr_cjtype_s;
+
+  typedef struct packed
+  {
+    union packed
+    {
+      rv64_instr_crtype_s  crtype;
+      rv64_instr_citype_s  citype;
+      rv64_instr_csstype_s csstype;
+      rv64_instr_ciwtype_s ciwtype;
+      rv64_instr_cltype_s  cltype;
+      rv64_instr_cstype_s  cstype;
+      rv64_instr_catype_s  catype;
+      rv64_instr_cbtype_s  cbtype;
+      rv64_instr_cjtype_s  cjtype;
+    }  t;
+  }  rv64_cinstr_s;
 
   typedef struct packed
   {

--- a/bp_fe/src/include/bp_fe_defines.svh
+++ b/bp_fe/src/include/bp_fe_defines.svh
@@ -15,11 +15,11 @@
   `define declare_bp_fe_branch_metadata_fwd_s(btb_tag_width_mp, btb_idx_width_mp, bht_idx_width_mp, ghist_width_mp, bht_row_width_mp) \
     typedef struct packed                                                                         \
     {                                                                                             \
-      logic                           site_br;                                                     \
-      logic                           site_jal;                                                    \
-      logic                           site_jalr;                                                   \
-      logic                           site_call;                                                   \
-      logic                           site_return;                                                    \
+      logic                           site_br;                                                    \
+      logic                           site_jal;                                                   \
+      logic                           site_jalr;                                                  \
+      logic                           site_call;                                                  \
+      logic                           site_return;                                                \
       logic                           src_ras;                                                    \
       logic                           src_btb;                                                    \
       logic [btb_tag_width_mp-1:0]    btb_tag;                                                    \
@@ -31,6 +31,9 @@
 
   `define bp_addr_is_aligned(addr_mp, num_bytes_mp) \
     (!(|{ addr_mp[$clog2(num_bytes_mp)-1:0] }))
+
+  `define bp_addr_align(addr_mp, num_bytes_mp) \
+    ((addr_mp >> $clog2(num_bytes_mp)) << $clog2(num_bytes_mp))
 
 `endif
 

--- a/bp_fe/src/include/bp_fe_pc_gen_pkgdef.svh
+++ b/bp_fe/src/include/bp_fe_pc_gen_pkgdef.svh
@@ -15,7 +15,7 @@
       logic jalr;
       logic call;
       logic _return;
-      logic [rv64_imm20_width_gp-1:0] imm20;
+      logic [19:0] imm20;
     }  bp_fe_instr_scan_s;
 
 `endif

--- a/bp_fe/src/include/bp_fe_pc_gen_pkgdef.svh
+++ b/bp_fe/src/include/bp_fe_pc_gen_pkgdef.svh
@@ -8,15 +8,17 @@
    * bp_fe_instr_scan_s specifies metadata about the instruction, including FE-special opcodes
    *   and the calculated branch target
    */
-    typedef struct packed
-    {
-      logic branch;
-      logic jal;
-      logic jalr;
-      logic call;
-      logic _return;
-      logic [19:0] imm20;
-    }  bp_fe_instr_scan_s;
+  typedef struct packed
+  {
+    logic branch;
+    logic jal;
+    logic jalr;
+    logic call;
+    logic _return;
+    logic clow;
+    logic chigh;
+    logic [19:0] imm20;
+  }  bp_fe_instr_scan_s;
 
 `endif
 

--- a/bp_fe/src/v/bp_fe_bht.sv
+++ b/bp_fe/src/v/bp_fe_bht.sv
@@ -91,7 +91,7 @@ module bp_fe_bht
 
   // GSELECT
   wire                            r_v_li = r_v_i;
-  wire [idx_width_lp-1:0]       r_idx_li = {r_addr_i[2+:bht_idx_width_p], r_ghist_i};
+  wire [idx_width_lp-1:0]       r_idx_li = {r_addr_i[bht_start_bit_p+:bht_idx_width_p], r_ghist_i};
   logic [bht_row_width_p-1:0] r_data_lo;
 
   assign rw_same_addr = r_v_i & w_v_i & (r_idx_li == w_idx_li);
@@ -116,7 +116,7 @@ module bp_fe_bht
   if (bht_row_els_p > 1)
     begin : fold
       wire [`BSG_SAFE_CLOG2(bht_row_width_p)-1:0] pred_idx_n =
-        1'b1 + (r_addr_i[2+bht_idx_width_p+:`BSG_SAFE_CLOG2(bht_row_els_p)] << 1'b1);
+        1'b1 + (r_addr_i[bht_start_bit_p+bht_idx_width_p+:`BSG_SAFE_CLOG2(bht_row_els_p)] << 1'b1);
       bsg_dff
        #(.width_p(`BSG_SAFE_CLOG2(bht_row_width_p)))
        pred_idx_reg

--- a/bp_fe/src/v/bp_fe_btb.sv
+++ b/bp_fe/src/v/bp_fe_btb.sv
@@ -89,8 +89,8 @@ module bp_fe_btb
     logic [vaddr_width_p-1:0]   tgt;
   }  bp_btb_entry_s;
 
-  wire [btb_idx_width_p-1:0] r_idx_li = r_addr_i[2+:btb_idx_width_p];
-  wire [btb_tag_width_p-1:0] r_tag_li = r_addr_i[2+btb_idx_width_p+:btb_tag_width_p];
+  wire [btb_idx_width_p-1:0] r_idx_li = r_addr_i[btb_start_bit_p+:btb_idx_width_p];
+  wire [btb_tag_width_p-1:0] r_tag_li = r_addr_i[btb_start_bit_p+btb_idx_width_p+:btb_tag_width_p];
 
   bp_btb_entry_s tag_mem_data_li;
   wire rw_same_addr = r_v_i & w_v_i & (r_idx_li == w_idx_i);

--- a/bp_fe/src/v/bp_fe_controller.sv
+++ b/bp_fe/src/v/bp_fe_controller.sv
@@ -24,7 +24,7 @@ module bp_fe_controller
 
    , output logic                                     redirect_v_o
    , output logic [vaddr_width_p-1:0]                 redirect_pc_o
-   , output logic [hinstr_width_gp-1:0]               redirect_instr_o
+   , output logic [cinstr_width_gp-1:0]               redirect_instr_o
    , output logic                                     redirect_resume_v_o
    , output logic                                     redirect_br_v_o
    , output logic                                     redirect_br_taken_o

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -495,7 +495,7 @@ module bp_fe_icache
 
   assign cache_req_v_o = v_tv & ~fill_tv_r & |{uncached_req, cached_req, fencei_req};
   assign cache_req_cast_o =
-   '{addr     : paddr_tv_r
+   '{addr     : `bp_addr_align(paddr_tv_r, 4)
      ,size    : bp_cache_req_size_e'(cached_req ? block_req_size : uncached_req_size)
      ,msg_type: cached_req ? e_miss_load : uncached_req ? e_uc_load : e_cache_clear
      ,subop   : e_req_amoswap

--- a/bp_fe/src/v/bp_fe_instr_scan.sv
+++ b/bp_fe/src/v/bp_fe_instr_scan.sv
@@ -17,6 +17,7 @@ module bp_fe_instr_scan
    , localparam instr_scan_width_lp = $bits(bp_fe_instr_scan_s)
    )
   (input                                    instr_v_i
+   , input [1:0]                            mask_i
    , input [instr_width_gp-1:0]             instr_i
 
    , output logic [instr_scan_width_lp-1:0] scan_o
@@ -25,27 +26,91 @@ module bp_fe_instr_scan
   `bp_cast_i(rv64_instr_rtype_s, instr);
   `bp_cast_o(bp_fe_instr_scan_s, scan);
   
-  wire dest_link   = (instr_cast_i.rd_addr inside {32'h1, 32'h5});
-  wire src_link    = (instr_cast_i.rs1_addr inside {32'h1, 32'h5});
-  wire dest_src_eq = (instr_cast_i.rd_addr == instr_cast_i.rs1_addr);
-  
+  rv64_cinstr_s cinstr_low_li, cinstr_high_li;
+  assign cinstr_low_li = instr_i[0+:cinstr_width_gp];
+  assign cinstr_high_li = instr_i[cinstr_width_gp+:cinstr_width_gp];
+
+  logic dest_link, src_link, dest_src_eq;
+
+  logic branch_found;
   always_comb
     begin
       scan_cast_o = '0;
+      branch_found = 0;
 
-      if (instr_v_i)
+      if (instr_v_i & mask_i[0])
         begin
+          dest_link   = (instr_cast_i.rd_addr inside {32'h1, 32'h5});
+          src_link    = (instr_cast_i.rs1_addr inside {32'h1, 32'h5});
+          dest_src_eq = (instr_cast_i.rd_addr == instr_cast_i.rs1_addr);
+
           scan_cast_o.branch  = (instr_cast_i.opcode == `RV64_BRANCH_OP);
           scan_cast_o.jal     = (instr_cast_i.opcode == `RV64_JAL_OP);
           scan_cast_o.jalr    = (instr_cast_i.opcode == `RV64_JALR_OP);
           scan_cast_o.call    = (instr_cast_i.opcode inside {`RV64_JAL_OP, `RV64_JALR_OP}) && dest_link;
           scan_cast_o._return = (instr_cast_i.opcode == `RV64_JALR_OP) && src_link && !dest_src_eq;
-  
+
           unique casez (instr_cast_i.opcode)
             `RV64_BRANCH_OP: scan_cast_o.imm20 = `rv64_signext_b_imm(instr_i);
             `RV64_JAL_OP   : scan_cast_o.imm20 = `rv64_signext_j_imm(instr_i);
             default : begin end
           endcase
+          branch_found = |{scan_cast_o.branch, scan_cast_o.jal, scan_cast_o.jalr};
+        end
+
+      //
+      // TODO: low and high branches....
+      // Low and high should both calculate targets...
+      // Instruction scan isn't making an opinion, just telling PC gen what's happening
+
+      // Opportunity for multiple branch prediction, but for now just assume only 1 branch
+      //   per 32b fetch packet
+      if (compressed_support_p & instr_v_i & mask_i[0] & ~branch_found)
+        begin
+          dest_link   = cinstr_low_li inside {`RV64_CJALR};
+          src_link    = (cinstr_low_li.t.crtype.rdrs1_addr inside {32'h1, 32'h5});
+          dest_src_eq = (cinstr_low_li.t.crtype.rdrs1_addr == 5'h1);
+
+          scan_cast_o.branch  = (cinstr_low_li inside {`RV64_CBEQZ, `RV64_CBNEZ});
+          scan_cast_o.jal     = (cinstr_low_li inside {`RV64_CJ});
+          scan_cast_o.jalr    = (cinstr_low_li inside {`RV64_CJR, `RV64_CJALR});
+          scan_cast_o.call    = (cinstr_low_li inside {`RV64_CJALR});
+          scan_cast_o._return = (cinstr_low_li inside {`RV64_CJR, `RV64_CJALR}) && src_link && !dest_src_eq;
+          scan_cast_o.clow    = 1'b1;
+
+          unique casez (cinstr_low_li)
+            `RV64_CJ:
+              scan_cast_o.imm20 = dword_width_gp'($signed({cinstr_low_li[12], cinstr_low_li[8], cinstr_low_li[10:9], cinstr_low_li[6], cinstr_low_li[7], cinstr_low_li[2], cinstr_low_li[11], cinstr_low_li[5:3], 1'b0}));
+            `RV64_CBEQZ, `RV64_CBNEZ:
+              scan_cast_o.imm20 = dword_width_gp'($signed({cinstr_low_li[12], cinstr_low_li[6:5], cinstr_low_li[2], cinstr_low_li[11:10], cinstr_low_li[4:3], 1'b0}));
+            default: begin end
+          endcase
+          branch_found = |{scan_cast_o.branch, scan_cast_o.jal, scan_cast_o.jalr};
+        end
+
+      if (compressed_support_p & instr_v_i & mask_i[1] & ~branch_found)
+        begin
+          dest_link   = cinstr_high_li inside {`RV64_CJALR};
+          src_link    = (cinstr_high_li.t.crtype.rdrs1_addr inside {32'h1, 32'h5});
+          dest_src_eq = (cinstr_high_li.t.crtype.rdrs1_addr == 5'h1);
+
+          scan_cast_o.branch  = (cinstr_high_li inside {`RV64_CBEQZ, `RV64_CBNEZ});
+          scan_cast_o.jal     = (cinstr_high_li inside {`RV64_CJ});
+          scan_cast_o.jalr    = (cinstr_high_li inside {`RV64_CJR, `RV64_CJALR});
+          scan_cast_o.call    = (cinstr_high_li inside {`RV64_CJALR});
+          scan_cast_o._return = (cinstr_high_li inside {`RV64_CJR, `RV64_CJALR}) && src_link && !dest_src_eq;
+          scan_cast_o.chigh   = 1'b1;
+
+          unique casez (cinstr_high_li)
+            `RV64_CJ:
+              scan_cast_o.imm20 = dword_width_gp'($signed({cinstr_high_li[12], cinstr_high_li[8], cinstr_high_li[10:9], cinstr_high_li[6], cinstr_high_li[7], cinstr_high_li[2], cinstr_high_li[11], cinstr_high_li[5:3], 1'b0}));
+            `RV64_CBEQZ, `RV64_CBNEZ:
+              scan_cast_o.imm20 = dword_width_gp'($signed({cinstr_high_li[12], cinstr_high_li[6:5], cinstr_high_li[2], cinstr_high_li[11:10], cinstr_high_li[4:3], 1'b0}));
+            default: begin end
+          endcase
+          // This is safe because the compressed immediate will never be >12b
+          scan_cast_o.imm20 += 2'b10;
+          branch_found = |{scan_cast_o.branch, scan_cast_o.jal, scan_cast_o.jalr};
         end
     end
 

--- a/bp_fe/src/v/bp_fe_realigner.sv
+++ b/bp_fe/src/v/bp_fe_realigner.sv
@@ -13,100 +13,125 @@ module bp_fe_realigner
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
  )
-  (input                             clk_i
-   , input                           reset_i
+  (input                               clk_i
+   , input                             reset_i
 
    // Fetch PC and I$ data
-   , input                           if2_instr_v_i
-   , input [vaddr_width_p-1:0]       if2_pc_i
-   , input [instr_width_gp-1:0]      if2_data_i
-   , input                           if2_taken_branch_site_i
-   , output logic                    if2_yumi_o
+   , input                             if2_instr_v_i
+   , input [vaddr_width_p-1:0]         if2_pc_i
+   , input [instr_width_gp-1:0]        if2_data_i
+   , input                             if2_taken_branch_site_i
+   , output logic                      if2_yumi_o
 
    // Redirection from backend
    //   and whether to restore the instruction data
    //   and PC to resume a fetch
-   , input                           redirect_v_i
-   , input                           redirect_resume_v_i
-   , input [cinstr_width_gp-1:0]     redirect_instr_i
-   , input [vaddr_width_p-1:0]       redirect_pc_i
+   , input                             redirect_v_i
+   , input                             redirect_resume_v_i
+   , input [vaddr_width_p-1:0]         redirect_pc_i
+   , input [cinstr_width_gp-1:0]       redirect_instr_i
+   , input [branch_metadata_fwd_width_p-1:0] redirect_br_metadata_fwd_i
 
-   , output [vaddr_width_p-1:0]      fetch_pc_o
-   , output [instr_width_gp-1:0]     fetch_instr_o
-   , output                          fetch_instr_v_o
-   , output                          fetch_partial_o
-   , output                          fetch_linear_o
-   , input                           fetch_ready_and_i
+   , output logic                      fetch_instr_v_o
+   , output logic [vaddr_width_p-1:0]  fetch_pc_o
+   , output logic [instr_width_gp-1:0] fetch_instr_o
+   , output logic                      fetch_linear_o
+   , output logic                      fetch_partial_o
+   , output logic                      fetch_realign_o
+   , output logic                      fetch_scan_o
+   , output logic                      fetch_stall_o
+   , output logic [1:0]                fetch_mask_o
+   , output logic                      fetch_eager_o
+   , input                             fetch_ready_and_i
    );
 
-  wire [cinstr_width_gp-1:0] icache_data_lower_half_li = if2_data_i[0                  +:cinstr_width_gp];
-  wire [cinstr_width_gp-1:0] icache_data_upper_half_li = if2_data_i[cinstr_width_gp+:cinstr_width_gp];
-
-  logic [vaddr_width_p-1:0] partial_pc_n, partial_pc_r;
+  logic partial_v_n, partial_v_r;
   logic [cinstr_width_gp-1:0] partial_instr_n, partial_instr_r;
-  logic partial_v_r;
+  logic [vaddr_width_p-1:0] partial_pc_n, partial_pc_r;
 
-  wire if2_pc_is_aligned  = `bp_addr_is_aligned(if2_pc_i, (instr_width_gp>>3));
-  wire if2_store_v = if2_yumi_o &
-    // Transition from aligned to misaligned
-    ((~partial_v_r & ~if2_pc_is_aligned)
-     // Continue misaligned to aligned/misaligned
-     || (partial_v_r & ~if2_taken_branch_site_i)
-     );
+  wire if2_pc_aligned = `bp_addr_is_aligned(if2_pc_i, (instr_width_gp>>3));
+  wire [1:0] if2_compressed = ~{&if2_data_i[cinstr_width_gp+:2], &if2_data_i[0+:2]};
 
-  wire [vaddr_width_p-1:0] redirect_pc_adjusted = redirect_pc_i - 2'b10;
-  wire [vaddr_width_p-1:0] if2_pc_adjusted = (partial_v_r & if2_pc_is_aligned) ? (if2_pc_i + 2'b10) : if2_pc_i;
+  wire [vaddr_width_p-1:0] redirect_partial_pc = redirect_pc_i - (redirect_resume_v_i ? 2'b10 : 2'b00);
+  wire [vaddr_width_p-1:0] if2_partial_pc = if2_pc_i + (if2_pc_aligned ? 2'b10 : 2'b00);
   wire [cinstr_width_gp-1:0] if2_data_lower = if2_data_i[0+:cinstr_width_gp];
   wire [cinstr_width_gp-1:0] if2_data_upper = if2_data_i[cinstr_width_gp+:cinstr_width_gp];
   bsg_mux
    #(.width_p(cinstr_width_gp+vaddr_width_p), .els_p(2))
-   partial_mux
-    (.data_i({{redirect_instr_i, redirect_pc_adjusted}, {if2_data_upper, if2_pc_adjusted}})
+   redirect_mux
+    (.data_i({{redirect_instr_i, redirect_partial_pc}, {if2_data_upper, if2_partial_pc}})
      ,.sel_i(redirect_v_i)
      ,.data_o({partial_instr_n, partial_pc_n})
      );
 
+  wire if2_store_v = if2_yumi_o & fetch_linear_o;
   wire partial_w_v = if2_store_v | redirect_v_i | fetch_instr_v_o;
-  wire partial_v_n = (if2_store_v & ~redirect_v_i) | (redirect_v_i & redirect_resume_v_i);
+  assign partial_v_n = if2_store_v | redirect_resume_v_i;
   bsg_dff_reset_en
-   #(.width_p(1))
-   partial_v_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.en_i(partial_w_v)
-     ,.data_i(partial_v_n)
-     ,.data_o(partial_v_r)
-     );
-
-  bsg_dff_reset_en
-   #(.width_p(cinstr_width_gp+vaddr_width_p))
+   #(.width_p(1+cinstr_width_gp+vaddr_width_p))
    partial_instr_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
      ,.en_i(partial_w_v)
-     ,.data_i({partial_pc_n, partial_instr_n})
-     ,.data_o({partial_pc_r, partial_instr_r})
+     ,.data_i({partial_v_n, partial_instr_n, partial_pc_n})
+     ,.data_o({partial_v_r, partial_instr_r, partial_pc_r})
      );
-
+  
+  wire [instr_width_gp-1:0] instr_aligned = if2_pc_aligned ? if2_data_i : {if2_data_lower, if2_data_upper};
   wire [instr_width_gp-1:0] instr_assembled = {if2_data_lower, partial_instr_r};
   bsg_mux
    #(.width_p(instr_width_gp+vaddr_width_p), .els_p(2))
-   fetch_mux
-    (.data_i({{instr_assembled, partial_pc_r}, {if2_data_i, if2_pc_i}})
+   instr_mux
+    (.data_i({{instr_assembled, partial_pc_r}, {instr_aligned, if2_pc_i}})
      ,.sel_i(partial_v_r)
      ,.data_o({fetch_instr_o, fetch_pc_o})
      );
 
-  // Either completing a partial instruction or fetching aligned instruction
-  assign fetch_instr_v_o = if2_instr_v_i & (partial_v_r | if2_pc_is_aligned);
-  // Force a linear fetch if we're storing in the realigner (need to complete instruction)
-  //   or if we need to complete an instruction and are not currently completing an instruction
-  assign fetch_linear_o  = if2_store_v;
-  assign fetch_partial_o = partial_v_r;
+  // Here is a table of the possible cases:
+  // partial_v  if2_aligned if2_comp[1] if2_comp[0] | fetch_mask fetch_eager fetch_linear fetch_stall fetch_realign fetch_scan |
+  //     0           0          0           x       |    00           0           1            0            0            0     | 
+  //     0           0          1           x       |    01           1           0            0            1            0     | 
+  //     0           1          0           0       |    11           0           0            0            0            0     | 
+  //     0           1          0           1       |    01           1         !if2_br        0            0            0     | 
+  //     0           1          1           0       |    --           0           -            -            -            -     |
+  //     0           1          1           1       |    11         !if2_br       0            0            0            0     | 
+  //     1           x          0           0       |    11           0         !if2_br        0            0            0     |
+  //     1           0          0           1       |    --           0           -            -            -            -     |
+  //     1           0          1           0       |    11           0           0            1            0            0     |
+  //     1           0          1           1       |    --           0           -            -            -            -     |
+  //     1           1          0           1       |    --           0           -            -            -            -     |
+  //     1           1          1           0       |    11           0           0            1            0            1     |
+  //     1           1          1           1       |    --           0           -            -            -            -     |
 
-  assign if2_yumi_o = fetch_ready_and_i & if2_instr_v_i;
+  // Fetching at least one valid instruction
+  assign fetch_instr_v_o = fetch_ready_and_i & if2_instr_v_i & (if2_pc_aligned | partial_v_r | if2_compressed[1]);
+  assign fetch_partial_o = partial_v_r;
+  // Force a linear fetch if we're storing in the realigner (need to complete instruction)
+  assign fetch_linear_o = if2_instr_v_i &&
+    // starting misaligned high
+    ((~partial_v_r & ~if2_pc_aligned & ~if2_compressed[1])
+     // starting misaligned after compressed
+     || (~partial_v_r &  if2_pc_aligned &  if2_compressed[0] & ~if2_compressed[1] & ~if2_taken_branch_site_i)
+     // continuing misaligned high
+     || ( partial_v_r & ~if2_compressed[1] & ~if2_taken_branch_site_i));
+  // Completing full instruction, still have compressed left
+  assign fetch_realign_o = if2_instr_v_i & ~partial_v_r & ~if2_pc_aligned & if2_compressed[1] & ~if2_taken_branch_site_i;
+  // Adjust the IF2 PC up to catchup after completing a misaligned instruction 
+  assign fetch_scan_o = if2_instr_v_i & partial_v_r & if2_compressed[1] & if2_pc_aligned & ~if2_taken_branch_site_i;
+  // Stall the pipeline to keep the same I$ data
+  assign fetch_stall_o = if2_instr_v_i & partial_v_r & if2_compressed[1] & ~if2_taken_branch_site_i;
+  // Eagerly fetch a low or high compressed instruction
+  assign fetch_eager_o = (~partial_v_r & ~if2_pc_aligned & if2_compressed[1])
+                         || (~partial_v_r & if2_pc_aligned & if2_compressed[0] & ~if2_compressed[1])
+                         // This messes up for {compressed branch, compressed}, saying eager even
+                         // though we have fetched two instructions, one of which is a branch
+                         || (~partial_v_r & if2_pc_aligned & if2_compressed[0] & if2_taken_branch_site_i);
+  assign fetch_mask_o[0] = partial_v_r | if2_pc_aligned | if2_compressed[0] | if2_compressed[1];
+  assign fetch_mask_o[1] = partial_v_r | (if2_pc_aligned & ~if2_compressed[0] & ~if2_compressed[1]) | (if2_pc_aligned & if2_compressed[0] & if2_compressed[1]);
+
+  assign if2_yumi_o = fetch_ready_and_i & if2_instr_v_i & ~fetch_stall_o;
 
 endmodule
+
 

--- a/bp_fe/src/v/bp_fe_realigner.sv
+++ b/bp_fe/src/v/bp_fe_realigner.sv
@@ -17,17 +17,18 @@ module bp_fe_realigner
    , input                           reset_i
 
    // Fetch PC and I$ data
-   , input                           if2_v_i
+   , input                           if2_instr_v_i
    , input [vaddr_width_p-1:0]       if2_pc_i
    , input [instr_width_gp-1:0]      if2_data_i
    , input                           if2_taken_branch_site_i
+   , output logic                    if2_yumi_o
 
    // Redirection from backend
    //   and whether to restore the instruction data
    //   and PC to resume a fetch
    , input                           redirect_v_i
    , input                           redirect_resume_v_i
-   , input [hinstr_width_gp-1:0]     redirect_instr_i
+   , input [cinstr_width_gp-1:0]     redirect_instr_i
    , input [vaddr_width_p-1:0]       redirect_pc_i
 
    , output [vaddr_width_p-1:0]      fetch_pc_o
@@ -35,18 +36,18 @@ module bp_fe_realigner
    , output                          fetch_instr_v_o
    , output                          fetch_partial_o
    , output                          fetch_linear_o
-   , input                           fetch_instr_yumi_i
+   , input                           fetch_ready_and_i
    );
 
-  wire [hinstr_width_gp-1:0] icache_data_lower_half_li = if2_data_i[0                  +:hinstr_width_gp];
-  wire [hinstr_width_gp-1:0] icache_data_upper_half_li = if2_data_i[hinstr_width_gp+:hinstr_width_gp];
+  wire [cinstr_width_gp-1:0] icache_data_lower_half_li = if2_data_i[0                  +:cinstr_width_gp];
+  wire [cinstr_width_gp-1:0] icache_data_upper_half_li = if2_data_i[cinstr_width_gp+:cinstr_width_gp];
 
   logic [vaddr_width_p-1:0] partial_pc_n, partial_pc_r;
-  logic [hinstr_width_gp-1:0] partial_instr_n, partial_instr_r;
+  logic [cinstr_width_gp-1:0] partial_instr_n, partial_instr_r;
   logic partial_v_r;
 
   wire if2_pc_is_aligned  = `bp_addr_is_aligned(if2_pc_i, (instr_width_gp>>3));
-  wire if2_store_v = if2_v_i &
+  wire if2_store_v = if2_yumi_o &
     // Transition from aligned to misaligned
     ((~partial_v_r & ~if2_pc_is_aligned)
      // Continue misaligned to aligned/misaligned
@@ -55,17 +56,17 @@ module bp_fe_realigner
 
   wire [vaddr_width_p-1:0] redirect_pc_adjusted = redirect_pc_i - 2'b10;
   wire [vaddr_width_p-1:0] if2_pc_adjusted = (partial_v_r & if2_pc_is_aligned) ? (if2_pc_i + 2'b10) : if2_pc_i;
-  wire [hinstr_width_gp-1:0] if2_data_lower = if2_data_i[0+:hinstr_width_gp];
-  wire [hinstr_width_gp-1:0] if2_data_upper = if2_data_i[hinstr_width_gp+:hinstr_width_gp];
+  wire [cinstr_width_gp-1:0] if2_data_lower = if2_data_i[0+:cinstr_width_gp];
+  wire [cinstr_width_gp-1:0] if2_data_upper = if2_data_i[cinstr_width_gp+:cinstr_width_gp];
   bsg_mux
-   #(.width_p(hinstr_width_gp+vaddr_width_p), .els_p(2))
+   #(.width_p(cinstr_width_gp+vaddr_width_p), .els_p(2))
    partial_mux
     (.data_i({{redirect_instr_i, redirect_pc_adjusted}, {if2_data_upper, if2_pc_adjusted}})
      ,.sel_i(redirect_v_i)
      ,.data_o({partial_instr_n, partial_pc_n})
      );
 
-  wire partial_w_v = if2_store_v | redirect_v_i | fetch_instr_yumi_i;
+  wire partial_w_v = if2_store_v | redirect_v_i | fetch_instr_v_o;
   wire partial_v_n = (if2_store_v & ~redirect_v_i) | (redirect_v_i & redirect_resume_v_i);
   bsg_dff_reset_en
    #(.width_p(1))
@@ -79,7 +80,7 @@ module bp_fe_realigner
      );
 
   bsg_dff_reset_en
-   #(.width_p(hinstr_width_gp+vaddr_width_p))
+   #(.width_p(cinstr_width_gp+vaddr_width_p))
    partial_instr_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
@@ -99,11 +100,13 @@ module bp_fe_realigner
      );
 
   // Either completing a partial instruction or fetching aligned instruction
-  assign fetch_instr_v_o = if2_v_i & (partial_v_r | if2_pc_is_aligned);
+  assign fetch_instr_v_o = if2_instr_v_i & (partial_v_r | if2_pc_is_aligned);
   // Force a linear fetch if we're storing in the realigner (need to complete instruction)
   //   or if we need to complete an instruction and are not currently completing an instruction
   assign fetch_linear_o  = if2_store_v;
   assign fetch_partial_o = partial_v_r;
+
+  assign if2_yumi_o = fetch_ready_and_i & if2_instr_v_i;
 
 endmodule
 

--- a/bp_fe/test/common/bp_fe_nonsynth_pc_gen_tracer.sv
+++ b/bp_fe/test/common/bp_fe_nonsynth_pc_gen_tracer.sv
@@ -175,7 +175,7 @@ module bp_fe_nonsynth_pc_gen_tracer
       return $sformatf("(%x)", addr);
   endfunction
 
-  function string render_half_instr_with_validity(logic [hinstr_width_gp-1:0] instr, logic valid);
+  function string render_half_instr_with_validity(logic [cinstr_width_gp-1:0] instr, logic valid);
     if (valid)
       return $sformatf("     %x ", instr);
     else

--- a/bp_fe/test/common/bp_fe_nonsynth_pc_gen_tracer.sv
+++ b/bp_fe/test/common/bp_fe_nonsynth_pc_gen_tracer.sv
@@ -109,7 +109,7 @@ module bp_fe_nonsynth_pc_gen_tracer
    , input [vaddr_width_p-1:0] if2_pc_i
    , input                     if2_v_i
    , input                     fetch_v_i
-   , input                     fetch_partial_i
+   , input                     fetch_eager_i
    , input [vaddr_width_p-1:0] fetch_pc_i
    , input [instr_width_gp-1:0] fetch_instr_i
    );
@@ -206,8 +206,8 @@ module bp_fe_nonsynth_pc_gen_tracer
         ,cycle_cnt
         ,render_addr_with_validity(if2_pc_i, if2_v_i)
         ,pc_src_fetch.name()
-        ,render_addr_with_validity(fetch_pc_i, fetch_partial_i)
-        ,render_half_instr_with_validity(fetch_instr_i, fetch_partial_i)
+        ,render_addr_with_validity(fetch_pc_i, fetch_eager_i)
+        ,render_half_instr_with_validity(fetch_instr_i, fetch_eager_i)
         ,ovr_ntaken_count
         ,state_resume_i ? "resume" : (state_wait_i ? "wait" : "run"));
 

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -219,6 +219,7 @@ $BP_BE_DIR/src/v/bp_be_calculator/bp_be_reg_to_fp.sv
 $BP_BE_DIR/src/v/bp_be_checker/bp_be_cmd_queue.sv
 $BP_BE_DIR/src/v/bp_be_checker/bp_be_detector.sv
 $BP_BE_DIR/src/v/bp_be_checker/bp_be_director.sv
+$BP_BE_DIR/src/v/bp_be_checker/bp_be_expander.sv
 $BP_BE_DIR/src/v/bp_be_checker/bp_be_instr_decoder.sv
 $BP_BE_DIR/src/v/bp_be_checker/bp_be_issue_queue.sv
 $BP_BE_DIR/src/v/bp_be_checker/bp_be_regfile.sv

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -477,7 +477,7 @@ module testbench
 
           ,.fe_cmd_nonattaboy_i(fe.fe_cmd_yumi_o & ~fe.controller.attaboy_v)
           ,.fe_cmd_fence_i(be.director.is_fence)
-          ,.fe_queue_empty_i(be.scheduler.fe_queue_fifo.empty)
+          ,.fe_queue_empty_i(be.scheduler.issue_queue.empty)
 
           ,.mispredict_i(be.director.poison_isd_o)
           ,.dcache_miss_i(~be.calculator.pipe_mem.dcache.ready_and_o)

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -557,7 +557,7 @@ module testbench
            ,.fetch_v_i(fe_queue_ready_and_i & fe_queue_v_o)
            ,.fetch_pc_i(fetch_pc_lo)
            ,.fetch_instr_i(fetch_instr_lo)
-           ,.fetch_partial_i(fetch_partial_lo)
+           ,.fetch_eager_i(fetch_eager_lo)
            );
 
       bind bp_be_top


### PR DESCRIPTION
## Summary
This PR adds compressed extension 'C' support to BlackParrot. This is a WIP 

## Issue Fixed
Generally unhappiness with lack of C support.

## Area
FE instruction scanning and BE instruction issuing

## Reasoning (outdated, confusing, verbose, etc.)
This extension is required by the 'A22' RISC-V profile, meaning that general purpose Linux distributions will require it in the future.

## Additional Changes Required (if any)
This PR is WIP because of a need for cleanup and optimization

## Analysis
There are potential new timing paths in FE and impact to performance in the worst and average cases. Branching to a misaligned instruction has an additional cycle of latency, which can degenerate for a mixed set.

## Verification
Standard regression, with manual inspection of erroneous instruction fetches

## Additional Context
#1098 provided the baseline for this work
