### PR TITLE
Initial debug support

### DIFF
--- a/bp_be/src/v/bp_be_checker/bp_be_director.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.sv
@@ -154,7 +154,7 @@ module bp_be_director
       if (commit_pkt_cast_i.unfreeze)
         begin
           fe_cmd_li.opcode = e_op_state_reset;
-          fe_cmd_li.npc = npc_r;
+          fe_cmd_li.npc = npc_n;
 
           fe_cmd_pc_redirect_operands.priv           = commit_pkt_cast_i.priv_n;
           fe_cmd_pc_redirect_operands.translation_en = commit_pkt_cast_i.translation_en_n;
@@ -245,7 +245,7 @@ module bp_be_director
                                                              : e_not_a_branch;
           fe_cmd_li.operands.pc_redirect_operands          = fe_cmd_pc_redirect_operands;
 
-          fe_cmd_v_li = is_run;
+          fe_cmd_v_li = ~cmd_full_r_o & is_run;
         end
       // Send an attaboy if there's a correct prediction
       else if (npc_match_v & last_instr_was_branch)
@@ -255,7 +255,7 @@ module bp_be_director
           fe_cmd_li.operands.attaboy.taken               = last_instr_was_btaken;
           fe_cmd_li.operands.attaboy.branch_metadata_fwd = issue_pkt_cast_i.branch_metadata_fwd;
 
-          fe_cmd_v_li = is_run;
+          fe_cmd_v_li = ~cmd_full_r_o & is_run;
         end
     end
 

--- a/bp_common/src/include/bp_common_addr_pkgdef.svh
+++ b/bp_common/src/include/bp_common_addr_pkgdef.svh
@@ -8,6 +8,8 @@
   localparam dev_id_width_gp   = 4;
   localparam dev_addr_width_gp = 20;
 
+  localparam core_offset_width_gp = dev_addr_width_gp + dev_id_width_gp;
+
   localparam host_dev_gp  = 1;
   localparam cfg_dev_gp   = 2;
   localparam clint_dev_gp = 3;

--- a/bp_common/src/include/bp_common_host_pkgdef.svh
+++ b/bp_common/src/include/bp_common_host_pkgdef.svh
@@ -25,5 +25,8 @@
   localparam paramrom_base_addr_gp     = (dev_addr_width_gp)'('h2_0000);
   localparam paramrom_match_addr_gp    = (dev_addr_width_gp)'('h2_????);
 
+  localparam debugrom_base_addr_gp     = (dev_addr_width_gp)'('h3_0800);
+  localparam debugrom_match_addr_gp    = (dev_addr_width_gp)'('h3_????);
+
 `endif
 

--- a/bp_top/test/common/bp_nonsynth_cosim.sv
+++ b/bp_top/test/common/bp_nonsynth_cosim.sv
@@ -257,15 +257,17 @@ module bp_nonsynth_cosim
   wire [dword_width_gp-1:0] cosim_frd_li    = frd_raw_li[commit_instr_r.rd_addr];
   wire [dword_width_gp-1:0] cosim_rd_li     = commit_fwb_li ? cosim_frd_li : cosim_ird_li;
   wire [dword_width_gp-1:0] cosim_status_li = mstatus_r;
-  integer ret_code = '0;
+  integer ret_code;
   always_ff @(posedge cosim_clk_i)
-    if (cosim_en_i & commit_fifo_yumi_li & trap_v_r)
+    if (cosim_reset_i)
+      ret_code <= 0;
+    else if (cosim_en_i & commit_fifo_yumi_li & trap_v_r)
       dromajo_trap(mhartid_i, cosim_cause_li);
     else if (~commit_debug_r & cosim_en_i & commit_fifo_yumi_li & instret_v_r & commit_pc_r != '0)
       ret_code <= dromajo_step(mhartid_i, cosim_pc_li, cosim_instr_li, cosim_rd_li, cosim_status_li);
 
    // ret_code: {exit_code, terminate}
-   always_ff @(posedge cosim_clk_i)
+   always_ff @(negedge cosim_clk_i)
      if (ret_code >> 1)
        begin
          // Successful termination

--- a/bp_top/test/common/bp_nonsynth_host.sv
+++ b/bp_top/test/common/bp_nonsynth_host.sv
@@ -9,7 +9,6 @@ module bp_nonsynth_host
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   , parameter io_data_width_p = dword_width_gp
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    , parameter icache_trace_p         = 0

--- a/bp_top/test/common/bp_nonsynth_nbf_loader.sv
+++ b/bp_top/test/common/bp_nonsynth_nbf_loader.sv
@@ -13,7 +13,6 @@ module bp_nonsynth_nbf_loader
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
-   , parameter io_data_width_p = dword_width_gp
 
    , parameter nbf_filename_p = "prog.nbf"
    , parameter verbose_p = 1
@@ -25,13 +24,13 @@ module bp_nonsynth_nbf_loader
    , input [did_width_p-1:0]                        did_i
 
    , output logic [mem_fwd_header_width_lp-1:0]     mem_fwd_header_o
-   , output logic [io_data_width_p-1:0]             mem_fwd_data_o
+   , output logic [dword_width_gp-1:0]              mem_fwd_data_o
    , output logic                                   mem_fwd_v_o
    , input                                          mem_fwd_ready_and_i
    , output logic                                   mem_fwd_last_o
 
-   , input  [mem_rev_header_width_lp-1:0]           mem_rev_header_i
-   , input  [io_data_width_p-1:0]                   mem_rev_data_i
+   , input [mem_rev_header_width_lp-1:0]            mem_rev_header_i
+   , input [dword_width_gp-1:0]                     mem_rev_data_i
    , input                                          mem_rev_v_i
    , output logic                                   mem_rev_ready_and_o
    , input                                          mem_rev_last_i
@@ -131,9 +130,8 @@ module bp_nonsynth_nbf_loader
 
   localparam sel_width_lp = `BSG_SAFE_CLOG2(nbf_data_width_lp>>3);
   localparam size_width_lp = `BSG_SAFE_CLOG2(sel_width_lp);
-  logic [io_data_width_p-1:0] test;
   bsg_bus_pack
-   #(.in_width_p(nbf_data_width_lp), .out_width_p(io_data_width_p))
+   #(.in_width_p(nbf_data_width_lp), .out_width_p(dword_width_gp))
    fwd_bus_pack
     (.data_i(curr_nbf.data)
      ,.sel_i('0) // We are aligned
@@ -203,7 +201,7 @@ module bp_nonsynth_nbf_loader
 
   if (nbf_data_width_lp != dword_width_gp)
     $error("NBF data width must be same as dword_width_gp");
-  if (io_data_width_p < nbf_data_width_lp)
+  if (dword_width_gp < nbf_data_width_lp)
     $error("NBF IO data width must be as large as NBF data width");
 
 endmodule

--- a/bp_top/test/common/dromajo_cosim.cpp
+++ b/bp_top/test/common/dromajo_cosim.cpp
@@ -9,12 +9,12 @@ using namespace std;
 
 dromajo_cosim_state_t* dromajo_pointer;
 vector<bool>* finish;
-char init = 0;
+char dromajo_init_done = 0;
 
 extern "C" void dromajo_init(char* cfg_f_name, int hartid, int ncpus, int memory_size, bool checkpoint, bool amo_en) {
   if (!hartid) {
-    if (!init) {
-      init = 1;
+    if (!dromajo_init_done) {
+      dromajo_init_done = 1;
       cout << "Running with Dromajo cosimulation" << endl;
 
       finish = new vector<bool>(ncpus, false);


### PR DESCRIPTION
### Summary
This PR adds debug support to the BlackParrot core, fixing some bugs related to its prior implementation. It has been tested to support GDB with an appropriate debug module. There are also a few some bug fixes required to run more modern versions of VCS which are stricter.

### Issue Fixed
None

### Area
Debug module, BE, CSRs

### Reasoning (new feature, inefficient, verbose, etc.)
GDB is a useful debug tool for complex programs.

### Additional Changes Required (if any)
A toplevel containing a debug module can be used for testing the implementation with riscv-tests/debug.

### Analysis
Other than minor control logic, there is an additional mux on APC in the CSR block. However, this is a non-critical signal.

### Verification
GDB running succesfully

### Additional Context
Add any other context about the problem here.
Logs, screenshots or videos that show the issue are very helpful.

