### PR TITLE
Adding Compressed Extension Support

### DIFF
--- a/bp_be/src/v/bp_be_checker/bp_be_expander.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_expander.sv
@@ -1,0 +1,198 @@
+
+`include "bp_common_defines.svh"
+`include "bp_be_defines.svh"
+
+module bp_be_expander
+ import bp_common_pkg::*;
+ import bp_be_pkg::*;
+  (input [cinstr_width_gp-1:0]         cinstr_i
+
+   , output logic [instr_width_gp-1:0] instr_o
+   );
+
+  logic [rv64_reg_addr_width_gp-1:0] rs1, rs2, rd;
+  logic [dword_width_gp-1:0] imm;
+  wire [11:0] zero_imm = '0;
+
+  localparam rv64_zero_addr_gp = 5'd0;
+  localparam rv64_link_addr_gp = 5'd1;
+  localparam rv64_sp_addr_gp = 5'd2;
+
+  always_comb
+    begin
+      instr_o = cinstr_i;
+
+      // Different per quadrant
+      casez (cinstr_i)
+        `RV64_C2_INSTR, `RV64_CADDI, `RV64_CADDIW, `RV64_CLI, `RV64_CADDI16SP, `RV64_CLUI:
+          begin
+            rs1 = cinstr_i[11:7];
+            rs2 = cinstr_i[6:2];
+            rd  = cinstr_i[11:7];
+          end
+        `RV64_C1_INSTR:
+          begin
+            rs1 = {2'b01, cinstr_i[9:7]};
+            rs2 = {2'b01, cinstr_i[4:2]};
+            rd  = {2'b01, cinstr_i[9:7]};
+          end
+        // `RV64_C0_INSTR:
+        default:
+          begin
+            rs1 = {2'b01, cinstr_i[9:7]};
+            rs2 = {2'b01, cinstr_i[4:2]};
+            rd  = {2'b01, cinstr_i[4:2]};
+          end
+      endcase
+
+      casez (cinstr_i)
+        `RV64_CADDI16SP:
+          imm = dword_width_gp'($signed({cinstr_i[12], cinstr_i[4:3], cinstr_i[5], cinstr_i[2], cinstr_i[6], 4'b0000}));
+        `RV64_CADDI4SPN:
+          imm = dword_width_gp'($unsigned({cinstr_i[10:7], cinstr_i[12:11], cinstr_i[5], cinstr_i[6], 2'b00}));
+        `RV64_CLWSP:
+          imm = dword_width_gp'($unsigned({cinstr_i[3:2], cinstr_i[12], cinstr_i[6:4], 2'b00}));
+        `RV64_CFLDSP, `RV64_CLDSP:
+          imm = dword_width_gp'($unsigned({cinstr_i[4:2], cinstr_i[12], cinstr_i[6:5], 3'b000}));
+        `RV64_CSWSP:
+          imm = dword_width_gp'($unsigned({cinstr_i[8:7], cinstr_i[12:9], 2'b00}));
+        `RV64_CFSDSP, `RV64_CSDSP:
+          imm = dword_width_gp'($unsigned({cinstr_i[9:7], cinstr_i[12:10], 3'b000}));
+        `RV64_CLW, `RV64_CSW:
+          imm = dword_width_gp'($unsigned({cinstr_i[5], cinstr_i[12:10], cinstr_i[6], 2'b00}));
+        `RV64_CFLD, `RV64_CLD, `RV64_CFSD, `RV64_CSD:
+          imm = dword_width_gp'($unsigned({cinstr_i[6:5], cinstr_i[12:10], 3'b000}));
+        `RV64_CJ:
+          imm = dword_width_gp'($signed({cinstr_i[12], cinstr_i[8], cinstr_i[10:9], cinstr_i[6] ,cinstr_i[7], cinstr_i[2], cinstr_i[11], cinstr_i[5:3], 1'b0}));
+        `RV64_CBEQZ, `RV64_CBNEZ:
+          imm = dword_width_gp'($signed({cinstr_i[12], cinstr_i[6:5], cinstr_i[2], cinstr_i[11:10], cinstr_i[4:3], 1'b0}));
+        `RV64_CLUI:
+          imm = dword_width_gp'($signed({cinstr_i[12], cinstr_i[6:2], 12'b0}));
+        `RV64_CNOP, `RV64_CADDI, `RV64_CADDIW, `RV64_CLI, `RV64_CANDI:
+          imm = dword_width_gp'($signed({cinstr_i[12], cinstr_i[6:2]}));
+        `RV64_CSLLI, `RV64_CSRLI:
+          imm = dword_width_gp'($unsigned({6'b000000, cinstr_i[12], cinstr_i[6:2]}));
+        `RV64_CSRAI:
+          imm = dword_width_gp'($unsigned({6'b010000, cinstr_i[12], cinstr_i[6:2]}));
+        default: imm = '0;
+      endcase
+
+      casez (cinstr_i)
+        // C.ILL -> 0000_0000_0000_0000
+        `RV64_CILL: instr_o = '0;
+        // C.ADDI4SPN -> addi rd', x2, nzuimm[9:2]
+        `RV64_CADDI4SPN: instr_o =
+            `rv64_i_type_exp(`RV64_OP_IMM_OP, rd, 3'b000, rv64_sp_addr_gp, imm);
+        // C.ADDI16SP -> addi x2, x2, nzimm[9:4]
+        `RV64_CADDI16SP: instr_o =
+          `rv64_i_type_exp(`RV64_OP_IMM_OP, rv64_sp_addr_gp, 3'b000, rv64_sp_addr_gp, imm);
+        // C.EBREAK   -> ebreak
+        `RV64_CEBREAK: instr_o = `RV64_EBREAK;
+        // C.LWSP     -> lw rd, offset[7:2] (x2)
+        `RV64_CLWSP: instr_o =
+          `rv64_i_type_exp(`RV64_LOAD_OP, rd, 3'b010, rv64_sp_addr_gp, imm);
+        // C.LDSP     -> ld rd, offset[8:3] (x2)
+        `RV64_CLDSP: instr_o =
+          `rv64_i_type_exp(`RV64_LOAD_OP, rd, 3'b011, rv64_sp_addr_gp, imm);
+        // C.SWSP     -> sw rs2, offset[7:2] (x2)
+        `RV64_CSWSP: instr_o =
+          `rv64_s_type_exp(`RV64_STORE_OP, 3'b010, rv64_sp_addr_gp, rs2, imm);
+        // C.SDSP     -> sd rs2, offset[8:3] (x2)
+        `RV64_CSDSP: instr_o =
+          `rv64_s_type_exp(`RV64_STORE_OP, 3'b011, rv64_sp_addr_gp, rs2, imm);
+        // C.FLDSP -> fld rd, offset(x2)
+        `RV64_CFLDSP: instr_o =
+          `rv64_i_type_exp(`RV64_FLOAD_OP, rd, 3'b011, rv64_sp_addr_gp, imm);
+        // C.FSDSP -> fsd rs2, offset(x2)
+        `RV64_CFSDSP: instr_o =
+          `rv64_s_type_exp(`RV64_FSTORE_OP, 3'b011, rv64_sp_addr_gp, rs2, imm);
+        // C.LW       -> lw rd', offset[6:2] (rs1')
+        `RV64_CLW: instr_o =
+          `rv64_i_type_exp(`RV64_LOAD_OP, rd, 3'b010, rs1, imm);
+        // C.LD       -> ld rd', offset[7:3] (rs1')
+        `RV64_CLD: instr_o =
+          `rv64_i_type_exp(`RV64_LOAD_OP, rd, 3'b011, rs1, imm);
+        // C.SW       -> sw rs2', offset[6:2] (rs1')
+        `RV64_CSW: instr_o =
+          `rv64_s_type_exp(`RV64_STORE_OP, 3'b010, rs1, rs2, imm);
+        // C.SD       -> sd rs2', offset[7:3] (rs1')
+        `RV64_CSD: instr_o =
+          `rv64_s_type_exp(`RV64_STORE_OP, 3'b011, rs1, rs2, imm);
+        // C.FLD -> fld rd', offset(rs1')
+        `RV64_CFLD: instr_o =
+          `rv64_i_type_exp(`RV64_FLOAD_OP, rd, 3'b011, rs1, imm);
+        // C.FSD -> fsd rs2', offset(rs1')
+        `RV64_CFSD: instr_o =
+          `rv64_s_type_exp(`RV64_FSTORE_OP, 3'b011, rs1, rs2, imm);
+        // C.J        -> jal x0, offset[11:1]
+        `RV64_CJ: instr_o =
+          `rv64_j_type_exp(`RV64_JAL_OP, rv64_zero_addr_gp, imm);
+        // C.JR       -> jalr x0, 0(rs1)
+        `RV64_CJR: instr_o =
+          `rv64_i_type_exp(`RV64_JALR_OP, rv64_zero_addr_gp, 3'b000, rs1, zero_imm);
+        // C.JALR     -> jalr x1, 0(rs1)
+        `RV64_CJALR: instr_o =
+          `rv64_i_type_exp(`RV64_JALR_OP, rv64_link_addr_gp, 3'b000, rs1, zero_imm);
+        // C.BEQZ     -> beq rs1', x0, offset[8:1]
+        `RV64_CBEQZ: instr_o =
+          `rv64_b_type_exp(`RV64_BRANCH_OP, 3'b000, rs1, rv64_zero_addr_gp, imm);
+        // C.BNEZ     -> bne rs1', x0, offset[8:1]
+        `RV64_CBNEZ: instr_o =
+          `rv64_b_type_exp(`RV64_BRANCH_OP, 3'b001, rs1, rv64_zero_addr_gp, imm);
+        // C.LI       -> addi rd, x0, imm[5:0]
+        `RV64_CLI: instr_o =
+          `rv64_i_type_exp(`RV64_OP_IMM_OP, rd, 3'b000, rv64_zero_addr_gp, imm);
+        // C.LUI      -> lui rd, nzimm[17:12]
+        `RV64_CLUI: instr_o =
+          `rv64_u_type_exp(`RV64_LUI_OP, rd, imm);
+        // C.NOP      -> addi x0, x0, 0
+        `RV64_CNOP: instr_o =
+          `rv64_i_type_exp(`RV64_OP_IMM_OP, rv64_zero_addr_gp, 3'b000, rv64_zero_addr_gp, zero_imm);
+        // C.ADDI     -> addi rd, rd, nzimm[5:0]
+        `RV64_CADDI: instr_o =
+          `rv64_i_type_exp(`RV64_OP_IMM_OP, rd, 3'b000, rd, imm);
+        // C.ADDIW    -> addiw rd, rd, imm[5:0]
+        `RV64_CADDIW: instr_o =
+          `rv64_i_type_exp(`RV64_OP_IMM_32_OP, rd, 3'b000, rd, imm);
+        // C.SLLI     -> slli rd, rd, shamt[5:0]
+        `RV64_CSLLI: instr_o =
+          `rv64_i_type_exp(`RV64_OP_IMM_OP, rd, 3'b001, rd, imm);
+        // C.SRLI     -> srli rd', rd', shamt[5:0]
+        `RV64_CSRLI: instr_o =
+          `rv64_i_type_exp(`RV64_OP_IMM_OP, rd, 3'b101, rd, imm);
+        // C.SRAI     -> srai rd', rd', shamt[5:0]
+        `RV64_CSRAI: instr_o =
+          `rv64_i_type_exp(`RV64_OP_IMM_OP, rd, 3'b101, rd, imm);
+        // C.ANDI     -> andi rd', rd', imm[5:0]
+        `RV64_CANDI: instr_o =
+          `rv64_i_type_exp(`RV64_OP_IMM_OP, rd, 3'b111, rd, imm);
+        // C.MV       -> add rd, x0, rs2
+        `RV64_CMV: instr_o =
+          `rv64_r_type_exp(`RV64_OP_OP, rd, 3'b000, rv64_zero_addr_gp, rs2, 7'b0);
+        // C.ADD      -> add rd, rd, rs2
+        `RV64_CADD: instr_o =
+          `rv64_r_type_exp(`RV64_OP_OP, rd, 3'b000, rd, rs2, 7'b0);
+        // C.AND      -> and rd', rd', rs2'
+        `RV64_CAND: instr_o =
+          `rv64_r_type_exp(`RV64_OP_OP, rd, 3'b111, rd, rs2, 7'b0);
+        // C.OR       -> or rd', rd', rs2'
+        `RV64_COR: instr_o =
+          `rv64_r_type_exp(`RV64_OP_OP, rd, 3'b110, rd, rs2, 7'b0);
+        // C.XOR      -> xor rd', rd', rs2'
+        `RV64_CXOR: instr_o =
+          `rv64_r_type_exp(`RV64_OP_OP, rd, 3'b100, rd, rs2, 7'b0);
+        // C.SUB      -> sub rd', rd', rs2'
+        `RV64_CSUB: instr_o =
+          `rv64_r_type_exp(`RV64_OP_OP, rd, 3'b000, rd, rs2, 7'b010_0000);
+        // C.ADDW     -> addw rd', rd', rs2'
+        `RV64_CADDW: instr_o =
+          `rv64_r_type_exp(`RV64_OP_32_OP, rd, 3'b000, rd, rs2, 7'b0);
+        // C.SUBW     -> subw rd', rd', rs2'
+        `RV64_CSUBW: instr_o =
+          `rv64_r_type_exp(`RV64_OP_32_OP, rd, 3'b000, rd, rs2, 7'b010_0000);
+        default: begin end
+      endcase
+    end
+
+endmodule
+

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -302,7 +302,7 @@
       ,fe_cmd_fifo_els   : 4
       ,muldiv_support    : (1 << e_div) | (1 << e_mul) | (1 << e_mulh)
       ,fpu_support       : 1
-      ,compressed_support: 0
+      ,compressed_support: 1
 
       ,async_coh_clk       : 0
       ,coh_noc_flit_width  : 128

--- a/bp_common/src/include/bp_common_rv64_instr_defines.svh
+++ b/bp_common/src/include/bp_common_rv64_instr_defines.svh
@@ -52,6 +52,9 @@
   `define RV64_C2_OP  2'b10
   `define RV64_32B_OP 2'b11
 
+  `define rv64_signext_cj_imm(instr) {{53{``instr``[12]}},``instr``[8],``instr``[10:9],``instr``[6],``instr``[7],``instr``[2],``instr``[11],``instr``[5:3],1'b0}
+  `define rv64_signext_cb_imm(instr) {{53{``instr``[12]}},``instr``[6:5],``instr``[2],``instr``[11:10],``instr``[4:3],1'b0}
+
   `define RV64_C0_INSTR   {14'b????_????_????_??,`RV64_C0_OP}
   `define RV64_C1_INSTR   {14'b????_????_????_??,`RV64_C1_OP}
   `define RV64_C2_INSTR   {14'b????_????_????_??,`RV64_C2_OP}
@@ -62,6 +65,7 @@
   `define RV64_AUIPC      `rv64_u_type(`RV64_AUIPC_OP)
   `define RV64_JAL        `rv64_u_type(`RV64_JAL_OP)
   `define RV64_JALR       `rv64_i_type(`RV64_JALR_OP,3'b000)
+  `define RV64_BRANCH     `rv64_s_type(`RV64_BRANCH_OP,3'b???)
   `define RV64_BEQ        `rv64_s_type(`RV64_BRANCH_OP,3'b000)
   `define RV64_BNE        `rv64_s_type(`RV64_BRANCH_OP,3'b001)
   `define RV64_BLT        `rv64_s_type(`RV64_BRANCH_OP,3'b100)

--- a/bp_fe/src/include/bp_fe_pc_gen_pkgdef.svh
+++ b/bp_fe/src/include/bp_fe_pc_gen_pkgdef.svh
@@ -8,15 +8,18 @@
    * bp_fe_instr_scan_s specifies metadata about the instruction, including FE-special opcodes
    *   and the calculated branch target
    */
-    typedef struct packed
-    {
-      logic branch;
-      logic jal;
-      logic jalr;
-      logic call;
-      logic _return;
-      logic [19:0] imm20;
-    }  bp_fe_instr_scan_s;
+  typedef struct packed
+  {
+    logic branch;
+    logic jal;
+    logic jalr;
+    logic call;
+    logic _return;
+    logic full;
+    logic clow;
+    logic chigh;
+    logic [19:0] imm20;
+  }  bp_fe_instr_scan_s;
 
 `endif
 

--- a/bp_fe/src/v/bp_fe_instr_scan.sv
+++ b/bp_fe/src/v/bp_fe_instr_scan.sv
@@ -23,26 +23,63 @@ module bp_fe_instr_scan
   `bp_cast_i(rv64_instr_rtype_s, instr);
   `bp_cast_o(bp_fe_instr_scan_s, scan);
 
-  logic dest_link, src_link, dest_src_eq;
+  rv64_cinstr_s cinstr_low_li, cinstr_high_li;
+  assign cinstr_low_li = instr_i[0+:cinstr_width_gp];
+  assign cinstr_high_li = instr_i[cinstr_width_gp+:cinstr_width_gp];
 
+  logic scan_full, scan_clow, scan_chigh;
+  logic dest_link, src_link, dest_src_eq;
+  rv64_instr_s selected_instr;
   always_comb
     begin
       dest_link   = (instr_cast_i.rd_addr inside {32'h1, 32'h5});
       src_link    = (instr_cast_i.rs1_addr inside {32'h1, 32'h5});
       dest_src_eq = (instr_cast_i.rd_addr == instr_cast_i.rs1_addr);
 
-      scan_cast_o = '0;
-      scan_cast_o.branch  = (instr_cast_i.opcode == `RV64_BRANCH_OP);
-      scan_cast_o.jal     = (instr_cast_i.opcode == `RV64_JAL_OP);
-      scan_cast_o.jalr    = (instr_cast_i.opcode == `RV64_JALR_OP);
-      scan_cast_o.call    = (instr_cast_i.opcode inside {`RV64_JAL_OP, `RV64_JALR_OP}) && dest_link;
-      scan_cast_o._return = (instr_cast_i.opcode == `RV64_JALR_OP) && src_link && !dest_src_eq;
-  
-      unique casez (instr_cast_i.opcode)
-        `RV64_BRANCH_OP: scan_cast_o.imm20 = `rv64_signext_b_imm(instr_i);
-        `RV64_JAL_OP   : scan_cast_o.imm20 = `rv64_signext_j_imm(instr_i);
-        default : begin end
+      scan_full = &instr_i[0+:2];
+      scan_clow = cinstr_low_li inside {`RV64_CBEQZ, `RV64_CBNEZ, `RV64_CJ, `RV64_CJR, `RV64_CJALR};
+      scan_chigh = cinstr_high_li inside {`RV64_CBEQZ, `RV64_CBNEZ, `RV64_CJ, `RV64_CJR, `RV64_CJALR};
+
+      dest_link   = (instr_cast_i.rd_addr inside {32'h1, 32'h5});
+      src_link    = (instr_cast_i.rs1_addr inside {32'h1, 32'h5});
+      dest_src_eq = dest_link & src_link & (instr_cast_i.rd_addr == instr_cast_i.rs1_addr);
+      selected_instr = instr_i;
+
+      if (compressed_support_p & ~scan_full & scan_clow)
+        begin
+          dest_link   = cinstr_low_li inside {`RV64_CJALR};
+          src_link    = (cinstr_low_li.t.crtype.rdrs1_addr inside {32'h1, 32'h5});
+          dest_src_eq = dest_link & src_link & (cinstr_low_li.t.crtype.rdrs1_addr == 5'h1);
+          selected_instr = cinstr_low_li;
+        end
+
+      if (compressed_support_p & ~scan_full & ~scan_clow & scan_chigh)
+        begin
+          dest_link   = cinstr_high_li inside {`RV64_CJALR};
+          src_link    = (cinstr_high_li.t.crtype.rdrs1_addr inside {32'h1, 32'h5});
+          dest_src_eq = dest_link & src_link & (cinstr_high_li.t.crtype.rdrs1_addr == 5'h1);
+          selected_instr = cinstr_high_li;
+        end
+
+      scan_cast_o.branch  = (selected_instr inside {`RV64_BRANCH, `RV64_CBEQZ, `RV64_CBNEZ});
+      scan_cast_o.jal     = (selected_instr inside {`RV64_JAL, `RV64_CJ});
+      scan_cast_o.jalr    = (selected_instr inside {`RV64_JALR, `RV64_CJR, `RV64_CJALR});
+      scan_cast_o.call    = (selected_instr inside {`RV64_JAL, `RV64_JALR, `RV64_CJALR}) && dest_link;
+      scan_cast_o._return = (selected_instr inside {`RV64_JALR, `RV64_CJR, `RV64_CJALR}) && src_link && !dest_src_eq;
+      scan_cast_o.full    =  scan_full;
+      scan_cast_o.clow    = ~scan_full &  scan_clow;
+      scan_cast_o.chigh   = ~scan_full & ~scan_clow & scan_chigh;
+
+      unique casez (selected_instr)
+        `RV64_BRANCH            : scan_cast_o.imm20 = `rv64_signext_b_imm(selected_instr);
+        `RV64_JAL               : scan_cast_o.imm20 = `rv64_signext_j_imm(selected_instr);
+        `RV64_CJ                : scan_cast_o.imm20 = `rv64_signext_cj_imm(selected_instr);
+        //`RV64_CBEQZ, `RV64_CBNEZ:
+        default: scan_cast_o.imm20 = `rv64_signext_cb_imm(selected_instr);
       endcase
+      // This is safe because the compressed imm is never more than 12b
+      if (scan_cast_o.chigh)
+        scan_cast_o.imm20 += 2'b10;
     end
 
 endmodule

--- a/bp_fe/src/v/bp_fe_realigner.sv
+++ b/bp_fe/src/v/bp_fe_realigner.sv
@@ -13,99 +13,132 @@ module bp_fe_realigner
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
  )
-  (input                             clk_i
-   , input                           reset_i
+  (input                               clk_i
+   , input                             reset_i
 
    // Fetch PC and I$ data
-   , input                           if2_instr_v_i
-   , input                           if2_exception_v_i
-   , input [vaddr_width_p-1:0]       if2_pc_i
-   , input [instr_width_gp-1:0]      if2_data_i
-   , input                           if2_taken_branch_site_i
-   , output logic                    if2_yumi_o
+   , input                             if2_instr_v_i
+   , input                             if2_exception_v_i
+   , input [vaddr_width_p-1:0]         if2_pc_i
+   , input [instr_width_gp-1:0]        if2_data_i
+   , input                             if2_taken_branch_site_i
+   , output logic                      if2_yumi_o
 
    // Redirection from backend
    //   and whether to restore the instruction data
    //   and PC to resume a fetch
-   , input                           redirect_v_i
-   , input                           redirect_resume_i
-   , input [cinstr_width_gp-1:0]     redirect_instr_i
-   , input [vaddr_width_p-1:0]       redirect_pc_i
+   , input                             redirect_v_i
+   , input                             redirect_resume_i
+   , input [cinstr_width_gp-1:0]       redirect_instr_i
+   , input [vaddr_width_p-1:0]         redirect_pc_i
 
-   , output [vaddr_width_p-1:0]      fetch_pc_o
-   , output [instr_width_gp-1:0]     fetch_instr_o
-   , output                          fetch_instr_v_o
-   , output                          fetch_exception_v_o
-   , output                          fetch_partial_o
-   , output                          fetch_linear_o
+   , output logic [vaddr_width_p-1:0]  fetch_pc_o
+   , output logic [instr_width_gp-1:0] fetch_instr_o
+   , output logic                      fetch_instr_v_o
+   , output logic                      fetch_exception_v_o
+   , output logic                      fetch_partial_o
+   , output logic                      fetch_eager_o
+   , output logic                      fetch_linear_o
+   , output logic                      fetch_scan_o
+   , output logic                      fetch_rebase_o
    );
 
-  logic [vaddr_width_p-1:0] partial_pc_n, partial_pc_r;
+  logic partial_v_n, partial_v_r;
+  logic partial_br_site_n, partial_br_site_r;
   logic [cinstr_width_gp-1:0] partial_instr_n, partial_instr_r;
-  logic partial_v_r;
+  logic [vaddr_width_p-1:0] partial_pc_n, partial_pc_r;
 
-  wire if2_pc_is_aligned  = `bp_addr_is_aligned(if2_pc_i, (instr_width_gp>>3));
-  wire if2_store_v = if2_yumi_o &
-    // Transition from aligned to misaligned
-    ((~partial_v_r & ~if2_pc_is_aligned)
-     // Continue misaligned to aligned/misaligned
-     || (partial_v_r & ~if2_taken_branch_site_i)
-     );
+  wire if2_pc_aligned = `bp_addr_is_aligned(if2_pc_i, (instr_width_gp>>3));
+  wire [1:0] if2_compressed = ~{&if2_data_i[cinstr_width_gp+:2], &if2_data_i[0+:2]};
+  wire if2_low_branch = if2_data_i[0+:cinstr_width_gp]
+    inside {`RV64_BRANCH, `RV64_JAL, `RV64_JALR, `RV64_CJ, `RV64_CJR, `RV64_CJALR, `RV64_CBEQZ, `RV64_CBNEZ};
+  wire if2_high_branch = if2_data_i[cinstr_width_gp+:cinstr_width_gp]
+    inside {`RV64_BRANCH, `RV64_JAL, `RV64_JALR, `RV64_CJ, `RV64_CJR, `RV64_CJALR, `RV64_CBEQZ, `RV64_CBNEZ};
 
-  wire [vaddr_width_p-1:0] redirect_pc_adjusted = redirect_pc_i - 2'b10;
-  wire [vaddr_width_p-1:0] if2_pc_adjusted = (partial_v_r & if2_pc_is_aligned) ? (if2_pc_i + 2'b10) : if2_pc_i;
+  wire [vaddr_width_p-1:0] redirect_partial_pc = redirect_pc_i - (redirect_resume_i ? 2'b10 : 2'b00);
+  wire [vaddr_width_p-1:0] if2_partial_pc = if2_pc_i + (if2_pc_aligned ? 2'b10 : 2'b00);
   wire [cinstr_width_gp-1:0] if2_data_lower = if2_data_i[0+:cinstr_width_gp];
   wire [cinstr_width_gp-1:0] if2_data_upper = if2_data_i[cinstr_width_gp+:cinstr_width_gp];
   bsg_mux
    #(.width_p(cinstr_width_gp+vaddr_width_p), .els_p(2))
-   partial_mux
-    (.data_i({{redirect_instr_i, redirect_pc_adjusted}, {if2_data_upper, if2_pc_adjusted}})
+   redirect_mux
+    (.data_i({{redirect_instr_i, redirect_partial_pc}, {if2_data_upper, if2_partial_pc}})
      ,.sel_i(redirect_v_i)
      ,.data_o({partial_instr_n, partial_pc_n})
      );
 
+  wire if2_store_v = if2_yumi_o & fetch_linear_o;
   wire partial_w_v = if2_store_v | redirect_v_i | fetch_instr_v_o;
-  wire partial_v_n = (if2_store_v & ~redirect_v_i) | (redirect_v_i & redirect_resume_i);
+  assign partial_v_n = (if2_store_v & ~redirect_v_i) | (redirect_v_i & redirect_resume_i);
+  assign partial_br_site_n = if2_high_branch;
   bsg_dff_reset_en
-   #(.width_p(1))
-   partial_v_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-
-     ,.en_i(partial_w_v)
-     ,.data_i(partial_v_n)
-     ,.data_o(partial_v_r)
-     );
-
-  bsg_dff_reset_en
-   #(.width_p(cinstr_width_gp+vaddr_width_p))
+   #(.width_p(2+cinstr_width_gp+vaddr_width_p))
    partial_instr_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
      ,.en_i(partial_w_v)
-     ,.data_i({partial_pc_n, partial_instr_n})
-     ,.data_o({partial_pc_r, partial_instr_r})
+     ,.data_i({partial_v_n, partial_br_site_n, partial_instr_n, partial_pc_n})
+     ,.data_o({partial_v_r, partial_br_site_r, partial_instr_r, partial_pc_r})
      );
 
+  wire [instr_width_gp-1:0] instr_aligned = if2_pc_aligned ? if2_data_i : {'0, if2_data_upper};
   wire [instr_width_gp-1:0] instr_assembled = {if2_data_lower, partial_instr_r};
   bsg_mux
    #(.width_p(instr_width_gp+vaddr_width_p), .els_p(2))
-   fetch_mux
-    (.data_i({{instr_assembled, partial_pc_r}, {if2_data_i, if2_pc_i}})
+   instr_mux
+    (.data_i({{instr_assembled, partial_pc_r}, {instr_aligned, if2_pc_i}})
      ,.sel_i(partial_v_r)
      ,.data_o({fetch_instr_o, fetch_pc_o})
      );
 
-  assign fetch_partial_o = if2_instr_v_i ? '0 : partial_v_r;
-  // Force a linear fetch if we're storing in the realigner (need to complete instruction)
-  //   or if we need to complete an instruction and are not currently completing an instruction
-  assign fetch_linear_o  = if2_store_v;
+  // Here is a table of the possible cases:
+  // partial_v  if2_aligned if2_comp[1] if2_comp[0] | fetch_linear fetch_eager fetch_scan fetch_rebase |
+  //     0           0          0           x       |      1            0           0          0       |
+  //     0           0          1           x       |      0            1           0          0       |
+  //     0           1          0           0       |      0            0           0          0       |
+  //     0           1          0           1       |  !if2_tbr         1       !if2_tbr    if2_dbr    |
+  //     0           1          1           0       |      -            -           -          -       |
+  //     0           1          1           1       |      0         if2_lbr    !if2_tbr    if2_dbr    |
+  //     1           x          0           0       |  !if2_tbr         0           0          0       |
+  //     1           0          0           1       |      -            -           -          -       |
+  //     1           0          1           0       |      -            -           -          -       |
+  //     1           0          1           1       |      -            -           -          -       |
+  //     1           1          0           1       |      -            -           -          -       |
+  //     1           1          1           0       |      0            0       !if2_tbr    if2_hbr    |
+  //     1           1          1           1       |      -            -           -          -       |
 
-  // Either completing a partial instruction or fetching aligned instruction
-  assign fetch_instr_v_o = if2_instr_v_i & (partial_v_r | if2_pc_is_aligned);
+  // Fetching at least one valid instruction
+  assign fetch_instr_v_o = if2_instr_v_i & (if2_pc_aligned | partial_v_r | if2_compressed[1]);
   assign fetch_exception_v_o = if2_exception_v_i;
-  assign if2_yumi_o = if2_instr_v_i | if2_exception_v_i;
+  assign fetch_partial_o = partial_v_r;
+  // Force a linear fetch if we're storing in the realigner (need to complete instruction)
+  assign fetch_linear_o = if2_instr_v_i &&
+    // starting misaligned high
+    ((~partial_v_r & ~if2_pc_aligned & ~if2_compressed[1])
+     // starting misaligned after compressed
+     || (~partial_v_r &  if2_pc_aligned & if2_compressed[0] & ~if2_compressed[1] & ~if2_taken_branch_site_i)
+     // continuing misaligned high
+     || ( partial_v_r & ~if2_compressed[1] & ~if2_taken_branch_site_i));
+  // Eagerly fetch a low or high compressed instruction
+  assign fetch_eager_o = if2_instr_v_i &
+    ((~partial_v_r & ~if2_pc_aligned & if2_compressed[1])
+      || (~partial_v_r & if2_pc_aligned & if2_compressed[0] & ~if2_compressed[1])
+      || (~partial_v_r & if2_pc_aligned & if2_compressed[0] & if2_low_branch)
+      );
+  // Adjust the IF2 PC up to catchup after completing a misaligned instruction or low compressed branch
+  assign fetch_scan_o = if2_instr_v_i &
+    ((partial_v_r & if2_compressed[1] & ~if2_taken_branch_site_i)
+     || (partial_v_r & if2_compressed[1] & ~partial_br_site_r & if2_high_branch & if2_taken_branch_site_i)
+     || (~partial_v_r & if2_pc_aligned & if2_compressed[0] & if2_low_branch & ~if2_taken_branch_site_i)
+     );
+  // Refetch a high branch because its site has been aliased
+  assign fetch_rebase_o = if2_instr_v_i &
+    ((partial_v_r & if2_compressed[1] & if2_high_branch & partial_br_site_r)
+     || (~partial_v_r & if2_pc_aligned & if2_compressed[0] & if2_low_branch & if2_high_branch)
+     );
+
+  assign if2_yumi_o = (if2_instr_v_i & ~fetch_scan_o) | if2_exception_v_i;
 
 endmodule
 

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -219,6 +219,7 @@ $BP_BE_DIR/src/v/bp_be_calculator/bp_be_reg_to_fp.sv
 $BP_BE_DIR/src/v/bp_be_checker/bp_be_cmd_queue.sv
 $BP_BE_DIR/src/v/bp_be_checker/bp_be_detector.sv
 $BP_BE_DIR/src/v/bp_be_checker/bp_be_director.sv
+$BP_BE_DIR/src/v/bp_be_checker/bp_be_expander.sv
 $BP_BE_DIR/src/v/bp_be_checker/bp_be_instr_decoder.sv
 $BP_BE_DIR/src/v/bp_be_checker/bp_be_issue_queue.sv
 $BP_BE_DIR/src/v/bp_be_checker/bp_be_regfile.sv


### PR DESCRIPTION
## Summary
This PR adds compressed extension 'C' support to BlackParrot

## Issue Fixed
Generally unhappiness with lack of C support.

## Area
FE instruction scanning and BE instruction issuing

## Reasoning (outdated, confusing, verbose, etc.)
This extension is required by the 'A22' RISC-V profile, meaning that general purpose Linux distributions will require it in the future.

## Additional Changes Required (if any)

## Analysis
There are potential new timing paths in FE and impact to performance in the worst and average cases. Branching to a misaligned instruction has an additional cycle of latency, which can degenerate for a mixed set.

## Verification
Boots Linux and runs Caremark at <1% performance penalty

## Additional Context
#1098 provided the baseline for this work
