### PR TITLE
Update FMA to fix neg zero mismatches

### DIFF
--- a/bp_be/src/include/bp_be_pkg.sv
+++ b/bp_be/src/include/bp_be_pkg.sv
@@ -20,6 +20,7 @@ package bp_be_pkg;
 
   localparam [dp_rec_width_gp-1:0] dp_rec_1_0 = 65'h0_80000000_00000000;
   localparam [dp_rec_width_gp-1:0] dp_rec_0_0 = 65'h0_00000000_00000000;
+  localparam [dp_rec_width_gp-1:0] dp_rec_neg_0_0 = 65'h1_00000000_00000000;
 
   localparam [dp_rec_width_gp-1:0] dp_canonical_rec = 65'h0_e0080000_00000000;
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_fma.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_fma.sv
@@ -176,6 +176,7 @@ module bp_be_pipe_fma
     (.clock(clk_i),
      .control(control_li)
      ,.op(fma_op_li)
+     ,.mul_not_fma(is_fmul_li)
      ,.a(fma_a_li)
      ,.b(fma_b_li)
      ,.c(fma_c_li)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_fma.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_fma.sv
@@ -124,7 +124,11 @@ module bp_be_pipe_fma
 
   wire [dp_rec_width_gp-1:0] fma_a_li = is_imul_li ? rs1 : frs1.rec;
   wire [dp_rec_width_gp-1:0] fma_b_li = is_imul_li ? rs2 : is_faddsub_li ? dp_rec_1_0 : frs2.rec;
-  wire [dp_rec_width_gp-1:0] fma_c_li = is_faddsub_li ? frs2.rec : is_fmul_li ? dp_rec_0_0 : frs3.rec;
+  wire [dp_rec_width_gp-1:0] fma_c_li = is_faddsub_li
+                                          ? frs2.rec
+                                          : is_fmul_li // correct for influence by unintentional sign of C
+                                            ? (frm_li == e_rdn) ? dp_rec_0_0 : dp_rec_neg_0_0
+                                            : frs3.rec;
 
   // Here, we switch the implementation based on synthesizing for Vivado or not. If this is
   //   a knob you'd like to turn, consider modifying the define yourself.
@@ -176,7 +180,6 @@ module bp_be_pipe_fma
     (.clock(clk_i),
      .control(control_li)
      ,.op(fma_op_li)
-     ,.mul_not_fma(is_fmul_li)
      ,.a(fma_a_li)
      ,.b(fma_b_li)
      ,.c(fma_c_li)


### PR DESCRIPTION
Mismatch explained here: https://github.com/black-parrot-sdk/bp-tests/pull/35

We can solve it two ways: 
1. By modifying HardFloat to switch sign based on whether the operation is true FMA or just multiplication.
2. By modifying bp_calculator_pipe_fma to load -0 or +0 to C (in FMA's A X B + C) depending on the sign of A X B (and rounding mode) for pure multiplication only. Sign here needs to be recomputed (it'll be computed again within FMA), so I think it's cleaner to go with (1).

This PR along with https://github.com/bsg-external/HardFloat/pull/24 do (1)

### Analysis
Potential impact of the change: I don't think it affects any other module, it might change the synthesis/placement a little bit.

### Verification
Tested with testcase in https://github.com/black-parrot-sdk/bp-tests/pull/35
