### PR TITLE
Hotfix for accidental timing loops

### DIFF
--- a/bp_common/src/v/bp_tlb.sv
+++ b/bp_common/src/v/bp_tlb.sv
@@ -91,7 +91,7 @@ module bp_tlb
      ,.w_tag_i(vtag_i)
      ,.w_empty_o(tag_empty_4k_lo)
 
-     ,.r_v_i(~|tag_4k_w_v_li)
+     ,.r_v_i(~w_v_li)
      ,.r_tag_i(vtag_r)
      ,.r_match_o(tag_r_match_4k_lo)
      );
@@ -125,7 +125,7 @@ module bp_tlb
      ,.w_tag_i(vtag_i)
      ,.w_empty_o(tag_empty_1g_lo)
 
-     ,.r_v_i(~|tag_1g_w_v_li)
+     ,.r_v_i(~w_v_li)
      ,.r_tag_i(vtag_r)
      ,.r_match_o(tag_r_match_1g_lo)
      );

--- a/bp_fe/src/v/bp_fe_controller.sv
+++ b/bp_fe/src/v/bp_fe_controller.sv
@@ -112,7 +112,7 @@ module bp_fe_controller
   wire cmd_immediate_v  = fe_cmd_v_i & (pc_redirect_v | icache_fill_response_v | wait_v);
   wire cmd_complex_v    = fe_cmd_v_i & ~cmd_immediate_v & cmd_nonattaboy_v;
 
-  assign redirect_v_o               = ~attaboy_v & fe_cmd_yumi_o;
+  assign redirect_v_o               = cmd_nonattaboy_v;
   assign redirect_pc_o              = fe_cmd_cast_i.npc;
   assign redirect_br_v_o            = br_miss_v;
   assign redirect_br_taken_o        = br_miss_taken;

--- a/bp_me/test/common/bp_nonsynth_dram.sv
+++ b/bp_me/test/common/bp_nonsynth_dram.sv
@@ -95,7 +95,7 @@ module bp_nonsynth_dram
        logic [`dram_pkg::channel_addr_width_p-1:0] dram_ch_addr_li;
        logic dram_write_not_read_li, dram_v_li, dram_yumi_lo;
        logic [`dram_pkg::data_width_p-1:0] dram_data_li;
-       logic [`dram_pkg::data_width_p>>3-1:0] dram_mask_li;
+       logic [(`dram_pkg::data_width_p>>3)-1:0] dram_mask_li;
 
        logic dram_data_v_li, dram_data_yumi_lo;
        logic [`dram_pkg::data_width_p-1:0] dram_data_lo;


### PR DESCRIPTION
## Summary
This PR fixes 2 timing loops introduced by #1130, one in the TLB and one in the FE controller.

## Issue Fixed
None; hotfix

## Area
FE and TLBs

## Reasoning (outdated, confusing, verbose, etc.)
Timing loops cause degenerate behaviors in CAD tools, especially FPGAs which may infer latches.

## Verification
Synthesis is now clean
