### PR TITLE
Bugfix for critical word stream pump

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - temp
   before_script:
       - git submodule update --init --checkout --recursive external/
       - cp -r $CI_RTL_INSTALL_DIR install/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - temp
   before_script:
       - git submodule update --init --checkout --recursive external/
       - cp -r $CI_RTL_INSTALL_DIR install/

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_fma.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_fma.sv
@@ -9,7 +9,7 @@
  * Notes:
  *   This module relies on cross-boundary flattening and retiming to achieve
  *     good QoR
- *   
+ *
  *   ASIC tools prefer to have retiming chains be pure register chains at the end of
  *   a combinational logic cloud, whereas FPGA tools prefer explicitly instantiated registers.
  *   With this FPGA optimization, we've achieved 50MHz on a Zynq 7020

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -245,7 +245,7 @@ module bp_be_detector
                      | (idiv_busy_i & issue_pkt_cast_i.long_v);
     end
 
-  // Dispatch if we have a valid issue. Don't stall on data hazards for exceptions 
+  // Dispatch if we have a valid issue. Don't stall on data hazards for exceptions
   assign dispatch_v_o = issue_pkt_cast_i.v & ~data_haz_v & ~control_haz_v & ~struct_haz_v;
   // Don't interrupt PTW. This could be made okay if we save the current privilege mode as well
   //   as the PTE mode

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -41,15 +41,15 @@ module bp_be_scheduler
    , input [decode_info_width_lp-1:0]         decode_info_i
    , input                                    dispatch_v_i
    , input                                    interrupt_v_i
- 
+
    // Fetch interface
    , input [fe_queue_width_lp-1:0]            fe_queue_i
    , input                                    fe_queue_v_i
    , output logic                             fe_queue_ready_and_o
- 
+
    // Dispatch interface
    , output logic [dispatch_pkt_width_lp-1:0] dispatch_pkt_o
- 
+
    , input [commit_pkt_width_lp-1:0]          commit_pkt_i
    , input [wb_pkt_width_lp-1:0]              iwb_pkt_i
    , input [wb_pkt_width_lp-1:0]              fwb_pkt_i

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -316,7 +316,7 @@ module bp_be_dcache
   // Concatenate unused bits from vaddr if any cache way size is not 4kb
   localparam ctag_vbits_lp = page_offset_width_gp - (block_offset_width_lp + sindex_width_lp);
   wire [ctag_vbits_lp-1:0] ctag_vbits = vaddr_tl_r[block_offset_width_lp+sindex_width_lp+:`BSG_MAX(ctag_vbits_lp,1)];
-  // Causes segfault in Synopsys DC O-2018.06-SP4 
+  // Causes segfault in Synopsys DC O-2018.06-SP4
   // wire [ctag_width_p-1:0] ctag_li = {ptag_i, {ctag_vbits_lp!=0{ctag_vbits}}};
   wire [ctag_width_p-1:0] ctag_li = ctag_vbits_lp ? {ptag_i, ctag_vbits} : ptag_i;
 
@@ -369,7 +369,7 @@ module bp_be_dcache
   assign tv_we_o = tv_we;
 
   logic [assoc_p-1:0] way_v_tv_n, store_hit_tv_n, load_hit_tv_n;
-  wire [assoc_p-1:0] tag_mem_pseudo_hit = 1'b1 << tag_mem_pkt_cast_i.way_id;
+  wire [assoc_p-1:0] tag_mem_pseudo_hit = 1'b1 << data_mem_pkt_cast_i.way_id;
   bsg_mux
    #(.width_p(3*assoc_p), .els_p(2))
    hit_mux
@@ -736,7 +736,7 @@ module bp_be_dcache
      );
   wire [bindex_width_lp-1:0] wbuf_entry_out_bank_offset = wbuf_entry_out.caddr[byte_offset_width_lp+:bindex_width_lp];
   wire [sindex_width_lp-1:0] wbuf_entry_out_index = wbuf_entry_out.caddr[block_offset_width_lp+:sindex_width_lp];
-  
+
   /////////////////////////////////////////////////////////////////////////////
   // Slow Path
   /////////////////////////////////////////////////////////////////////////////

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -369,11 +369,12 @@ module bp_be_dcache
   assign tv_we_o = tv_we;
 
   logic [assoc_p-1:0] way_v_tv_n, store_hit_tv_n, load_hit_tv_n;
-  wire [assoc_p-1:0] tag_mem_pseudo_hit = 1'b1 << data_mem_pkt_cast_i.way_id;
+  wire [assoc_p-1:0] pseudo_hit =
+    (data_mem_pkt_v_i << data_mem_pkt_cast_i.way_id) | (tag_mem_pkt_v_i << tag_mem_pkt_cast_i.way_id);
   bsg_mux
    #(.width_p(3*assoc_p), .els_p(2))
    hit_mux
-    (.data_i({{3{tag_mem_pseudo_hit}}, {way_v_tl, store_hit_tl, load_hit_tl}})
+    (.data_i({{3{pseudo_hit}}, {way_v_tl, store_hit_tl, load_hit_tl}})
      ,.sel_i(cache_req_critical_i)
      ,.data_o({way_v_tv_n, store_hit_tv_n, load_hit_tv_n})
      );

--- a/bp_be/syn/flist.vcs
+++ b/bp_be/syn/flist.vcs
@@ -259,10 +259,12 @@ $BP_ME_DIR/src/v/dev/bp_me_clint_slice.sv
 $BP_ME_DIR/src/v/dev/bp_me_loopback.sv
 # Network
 $BP_ME_DIR/src/v/cce/bp_uce.sv
+$BP_ME_DIR/src/v/cce/bp_bedrock_size_to_len.sv
 $BP_ME_DIR/src/v/network/bp_me_addr_to_cce_id.sv
 $BP_ME_DIR/src/v/network/bp_me_cce_id_to_cord.sv
 $BP_ME_DIR/src/v/network/bp_me_cord_to_id.sv
 $BP_ME_DIR/src/v/network/bp_me_lce_id_to_cord.sv
+$BP_ME_DIR/src/v/network/bp_me_stream_gearbox.sv
 $BP_ME_DIR/src/v/network/bp_me_stream_pump_in.sv
 $BP_ME_DIR/src/v/network/bp_me_stream_pump_out.sv
 $BP_ME_DIR/src/v/network/bp_me_stream_pump_control.sv
@@ -271,4 +273,6 @@ $BP_ME_DIR/src/v/network/bp_me_xbar_stream.sv
 # BSG Staging area
 $BP_COMMON_DIR/src/v/bsg_async_noc_link.sv
 $BP_COMMON_DIR/src/v/bsg_dff_sync_read.v
+$BP_COMMON_DIR/src/v/bsg_parallel_in_serial_out_passthrough_dynamic.v
+$BP_COMMON_DIR/src/v/bsg_serial_in_parallel_out_passthrough_dynamic.v
 

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -327,11 +327,12 @@ module bp_fe_icache
   wire v_tv = is_ready & v_tv_r;
 
   logic [assoc_p-1:0] ld_data_way_select_tv_n, way_v_tv_n, hit_v_tv_n;
-  wire [assoc_p-1:0] tag_mem_pseudo_hit = 1'b1 << data_mem_pkt_cast_i.way_id;
+  wire [assoc_p-1:0] pseudo_hit =
+    (data_mem_pkt_v_i << data_mem_pkt_cast_i.way_id) | (tag_mem_pkt_v_i << tag_mem_pkt_cast_i.way_id);
   bsg_mux
    #(.width_p(3*assoc_p), .els_p(2))
    hit_mux
-    (.data_i({{3{tag_mem_pseudo_hit}}, {ld_data_way_select_tl, way_v_tl, hit_v_tl}})
+    (.data_i({{3{pseudo_hit}}, {ld_data_way_select_tl, way_v_tl, hit_v_tl}})
      ,.sel_i(cache_req_critical_i)
      ,.data_o({ld_data_way_select_tv_n, way_v_tv_n, hit_v_tv_n})
      );

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -266,7 +266,7 @@ module bp_fe_icache
   // Concatenate unused bits from vaddr if any cache way size is not 4kb
   localparam ctag_vbits_lp = page_offset_width_gp - (block_offset_width_lp + sindex_width_lp);
   wire [ctag_vbits_lp-1:0] ctag_vbits = vaddr_tl_r[block_offset_width_lp+sindex_width_lp+:`BSG_MAX(ctag_vbits_lp,1)];
-  // Causes segfault in Synopsys DC O-2018.06-SP4 
+  // Causes segfault in Synopsys DC O-2018.06-SP4
   // wire [ctag_width_p-1:0] ctag_li = {ptag_i, {ctag_vbits_lp!=0{ctag_vbits}}};
   wire [ctag_width_p-1:0] ctag_li = ctag_vbits_lp ? {ptag_i, ctag_vbits} : ptag_i;
 
@@ -327,7 +327,7 @@ module bp_fe_icache
   wire v_tv = is_ready & v_tv_r;
 
   logic [assoc_p-1:0] ld_data_way_select_tv_n, way_v_tv_n, hit_v_tv_n;
-  wire [assoc_p-1:0] tag_mem_pseudo_hit = 1'b1 << tag_mem_pkt_cast_i.way_id;
+  wire [assoc_p-1:0] tag_mem_pseudo_hit = 1'b1 << data_mem_pkt_cast_i.way_id;
   bsg_mux
    #(.width_p(3*assoc_p), .els_p(2))
    hit_mux

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -125,7 +125,7 @@ module bp_fe_pc_gen
   ///////////////////////////
   // BTB
   ///////////////////////////
-  logic btb_w_yumi_lo, btb_init_done_lo; 
+  logic btb_w_yumi_lo, btb_init_done_lo;
   wire btb_r_v_li = if1_we_i;
   wire btb_w_v_li = (redirect_br_v_i & redirect_br_taken_i)
     | (redirect_br_v_i & redirect_br_nonbr_i & redirect_br_metadata_fwd_cast_i.src_btb)

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -335,7 +335,7 @@ module bp_fe_top
       assign fetch_scan_lo = '0;
       assign fetch_rebase_lo = '0;
     end
-  
+
   bp_fe_instr_scan
    #(.bp_params_p(bp_params_p))
    instr_scan

--- a/bp_fe/syn/flist.vcs
+++ b/bp_fe/syn/flist.vcs
@@ -230,10 +230,12 @@ $BP_ME_DIR/src/v/dev/bp_me_cfg_slice.sv
 $BP_ME_DIR/src/v/dev/bp_me_loopback.sv
 # Network
 $BP_ME_DIR/src/v/cce/bp_uce.sv
+$BP_ME_DIR/src/v/cce/bp_bedrock_size_to_len.sv
 $BP_ME_DIR/src/v/network/bp_me_addr_to_cce_id.sv
 $BP_ME_DIR/src/v/network/bp_me_cce_id_to_cord.sv
 $BP_ME_DIR/src/v/network/bp_me_cord_to_id.sv
 $BP_ME_DIR/src/v/network/bp_me_lce_id_to_cord.sv
+$BP_ME_DIR/src/v/network/bp_me_stream_gearbox.sv
 $BP_ME_DIR/src/v/network/bp_me_stream_pump_in.sv
 $BP_ME_DIR/src/v/network/bp_me_stream_pump_out.sv
 $BP_ME_DIR/src/v/network/bp_me_stream_pump_control.sv
@@ -242,4 +244,6 @@ $BP_ME_DIR/src/v/network/bp_me_xbar_stream.sv
 # BSG Staging area
 $BP_COMMON_DIR/src/v/bsg_async_noc_link.sv
 $BP_COMMON_DIR/src/v/bsg_dff_sync_read.v
+$BP_COMMON_DIR/src/v/bsg_parallel_in_serial_out_passthrough_dynamic.v
+$BP_COMMON_DIR/src/v/bsg_serial_in_parallel_out_passthrough_dynamic.v
 

--- a/bp_fe/test/common/bp_fe_nonsynth_pc_gen_tracer.sv
+++ b/bp_fe/test/common/bp_fe_nonsynth_pc_gen_tracer.sv
@@ -10,7 +10,7 @@ with:
   - The PC currently in the IF2 stage. If it is enclosed in parentheses, this entry was
     invalidated and won't be issued.
   - The reason the above PC was fetched:
-    - undefined: the simulation just started and nothing has propagated to IF2 yet 
+    - undefined: the simulation just started and nothing has propagated to IF2 yet
     - redirect: either a BE->FE command or resuming after a stall
     - override_ntaken: a misaligned instruction required a second fetch for the same PC
     - override_ras: the RAS was used to predict a JALR (IF2)
@@ -35,30 +35,30 @@ Exmple trace ("cuts" introduced for brevity):
 
         time |   cycle,       IF2 PC,           IF2 PC src, state, events
     [============================ cut ===========================]
-    76356000 | 0022607, (0080000998), last_fetch_plus_four,   run, 
-    76357000 | 0022608,  0080000954 ,             redirect,   run, 
-    76358000 | 0022609, (0080000958), last_fetch_plus_four,   run, 
-    76359000 | 0022610,  00800007f8 ,      override_branch,   run, 
-    76360000 | 0022611,  00800007fc , last_fetch_plus_four,   run, 
-    76361000 | 0022612,  0080000800 , last_fetch_plus_four,   run, 
-    76362000 | 0022613,  0080000804 , last_fetch_plus_four,   run, 
-    76363000 | 0022614,  0080000808 , last_fetch_plus_four,   run, 
-    76364000 | 0022615,  008000080c , last_fetch_plus_four,   run, 
-    76365000 | 0022616,  0080000810 , last_fetch_plus_four,   run, 
-    76366000 | 0022617,  0080000814 , last_fetch_plus_four,   run, 
-    76367000 | 0022618,  0080000818 , last_fetch_plus_four,   run, 
-    76368000 | 0022619, (008000081c), last_fetch_plus_four,   run, 
-    76369000 | 0022620,  0080000710 ,      override_branch,   run, queue miss; i$ miss; 
-    76370000 | 0022621, (0080000714), last_fetch_plus_four, stall, 
-    76371000 | 0022622, (0080000718), last_fetch_plus_four, stall, 
+    76356000 | 0022607, (0080000998), last_fetch_plus_four,   run,
+    76357000 | 0022608,  0080000954 ,             redirect,   run,
+    76358000 | 0022609, (0080000958), last_fetch_plus_four,   run,
+    76359000 | 0022610,  00800007f8 ,      override_branch,   run,
+    76360000 | 0022611,  00800007fc , last_fetch_plus_four,   run,
+    76361000 | 0022612,  0080000800 , last_fetch_plus_four,   run,
+    76362000 | 0022613,  0080000804 , last_fetch_plus_four,   run,
+    76363000 | 0022614,  0080000808 , last_fetch_plus_four,   run,
+    76364000 | 0022615,  008000080c , last_fetch_plus_four,   run,
+    76365000 | 0022616,  0080000810 , last_fetch_plus_four,   run,
+    76366000 | 0022617,  0080000814 , last_fetch_plus_four,   run,
+    76367000 | 0022618,  0080000818 , last_fetch_plus_four,   run,
+    76368000 | 0022619, (008000081c), last_fetch_plus_four,   run,
+    76369000 | 0022620,  0080000710 ,      override_branch,   run, queue miss; i$ miss;
+    76370000 | 0022621, (0080000714), last_fetch_plus_four, stall,
+    76371000 | 0022622, (0080000718), last_fetch_plus_four, stall,
     [============================ cut ===========================]
-    76383000 | 0022634, (0080000748), last_fetch_plus_four, stall, 
-    76384000 | 0022635, (008000074c), last_fetch_plus_four, stall, 
-    76385000 | 0022636, (0080000750), last_fetch_plus_four,   run, 
-    76386000 | 0022637,  0080000710 ,             redirect,   run, 
-    76387000 | 0022638,  0080000714 , last_fetch_plus_four,   run, 
-    76388000 | 0022639,  0080000718 , last_fetch_plus_four,   run, 
-    76389000 | 0022640,  008000071c , last_fetch_plus_four,   run, 
+    76383000 | 0022634, (0080000748), last_fetch_plus_four, stall,
+    76384000 | 0022635, (008000074c), last_fetch_plus_four, stall,
+    76385000 | 0022636, (0080000750), last_fetch_plus_four,   run,
+    76386000 | 0022637,  0080000710 ,             redirect,   run,
+    76387000 | 0022638,  0080000714 , last_fetch_plus_four,   run,
+    76388000 | 0022639,  0080000718 , last_fetch_plus_four,   run,
+    76389000 | 0022640,  008000071c , last_fetch_plus_four,   run,
 */
 
 typedef enum logic [2:0]
@@ -84,7 +84,7 @@ module bp_fe_nonsynth_pc_gen_tracer
    )
   (input clk_i
    , input reset_i
-   , input freeze_i 
+   , input freeze_i
 
    , input [`BSG_SAFE_CLOG2(num_core_p)-1:0] mhartid_i
 

--- a/bp_me/src/v/cce/bp_uce.sv
+++ b/bp_me/src/v/cce/bp_uce.sv
@@ -378,8 +378,7 @@ module bp_uce
      ,.data_o(writeback_data)
      );
 
-  assign cache_req_critical_o = data_mem_pkt_yumi_i & fsm_rev_critical_li
-    & data_mem_pkt_cast_o.opcode inside {e_cache_data_mem_write, e_cache_data_mem_uncached};
+  assign cache_req_critical_o = load_resp_v_li & fsm_rev_v_li & fsm_rev_critical_li;
 
   bp_cache_req_wr_subop_e cache_wr_subop;
   bp_bedrock_wr_subop_e mem_wr_subop;

--- a/bp_me/src/v/dev/bp_me_cce_to_cache.sv
+++ b/bp_me/src/v/dev/bp_me_cce_to_cache.sv
@@ -180,7 +180,7 @@ module bp_me_cce_to_cache
                                               ? lg_mux_els_lp'(mux_els_lp-1)
                                               : fsm_fwd_header_li.size[0+:lg_mux_els_lp];
   bsg_mux
-   #(.width_p(data_bytes_lp), .els_p(mux_els_lp)) 
+   #(.width_p(data_bytes_lp), .els_p(mux_els_lp))
    cache_pkt_mask_mux
     (.data_i(cache_pkt_mask_mux_li)
      ,.sel_i(cache_pkt_sel_li)

--- a/bp_me/src/v/lce/bp_lce.sv
+++ b/bp_me/src/v/lce/bp_lce.sv
@@ -32,7 +32,7 @@ module bp_lce
    // BP caches' metadata arrives cycle after request, by default
    , parameter `BSG_INV_PARAM(metadata_latency_p)
    , parameter `BSG_INV_PARAM(ctag_width_p)
-  
+
    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache)
   )
@@ -174,7 +174,7 @@ module bp_lce
   //   perhaps a bit less overhead at the netlist level, but it's more challenging to
   //   verify protocol/deadlock correctness at that level. At this level, we can simply
   //   say that it's sufficient to buffer a full output fill message such that it's never
-  //   the case that an input cmd is blocked by an output fill 
+  //   the case that an input cmd is blocked by an output fill
   bp_bedrock_lce_cmd_header_s lce_cmd_header_li;
   logic [fill_width_p-1:0] lce_cmd_data_li;
   logic lce_cmd_v_li, lce_cmd_ready_and_lo;

--- a/bp_me/src/v/network/bp_me_stream_gearbox.sv
+++ b/bp_me/src/v/network/bp_me_stream_gearbox.sv
@@ -1,4 +1,4 @@
-  
+
 `include "bp_common_defines.svh"
 `include "bp_me_defines.svh"
 
@@ -49,8 +49,8 @@ module bp_me_stream_gearbox
          ,.data_i({msg_header_cast_i, msg_data_i})
          ,.v_i(msg_v_i)
          ,.ready_o(msg_ready_and_o)
-       
-         ,.data_o({msg_header_li, msg_data_li})         
+
+         ,.data_o({msg_header_li, msg_data_li})
          ,.v_o(msg_v_li)
          ,.yumi_i(msg_ready_and_lo & msg_v_li)
          );

--- a/bp_me/src/v/network/bp_me_stream_pump_control.sv
+++ b/bp_me/src/v/network/bp_me_stream_pump_control.sv
@@ -55,7 +55,9 @@ module bp_me_stream_pump_control
 
   if (block_width_p == data_width_p)
     begin : z
+      assign addr_o = header_cast_i.addr;
       assign first_o = 1'b1;
+      assign critical_o = 1'b1;
       assign last_o = 1'b1;
     end
   else
@@ -72,10 +74,11 @@ module bp_me_stream_pump_control
       wire [paddr_width_p-1:0] beat_mask = ~((1'b1 << beat_size) - 1'b1);
       wire [paddr_width_p-1:0] final_mask = `BSG_MAX(addr_mask, beat_mask);
 
-      wire [paddr_width_p-1:0] base_addr = header_cast_i.addr & addr_mask;
+      wire [paddr_width_p-1:0] base_addr     = header_cast_i.addr & addr_mask;
+      wire [paddr_width_p-1:0] critical_addr = header_cast_i.addr & beat_mask;
 
       wire [width_lp-1:0] first_cnt    = base_addr[offset_width_lp+:width_lp];
-      wire [width_lp-1:0] critical_cnt = header_cast_i.addr[offset_width_lp+:width_lp];
+      wire [width_lp-1:0] critical_cnt = critical_addr[offset_width_lp+:width_lp];
       wire [width_lp-1:0] last_cnt     = first_cnt + size_li;
 
       logic [width_lp-1:0] cnt_r;

--- a/bp_me/src/v/network/bp_me_stream_to_wormhole.sv
+++ b/bp_me/src/v/network/bp_me_stream_to_wormhole.sv
@@ -103,7 +103,7 @@ module bp_me_stream_to_wormhole
 
   `declare_bp_bedrock_wormhole_header_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, bp_bedrock_msg_header_s, bedrock);
   bp_bedrock_wormhole_header_s pr_wh_hdr_lo;
-  
+
   bp_me_wormhole_header_encode
    #(.bp_params_p(bp_params_p)
      ,.flit_width_p(flit_width_p)

--- a/bp_me/syn/flist.vcs
+++ b/bp_me/syn/flist.vcs
@@ -162,6 +162,7 @@ $BP_ME_DIR/src/v/lce/bp_lce_cmd.sv
 $BP_ME_DIR/src/v/lce/bp_lce_req.sv
 $BP_ME_DIR/src/v/lce/bp_lce.sv
 # CCE
+$BP_ME_DIR/src/v/cce/bp_bedrock_size_to_len.sv
 $BP_ME_DIR/src/v/cce/bp_cce_alu.sv
 $BP_ME_DIR/src/v/cce/bp_cce_arbitrate.sv
 $BP_ME_DIR/src/v/cce/bp_cce_branch.sv
@@ -189,6 +190,7 @@ $BP_ME_DIR/src/v/dev/bp_me_cache_slice.sv
 $BP_ME_DIR/src/v/dev/bp_me_cfg_slice.sv
 # NETWORK
 $BP_ME_DIR/src/v/network/bp_me_addr_to_cce_id.sv
+$BP_ME_DIR/src/v/network/bp_me_stream_gearbox.sv
 $BP_ME_DIR/src/v/network/bp_me_stream_pump_in.sv
 $BP_ME_DIR/src/v/network/bp_me_stream_pump_out.sv
 $BP_ME_DIR/src/v/network/bp_me_stream_pump_control.sv
@@ -198,4 +200,6 @@ $BP_ME_DIR/src/v/network/bp_me_xbar_stream.sv
 # BSG Staging area
 $BP_COMMON_DIR/src/v/bsg_async_noc_link.sv
 $BP_COMMON_DIR/src/v/bsg_dff_sync_read.v
+$BP_COMMON_DIR/src/v/bsg_parallel_in_serial_out_passthrough_dynamic.v
+$BP_COMMON_DIR/src/v/bsg_serial_in_parallel_out_passthrough_dynamic.v
 

--- a/bp_top/src/v/bp_io_tile.sv
+++ b/bp_top/src/v/bp_io_tile.sv
@@ -353,7 +353,7 @@ module bp_io_tile
      ,.link_data_o(mem_rev_link_cast_o.data)
      ,.link_v_o(mem_rev_link_cast_o.v)
      ,.link_ready_and_i(mem_rev_link_cast_i.ready_and_rev)
-     );  
+     );
 
   bp_me_wormhole_to_stream
    #(.bp_params_p(bp_params_p)

--- a/bp_top/src/v/bp_sacc_scratchpad.sv
+++ b/bp_top/src/v/bp_sacc_scratchpad.sv
@@ -57,7 +57,7 @@ module bp_sacc_scratchpad
   bp_global_addr_s global_addr_lo;
   assign global_addr_lo = addr_lo;
   assign local_addr_lo = addr_lo;
- 
+
   wire csr_w_v_li = w_v_li && (addr_lo inside {accel_wr_cnt_csr_idx_gp});
   wire csr_r_v_li = r_v_li && (addr_lo inside {accel_wr_cnt_csr_idx_gp});
   wire [dword_width_gp-1:0] csr_data_li = data_lo;

--- a/bp_top/src/v/bp_sacc_vdp.sv
+++ b/bp_top/src/v/bp_sacc_vdp.sv
@@ -65,7 +65,7 @@ module bp_sacc_vdp
   logic [2:0] len_a_cnt, len_b_cnt;
   logic second_operand;
 
-  enum logic [3:0] 
+  enum logic [3:0]
   {
     e_wait
     ,e_fetch_vec1
@@ -131,13 +131,13 @@ module bp_sacc_vdp
     begin
       if (reset_i)
         begin
-          input_a_ptr <= '0; 
-          input_b_ptr <= '0; 
-          input_len   <= '0; 
-          start_cmd   <= '0; 
-          res_ptr     <= '0; 
-          res_len     <= '0; 
-          operation   <= '0; 
+          input_a_ptr <= '0;
+          input_b_ptr <= '0;
+          input_len   <= '0;
+          start_cmd   <= '0;
+          res_ptr     <= '0;
+          res_len     <= '0;
+          operation   <= '0;
         end
       else if (csr_w_v_li)
         unique casez (local_addr_lo.addr)

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -457,7 +457,7 @@ module testbench
           ,.mhartid_i(be.calculator.pipe_sys.csr.cfg_bus_cast_i.core_id)
 
           ,.fe_queue_ready_and_i(fe.fe_queue_ready_and_i)
-     
+
           ,.br_ovr_i(fe.pc_gen.ovr_btaken | fe.pc_gen.ovr_jmp)
           ,.ret_ovr_i(fe.pc_gen.ovr_ret)
           ,.icache_data_v_i(fe.icache.data_v_o)


### PR DESCRIPTION
### Summary
This PR fixes two bugs from #1169 and #1170. First, it eliminates a dependence on the tag_mem_pkt during upgrades in the cache. Second, it adds a buffer in the L2 cache slice to eliminate a deadlock occurring during a write back sequence to the same cache bank 

### Area
Stream pumps

### Additional Changes Required (if any)
None

### Verification
Standard regression

