### PR TITLE
Enable assertions

### DIFF
--- a/bp_common/syn/Makefile.verilator
+++ b/bp_common/syn/Makefile.verilator
@@ -24,6 +24,7 @@ VV_OPTS += config.vlt
 VV_OPTS += --build --exe
 VV_OPTS += -o simsc
 VV_OPTS += -Wno-timescalemod
+VV_OPTS += --assert
 
 LINT_OPTS   = --lint-only -Wall --Wno-unoptflat --top-module testbench -f flist.vcs config.vlt
 BUILD_OPTS  = --Wno-fatal --Wno-lint --Wno-style --Wno-widthconcat --Wno-unoptflat -CFLAGS -std=c++14


### PR DESCRIPTION
### Summary
Addresses: https://github.com/black-parrot/black-parrot/issues/789
Just realised in one of my own projects that assertions need to be enabled with the `--assert` flag before they work in Verilator.
https://veripool.org/guide/latest/exe_verilator.html

### Verification

Just place a little `assert(0);` in some `initial` blog.
For example for the `tire_kick` I get this without `--assert` flag:
```
Hello World!
[CORE0 FSH] PASS
All cores finished! Terminating...
```

With  `--assert` flag I get this:
```
Hello World!
[CORE0 FSH] PASS
[25866000] %Error: bp_nonsynth_host.sv:184: Assertion failed in testbench.testbench.host: 'assert' failed.
```
Of course don't forget to `make clean` in between.

