### PR TITLE
Adding yosys synthesis and simulation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ stages:
 #    policy: pull
   dependencies: []
   retry:
-    max: 2
+    max: 1
     when:
       - script_failure
 
@@ -66,6 +66,14 @@ surelog:
     - bsg
   script:
     - $CI_PROJECT_DIR/ci/surelog.sh $CI_CORES
+
+yosys:
+  <<: *job_definition
+  stage: check
+  tags:
+    - bsg
+  script:
+    - $CI_PROJECT_DIR/ci/yosys.sh $CI_CORES
 
 # Some licensing issue as of 02/10/21
 synth-vivado:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ tidy:
 	echo "BlackParrot RTL is tidy enough"
 
 clean:
-	-$(MAKE) libs_clean
+	$(MAKE) libs_clean
 
 ## This target just wipes the whole repo clean.
 #  Use with caution.

--- a/bp_common/syn/Makefile.common
+++ b/bp_common/syn/Makefile.common
@@ -7,11 +7,14 @@ include $(TOP)/Makefile.common
 
 .DEFAULT: help
 
-RISCV_OBJDUMP ?= $(CROSS_COMPILE)objdump -d -t
-RISCV_OBJCOPY ?= $(CROSS_COMPILE)objcopy
-MEM2NBF       ?= $(BP_COMMON_DIR)/software/py/nbf.py
-DROMAJO       ?= dromajo
-SED           ?= sed
+RISCV_OBJDUMP    ?= $(CROSS_COMPILE)objdump -d -t
+RISCV_OBJCOPY    ?= $(CROSS_COMPILE)objcopy
+MEM2NBF          ?= $(BP_COMMON_DIR)/software/py/nbf.py
+DROMAJO          ?= dromajo
+SED              ?= sed
+PDK_ROOT         ?= $(SKY130_DIR)
+PDK              ?= $(SKY130_VER)
+STD_CELL_LIBRARY ?= sky130_fd_sc_hd
 
 report:
 	$(eval REPORT_LIST := $(shell find $(REPORT_PATH) -type f -name "*.rpt"))

--- a/bp_common/syn/Makefile.vcs
+++ b/bp_common/syn/Makefile.vcs
@@ -110,6 +110,11 @@ build_vivado.v: SIM_SYNTH_VIVADO_P := 1
 build_vivado.v: NO_BIND_P          := 1
 build_vivado.v: build.v
 
+build_vivado_dump.v: VCS_BUILD_OPTS += -debug_pp
+build_vivado_dump.v: VCS_BUILD_OPTS += +vcs+vcdpluson
+build_vivado_dump.v: VCS_BUILD_OPTS += +vcs+vcdplusautoflushon
+build_vivado_dump.v: build_vivado.v
+
 sim_vivado.v: SIM_SYNTH_VIVADO_P := 1
 sim_vivado.v: NO_BIND_P          := 1
 sim_vivado.v: sim.v
@@ -119,6 +124,34 @@ sim_vivado_dump.v: VCS_OPTIONS += +vcs+vcdpluson
 sim_vivado_dump.v: VCS_OPTIONS += +vcs+vcdplusmemon
 sim_vivado_dump.v: VCS_OPTIONS += +vcs+vcdplusautoflushon
 sim_vivado_dump.v: sim_vivado.v
+
+build_yosys.v: SIM_SYNTH_YOSYS_P := 1
+build_yosys.v: NO_BIND_P         := 1
+build_yosys.v: VCS_BUILD_OPTS += -top testbench
+build_yosys.v: VCS_BUILD_OPTS += +define+FUNCTIONAL
+build_yosys.v: VCS_BUILD_OPTS += +define+UNIT_DELAY
+build_yosys.v: VCS_BUILD_OPTS += $(PDK_ROOT)/$(PDK)/libs.ref/$(STD_CELL_LIBRARY)/verilog/primitives.v
+build_yosys.v: VCS_BUILD_OPTS += $(PDK_ROOT)/$(PDK)/libs.ref/$(STD_CELL_LIBRARY)/verilog/sky130_fd_sc_hd.v
+build_yosys.v: VCS_BUILD_OPTS += $(BP_TOOLS_SHARE_DIR)/yosys/simcells.v
+build_yosys.v: VCS_BUILD_OPTS += $(BP_TOOLS_SHARE_DIR)/yosys/simlib.v
+build_yosys.v: VCS_BUILD_OPTS += +vcs+initreg+zero
+build_yosys.v: build.v
+
+sim_yosys.v: SIM_SYNTH_VIVADO_P := 1
+sim_yosys.v: NO_BIND_P          := 1
+sim_yosys.v: VCS_OPTIONS += +nospecify +notimingchecks
+sim_yosys.v: sim.v
+
+build_yosys_dump.v: VCS_BUILD_OPTS += -debug_pp
+build_yosys_dump.v: VCS_BUILD_OPTS += +vcs+vcdpluson
+build_yosys_dump.v: VCS_BUILD_OPTS += +vcs+vcdplusautoflushon
+build_yosys_dump.v: build_yosys.v
+
+sim_yosys_dump.v: VCS_OPTIONS += +memcbk
+sim_yosys_dump.v: VCS_OPTIONS += +vcs+vcdpluson
+sim_yosys_dump.v: VCS_OPTIONS += +vcs+vcdplusmemon
+sim_yosys_dump.v: VCS_OPTIONS += +vcs+vcdplusautoflushon
+sim_yosys_dump.v: sim_yosys.v
 
 sim_dump.v: VCS_OPTIONS += +memcbk
 sim_dump.v: VCS_OPTIONS += +vcs+vcdpluson

--- a/bp_common/syn/Makefile.yosys
+++ b/bp_common/syn/Makefile.yosys
@@ -1,0 +1,41 @@
+override TOOL := yosys
+
+override LOG_DIR     := $(LOG_PATH)/$(TOOL)
+override RESULTS_DIR := $(RESULTS_PATH)/$(TOOL)
+override REPORT_DIR  := $(REPORT_PATH)/$(TOOL)
+override TOUCH_DIR   := $(TOUCH_PATH)/$(TOOL)
+
+override SYNTH_DIR   := $(RESULTS_DIR)/$(TB).$(CFG).$(TAG).synth
+override CONVERT_DIR := $(RESULTS_PATH)/sv2v/$(TB).$(CFG).$(TAG).convert
+
+$(TOUCH_DIR) $(RESULTS_DIR) $(LOG_DIR) $(REPORT_DIR) $(SYNTH_DIR):
+	mkdir -p $@
+
+.PHONY: clean.yosys
+
+include $(TB_PATH)/$(TB)/Makefile.yosys
+
+## Tool specific options
+export WRAPPER_SV2V  ?= $(CONVERT_DIR)/wrapper.sv2v.v
+export WRAPPER_SYNTH ?= $(SYNTH_DIR)/wrapper.synth.v
+export TECHMAP_DIR   ?= $(PDK_ROOT)/$(PDK)/libs.tech/openlane/$(STD_CELL_LIBRARY)
+export PDK_ROOT
+export PDK
+export STD_CELL_LIBRARY
+export SYNTH_DIR
+
+synth.yosys: $(SYNTH_DIR)/synth_yosys
+synth.yosys: SYNTH_LOG     := $(LOG_DIR)/$(TB).$(CFG).$(TAG).synth.log
+synth.yosys: SYNTH_REPORT  := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).synth.rpt
+synth.yosys: SYNTH_ERROR   := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).synth.err
+$(SYNTH_COLLATERAL): | $(TOUCH_DIR) $(RESULTS_DIR) $(LOG_DIR) $(REPORT_DIR) $(SYNTH_DIR)
+$(SYNTH_DIR)/synth_yosys: $(SYNTH_COLLATERAL)
+	cd $(SYNTH_DIR); \
+		$(YOSYS) -c $(BP_COMMON_DIR)/syn/tcl/yosys_synth.tcl
+
+clean.yosys:
+	@-rm -rf touchfiles/yosys
+	@-rm -rf results/yosys
+	@-rm -rf reports/yosys
+	@-rm -rf logs/yosys
+

--- a/bp_common/syn/tcl/yosys_synth.tcl
+++ b/bp_common/syn/tcl/yosys_synth.tcl
@@ -1,0 +1,70 @@
+# Based on https://yosyshq.net/yosys/
+yosys -import
+
+set techmap_dir $::env(TECHMAP_DIR)
+source ${techmap_dir}/config.tcl
+
+set design           wrapper
+set lib_file         $::env(LIB_SYNTH)
+set in_v_file        $::env(WRAPPER_SV2V)
+set out_v_file       $::env(WRAPPER_SYNTH)
+set stat_file        stats.json
+set check_file       checks.txt
+
+set tiehi_cell       sky130_fd_sc_hd__conb
+set tiehi_pin        HI
+set tielo_cell       sky130_fd_sc_hd__conb
+set tielo_pin        LO
+set clkbuf_cell      sky130_fd_sc_hd__clkbuf
+set clkbuf_pin       X
+set buf_cell         sky130_fd_sc_hd__buf
+set buf_ipin         A
+set buf_opin         X
+
+
+# read design
+read_verilog $in_v_file
+
+# elaborate design hierarchy
+hierarchy -check -top ${design}
+
+# the high-level stuff
+yosys proc; opt; fsm; opt; yosys memory; opt
+
+# mapping to internal cell library
+techmap; opt
+techmap -map ${techmap_dir}/csa_map.v
+techmap -map ${techmap_dir}/fa_map.v
+techmap -map ${techmap_dir}/latch_map.v
+techmap -map ${techmap_dir}/mux2_map.v
+techmap -map ${techmap_dir}/mux4_map.v
+techmap -map ${techmap_dir}/rca_map.v
+techmap -map ${techmap_dir}/tribuff_map.v
+
+# mapping to cell lib
+dfflibmap -liberty ${lib_file}
+
+# mapping logic to cell lib
+abc -liberty ${lib_file}
+
+# Set X to zero
+setundef -zero
+
+# mapping constants and clock buffers to cell lib
+hilomap -hicell ${tiehi_cell} ${tiehi_pin} -locell ${tielo_cell} ${tielo_pin}
+clkbufmap -buf ${clkbuf_cell} ${clkbuf_pin}
+
+# Split nets to single bits and map to buffers
+splitnets
+insbuf -buf ${buf_cell} ${buf_ipin} ${buf_opin}
+
+# Clean up the design
+opt_clean -purge
+
+# Check and print statistics
+tee -o ${check_file} check -mapped -noinit
+tee -o ${stat_file} stat -top ${design} -liberty ${lib_file} -tech cmos -width -json
+
+# write synthesized design
+write_verilog -nostr -noattr -noexpr -nohex -nodec ${out_v_file}
+

--- a/bp_top/syn/Makefile
+++ b/bp_top/syn/Makefile
@@ -28,4 +28,5 @@ include $(BP_COMMON_DIR)/syn/Makefile.sv2v
 include $(BP_COMMON_DIR)/syn/Makefile.verilator
 include $(BP_COMMON_DIR)/syn/Makefile.vcs
 include $(BP_COMMON_DIR)/syn/Makefile.vivado
+include $(BP_COMMON_DIR)/syn/Makefile.yosys
 

--- a/bp_top/test/tb/bp_tethered/Makefile.sv2v
+++ b/bp_top/test/tb/bp_tethered/Makefile.sv2v
@@ -1,3 +1,8 @@
+
+# We need to build openram into the flow to fully support hardening SRAMs here
+HARDEN_SRAMS ?= 0
+
+ifeq ($(HARDEN_SRAMS),1)
 $(CONVERT_DIR)/flist.vcs:
 	grep -v -e "^\#" $(SYN_PATH)/flist.vcs                                        > $@
 	echo $(CONVERT_DIR)/wrapper.sv                                               >> $@
@@ -21,23 +26,28 @@ $(CONVERT_DIR)/flist.vcs:
 	echo "$(CONVERT_DIR)/bsg_mem_1rw_sync.v"                                     >> $@
 	echo "$(CONVERT_DIR)/bsg_mem_1rw_sync_mask_write_byte.v"                     >> $@
 	echo "$(CONVERT_DIR)/bsg_mem_1rw_sync_mask_write_bit.v"                      >> $@
+else
+$(CONVERT_DIR)/flist.vcs:
+	grep -v -e "^\#" $(SYN_PATH)/flist.vcs                                        > $@
+	echo $(CONVERT_DIR)/wrapper.sv                                               >> $@
+endif
 
 $(CONVERT_DIR)/wrapper.sv:
 	@sed "s/BP_CFG_FLOWVAR/$(CFG)/g" $(TB_PATH)/$(TB)/$(@F) > $@
 
 $(CONVERT_DIR)/memgen.json:
 	# Must be python2 or this will generate incorrect decimals
-	python2 $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 1rw  0 > $(CONVERT_DIR)/bsg_mem_1rw_sync.v
-	python2 $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 1rw  1 > $(CONVERT_DIR)/bsg_mem_1rw_sync_mask_write_bit.v
-	python2 $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 1rw  8 > $(CONVERT_DIR)/bsg_mem_1rw_sync_mask_write_byte.v
-	python2 $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 2rw  0 > $(CONVERT_DIR)/bsg_mem_2rw_sync.v
-	python2 $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 2rw  1 > $(CONVERT_DIR)/bsg_mem_2rw_sync_mask_write_bit.v
-	python2 $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 2rw  8 > $(CONVERT_DIR)/bsg_mem_2rw_sync_mask_write_byte.v
-	python2 $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 1r1w 0 > $(CONVERT_DIR)/bsg_mem_1r1w_sync.v
-	python2 $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 1r1w 1 > $(CONVERT_DIR)/bsg_mem_1r1w_sync_mask_write_bit.v
-	python2 $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 1r1w 8 > $(CONVERT_DIR)/bsg_mem_1r1w_sync_mask_write_byte.v
-	python2 $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 2r1w 0 > $(CONVERT_DIR)/bsg_mem_2r1w_sync.v
-	python2 $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 3r1w 0 > $(CONVERT_DIR)/bsg_mem_3r1w_sync.v
+	$(PYTHON) $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 1rw  0 > $(CONVERT_DIR)/bsg_mem_1rw_sync.v
+	$(PYTHON) $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 1rw  1 > $(CONVERT_DIR)/bsg_mem_1rw_sync_mask_write_bit.v
+	$(PYTHON) $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 1rw  8 > $(CONVERT_DIR)/bsg_mem_1rw_sync_mask_write_byte.v
+	$(PYTHON) $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 2rw  0 > $(CONVERT_DIR)/bsg_mem_2rw_sync.v
+	$(PYTHON) $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 2rw  1 > $(CONVERT_DIR)/bsg_mem_2rw_sync_mask_write_bit.v
+	$(PYTHON) $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 2rw  8 > $(CONVERT_DIR)/bsg_mem_2rw_sync_mask_write_byte.v
+	$(PYTHON) $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 1r1w 0 > $(CONVERT_DIR)/bsg_mem_1r1w_sync.v
+	$(PYTHON) $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 1r1w 1 > $(CONVERT_DIR)/bsg_mem_1r1w_sync_mask_write_bit.v
+	$(PYTHON) $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 1r1w 8 > $(CONVERT_DIR)/bsg_mem_1r1w_sync_mask_write_byte.v
+	$(PYTHON) $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 2r1w 0 > $(CONVERT_DIR)/bsg_mem_2r1w_sync.v
+	$(PYTHON) $(BASEJUMP_STL_DIR)/hard/common/bsg_mem/bsg_mem_generator.py $(TB_PATH)/$(TB)/memgen.json 3r1w 0 > $(CONVERT_DIR)/bsg_mem_3r1w_sync.v
 	cp $(TB_PATH)/$(TB)/$(@F) $@
 
 CONVERT_COLLATERAL = $(addprefix $(CONVERT_DIR)/, flist.vcs wrapper.sv memgen.json)

--- a/bp_top/test/tb/bp_tethered/Makefile.vcs
+++ b/bp_top/test/tb/bp_tethered/Makefile.vcs
@@ -29,6 +29,8 @@ $(BUILD_DIR)/testbench.sv:
 $(BUILD_DIR)/wrapper.sv:
 	if [ "$(SIM_SYNTH_VIVADO_P)" = "1" ]; then \
 		cp $(SYN_PATH)/results/vivado/bp_tethered.$(CFG).$(TAG).build/wrapper_synth.sv $@; \
+	elif [ "$(SIM_SYNTH_YOSYS_P)" = "1" ]; then \
+		cp $(SYN_PATH)/results/yosys/bp_tethered.$(CFG).$(TAG).synth/wrapper.synth.v $@; \
 	else \
 		sed "s/BP_CFG_FLOWVAR/$(CFG)/g" $(TB_PATH)/$(TB)/$(@F) > $@; \
 		sed -i 's/BP_DRAM_FLOWVAR/"$(DRAM)"/g' $@; \

--- a/bp_top/test/tb/bp_tethered/Makefile.yosys
+++ b/bp_top/test/tb/bp_tethered/Makefile.yosys
@@ -1,0 +1,6 @@
+
+$(SYNTH_DIR)/wrapper.sv2v.v: $(CONVERT_DIR)/wrapper.sv2v.v
+	cp $< $@
+
+SYNTH_COLLATERAL = $(addprefix $(SYNTH_DIR)/, wrapper.sv2v.v)
+

--- a/ci/yosys.sh
+++ b/ci/yosys.sh
@@ -6,17 +6,13 @@
 N=${1:-1}
 
 # Bash array to iterate over for configurations
+# Only works with tinyparrot_cfg at the moment
 cfgs=(\
-    "e_bp_unicore_cfg"
     "e_bp_unicore_tinyparrot_cfg"
-    "e_bp_multicore_1_cfg"
-    "e_bp_multicore_1_cce_ucode_cfg"
-    "e_bp_multicore_4_cfg"
-    "e_bp_multicore_4_cce_ucode_cfg"
     )
 
 # The base command to append the configuration to
-cmd_base="make -C bp_top/syn convert.bsg_sv2v"
+cmd_base="make -C bp_top/syn convert.bsg_sv2v synth.yosys build_yosys.v sim_yosys.v"
 
 # Any setup needed for the job
 echo "Cleaning bp_top"


### PR DESCRIPTION
### Summary
This PR adds yosys synthesis and simulation. Make sure to update black-parrot-tools to take advantage of this flow

### Issue Fixed
None

### Area
Adds Makefile infrastructure

### Reasoning (new feature, inefficient, verbose, etc.)
yosys is a FOSS toolchain for synthesizing and sky130 is an open-source PDK we can synthesize with. This is the easiest way to get started with ASIC BP. 

### Additional Changes Required (if any)
This flow relies on bsg_sv2v which needs a Synopsys DC license. We would like to avoid this commercial requirement in the future.

### Analysis
None

### Verification
Standard regression with the sv2v and yosys outputs

### Additional Context
None
