### PR TITLE
Cache Engine Refactor

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - engine_refactor
   before_script:
       - git submodule update --init --checkout --recursive external/
       - cp -r $CI_RTL_INSTALL_DIR install/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - engine_refactor
   before_script:
       - git submodule update --init --checkout --recursive external/
       - cp -r $CI_RTL_INSTALL_DIR install/

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ Upon commit to the listed branch, a functional regression consisting of full-sys
 
 Our goal with BlackParrot is to bootstrap a community-maintained RISC-V core, and we would love for you to get involved. Here are a few starter projects you could do to get your feet wet! Contact us more for details.
 
-- Our integer divider could be parameterized to do 2 or more cycles per iteration, or to skip zeros. (Note: Currently somebody is working on this.)
+- Our integer divider could be parameterized to iterate faster on smaller numbers. (Note: Currently somebody is working on this.)
+- Our floating point divider could be parameterized to do two iterates per cycle.
 - We would like to configure BlackParrot for ultra-tiny caches (e.g. 8-way set associative, 4 sets, 2 word = 16 byte cache lines)
 - We could use a stream buffer (prefetcher) implementation for our L2 cache.
 - Add a parameter to enable / disable FPU logic (including register file, bypass paths, FP divider and FMAC, etc.)

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -70,7 +70,7 @@ module bp_be_calculator_top
   , output logic                                    cache_req_metadata_v_o
   , input [paddr_width_p-1:0]                       cache_req_addr_i
   , input                                           cache_req_critical_i
-  , input                                           cache_req_complete_i
+  , input                                           cache_req_last_i
   , input                                           cache_req_credits_full_i
   , input                                           cache_req_credits_empty_i
 
@@ -301,7 +301,7 @@ module bp_be_calculator_top
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
      ,.cache_req_addr_i(cache_req_addr_i)
      ,.cache_req_critical_i(cache_req_critical_i)
-     ,.cache_req_complete_i(cache_req_complete_i)
+     ,.cache_req_last_i(cache_req_last_i)
      ,.cache_req_credits_full_i(cache_req_credits_full_i)
      ,.cache_req_credits_empty_i(cache_req_credits_empty_i)
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -68,6 +68,7 @@ module bp_be_calculator_top
   , input                                           cache_req_busy_i
   , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
   , output logic                                    cache_req_metadata_v_o
+  , input [paddr_width_p-1:0]                       cache_req_addr_i
   , input                                           cache_req_critical_i
   , input                                           cache_req_complete_i
   , input                                           cache_req_credits_full_i
@@ -298,6 +299,7 @@ module bp_be_calculator_top
      ,.cache_req_busy_i(cache_req_busy_i)
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
+     ,.cache_req_addr_i(cache_req_addr_i)
      ,.cache_req_critical_i(cache_req_critical_i)
      ,.cache_req_complete_i(cache_req_complete_i)
      ,.cache_req_credits_full_i(cache_req_credits_full_i)

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -64,7 +64,7 @@ module bp_be_calculator_top
 
   , output logic [dcache_req_width_lp-1:0]          cache_req_o
   , output logic                                    cache_req_v_o
-  , input                                           cache_req_ready_and_i
+  , input                                           cache_req_yumi_i
   , input                                           cache_req_busy_i
   , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
   , output logic                                    cache_req_metadata_v_o
@@ -295,7 +295,7 @@ module bp_be_calculator_top
 
      ,.cache_req_o(cache_req_o)
      ,.cache_req_v_o(cache_req_v_o)
-     ,.cache_req_ready_and_i(cache_req_ready_and_i)
+     ,.cache_req_yumi_i(cache_req_yumi_i)
      ,.cache_req_busy_i(cache_req_busy_i)
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -78,6 +78,7 @@ module bp_be_pipe_mem
    , input                                           cache_req_busy_i
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
+   , input [paddr_width_p-1:0]                       cache_req_addr_i
    , input                                           cache_req_critical_i
    , input                                           cache_req_complete_i
    , input                                           cache_req_credits_full_i
@@ -328,6 +329,7 @@ module bp_be_pipe_mem
       ,.cache_req_busy_i(cache_req_busy_i)
       ,.cache_req_metadata_o(cache_req_metadata_o)
       ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
+      ,.cache_req_addr_i(cache_req_addr_i)
       ,.cache_req_critical_i(cache_req_critical_i)
       ,.cache_req_complete_i(cache_req_complete_i)
       ,.cache_req_credits_full_i(cache_req_credits_full_i)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -165,9 +165,8 @@ module bp_be_pipe_mem
 
   logic [dword_width_gp-1:0] dcache_data;
   logic [reg_addr_width_gp-1:0] dcache_rd_addr;
-  logic                     dcache_ret, dcache_store, dcache_late, dcache_fencei, dcache_v;
+  logic                     dcache_req, dcache_ret, dcache_store, dcache_late, dcache_fencei, dcache_v;
   logic                     dcache_float;
-  logic                     dcache_tv_we;
 
   logic load_access_fault_v, store_access_fault_v;
   logic load_page_fault_v, store_page_fault_v;
@@ -310,17 +309,17 @@ module bp_be_pipe_mem
       ,.ptag_uncached_i(dcache_ptag_uncached)
       ,.ptag_dram_i(dcache_ptag_dram)
       ,.st_data_i(dcache_st_data)
-      ,.tv_we_o(dcache_tv_we)
       ,.flush_i(flush_i)
 
       ,.v_o(dcache_v)
-      ,.late_o(dcache_late)
+      ,.data_o(dcache_data)
       ,.rd_addr_o(dcache_rd_addr)
+      ,.late_o(dcache_late)
       ,.fencei_o(dcache_fencei)
       ,.float_o(dcache_float)
       ,.ret_o(dcache_ret)
+      ,.req_o(dcache_req)
       ,.store_o(dcache_store)
-      ,.data_o(dcache_data)
 
       // D$-LCE Interface
       ,.cache_req_o(cache_req_cast_o)
@@ -419,15 +418,6 @@ module bp_be_pipe_mem
      ,.data_o(dtlb_r_v_r)
      );
 
-  logic dcache_tv_r;
-  bsg_dff
-   #(.width_p(1))
-   dcache_v_r
-    (.clk_i(negedge_clk)
-     ,.data_i(dcache_tv_we)
-     ,.data_o(dcache_tv_r)
-     );
-
   assign tlb_load_miss_v_o      = dtlb_r_v_r & tlb_load_miss_v;
   assign tlb_store_miss_v_o     = dtlb_r_v_r & tlb_store_miss_v;
 
@@ -438,10 +428,10 @@ module bp_be_pipe_mem
   assign store_misaligned_v_o   = dtlb_r_v_r & store_misaligned_v;
   assign load_misaligned_v_o    = dtlb_r_v_r & load_misaligned_v;
 
-  assign fencei_clean_v_o       = early_v_r & dcache_tv_r &  dcache_v & ~dcache_late & dcache_fencei;
-  assign cache_store_miss_v_o   = early_v_r & dcache_tv_r & ~dcache_v & dcache_store;
-  assign cache_load_miss_v_o    = early_v_r & dcache_tv_r & ~dcache_v & dcache_ret;
-  assign cache_replay_v_o       = early_v_r &               ~dcache_v & ~cache_load_miss_v_o & ~cache_store_miss_v_o;
+  assign fencei_clean_v_o       = early_v_r &  dcache_v & dcache_fencei & ~dcache_late;
+  assign cache_store_miss_v_o   = early_v_r & ~dcache_v & dcache_store  & dcache_req;
+  assign cache_load_miss_v_o    = early_v_r & ~dcache_v & dcache_ret    & dcache_req;
+  assign cache_replay_v_o       = early_v_r & ~dcache_v & ~cache_load_miss_v_o & ~cache_store_miss_v_o;
 
   // Save the data coming out the D$ so we can recode it for floating-point loads
   logic [dword_width_gp-1:0] dcache_data_r;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -80,7 +80,7 @@ module bp_be_pipe_mem
    , output logic                                    cache_req_metadata_v_o
    , input [paddr_width_p-1:0]                       cache_req_addr_i
    , input                                           cache_req_critical_i
-   , input                                           cache_req_complete_i
+   , input                                           cache_req_last_i
    , input                                           cache_req_credits_full_i
    , input                                           cache_req_credits_empty_i
 
@@ -330,7 +330,7 @@ module bp_be_pipe_mem
       ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
       ,.cache_req_addr_i(cache_req_addr_i)
       ,.cache_req_critical_i(cache_req_critical_i)
-      ,.cache_req_complete_i(cache_req_complete_i)
+      ,.cache_req_last_i(cache_req_last_i)
       ,.cache_req_credits_full_i(cache_req_credits_full_i)
       ,.cache_req_credits_empty_i(cache_req_credits_empty_i)
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -74,7 +74,7 @@ module bp_be_pipe_mem
    // signals to LCE
    , output logic [dcache_req_width_lp-1:0]          cache_req_o
    , output logic                                    cache_req_v_o
-   , input                                           cache_req_ready_and_i
+   , input                                           cache_req_yumi_i
    , input                                           cache_req_busy_i
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
@@ -325,7 +325,7 @@ module bp_be_pipe_mem
       // D$-LCE Interface
       ,.cache_req_o(cache_req_cast_o)
       ,.cache_req_v_o(cache_req_v_o)
-      ,.cache_req_ready_and_i(cache_req_ready_and_i)
+      ,.cache_req_yumi_i(cache_req_yumi_i)
       ,.cache_req_busy_i(cache_req_busy_i)
       ,.cache_req_metadata_o(cache_req_metadata_o)
       ,.cache_req_metadata_v_o(cache_req_metadata_v_o)

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -70,7 +70,7 @@ module bp_be_detector
 
   bp_be_dep_status_s [3:0] dep_status_r;
 
-  logic fence_haz_v, cmd_haz_v, fflags_haz_v, csr_haz_v;
+  logic fence_haz_v, cmd_haz_v, fflags_haz_v, csr_haz_v, exception_haz_v;
   logic data_haz_v, control_haz_v, struct_haz_v;
   logic long_haz_v;
 
@@ -225,7 +225,9 @@ module bp_be_detector
                          | (dep_status_r[2].v)
                          );
 
-      control_haz_v = fence_haz_v | csr_haz_v | fflags_haz_v | long_haz_v;
+      exception_haz_v = commit_pkt_cast_i.npc_w_v;
+
+      control_haz_v = fence_haz_v | csr_haz_v | fflags_haz_v | long_haz_v | exception_haz_v;
 
       // Combine all data hazard information
       // TODO: Parameterize away floating point data hazards without hardware support

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -152,7 +152,7 @@ module bp_be_dcache
    , output logic                                    cache_req_metadata_v_o
    , input [paddr_width_p-1:0]                       cache_req_addr_i
    , input                                           cache_req_critical_i
-   , input                                           cache_req_complete_i
+   , input                                           cache_req_last_i
    // Unused
    , input                                           cache_req_credits_full_i
    , input                                           cache_req_credits_empty_i
@@ -208,7 +208,7 @@ module bp_be_dcache
     & (~stat_mem_pkt_v_i | stat_mem_pkt_yumi_o)
     & (~tag_mem_pkt_v_i | tag_mem_pkt_yumi_o)
     & (~data_mem_pkt_v_i | data_mem_pkt_yumi_o);
-  wire complete_recv = cache_req_complete_i
+  wire complete_recv = cache_req_last_i
     & (~stat_mem_pkt_v_i | stat_mem_pkt_yumi_o)
     & (~tag_mem_pkt_v_i | tag_mem_pkt_yumi_o)
     & (~data_mem_pkt_v_i | data_mem_pkt_yumi_o);

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -126,7 +126,6 @@ module bp_be_dcache
    , input                                           ptag_uncached_i
    , input                                           ptag_dram_i
    , input [dword_width_gp-1:0]                      st_data_i
-   , output logic                                    tv_we_o
    , input                                           flush_i
 
    // Cycle 2: "Tag Verify"
@@ -139,6 +138,7 @@ module bp_be_dcache
    , output logic                                    ret_o
    , output logic                                    late_o
    , output logic                                    store_o
+   , output logic                                    req_o
 
    // Cache Engine Interface
    // This is considered the "slow path", handling uncached requests
@@ -189,15 +189,29 @@ module bp_be_dcache
     ? (bindex_width_lp+byte_offset_width_lp)
     : byte_offset_width_lp;
 
+  // State machine declaration
+  enum logic {e_ready, e_miss} state_n, state_r;
+  wire is_ready  = (state_r == e_ready);
+  wire is_miss   = (state_r == e_miss);
+
   // Global signals
   logic tl_we, tv_we;
   logic safe_tl_we, safe_tv_we;
   logic v_tl_r, v_tv_r;
-  logic gdirty_r, cache_lock;
+  logic gdirty_r;
   logic tag_mem_write_hazard, data_mem_write_hazard, blocking_hazard, engine_hazard;
-  logic blocking_sent, nonblocking_sent, critical_recv;
+  logic blocking_sent, nonblocking_sent;
 
   wire flush_self = flush_i | tag_mem_write_hazard | data_mem_write_hazard | blocking_hazard | engine_hazard;
+
+  wire critical_recv = cache_req_critical_i
+    & (~stat_mem_pkt_v_i | stat_mem_pkt_yumi_o)
+    & (~tag_mem_pkt_v_i | tag_mem_pkt_yumi_o)
+    & (~data_mem_pkt_v_i | data_mem_pkt_yumi_o);
+  wire complete_recv = cache_req_complete_i
+    & (~stat_mem_pkt_v_i | stat_mem_pkt_yumi_o)
+    & (~tag_mem_pkt_v_i | tag_mem_pkt_yumi_o)
+    & (~data_mem_pkt_v_i | data_mem_pkt_yumi_o);
 
   /////////////////////////////////////////////////////////////////////////////
   // Decode Stage
@@ -276,22 +290,6 @@ module bp_be_dcache
          );
     end
 
-  // wire [sindex_width_lp-1:0]       vaddr_index = vaddr[block_offset_width_lp+:sindex_width_lp];
-  // wire [bindex_width_lp-1:0]       vaddr_bank  = vaddr[byte_offset_width_lp+:bindex_width_lp];
-  // wire [vtag_width_p-1:0]          vaddr_tag   = vaddr[vaddr_width_p-1-:vtag_width_p];
-  // fast_read = {vaddr_index, {(assoc_p > 1){vaddr_bank}}}
-  //        ? {vaddr_index, {(assoc_p > 1){vaddr_bank}}}
-  //        : {data_mem_pkt_cast_i.index, {(assoc_p > 1){data_mem_pkt_offset}}};
-  typedef struct packed
-  {
-    logic                              pending;
-    logic [rv64_reg_addr_width_gp-1:0] rd_addr;    
-    logic [lg_assoc_lp-1:0]            way;
-    logic [sindex_width_lp-1:0]        index;
-    logic [assoc_p-1:0]                bank_v;
-  }  bp_be_dcache_fill_status_s;
-  bp_be_dcache_fill_status_s fill_status_tl_n, fill_status_tl_r, fill_status_tv_r;
-
   /////////////////////////////////////////////////////////////////////////////
   // TL Stage
   /////////////////////////////////////////////////////////////////////////////
@@ -349,25 +347,24 @@ module bp_be_dcache
      );
 
   wire uncached_op_tl =  ptag_uncached_i | decode_tl_r.uncached_op;
+  wire dram_op_tl =  ptag_dram_i;
   wire [dword_width_gp-1:0] st_data_tl = st_data_i;
 
   /////////////////////////////////////////////////////////////////////////////
   // TV Stage
   /////////////////////////////////////////////////////////////////////////////
   localparam snoop_offset_width_lp = `BSG_SAFE_CLOG2(fill_width_p/dword_width_gp);
-  logic uncached_op_tv_r, fill_tv_r;
+  logic uncached_op_tv_r, dram_op_tv_r, fill_tv_r;
   logic [paddr_width_p-1:0] paddr_tv_r;
   logic [dword_width_gp-1:0] st_data_tv_r;
   logic [assoc_p-1:0][bank_width_lp-1:0] ld_data_tv_r;
   logic [assoc_p-1:0] load_hit_tv_r, store_hit_tv_r, way_v_tv_r, bank_sel_one_hot_tv_r;
   bp_be_dcache_decode_s decode_tv_r;
   logic load_reservation_match_tv;
-  logic [dword_width_gp-1:0] snoop_word;
-
-  wire [bindex_width_lp-1:0] paddr_bank_tv  = paddr_tv_r[byte_offset_width_lp+:bindex_width_lp];
   wire [sindex_width_lp-1:0] paddr_index_tv = paddr_tv_r[block_offset_width_lp+:sindex_width_lp];
   wire [ctag_width_p-1:0]    paddr_tag_tv   = paddr_tv_r[block_offset_width_lp+sindex_width_lp+:ctag_width_p];
 
+  // fencei does not require a ptag
   assign safe_tv_we = v_tl_r & (ptag_v_i | decode_tl_r.fencei_op);
   assign tv_we = safe_tv_we & ~flush_self;
   bsg_dff_reset
@@ -376,51 +373,88 @@ module bp_be_dcache
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
      // Inject in-line for non-blocking cache
-     ,.data_i(tv_we | cache_req_complete_i | engine_hazard)
+     ,.data_i(tv_we | critical_recv)
      ,.data_o(v_tv_r)
      );
-  assign tv_we_o = tv_we;
 
   logic [assoc_p-1:0] way_v_tv_n, store_hit_tv_n, load_hit_tv_n;
-  logic [block_width_p-1:0] ld_data_tv_n;
-  logic [paddr_width_p-1:0] paddr_tv_n;
   wire [assoc_p-1:0] pseudo_hit =
     (data_mem_pkt_v_i << data_mem_pkt_cast_i.way_id) | (tag_mem_pkt_v_i << tag_mem_pkt_cast_i.way_id);
-  wire [block_width_p-1:0] snoop_data_lo = {block_width_p/dword_width_gp{snoop_word}};
   bsg_mux
-   #(.width_p(3*assoc_p+block_width_p+paddr_width_p), .els_p(2))
+   #(.width_p(3*assoc_p), .els_p(2))
    hit_mux
-    (.data_i({{{3{pseudo_hit}}, snoop_data_lo, cache_req_addr_i}
-              ,{way_v_tl, store_hit_tl, load_hit_tl, data_mem_data_lo, paddr_tl}
-              })
+    (.data_i({{3{pseudo_hit}}, {way_v_tl, store_hit_tl, load_hit_tl}})
      ,.sel_i(critical_recv)
-     ,.data_o({way_v_tv_n, store_hit_tv_n, load_hit_tv_n, ld_data_tv_n, paddr_tv_n})
+     ,.data_o({way_v_tv_n, store_hit_tv_n, load_hit_tv_n})
      );
 
-  wire fill_tv_n = critical_recv;
   bsg_dff_reset_en
-   #(.width_p(1+3*assoc_p+paddr_width_p+block_width_p))
+   #(.width_p(3*assoc_p))
    hit_tv_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
      ,.en_i(tv_we | critical_recv)
-     ,.data_i({fill_tv_n, way_v_tv_n, store_hit_tv_n, load_hit_tv_n, paddr_tv_n, ld_data_tv_n})
-     ,.data_o({fill_tv_r, way_v_tv_r, store_hit_tv_r, load_hit_tv_r, paddr_tv_r, ld_data_tv_r})
+     ,.data_i({way_v_tv_n, store_hit_tv_n, load_hit_tv_n})
+     ,.data_o({way_v_tv_r, store_hit_tv_r, load_hit_tv_r})
+     );
+
+  // Fill if we're actually returning
+  wire fill_tv_n = critical_recv | nonblocking_sent;
+  bsg_dff_reset_en
+   #(.width_p(1))
+   fill_tv_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.en_i(tv_we | critical_recv)
+     ,.data_i(fill_tv_n)
+     ,.data_o(fill_tv_r)
+     );
+
+  // Snoop logic
+  logic [dword_width_gp-1:0] snoop_word;
+  wire [snoop_offset_width_lp-1:0] snoop_word_offset = paddr_tv_r[3+:snoop_offset_width_lp];
+  bsg_mux
+   #(.width_p(dword_width_gp), .els_p(fill_width_p/dword_width_gp))
+   snoop_mux
+    (.data_i(data_mem_pkt_cast_i.data)
+     ,.sel_i(snoop_word_offset)
+     ,.data_o(snoop_word)
+     );
+  wire [block_width_p-1:0] snoop_data_lo = {block_width_p/dword_width_gp{snoop_word}};
+
+  logic [block_width_p-1:0] ld_data_tv_n;
+  bsg_mux
+   #(.width_p(block_width_p), .els_p(2))
+   ld_data_mux
+    (.data_i({snoop_data_lo, data_mem_data_lo})
+     ,.sel_i(critical_recv)
+     ,.data_o(ld_data_tv_n)
      );
 
   bsg_dff_en
-   #(.width_p(dword_width_gp+assoc_p+1+$bits(bp_be_dcache_decode_s)))
+   #(.width_p(block_width_p))
+   ld_data_tv_reg
+    (.clk_i(clk_i)
+     ,.en_i(tv_we | critical_recv)
+     ,.data_i(ld_data_tv_n)
+     ,.data_o(ld_data_tv_r)
+     );
+
+  bsg_dff_en
+   #(.width_p(paddr_width_p+dword_width_gp+assoc_p+2+$bits(bp_be_dcache_decode_s)))
    tv_stage_reg
     (.clk_i(clk_i)
      ,.en_i(tv_we)
-     ,.data_i({st_data_tl
+     ,.data_i({paddr_tl
+               ,st_data_tl
                ,bank_sel_one_hot_tl
-               ,uncached_op_tl
+               ,uncached_op_tl, dram_op_tl
                ,decode_tl_r
                })
-     ,.data_o({st_data_tv_r
+     ,.data_o({paddr_tv_r
+               ,st_data_tv_r
                ,bank_sel_one_hot_tv_r
-               ,uncached_op_tv_r
+               ,uncached_op_tv_r, dram_op_tv_r
                ,decode_tv_r
                })
      );
@@ -529,17 +563,13 @@ module bp_be_dcache
 
   // Store no-allocate, so keep going if we have a store miss on a writethrough cache
   wire store_miss_tv    = ~uncached_op_tv_r & (decode_tv_r.store_op | decode_tv_r.lr_op) & ~decode_tv_r.sc_op & ~store_hit_tv & writeback_p;
-  wire load_miss_tv     = decode_tv_r.load_op & ~decode_tv_r.sc_op & ~load_hit_tv;
-
-  wire fill_miss_tv     = fill_status_tv_r.pending
-    &&  (fill_status_tv_r.way == load_hit_way_tv)
-    &&  (fill_status_tv_r.index == paddr_index_tv)
-    && ~(fill_status_tv_r.bank_v & bank_sel_one_hot_tv_r);
+  wire load_miss_tv     = ~uncached_op_tv_r & decode_tv_r.load_op & ~decode_tv_r.sc_op & ~load_hit_tv;
 
   wire cached_miss_tv   = load_miss_tv | store_miss_tv;
   wire fencei_miss_tv   = decode_tv_r.fencei_op & gdirty_r;
+  wire uncached_miss_tv = uncached_op_tv_r & decode_tv_r.load_op & ~fill_tv_r;
   wire engine_miss_tv   = cache_req_v_o & ~cache_req_yumi_i;
-  wire any_miss_tv      = cached_miss_tv | fencei_miss_tv | engine_miss_tv | fill_miss_tv;
+  wire any_miss_tv      = cached_miss_tv | fencei_miss_tv | uncached_miss_tv | engine_miss_tv;
 
   assign data_o = (decode_tv_r.sc_op & ~uncached_op_tv_r)
     ? (sc_success_tv != 1'b1)
@@ -552,6 +582,7 @@ module bp_be_dcache
   assign late_o    = fill_tv_r;
   assign ret_o     = decode_tv_r.ret_op;
   assign store_o   = decode_tv_r.store_op;
+  assign req_o     = cache_req_yumi_i;
 
   ///////////////////////////
   // Stat Mem Storage
@@ -595,9 +626,9 @@ module bp_be_dcache
   logic wbuf_v_li, wbuf_v_lo, wbuf_force_lo, wbuf_yumi_li;
 
   assign wbuf_v_li = v_tv_r
-    & decode_tv_r.store_op & ~uncached_op_tv_r
-    & store_hit_tv & ~sc_fail_tv
-    & (writeback_p | cache_req_yumi_i);
+        & decode_tv_r.store_op & ~uncached_op_tv_r
+        & store_hit_tv & ~sc_fail_tv
+        & (writeback_p | cache_req_yumi_i);
 
   //
   // Atomic operations
@@ -723,24 +754,24 @@ module bp_be_dcache
   `bp_cast_o(bp_dcache_req_s, cache_req);
   `bp_cast_o(bp_dcache_req_metadata_s, cache_req_metadata);
 
-  wire cached_req         = ~uncached_op_tv_r & (store_miss_tv | load_miss_tv);
-  wire wt_req             = ~uncached_op_tv_r & (decode_tv_r.store_op & ~sc_fail_tv & !writeback_p);
-  wire uncached_amo_req   =  uncached_op_tv_r & store_miss_tv & decode_tv_r.amo_op & decode_tv_r.ret_op;
-  wire uncached_load_req  =  uncached_op_tv_r & load_miss_tv & ~decode_tv_r.amo_op & decode_tv_r.load_op;
-  wire uncached_store_req =  uncached_op_tv_r & decode_tv_r.store_op & ~decode_tv_r.ret_op;
-  wire fencei_req         = fencei_miss_tv & (coherent_p == 0);
+  wire cached_req          = ~uncached_op_tv_r & (store_miss_tv | load_miss_tv);
+  wire wt_req              = ~uncached_op_tv_r & (decode_tv_r.store_op & ~sc_fail_tv & !writeback_p);
+  wire uncached_amo_req    =  uncached_op_tv_r & decode_tv_r.amo_op & decode_tv_r.ret_op & ~fill_tv_r;
+  wire uncached_load_req   =  uncached_op_tv_r & ~decode_tv_r.amo_op & decode_tv_r.load_op & ~fill_tv_r;
+  wire uncached_store_req  =  uncached_op_tv_r & decode_tv_r.store_op & ~decode_tv_r.ret_op & ~fill_tv_r;
+  wire fencei_req          = fencei_miss_tv & (coherent_p == 0);
+  wire backoff_req         = sc_fail_tv & (coherent_p == 1);
 
   // Uncached stores and writethrough requests are non-blocking
-  wire nonblocking_req    = (uncached_store_req | wt_req);
-  wire blocking_req       = (fencei_req | cached_req | uncached_amo_req | uncached_load_req);
-  assign nonblocking_sent = nonblocking_req & cache_req_yumi_i & cache_req_v_o;
-  assign blocking_sent    = blocking_req & cache_req_yumi_i & cache_req_v_o;
+  wire nonblocking_req     = (uncached_store_req | wt_req | backoff_req);
+  wire blocking_req        = (fencei_req | cached_req | uncached_amo_req | uncached_load_req);
+  assign nonblocking_sent  = nonblocking_req & cache_req_yumi_i;
+  assign blocking_sent     = blocking_req & cache_req_yumi_i;
 
-  assign cache_req_v_o = v_tv_r
-    & (|{cached_req, fencei_req, uncached_amo_req, uncached_load_req, uncached_store_req, wt_req});
+  assign cache_req_v_o = v_tv_r & (blocking_req | nonblocking_req);
 
-  assign blocking_hazard =  cache_req_v_o & blocking_req;
-  assign engine_hazard   = ~cache_req_yumi_i & cache_req_v_o;
+  assign blocking_hazard = cache_req_v_o & blocking_req;
+  assign engine_hazard   = cache_req_v_o & ~cache_req_yumi_i;
 
   always_comb
     begin
@@ -781,18 +812,18 @@ module bp_be_dcache
         default: cache_req_cast_o.subop = e_req_store;
       endcase
 
-      if (fencei_miss_tv)
+      if (backoff_req)
+        cache_req_cast_o.msg_type = e_cache_backoff;
+      else if (fencei_req)
         cache_req_cast_o.msg_type = e_cache_flush;
+      else if (cached_req)
+        cache_req_cast_o.msg_type = store_miss_tv ? e_miss_store : e_miss_load;
       else if (uncached_amo_req)
         cache_req_cast_o.msg_type = e_uc_amo;
       else if (uncached_store_req)
         cache_req_cast_o.msg_type = e_uc_store;
       else if (uncached_load_req)
         cache_req_cast_o.msg_type = e_uc_load;
-      else if (store_miss_tv)
-        cache_req_cast_o.msg_type = e_miss_store;
-      else if (load_miss_tv)
-        cache_req_cast_o.msg_type = e_miss_load;
       else
         cache_req_cast_o.msg_type = e_wt_store;
     end
@@ -822,10 +853,6 @@ module bp_be_dcache
   assign cache_req_metadata_cast_o.hit_or_repl_way = hit_or_repl_way;
   assign cache_req_metadata_cast_o.dirty = stat_mem_data_lo.dirty[hit_or_repl_way];
 
-  // State machine declaration
-  enum logic {e_ready, e_miss} state_n, state_r;
-  wire is_ready  = (state_r == e_ready);
-  wire is_miss   = (state_r == e_miss);
   /////////////////////////////////////////////////////////////////////////////
   // State machine
   //   e_ready  : Cache is ready to accept requests
@@ -833,8 +860,8 @@ module bp_be_dcache
   /////////////////////////////////////////////////////////////////////////////
   always_comb
     case (state_r)
-      e_ready : state_n = (engine_hazard    | blocking_sent       ) ? e_miss : e_ready;
-      e_miss  : state_n = (nonblocking_sent | cache_req_complete_i) ? e_ready : e_miss;
+      e_ready : state_n = blocking_sent ? e_miss : e_ready;
+      e_miss  : state_n = complete_recv ? e_ready : e_miss;
       default: state_n = e_ready;
     endcase
 
@@ -846,9 +873,7 @@ module bp_be_dcache
       state_r <= state_n;
 
   assign ready_and_o = is_ready & ~cache_req_busy_i;
-
-  //assign ready_and_o = ~cache_req_busy_i;
-  assign ordered_o = ~v_tl_r & ~v_tv_r & cache_req_credits_empty_i;
+  assign ordered_o = is_ready & ~v_tl_r & ~v_tv_r & cache_req_credits_empty_i;
 
   /////////////////////////////////////////////////////////////////////////////
   // SRAM Control
@@ -860,7 +885,7 @@ module bp_be_dcache
   wire tag_mem_fast_read = (safe_tl_we & ~decode_lo.fencei_op) & ~tag_mem_write_hazard;
   wire tag_mem_slow_read = tag_mem_pkt_yumi_o & (tag_mem_pkt_cast_i.opcode == e_cache_tag_mem_read);
   wire tag_mem_slow_write = tag_mem_pkt_yumi_o & (tag_mem_pkt_cast_i.opcode != e_cache_tag_mem_read);
-  wire tag_mem_fast_write = v_tv_r & (uncached_op_tv_r & load_hit_tv & ~fill_tv_r);
+  wire tag_mem_fast_write = v_tv_r & (uncached_op_tv_r & dram_op_tv_r & ~fill_tv_r & load_hit_tv);
   assign tag_mem_write_hazard = tag_mem_fast_write;
 
   assign tag_mem_v_li = tag_mem_fast_read | tag_mem_slow_read | tag_mem_slow_write | tag_mem_fast_write;
@@ -870,7 +895,7 @@ module bp_be_dcache
     : tag_mem_fast_read
       ? vaddr_index
       : tag_mem_pkt_cast_i.index;
-  assign tag_mem_pkt_yumi_o = ~cache_lock & tag_mem_pkt_v_i & ~tag_mem_fast_read & ~tag_mem_fast_write;
+  assign tag_mem_pkt_yumi_o = tag_mem_pkt_v_i & ~tag_mem_fast_read & ~tag_mem_fast_write;
 
   logic [assoc_p-1:0] tag_mem_way_one_hot;
   bsg_decode
@@ -1011,11 +1036,8 @@ module bp_be_dcache
   // A similar scheme could be adopted for a non-blocking version, where we snoop the bank
   // TODO: With blocking TL and TV, we really should implement snooping for performance
   assign data_mem_pkt_yumi_o = (data_mem_pkt_cast_i.opcode == e_cache_data_mem_uncached)
-    ? ~cache_lock & data_mem_pkt_v_i
-    : ~cache_lock & data_mem_pkt_v_i & ~|data_mem_fast_read & ~wbuf_v_lo & ~(v_tl_r &
-decode_tl_r.store_op) & ~(v_tv_r & decode_tv_r.store_op);// & ~(cache_req_critical_i & tv_we);
-
-  assign critical_recv = cache_req_critical_i & (tag_mem_pkt_yumi_o | data_mem_pkt_yumi_o);
+    ? data_mem_pkt_v_i
+    : data_mem_pkt_v_i & ~|data_mem_fast_read & ~(v_tl_r & decode_tl_r.store_op) & ~(wbuf_v_lo & ~fill_tv_r);
 
   logic [lg_assoc_lp-1:0] data_mem_pkt_way_r;
   bsg_dff
@@ -1035,16 +1057,6 @@ decode_tl_r.store_op) & ~(v_tv_r & decode_tv_r.store_op);// & ~(cache_req_critic
      ,.o(data_mem_o)
      );
 
-  // Snoop logic
-  wire [snoop_offset_width_lp-1:0] snoop_word_offset = cache_req_addr_i[3+:snoop_offset_width_lp];
-  bsg_mux
-   #(.width_p(dword_width_gp), .els_p(fill_width_p/dword_width_gp))
-   snoop_mux
-    (.data_i(data_mem_pkt_cast_i.data)
-     ,.sel_i(snoop_word_offset)
-     ,.data_o(snoop_word)
-     );
-
   ///////////////////////////
   // Stat Mem Control
   ///////////////////////////
@@ -1058,7 +1070,7 @@ decode_tl_r.store_op) & ~(v_tv_r & decode_tv_r.store_op);// & ~(cache_req_critic
   assign stat_mem_addr_li = (stat_mem_fast_write | stat_mem_fast_read)
     ? paddr_tv_r[block_offset_width_lp+:sindex_width_lp]
     : stat_mem_pkt_cast_i.index;
-  assign stat_mem_pkt_yumi_o = ~cache_lock & stat_mem_pkt_v_i & ~stat_mem_fast_read & ~stat_mem_fast_write;
+  assign stat_mem_pkt_yumi_o = stat_mem_pkt_v_i & ~stat_mem_fast_read & ~stat_mem_fast_write;
 
   logic [`BSG_SAFE_MINUS(assoc_p, 2):0] lru_decode_data_lo;
   logic [`BSG_SAFE_MINUS(assoc_p, 2):0] lru_decode_mask_lo;
@@ -1104,7 +1116,7 @@ decode_tl_r.store_op) & ~(v_tv_r & decode_tv_r.store_op);// & ~(cache_req_critic
       // For a non-coherent writethrough write-no-allocate cache, we set the dirty regardless of hit
       // For a coherent cache, we never set the dirty bit as the coherence system should handle it
       wire set_dirty = wbuf_v_li;
-      wire clear_dirty = (cache_req_complete_i & decode_tv_r.fencei_op);
+      wire clear_dirty = complete_recv & decode_tv_r.fencei_op;
       bsg_dff_reset_set_clear
        #(.width_p(1))
        gdirty_reg
@@ -1194,60 +1206,11 @@ decode_tl_r.store_op) & ~(v_tv_r & decode_tv_r.store_op);// & ~(cache_req_critic
         assign load_reservation_match_tv = load_reserved_v_r
           & (load_reserved_index_r == paddr_index_tv)
           & (load_reserved_tag_r == paddr_tag_tv);
-
-        // Linear backoff
-        localparam lock_max_limit_lp = 8;
-        logic [`BSG_SAFE_CLOG2(lock_max_limit_lp+1)-1:0] lock_cnt_r;
-        wire lock_clr = sc_success_tv || (lock_cnt_r == lock_max_limit_lp);
-        wire lock_inc = ~lock_clr & (lr_hit_tv || (lock_cnt_r > 0));
-        bsg_counter_clear_up
-         #(.max_val_p(lock_max_limit_lp), .init_val_p(0))
-         lock_counter
-          (.clk_i(clk_i)
-           ,.reset_i(reset_i)
-
-           ,.clear_i(lock_clr)
-           ,.up_i(lock_inc)
-           ,.count_o(lock_cnt_r)
-           );
-        assign cache_lock = (lock_cnt_r != '0);
     end
   else
     begin : no_l1_lrsc
         assign load_reservation_match_tv = '0;
-        assign cache_lock                = '0;
     end
-
-
-  always_comb begin
-    fill_status_tl_n = fill_status_tl_r;
-    if (cache_req_complete_i) begin
-        fill_status_tl_n = '0;
-    end else if (blocking_sent) begin
-        fill_status_tl_n.pending = 1'b1;
-        fill_status_tl_n.index = paddr_tv_r[block_offset_width_lp+:sindex_width_lp];
-    end else if (data_mem_pkt_yumi_o & data_mem_pkt_cast_i.opcode == e_cache_data_mem_write) begin
-        fill_status_tl_n.pending = 1'b1;
-        fill_status_tl_n.way = data_mem_pkt_cast_i.way_id;
-        fill_status_tl_n.bank_v |= data_mem_pkt_fill_mask_expanded;
-    end
-  end
-
-  always_ff @(posedge clk_i) begin
-    if (reset_i)
-      fill_status_tl_r <= '0;
-    else if (blocking_sent | (data_mem_pkt_yumi_o & data_mem_pkt_cast_i.opcode == e_cache_data_mem_write) | cache_req_complete_i) begin
-      fill_status_tl_r <= fill_status_tl_n;
-    end
-  end
-
-  always_ff @(posedge clk_i) begin
-    if (reset_i) 
-      fill_status_tv_r <= '0;
-    else if (tv_we)
-      fill_status_tv_r <= fill_status_tl_r;
-    end
-
 
   // synopsys translate_off
   `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -43,6 +43,7 @@ module bp_be_top
    , input                                           cache_req_busy_i
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
+   , input [paddr_width_p-1:0]                       cache_req_addr_i
    , input                                           cache_req_critical_i
    , input                                           cache_req_complete_i
    , input                                           cache_req_credits_full_i
@@ -206,6 +207,7 @@ module bp_be_top
      ,.cache_req_ready_and_i(cache_req_ready_and_i)
      ,.cache_req_busy_i(cache_req_busy_i)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
+     ,.cache_req_addr_i(cache_req_addr_i)
      ,.cache_req_critical_i(cache_req_critical_i)
      ,.cache_req_complete_i(cache_req_complete_i)
      ,.cache_req_credits_full_i(cache_req_credits_full_i)

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -39,7 +39,7 @@ module bp_be_top
    // signals to LCE
    , output logic [dcache_req_width_lp-1:0]          cache_req_o
    , output logic                                    cache_req_v_o
-   , input                                           cache_req_ready_and_i
+   , input                                           cache_req_yumi_i
    , input                                           cache_req_busy_i
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
@@ -204,7 +204,7 @@ module bp_be_top
      ,.cache_req_o(cache_req_o)
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_v_o(cache_req_v_o)
-     ,.cache_req_ready_and_i(cache_req_ready_and_i)
+     ,.cache_req_yumi_i(cache_req_yumi_i)
      ,.cache_req_busy_i(cache_req_busy_i)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
      ,.cache_req_addr_i(cache_req_addr_i)

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -45,7 +45,7 @@ module bp_be_top
    , output logic                                    cache_req_metadata_v_o
    , input [paddr_width_p-1:0]                       cache_req_addr_i
    , input                                           cache_req_critical_i
-   , input                                           cache_req_complete_i
+   , input                                           cache_req_last_i
    , input                                           cache_req_credits_full_i
    , input                                           cache_req_credits_empty_i
 
@@ -209,7 +209,7 @@ module bp_be_top
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
      ,.cache_req_addr_i(cache_req_addr_i)
      ,.cache_req_critical_i(cache_req_critical_i)
-     ,.cache_req_complete_i(cache_req_complete_i)
+     ,.cache_req_last_i(cache_req_last_i)
      ,.cache_req_credits_full_i(cache_req_credits_full_i)
      ,.cache_req_credits_empty_i(cache_req_credits_empty_i)
 

--- a/bp_be/test/common/bp_be_nonsynth_dcache_tracer.sv
+++ b/bp_be/test/common/bp_be_nonsynth_dcache_tracer.sv
@@ -40,7 +40,7 @@ module bp_be_nonsynth_dcache_tracer
    , input [cache_req_metadata_width_lp-1:0]              cache_req_metadata_o
    , input                                                cache_req_metadata_v_o
    , input                                                cache_req_critical_i
-   , input                                                cache_req_complete_i
+   , input                                                cache_req_last_i
    // Unused
    , input                                                cache_req_credits_full_i
    , input                                                cache_req_credits_empty_i
@@ -164,8 +164,8 @@ module bp_be_nonsynth_dcache_tracer
         $fwrite(eng_file, "%12t | cache_req_metadata: %p\n", $time, cache_req_metadata_cast_o);
       if (cache_req_critical_i)
         $fwrite(eng_file, "%12t | cache_req_critical_i: %b \n", $time, cache_req_critical_i);
-      if (cache_req_complete_i)
-        $fwrite(eng_file, "%12t | cache_req_complete_i: %b \n", $time, cache_req_complete_i);
+      if (cache_req_last_i)
+        $fwrite(eng_file, "%12t | cache_req_last_i: %b \n", $time, cache_req_last_i);
 
       if (data_mem_pkt_yumi_o)
         $fwrite(eng_file, "%12t | data_mem_pkt: %p\n", $time, data_mem_pkt_cast_i);

--- a/bp_be/test/common/bp_be_nonsynth_dcache_tracer.sv
+++ b/bp_be/test/common/bp_be_nonsynth_dcache_tracer.sv
@@ -35,7 +35,7 @@ module bp_be_nonsynth_dcache_tracer
 
    , input [cache_req_width_lp-1:0]                       cache_req_o
    , input                                                cache_req_v_o
-   , input                                                cache_req_ready_and_i
+   , input                                                cache_req_yumi_i
    , input                                                cache_req_busy_i
    , input [cache_req_metadata_width_lp-1:0]              cache_req_metadata_o
    , input                                                cache_req_metadata_v_o
@@ -158,7 +158,7 @@ module bp_be_nonsynth_dcache_tracer
       if (wbuf_yumi_li)
         $fwrite(acc_file, "%12t | wbuf: %p\n", $time, wbuf_entry_out_cast);
 
-      if (cache_req_ready_and_i & cache_req_v_o)
+      if (cache_req_yumi_i)
         $fwrite(eng_file, "%12t | cache_req: %p\n", $time, cache_req_cast_o);
       if (cache_req_metadata_v_o)
         $fwrite(eng_file, "%12t | cache_req_metadata: %p\n", $time, cache_req_metadata_cast_o);

--- a/bp_be/test/tb/bp_be_dcache/testbench.sv
+++ b/bp_be/test/tb/bp_be_dcache/testbench.sv
@@ -353,7 +353,7 @@ module testbench
           ,.lce_fill_o_v_i(lce_fill_v_o)
           ,.lce_fill_o_ready_and_i(lce_fill_ready_and_i)
 
-          ,.cache_req_complete_i(cache_req_complete_o)
+          ,.cache_req_last_i(cache_req_last_o)
           ,.uc_store_req_complete_i(uc_store_req_complete_lo)
           );
 

--- a/bp_be/test/tb/bp_be_dcache/testbench.sv
+++ b/bp_be/test/tb/bp_be_dcache/testbench.sv
@@ -354,7 +354,6 @@ module testbench
           ,.lce_fill_o_ready_and_i(lce_fill_ready_and_i)
 
           ,.cache_req_last_i(cache_req_last_o)
-          ,.uc_store_req_complete_i(uc_store_req_complete_lo)
           );
 
     bind bp_cce_fsm

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -73,7 +73,7 @@ module wrapper
   // Miss, Management Interfaces
   logic [num_caches_p-1:0] cache_req_v_lo, cache_req_metadata_v_lo;
   logic [num_caches_p-1:0] cache_req_yumi_lo, cache_req_busy_lo;
-  logic [num_caches_p-1:0] cache_req_complete_lo, cache_req_critical_lo;
+  logic [num_caches_p-1:0] cache_req_last_lo, cache_req_critical_lo;
   logic [num_caches_p-1:0][paddr_width_p-1:0] cache_req_addr_lo;
   logic [num_caches_p-1:0][dcache_req_width_lp-1:0] cache_req_lo;
   logic [num_caches_p-1:0][dcache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
@@ -217,7 +217,7 @@ module wrapper
       ,.cache_req_busy_i(cache_req_busy_lo[i])
       ,.cache_req_addr_i(cache_req_addr_lo[i])
       ,.cache_req_critical_i(cache_req_critical_lo[i])
-      ,.cache_req_complete_i(cache_req_complete_lo[i])
+      ,.cache_req_last_i(cache_req_last_lo[i])
       ,.cache_req_credits_full_i(cache_req_credits_full_lo[i])
       ,.cache_req_credits_empty_i(cache_req_credits_empty_lo[i])
 
@@ -265,7 +265,7 @@ module wrapper
              ,.cache_req_metadata_v_i(cache_req_metadata_v_lo[i])
              ,.cache_req_addr_o(cache_req_addr_lo[i])
              ,.cache_req_critical_o(cache_req_critical_lo[i])
-             ,.cache_req_complete_o(cache_req_complete_lo[i])
+             ,.cache_req_last_o(cache_req_last_lo[i])
              ,.cache_req_credits_full_o(cache_req_credits_full_lo[i])
              ,.cache_req_credits_empty_o(cache_req_credits_empty_lo[i])
 
@@ -339,7 +339,7 @@ module wrapper
             ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
             ,.cache_req_addr_o(cache_req_addr_lo)
             ,.cache_req_critical_o(cache_req_critical_lo)
-            ,.cache_req_complete_o(cache_req_complete_lo)
+            ,.cache_req_last_o(cache_req_last_lo)
             ,.cache_req_credits_full_o(cache_req_credits_full_lo)
             ,.cache_req_credits_empty_o(cache_req_credits_empty_lo)
 

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -72,7 +72,7 @@ module wrapper
   // D$ - LCE Interface signals
   // Miss, Management Interfaces
   logic [num_caches_p-1:0] cache_req_v_lo, cache_req_metadata_v_lo;
-  logic [num_caches_p-1:0] cache_req_ready_and_lo, cache_req_busy_lo;
+  logic [num_caches_p-1:0] cache_req_yumi_lo, cache_req_busy_lo;
   logic [num_caches_p-1:0] cache_req_complete_lo, cache_req_critical_lo;
   logic [num_caches_p-1:0][paddr_width_p-1:0] cache_req_addr_lo;
   logic [num_caches_p-1:0][dcache_req_width_lp-1:0] cache_req_lo;
@@ -213,7 +213,7 @@ module wrapper
       ,.cache_req_o(cache_req_lo[i])
       ,.cache_req_metadata_o(cache_req_metadata_lo[i])
       ,.cache_req_metadata_v_o(cache_req_metadata_v_lo[i])
-      ,.cache_req_ready_and_i(cache_req_ready_and_lo[i])
+      ,.cache_req_yumi_i(cache_req_yumi_lo[i])
       ,.cache_req_busy_i(cache_req_busy_lo[i])
       ,.cache_req_addr_i(cache_req_addr_lo[i])
       ,.cache_req_critical_i(cache_req_critical_lo[i])
@@ -259,7 +259,7 @@ module wrapper
 
              ,.cache_req_i(cache_req_lo[i])
              ,.cache_req_v_i(cache_req_v_lo[i])
-             ,.cache_req_ready_and_o(cache_req_ready_and_lo[i])
+             ,.cache_req_yumi_o(cache_req_yumi_lo[i])
              ,.cache_req_busy_o(cache_req_busy_lo[i])
              ,.cache_req_metadata_i(cache_req_metadata_lo[i])
              ,.cache_req_metadata_v_i(cache_req_metadata_v_lo[i])
@@ -333,7 +333,7 @@ module wrapper
 
             ,.cache_req_i(cache_req_lo)
             ,.cache_req_v_i(cache_req_v_lo)
-            ,.cache_req_ready_and_o(cache_req_ready_and_lo)
+            ,.cache_req_yumi_o(cache_req_yumi_lo)
             ,.cache_req_busy_o(cache_req_busy_lo)
             ,.cache_req_metadata_i(cache_req_metadata_lo)
             ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -74,6 +74,7 @@ module wrapper
   logic [num_caches_p-1:0] cache_req_v_lo, cache_req_metadata_v_lo;
   logic [num_caches_p-1:0] cache_req_ready_and_lo, cache_req_busy_lo;
   logic [num_caches_p-1:0] cache_req_complete_lo, cache_req_critical_lo;
+  logic [num_caches_p-1:0][paddr_width_p-1:0] cache_req_addr_lo;
   logic [num_caches_p-1:0][dcache_req_width_lp-1:0] cache_req_lo;
   logic [num_caches_p-1:0][dcache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
 
@@ -214,8 +215,9 @@ module wrapper
       ,.cache_req_metadata_v_o(cache_req_metadata_v_lo[i])
       ,.cache_req_ready_and_i(cache_req_ready_and_lo[i])
       ,.cache_req_busy_i(cache_req_busy_lo[i])
-      ,.cache_req_complete_i(cache_req_complete_lo[i])
+      ,.cache_req_addr_i(cache_req_addr_lo[i])
       ,.cache_req_critical_i(cache_req_critical_lo[i])
+      ,.cache_req_complete_i(cache_req_complete_lo[i])
       ,.cache_req_credits_full_i(cache_req_credits_full_lo[i])
       ,.cache_req_credits_empty_i(cache_req_credits_empty_lo[i])
 
@@ -261,6 +263,7 @@ module wrapper
              ,.cache_req_busy_o(cache_req_busy_lo[i])
              ,.cache_req_metadata_i(cache_req_metadata_lo[i])
              ,.cache_req_metadata_v_i(cache_req_metadata_v_lo[i])
+             ,.cache_req_addr_o(cache_req_addr_lo[i])
              ,.cache_req_critical_o(cache_req_critical_lo[i])
              ,.cache_req_complete_o(cache_req_complete_lo[i])
              ,.cache_req_credits_full_o(cache_req_credits_full_lo[i])
@@ -334,6 +337,7 @@ module wrapper
             ,.cache_req_busy_o(cache_req_busy_lo)
             ,.cache_req_metadata_i(cache_req_metadata_lo)
             ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
+            ,.cache_req_addr_o(cache_req_addr_lo)
             ,.cache_req_critical_o(cache_req_critical_lo)
             ,.cache_req_complete_o(cache_req_complete_lo)
             ,.cache_req_credits_full_o(cache_req_credits_full_lo)

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -199,6 +199,7 @@ module wrapper
       ,.ordered_o()
       ,.float_o()
       ,.store_o()
+      ,.req_o()
 
       ,.ptag_v_i(1'b1)
       ,.ptag_i(rolly_ptag_r[i])
@@ -207,7 +208,6 @@ module wrapper
       ,.st_data_i(st_data_i)
 
       ,.flush_i('0)
-      ,.tv_we_o()
 
       ,.cache_req_v_o(cache_req_v_lo[i])
       ,.cache_req_o(cache_req_lo[i])

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -181,7 +181,6 @@
     //   bit 0: fpu enabled
     integer unsigned fpu_support;
     // Whether to enable the "c" extension.
-    // Currently, this only enables support for misaligned 32-bit instructions; full "C" support is not yet implemented.
     integer unsigned compressed_support;
 
     // Whether the coherence network is on the core clock or on its own clock

--- a/bp_common/src/include/bp_common_cache_engine_pkgdef.svh
+++ b/bp_common/src/include/bp_common_cache_engine_pkgdef.svh
@@ -12,6 +12,7 @@
     ,e_uc_amo           = 4'b0101
     ,e_cache_flush      = 4'b0110
     ,e_cache_clear      = 4'b0111
+    ,e_cache_backoff    = 4'b1000
   } bp_cache_req_msg_type_e;
 
   typedef enum logic [2:0]

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -109,7 +109,7 @@ module bp_fe_icache
    , output logic                                     cache_req_metadata_v_o
    , input [paddr_width_p-1:0]                        cache_req_addr_i
    , input                                            cache_req_critical_i
-   , input                                            cache_req_complete_i
+   , input                                            cache_req_last_i
    , input                                            cache_req_credits_full_i
    , input                                            cache_req_credits_empty_i
 
@@ -161,7 +161,7 @@ module bp_fe_icache
     & (~stat_mem_pkt_v_i | stat_mem_pkt_yumi_o)
     & (~tag_mem_pkt_v_i | tag_mem_pkt_yumi_o)
     & (~data_mem_pkt_v_i | data_mem_pkt_yumi_o);
-  wire complete_recv = cache_req_complete_i
+  wire complete_recv = cache_req_last_i
     & (~stat_mem_pkt_v_i | stat_mem_pkt_yumi_o)
     & (~tag_mem_pkt_v_i | tag_mem_pkt_yumi_o)
     & (~data_mem_pkt_v_i | data_mem_pkt_yumi_o);

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -107,6 +107,7 @@ module bp_fe_icache
    , input                                            cache_req_busy_i
    , output logic [icache_req_metadata_width_lp-1:0]  cache_req_metadata_o
    , output logic                                     cache_req_metadata_v_o
+   , input [paddr_width_p-1:0]                        cache_req_addr_i
    , input                                            cache_req_critical_i
    , input                                            cache_req_complete_i
    , input                                            cache_req_credits_full_i

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -103,7 +103,7 @@ module bp_fe_icache
    //   configurations which support that behavior
    , output logic [icache_req_width_lp-1:0]           cache_req_o
    , output logic                                     cache_req_v_o
-   , input                                            cache_req_ready_and_i
+   , input                                            cache_req_yumi_i
    , input                                            cache_req_busy_i
    , output logic [icache_req_metadata_width_lp-1:0]  cache_req_metadata_o
    , output logic                                     cache_req_metadata_v_o
@@ -505,7 +505,7 @@ module bp_fe_icache
      };
 
   // The cache pipeline is designed to always send metadata a cycle after the request
-  wire cache_req_metadata_v = cache_req_ready_and_i & cache_req_v_o;
+  wire cache_req_metadata_v = cache_req_yumi_i & cache_req_v_o;
   bsg_dff_reset
    #(.width_p(1))
    cache_req_v_reg
@@ -538,7 +538,7 @@ module bp_fe_icache
   /////////////////////////////////////////////////////////////////////////////
   always_comb
     case (state_r)
-      e_ready  : state_n = (cache_req_ready_and_i & cache_req_v_o) ? e_miss : e_ready;
+      e_ready  : state_n = cache_req_yumi_i ? e_miss : e_ready;
       e_miss   : state_n = cache_req_complete_i ? e_recover: e_miss;
       // e_recover:
       default  : state_n = e_ready;

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -37,7 +37,7 @@ module bp_fe_top
    , output logic                                     cache_req_metadata_v_o
    , input [paddr_width_p-1:0]                        cache_req_addr_i
    , input                                            cache_req_critical_i
-   , input                                            cache_req_complete_i
+   , input                                            cache_req_last_i
    , input                                            cache_req_credits_full_i
    , input                                            cache_req_credits_empty_i
 
@@ -257,7 +257,7 @@ module bp_fe_top
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
      ,.cache_req_addr_i(cache_req_addr_i)
      ,.cache_req_critical_i(cache_req_critical_i)
-     ,.cache_req_complete_i(cache_req_complete_i)
+     ,.cache_req_last_i(cache_req_last_i)
      ,.cache_req_credits_full_i(cache_req_credits_full_i)
      ,.cache_req_credits_empty_i(cache_req_credits_empty_i)
 

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -31,7 +31,7 @@ module bp_fe_top
 
    , output logic [icache_req_width_lp-1:0]           cache_req_o
    , output logic                                     cache_req_v_o
-   , input                                            cache_req_ready_and_i
+   , input                                            cache_req_yumi_i
    , input                                            cache_req_busy_i
    , output logic [icache_req_metadata_width_lp-1:0]  cache_req_metadata_o
    , output logic                                     cache_req_metadata_v_o
@@ -251,7 +251,7 @@ module bp_fe_top
 
      ,.cache_req_o(cache_req_o)
      ,.cache_req_v_o(cache_req_v_o)
-     ,.cache_req_ready_and_i(cache_req_ready_and_i)
+     ,.cache_req_yumi_i(cache_req_yumi_i)
      ,.cache_req_busy_i(cache_req_busy_i)
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -35,6 +35,7 @@ module bp_fe_top
    , input                                            cache_req_busy_i
    , output logic [icache_req_metadata_width_lp-1:0]  cache_req_metadata_o
    , output logic                                     cache_req_metadata_v_o
+   , input [paddr_width_p-1:0]                        cache_req_addr_i
    , input                                            cache_req_critical_i
    , input                                            cache_req_complete_i
    , input                                            cache_req_credits_full_i
@@ -254,6 +255,7 @@ module bp_fe_top
      ,.cache_req_busy_i(cache_req_busy_i)
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
+     ,.cache_req_addr_i(cache_req_addr_i)
      ,.cache_req_critical_i(cache_req_critical_i)
      ,.cache_req_complete_i(cache_req_complete_i)
      ,.cache_req_credits_full_i(cache_req_credits_full_i)

--- a/bp_fe/test/common/bp_fe_nonsynth_icache_tracer.sv
+++ b/bp_fe/test/common/bp_fe_nonsynth_icache_tracer.sv
@@ -41,7 +41,7 @@ module bp_fe_nonsynth_icache_tracer
    , input [cache_req_metadata_width_lp-1:0]              cache_req_metadata_o
    , input                                                cache_req_metadata_v_o
    , input                                                cache_req_critical_i
-   , input                                                cache_req_complete_i
+   , input                                                cache_req_last_i
    // Unused
    , input                                                cache_req_credits_full_i
    , input                                                cache_req_credits_empty_i
@@ -147,8 +147,8 @@ module bp_fe_nonsynth_icache_tracer
       if (cache_req_critical_i)
         $fwrite(file, "%12t | cache_req_critical_i raised\n", $time);
 
-      if (cache_req_complete_i)
-        $fwrite(file, "%12t | cache_req_complete_i raised\n", $time);
+      if (cache_req_last_i)
+        $fwrite(file, "%12t | cache_req_last_i raised\n", $time);
     end
 
 endmodule

--- a/bp_fe/test/common/bp_fe_nonsynth_icache_tracer.sv
+++ b/bp_fe/test/common/bp_fe_nonsynth_icache_tracer.sv
@@ -36,7 +36,7 @@ module bp_fe_nonsynth_icache_tracer
 
    , input [cache_req_width_lp-1:0]                       cache_req_o
    , input                                                cache_req_v_o
-   , input                                                cache_req_ready_and_i
+   , input                                                cache_req_yumi_i
    , input                                                cache_req_busy_i
    , input [cache_req_metadata_width_lp-1:0]              cache_req_metadata_o
    , input                                                cache_req_metadata_v_o
@@ -138,7 +138,7 @@ module bp_fe_nonsynth_icache_tracer
       if (spec_v_o)
         $fwrite(file, "%12t | spec miss: [%x]\n", $time, paddr_tv_r);
 
-      if (cache_req_ready_and_i & cache_req_v_o)
+      if (cache_req_yumi_i)
         $fwrite(file, "%12t | cache_req: %p\n", $time, cache_req_cast_o);
 
       if (cache_req_metadata_v_o)

--- a/bp_fe/test/tb/bp_fe_icache/testbench.sv
+++ b/bp_fe/test/tb/bp_fe_icache/testbench.sv
@@ -315,7 +315,7 @@ module testbench
           ,.lce_resp_v_i(lce_resp_v_o)
           ,.lce_resp_ready_and_i(lce_resp_ready_and_i)
 
-          ,.cache_req_complete_i(cache_req_complete_o)
+          ,.cache_req_last_i(cache_req_last_o)
           ,.uc_store_req_complete_i(uc_store_req_complete_lo)
           );
 

--- a/bp_fe/test/tb/bp_fe_icache/testbench.sv
+++ b/bp_fe/test/tb/bp_fe_icache/testbench.sv
@@ -316,7 +316,6 @@ module testbench
           ,.lce_resp_ready_and_i(lce_resp_ready_and_i)
 
           ,.cache_req_last_i(cache_req_last_o)
-          ,.uc_store_req_complete_i(uc_store_req_complete_lo)
           );
 
     bind bp_cce_fsm

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -58,7 +58,7 @@ module wrapper
   logic [icache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
   logic cache_req_metadata_v_lo;
   logic [paddr_width_p-1:0] cache_req_addr_li;
-  logic cache_req_critical_li, cache_req_complete_li;
+  logic cache_req_critical_li, cache_req_last_li;
   logic cache_req_credits_full_li, cache_req_credits_empty_li;
 
   // Fill Interfaces
@@ -132,7 +132,7 @@ module wrapper
      ,.cache_req_metadata_v_o(cache_req_metadata_v_lo)
      ,.cache_req_addr_i(cache_req_addr_li)
      ,.cache_req_critical_i(cache_req_critical_li)
-     ,.cache_req_complete_i(cache_req_complete_li)
+     ,.cache_req_last_i(cache_req_last_li)
      ,.cache_req_credits_full_i(cache_req_credits_full_li)
      ,.cache_req_credits_empty_i(cache_req_credits_empty_li)
 
@@ -201,7 +201,7 @@ module wrapper
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
        ,.cache_req_addr_o(cache_req_addr_li)
        ,.cache_req_critical_o(cache_req_critical_li)
-       ,.cache_req_complete_o(cache_req_complete_li)
+       ,.cache_req_last_o(cache_req_last_li)
        ,.cache_req_credits_full_o(cache_req_credits_full_li)
        ,.cache_req_credits_empty_o(cache_req_credits_empty_li)
 
@@ -311,7 +311,7 @@ module wrapper
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
        ,.cache_req_addr_o(cache_req_addr_li)
        ,.cache_req_critical_o(cache_req_critical_li)
-       ,.cache_req_complete_o(cache_req_complete_li)
+       ,.cache_req_last_o(cache_req_last_li)
        ,.cache_req_credits_full_o(cache_req_credits_full_li)
        ,.cache_req_credits_empty_o(cache_req_credits_empty_li)
 

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -52,7 +52,7 @@ module wrapper
 
   // I$-LCE Interface signals
   // Miss, Management Interfaces
-  logic cache_req_ready_and_li, cache_req_busy_li;
+  logic cache_req_yumi_li, cache_req_busy_li;
   logic [icache_req_width_lp-1:0] cache_req_lo;
   logic cache_req_v_lo;
   logic [icache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
@@ -126,7 +126,7 @@ module wrapper
 
      ,.cache_req_o(cache_req_lo)
      ,.cache_req_v_o(cache_req_v_lo)
-     ,.cache_req_ready_and_i(cache_req_ready_and_li)
+     ,.cache_req_yumi_i(cache_req_yumi_li)
      ,.cache_req_busy_i(cache_req_busy_li)
      ,.cache_req_metadata_o(cache_req_metadata_lo)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_lo)
@@ -195,7 +195,7 @@ module wrapper
 
        ,.cache_req_v_i(cache_req_v_lo)
        ,.cache_req_i(cache_req_lo)
-       ,.cache_req_ready_and_o(cache_req_ready_and_li)
+       ,.cache_req_yumi_o(cache_req_yumi_li)
        ,.cache_req_busy_o(cache_req_busy_li)
        ,.cache_req_metadata_i(cache_req_metadata_lo)
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
@@ -305,7 +305,7 @@ module wrapper
 
        ,.cache_req_i(cache_req_lo)
        ,.cache_req_v_i(cache_req_v_lo)
-       ,.cache_req_ready_and_o(cache_req_ready_and_li)
+       ,.cache_req_yumi_o(cache_req_yumi_li)
        ,.cache_req_busy_o(cache_req_busy_li)
        ,.cache_req_metadata_i(cache_req_metadata_lo)
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -57,6 +57,7 @@ module wrapper
   logic cache_req_v_lo;
   logic [icache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
   logic cache_req_metadata_v_lo;
+  logic [paddr_width_p-1:0] cache_req_addr_li;
   logic cache_req_critical_li, cache_req_complete_li;
   logic cache_req_credits_full_li, cache_req_credits_empty_li;
 
@@ -129,6 +130,7 @@ module wrapper
      ,.cache_req_busy_i(cache_req_busy_li)
      ,.cache_req_metadata_o(cache_req_metadata_lo)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_lo)
+     ,.cache_req_addr_i(cache_req_addr_li)
      ,.cache_req_critical_i(cache_req_critical_li)
      ,.cache_req_complete_i(cache_req_complete_li)
      ,.cache_req_credits_full_i(cache_req_credits_full_li)
@@ -197,6 +199,7 @@ module wrapper
        ,.cache_req_busy_o(cache_req_busy_li)
        ,.cache_req_metadata_i(cache_req_metadata_lo)
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
+       ,.cache_req_addr_o(cache_req_addr_li)
        ,.cache_req_critical_o(cache_req_critical_li)
        ,.cache_req_complete_o(cache_req_complete_li)
        ,.cache_req_credits_full_o(cache_req_credits_full_li)
@@ -306,6 +309,7 @@ module wrapper
        ,.cache_req_busy_o(cache_req_busy_li)
        ,.cache_req_metadata_i(cache_req_metadata_lo)
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
+       ,.cache_req_addr_o(cache_req_addr_li)
        ,.cache_req_critical_o(cache_req_critical_li)
        ,.cache_req_complete_o(cache_req_complete_li)
        ,.cache_req_credits_full_o(cache_req_credits_full_li)

--- a/bp_me/src/v/cce/bp_cce_msg.sv
+++ b/bp_me/src/v/cce/bp_cce_msg.sv
@@ -161,12 +161,6 @@ module bp_cce_msg
   bp_cce_mshr_s mshr;
   assign mshr = mshr_i;
 
-  // address mask for bedrock data width aligned, critical word first operations
-  wire [paddr_width_p-1:0] addr_bedrock_mask =
-    {{(paddr_width_p-lg_bedrock_data_bytes_lp){1'b1}}
-     , {(lg_bedrock_data_bytes_lp){1'b0}}
-    };
-
   // address mask for block-aligned operations
   wire [paddr_width_p-1:0] addr_block_mask =
     {{(paddr_width_p-lg_block_size_in_bytes_lp){1'b1}}
@@ -767,7 +761,7 @@ module bp_cce_msg
               // cached read - send single beat, no data
               e_bedrock_mem_rd: begin
                 mem_fwd_v_o = ~mem_credits_empty;
-                mem_fwd_header_cast_o.addr = addr_i & addr_bedrock_mask;
+                mem_fwd_header_cast_o.addr = addr_i;
                 // set uncached bit based on uncached flag in MSHR
                 // this bit indicates if the LCE should receive the data as cached or uncached
                 // when it returns from memory
@@ -800,7 +794,7 @@ module bp_cce_msg
                 // patch through data
                 mem_fwd_data_o = lce_resp_data_i;
 
-                mem_fwd_header_cast_o.addr = addr_i & addr_bedrock_mask;
+                mem_fwd_header_cast_o.addr = addr_i;
                 // set uncached bit based on uncached flag in MSHR
                 // this bit indicates if the LCE should receive the data as cached or uncached
                 // when it returns from memory
@@ -843,7 +837,7 @@ module bp_cce_msg
             // defaults provided here, but may be overridden below
             lce_cmd_header_cast_o.payload.dst_id = lce_i;
             lce_cmd_header_cast_o.msg_type.cmd = decoded_inst_i.lce_cmd;
-            lce_cmd_header_cast_o.addr = addr_i & addr_bedrock_mask;
+            lce_cmd_header_cast_o.addr = addr_i;
             lce_cmd_data_o = mem_rev_data_i;
 
             if (decoded_inst_i.pushq_custom) begin

--- a/bp_me/src/v/cce/bp_uce.sv
+++ b/bp_me/src/v/cce/bp_uce.sv
@@ -34,7 +34,7 @@ module bp_uce
 
     , input [cache_req_width_lp-1:0]                 cache_req_i
     , input                                          cache_req_v_i
-    , output logic                                   cache_req_ready_and_o
+    , output logic                                   cache_req_yumi_o
     , output logic                                   cache_req_busy_o
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
@@ -151,7 +151,7 @@ module bp_uce
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.set_i(cache_req_ready_and_o & cache_req_v_i)
+     ,.set_i(cache_req_yumi_o)
      ,.clear_i(cache_req_done)
      ,.data_o(cache_req_v_r)
      );
@@ -163,7 +163,7 @@ module bp_uce
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.en_i(cache_req_ready_and_o & cache_req_v_i)
+     ,.en_i(cache_req_yumi_o)
      ,.data_i(cache_req_cast_i)
      ,.data_o(cache_req_r)
      );
@@ -409,7 +409,7 @@ module bp_uce
   assign cache_req_busy_o = is_reset | is_init;
   always_comb
     begin
-      cache_req_ready_and_o = '0;
+      cache_req_yumi_o = '0;
 
       index_up = '0;
       way_up   = '0;
@@ -538,9 +538,9 @@ module bp_uce
               end
 
             // We can accept a new request as long as we send out an old one this cycle
-            cache_req_ready_and_o = ~cache_req_v_r | cache_req_done;
+            cache_req_yumi_o = cache_req_v_i & (~cache_req_v_r | cache_req_done);
 
-            state_n = (cache_req_ready_and_o & cache_req_v_i)
+            state_n = cache_req_yumi_o
                       ? flush_v_li
                         ? e_flush_read
                         : clear_v_li

--- a/bp_me/src/v/cce/bp_uce.sv
+++ b/bp_me/src/v/cce/bp_uce.sv
@@ -40,7 +40,7 @@ module bp_uce
     , input                                          cache_req_metadata_v_i
     , output logic [paddr_width_p-1:0]               cache_req_addr_o
     , output logic                                   cache_req_critical_o
-    , output logic                                   cache_req_complete_o
+    , output logic                                   cache_req_last_o
     , output logic                                   cache_req_credits_full_o
     , output logic                                   cache_req_credits_empty_o
 
@@ -419,7 +419,7 @@ module bp_uce
       stat_mem_pkt_v_o    = '0;
 
       cache_req_done = '0;
-      cache_req_complete_o = '0;
+      cache_req_last_o = '0;
 
       fsm_fwd_header_lo = '0;
       fsm_fwd_data_lo = '0;
@@ -448,7 +448,7 @@ module bp_uce
             index_up = tag_mem_pkt_yumi_i & stat_mem_pkt_yumi_i;
 
             cache_req_done = (index_done & index_up);
-            cache_req_complete_o = is_clear & cache_req_done;
+            cache_req_last_o = is_clear & cache_req_done;
 
             state_n = cache_req_done ? e_ready : state_r;
           end
@@ -524,9 +524,9 @@ module bp_uce
         e_flush_fence:
           begin
             cache_req_done = (credit_count_lo == '0);
-            cache_req_complete_o = cache_req_done;
+            cache_req_last_o = cache_req_done;
 
-            state_n = cache_req_complete_o ? e_ready : state_r;
+            state_n = cache_req_last_o ? e_ready : state_r;
           end
 
         e_ready:
@@ -667,8 +667,8 @@ module bp_uce
             data_mem_pkt_v_o = load_resp_v_li;
 
             load_resp_yumi_lo = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
-            cache_req_complete_o = load_resp_v_li & fsm_rev_last_li;
-            cache_req_done = load_resp_yumi_lo & cache_req_complete_o;
+            cache_req_last_o = load_resp_v_li & fsm_rev_last_li;
+            cache_req_done = load_resp_yumi_lo & cache_req_last_o;
 
             state_n = cache_req_done ? e_writeback_write_req : e_writeback_read_req;
           end
@@ -704,8 +704,8 @@ module bp_uce
             data_mem_pkt_v_o = load_resp_v_li;
 
             load_resp_yumi_lo = tag_mem_pkt_yumi_i & data_mem_pkt_yumi_i;
-            cache_req_complete_o = load_resp_v_li & fsm_rev_last_li;
-            cache_req_done = cache_req_complete_o & load_resp_yumi_lo;
+            cache_req_last_o = load_resp_v_li & fsm_rev_last_li;
+            cache_req_done = cache_req_last_o & load_resp_yumi_lo;
 
             state_n = cache_req_done ? e_ready : e_read_wait;
           end
@@ -717,8 +717,8 @@ module bp_uce
             data_mem_pkt_v_o = load_resp_v_li;
 
             load_resp_yumi_lo = data_mem_pkt_yumi_i;
-            cache_req_complete_o = load_resp_v_li & fsm_rev_last_li;
-            cache_req_done = cache_req_complete_o & load_resp_yumi_lo;
+            cache_req_last_o = load_resp_v_li & fsm_rev_last_li;
+            cache_req_done = cache_req_last_o & load_resp_yumi_lo;
 
             state_n = cache_req_done ? e_ready : e_uc_read_wait;
           end

--- a/bp_me/src/v/cce/bp_uce.sv
+++ b/bp_me/src/v/cce/bp_uce.sv
@@ -39,6 +39,7 @@ module bp_uce
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
     , output logic                                   cache_req_critical_o
+    , output logic [paddr_width_p-1:0]               cache_req_addr_o
     , output logic                                   cache_req_complete_o
     , output logic                                   cache_req_credits_full_o
     , output logic                                   cache_req_credits_empty_o
@@ -379,6 +380,7 @@ module bp_uce
      );
 
   assign cache_req_critical_o = load_resp_v_li & fsm_rev_v_li & fsm_rev_critical_li;
+  assign cache_req_addr_o = fsm_rev_header_li.addr;
 
   bp_cache_req_wr_subop_e cache_wr_subop;
   bp_bedrock_wr_subop_e mem_wr_subop;
@@ -587,7 +589,7 @@ module bp_uce
           if (miss_v_r)
             begin
               fsm_fwd_header_lo.msg_type = e_bedrock_mem_rd;
-              fsm_fwd_header_lo.addr     = {cache_req_r.addr[paddr_width_p-1:fill_offset_width_lp], {fill_offset_width_lp{1'b0}}};
+              fsm_fwd_header_lo.addr     = cache_req_r.addr;
               fsm_fwd_header_lo.size     = block_msg_size_lp;
               fsm_fwd_header_lo.payload.way_id = lce_assoc_p'(cache_req_metadata_r.hit_or_repl_way);
               fsm_fwd_header_lo.payload.lce_id = lce_id_i;

--- a/bp_me/src/v/dev/bp_me_cce_to_cache.sv
+++ b/bp_me/src/v/dev/bp_me_cce_to_cache.sv
@@ -409,8 +409,8 @@ module bp_me_cce_to_cache
   // synopsys translate_off
   always_ff @(negedge clk_i)
     begin
-      assert(reset_i !== '0
-             || ~(fsm_fwd_v_li & fsm_fwd_header_li.msg_type inside {e_bedrock_mem_wr, e_bedrock_mem_uc_wr})
+      assert(reset_i !== '0 || ~fsm_fwd_v_li
+             || ~(fsm_fwd_header_li.msg_type inside {e_bedrock_mem_wr, e_bedrock_mem_uc_wr})
              || ~(fsm_fwd_header_li.subop inside {e_bedrock_amolr, e_bedrock_amosc})
              )
           else $error("LR/SC not supported in bsg_cache");

--- a/bp_me/src/v/lce/bp_lce.sv
+++ b/bp_me/src/v/lce/bp_lce.sv
@@ -50,7 +50,7 @@ module bp_lce
     // can arrive, as indicated by the metadata_v_i signal
     , input [cache_req_width_lp-1:0]                 cache_req_i
     , input                                          cache_req_v_i
-    , output logic                                   cache_req_ready_and_o
+    , output logic                                   cache_req_yumi_o
     , output logic                                   cache_req_busy_o
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
@@ -155,7 +155,7 @@ module bp_lce
 
      ,.cache_req_i(cache_req_i)
      ,.cache_req_v_i(cache_req_v_i)
-     ,.cache_req_ready_and_o(cache_req_ready_and_o)
+     ,.cache_req_yumi_o(cache_req_yumi_o)
      ,.cache_req_metadata_i(cache_req_metadata_i)
      ,.cache_req_metadata_v_i(cache_req_metadata_v_i)
      ,.cache_req_complete_i(cache_req_complete_o)
@@ -309,7 +309,7 @@ module bp_lce
   // - LCE Request module is ready to accept a request (does not account for a free credit)
   // - timout signal is low, indicating LCE isn't blocked on using data/tag/stat mem
   // This signal acts as a hint to the cache that the LCE is not ready for a request.
-  // The cache_req_ready_and_o signal actually controls whether the LCE accepts a request.
+  // The cache_req_yumi_o signal actually controls whether the LCE accepts a request.
   assign cache_req_busy_o = timeout | req_busy_lo;
 
 endmodule

--- a/bp_me/src/v/lce/bp_lce.sv
+++ b/bp_me/src/v/lce/bp_lce.sv
@@ -54,6 +54,7 @@ module bp_lce
     , output logic                                   cache_req_busy_o
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
+    , output logic [paddr_width_p-1:0]               cache_req_addr_o
     , output logic                                   cache_req_critical_o
     , output logic                                   cache_req_complete_o
     , output logic                                   cache_req_credits_full_o
@@ -240,8 +241,9 @@ module bp_lce
 
      ,.cache_init_done_o(cache_init_done_lo)
      ,.sync_done_o(sync_done_lo)
-     ,.cache_req_complete_o(cache_req_complete_o)
+     ,.cache_req_addr_o(cache_req_addr_o)
      ,.cache_req_critical_o(cache_req_critical_o)
+     ,.cache_req_complete_o(cache_req_complete_o)
      ,.uc_store_req_complete_o(uc_store_req_complete_lo)
 
      ,.data_mem_pkt_o(data_mem_pkt_o)

--- a/bp_me/src/v/lce/bp_lce.sv
+++ b/bp_me/src/v/lce/bp_lce.sv
@@ -129,6 +129,7 @@ module bp_lce
   // LCE Request Module
   logic req_busy_lo;
   logic credit_return_lo;
+  logic cache_req_done_lo;
   logic backoff_lo;
   logic sync_done_lo;
   logic cache_init_done_lo;
@@ -162,6 +163,7 @@ module bp_lce
      ,.credits_full_o(cache_req_credits_full_o)
      ,.credits_empty_o(cache_req_credits_empty_o)
      ,.credit_return_i(credit_return_lo)
+     ,.cache_req_done_i(cache_req_done_lo)
      ,.backoff_o(backoff_lo)
 
      ,.lce_req_header_o(lce_req_header_o)
@@ -245,6 +247,7 @@ module bp_lce
      ,.cache_req_critical_o(cache_req_critical_o)
      ,.cache_req_complete_o(cache_req_complete_o)
      ,.credit_return_o(credit_return_lo)
+     ,.cache_req_done_o(cache_req_done_lo)
      ,.backoff_i(backoff_lo)
 
      ,.data_mem_pkt_o(data_mem_pkt_o)

--- a/bp_me/src/v/lce/bp_lce.sv
+++ b/bp_me/src/v/lce/bp_lce.sv
@@ -128,7 +128,8 @@ module bp_lce
 
   // LCE Request Module
   logic req_busy_lo;
-  logic uc_store_req_complete_lo;
+  logic credit_return_lo;
+  logic backoff_lo;
   logic sync_done_lo;
   logic cache_init_done_lo;
   bp_lce_req
@@ -158,11 +159,10 @@ module bp_lce
      ,.cache_req_yumi_o(cache_req_yumi_o)
      ,.cache_req_metadata_i(cache_req_metadata_i)
      ,.cache_req_metadata_v_i(cache_req_metadata_v_i)
-     ,.cache_req_complete_i(cache_req_complete_o)
      ,.credits_full_o(cache_req_credits_full_o)
      ,.credits_empty_o(cache_req_credits_empty_o)
-
-     ,.uc_store_req_complete_i(uc_store_req_complete_lo)
+     ,.credit_return_i(credit_return_lo)
+     ,.backoff_o(backoff_lo)
 
      ,.lce_req_header_o(lce_req_header_o)
      ,.lce_req_data_o(lce_req_data_o)
@@ -244,7 +244,8 @@ module bp_lce
      ,.cache_req_addr_o(cache_req_addr_o)
      ,.cache_req_critical_o(cache_req_critical_o)
      ,.cache_req_complete_o(cache_req_complete_o)
-     ,.uc_store_req_complete_o(uc_store_req_complete_lo)
+     ,.credit_return_o(credit_return_lo)
+     ,.backoff_i(backoff_lo)
 
      ,.data_mem_pkt_o(data_mem_pkt_o)
      ,.data_mem_pkt_v_o(data_mem_pkt_v_o)

--- a/bp_me/src/v/lce/bp_lce.sv
+++ b/bp_me/src/v/lce/bp_lce.sv
@@ -56,7 +56,7 @@ module bp_lce
     , input                                          cache_req_metadata_v_i
     , output logic [paddr_width_p-1:0]               cache_req_addr_o
     , output logic                                   cache_req_critical_o
-    , output logic                                   cache_req_complete_o
+    , output logic                                   cache_req_last_o
     , output logic                                   cache_req_credits_full_o
     , output logic                                   cache_req_credits_empty_o
 
@@ -245,7 +245,7 @@ module bp_lce
      ,.sync_done_o(sync_done_lo)
      ,.cache_req_addr_o(cache_req_addr_o)
      ,.cache_req_critical_o(cache_req_critical_o)
-     ,.cache_req_complete_o(cache_req_complete_o)
+     ,.cache_req_last_o(cache_req_last_o)
      ,.credit_return_o(credit_return_lo)
      ,.cache_req_done_o(cache_req_done_lo)
      ,.backoff_i(backoff_lo)

--- a/bp_me/src/v/lce/bp_lce.sv
+++ b/bp_me/src/v/lce/bp_lce.sv
@@ -314,7 +314,7 @@ module bp_lce
   // - timout signal is low, indicating LCE isn't blocked on using data/tag/stat mem
   // This signal acts as a hint to the cache that the LCE is not ready for a request.
   // The cache_req_yumi_o signal actually controls whether the LCE accepts a request.
-  assign cache_req_busy_o = timeout | req_busy_lo;
+  assign cache_req_busy_o = timeout | req_busy_lo | ~cache_init_done_lo;
 
 endmodule
 

--- a/bp_me/src/v/lce/bp_lce_cmd.sv
+++ b/bp_me/src/v/lce/bp_lce_cmd.sv
@@ -59,10 +59,10 @@ module bp_lce_cmd
 
     // request complete signals
     // cached requests and uncached loads block in the caches, but uncached stores do not
-    // cache_req_complete_o is routed to the cache to indicate a blocking request is complete
+    // cache_req_last_o is routed to the cache to indicate a blocking request is complete
     , output logic [paddr_width_p-1:0]               cache_req_addr_o
     , output logic                                   cache_req_critical_o
-    , output logic                                   cache_req_complete_o
+    , output logic                                   cache_req_last_o
 
     // uncached store request complete is used by the LCE to decrement the request credit counter
     // when an uncached store complete, but is not routed to the cache because the caches do not
@@ -335,7 +335,7 @@ module bp_lce_cmd
     credit_return_o = '0;
     cache_req_done_o = '0;
     // raised request is fully resolved
-    cache_req_complete_o = 1'b0;
+    cache_req_last_o = 1'b0;
     cache_req_critical_o = 1'b0;
     cache_req_addr_o = fsm_cmd_header_li.addr;
 
@@ -526,8 +526,8 @@ module bp_lce_cmd
 
             // raise request complete signal when data consumed
             cache_req_critical_o = fsm_cmd_v_li & fsm_cmd_critical_li;
-            cache_req_complete_o = cache_req_critical_o;
-            cache_req_done_o = fsm_cmd_yumi_lo & cache_req_complete_o;
+            cache_req_last_o = cache_req_critical_o;
+            cache_req_done_o = fsm_cmd_yumi_lo & cache_req_last_o;
             credit_return_o = cache_req_done_o;
           end
 
@@ -702,8 +702,8 @@ module bp_lce_cmd
         fsm_resp_v_lo = 1'b1;
 
         // cache request is complete when coherence ack sends
-        cache_req_complete_o = fsm_resp_v_lo & fsm_resp_last_lo;
-        cache_req_done_o = fsm_resp_yumi_li & cache_req_complete_o;
+        cache_req_last_o = fsm_resp_v_lo & fsm_resp_last_lo;
+        cache_req_done_o = fsm_resp_yumi_li & cache_req_last_o;
         credit_return_o = cache_req_done_o;
 
         state_n = credit_return_o ? e_ready : state_r;

--- a/bp_me/src/v/lce/bp_lce_req.sv
+++ b/bp_me/src/v/lce/bp_lce_req.sv
@@ -181,10 +181,6 @@ module bp_lce_req
   assign credits_full_o  =  cache_req_v_r && (credit_count_lo == credits_p);
   assign credits_empty_o = ~cache_req_v_r && (credit_count_lo == '0);
 
-  // align request address to BedRock data channel width for sending critical beat address
-  // note: if fill width != bedrock data width, this may be incorrect
-  wire [paddr_width_p-1:0] critical_req_addr = (cache_req_r.addr & req_addr_mask);
-
   // Request Address to CCE
   logic [cce_id_width_p-1:0] req_cce_id_lo;
   bp_me_addr_to_cce_id
@@ -280,8 +276,7 @@ module bp_lce_req
           e_miss_load: begin
             fsm_req_v_lo = cache_req_v_r & (credit_count_lo < credits_p);
             fsm_req_header_lo.size = bp_bedrock_msg_size_e'(cache_req_r.size);
-            // align address to data width and send address of critical beat
-            fsm_req_header_lo.addr = critical_req_addr;
+            fsm_req_header_lo.addr = cache_req_r.addr;
             fsm_req_header_lo.msg_type.req = e_bedrock_req_rd_miss;
             fsm_req_header_lo.payload.lru_way_id = lce_assoc_width_p'(cache_req_metadata_r.hit_or_repl_way);
             fsm_req_header_lo.payload.non_exclusive = (non_excl_reads_p == 1)
@@ -292,8 +287,7 @@ module bp_lce_req
           e_miss_store: begin
             fsm_req_v_lo = cache_req_v_r & (credit_count_lo < credits_p);
             fsm_req_header_lo.size = bp_bedrock_msg_size_e'(cache_req_r.size);
-            // align address to data width and send address of critical beat
-            fsm_req_header_lo.addr = critical_req_addr;
+            fsm_req_header_lo.addr = cache_req_r.addr;
             fsm_req_header_lo.msg_type.req = e_bedrock_req_wr_miss;
             fsm_req_header_lo.payload.lru_way_id = lce_assoc_width_p'(cache_req_metadata_r.hit_or_repl_way);
             fsm_req_header_lo.payload.non_exclusive = e_bedrock_req_excl;

--- a/bp_me/src/v/lce/bp_lce_req.sv
+++ b/bp_me/src/v/lce/bp_lce_req.sv
@@ -61,7 +61,7 @@ module bp_lce_req
     // can arrive, as indicated by the metadata_v_i signal
     , input [cache_req_width_lp-1:0]                 cache_req_i
     , input                                          cache_req_v_i
-    , output logic                                   cache_req_ready_and_o
+    , output logic                                   cache_req_yumi_o
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
 
@@ -104,7 +104,7 @@ module bp_lce_req
    cache_req_v_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
-     ,.set_i(cache_req_ready_and_o & cache_req_v_i)
+     ,.set_i(cache_req_yumi_o & cache_req_v_i)
      ,.clear_i(req_sent)
      ,.data_o(cache_req_v_r)
      );
@@ -114,7 +114,7 @@ module bp_lce_req
    #(.width_p($bits(bp_cache_req_s)))
    req_reg
     (.clk_i(clk_i)
-     ,.en_i(cache_req_ready_and_o & cache_req_v_i)
+     ,.en_i(cache_req_yumi_o & cache_req_v_i)
      ,.data_i(cache_req_i)
      ,.data_o(cache_req_r)
      );
@@ -205,11 +205,11 @@ module bp_lce_req
 
   // LCE should suppress messages if in reset or we are not synchronized with the CCE
   // busy being lower does not guarantee that this module will accept a valid cache request
-  // packet (refer to cache_req_ready_and_o below).
+  // packet (refer to cache_req_yumi_o below).
   assign busy_o = is_reset || (~sync_done_i && (lce_mode_i == e_lce_mode_normal));
 
   // consume cache request if the previous request has been issued or is being issued in the current cycle
-  assign cache_req_ready_and_o = (~cache_req_v_r | (cache_req_v_r & req_sent));
+  assign cache_req_yumi_o = cache_req_v_i & (~cache_req_v_r | (cache_req_v_r & req_sent));
 
   // atomic request subop determination
   bp_bedrock_wr_subop_e req_subop;

--- a/bp_me/src/v/lce/bp_lce_req.sv
+++ b/bp_me/src/v/lce/bp_lce_req.sv
@@ -73,10 +73,8 @@ module bp_lce_req
     // request complete signal from LCE Cmd module - Cached Load/Store and Uncached Load
     // this signal is raised exactly once, for a single cycle, per request completing, and it
     // can be raised at any time after the LCE request sends out
-    , input                                          cache_req_complete_i
-
-    // Uncached Store request complete signal
-    , input                                          uc_store_req_complete_i
+    , input                                          credit_return_i
+    , output logic                                   backoff_o
 
     // LCE-CCE Interface
     // BedRock Burst protocol: ready&valid
@@ -98,14 +96,14 @@ module bp_lce_req
   // set over clear because new request can be captured same cycle existing request sends
   // cache_req_v_r indicates if a valid request is in the buffer
   logic cache_req_v_r;
-  logic req_sent;
+  logic req_done;
   bsg_dff_reset_set_clear
    #(.width_p(1))
    cache_req_v_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
      ,.set_i(cache_req_yumi_o & cache_req_v_i)
-     ,.clear_i(req_sent)
+     ,.clear_i(req_done)
      ,.data_o(cache_req_v_r)
      );
 
@@ -162,12 +160,20 @@ module bp_lce_req
      ,.fsm_last_o(fsm_req_last_lo)
      );
 
+  wire miss_load_v_r  = cache_req_v_r & cache_req_r.msg_type inside {e_miss_load};
+  wire miss_store_v_r = cache_req_v_r & cache_req_r.msg_type inside {e_miss_store};
+  wire miss_v_r       = cache_req_v_r & miss_load_v_r | miss_store_v_r;
+  wire uc_store_v_r   = cache_req_v_r & cache_req_r.msg_type inside {e_uc_store};
+  wire uc_load_v_r    = cache_req_v_r & cache_req_r.msg_type inside {e_uc_load};
+  wire uc_amo_v_r     = cache_req_v_r & cache_req_r.msg_type inside {e_uc_amo};
+  wire backoff_v_r    = cache_req_v_r & cache_req_r.msg_type inside {e_cache_backoff};
+
   // Outstanding request credit counter
   // one credit used per LCE request sent
   logic [`BSG_WIDTH(credits_p)-1:0] credit_count_lo;
   wire credit_v_li = fsm_req_v_lo & fsm_req_new_lo;
   wire credit_ready_li = fsm_req_yumi_li;
-  wire credit_returned_li = cache_req_complete_i | uc_store_req_complete_i;
+  wire credit_returned_li = credit_return_i;
   bsg_flow_counter
     #(.els_p(credits_p))
     req_counter
@@ -181,6 +187,22 @@ module bp_lce_req
   assign credits_full_o  =  cache_req_v_r && (credit_count_lo == credits_p);
   assign credits_empty_o = ~cache_req_v_r && (credit_count_lo == '0);
 
+  // Linear backoff
+  localparam lock_max_limit_lp = 7;
+  logic [`BSG_SAFE_CLOG2(lock_max_limit_lp+1)-1:0] lock_cnt_r;
+  wire lock_inc = backoff_v_r || (lock_cnt_r > '0);
+  bsg_counter_clear_up
+   #(.max_val_p(lock_max_limit_lp), .init_val_p(0), .disable_overflow_warning_p(1))
+   lock_counter
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.clear_i('0)
+     ,.up_i(lock_inc)
+     ,.count_o(lock_cnt_r)
+     );
+  assign backoff_o = (lock_cnt_r != '0);
+
   // Request Address to CCE
   logic [cce_id_width_p-1:0] req_cce_id_lo;
   bp_me_addr_to_cce_id
@@ -190,26 +212,10 @@ module bp_lce_req
      ,.cce_id_o(req_cce_id_lo)
      );
 
-  // FSM states
-  typedef enum logic [1:0] {
-    e_reset
-    ,e_ready
-  } lce_req_state_e;
-  lce_req_state_e state_n, state_r;
-
-  wire is_reset = (state_r == e_reset);
-  wire is_ready = (state_r == e_ready);
-
-  // request finishes sending when header sends for no data message or last data sends
-  assign req_sent = fsm_req_yumi_li & fsm_req_last_lo;
-
   // LCE should suppress messages if in reset or we are not synchronized with the CCE
-  // busy being lower does not guarantee that this module will accept a valid cache request
+  // busy being lowered does not guarantee that this module will accept a valid cache request
   // packet (refer to cache_req_yumi_o below).
-  assign busy_o = is_reset || (~sync_done_i && (lce_mode_i == e_lce_mode_normal));
-
-  // consume cache request if the previous request has been issued or is being issued in the current cycle
-  assign cache_req_yumi_o = cache_req_v_i & (~cache_req_v_r | (cache_req_v_r & req_sent));
+  assign busy_o = ~sync_done_i && (lce_mode_i == e_lce_mode_normal);
 
   // atomic request subop determination
   bp_bedrock_wr_subop_e req_subop;
@@ -230,88 +236,36 @@ module bp_lce_req
     endcase
 
   always_comb begin
-    state_n = state_r;
-
-    fsm_req_v_lo = 1'b0;
-
     // Request message defaults
     fsm_req_header_lo = '0;
+    fsm_req_header_lo.addr = cache_req_r.addr;
+    fsm_req_header_lo.size = bp_bedrock_msg_size_e'(cache_req_r.size);
     fsm_req_header_lo.payload.dst_id = req_cce_id_lo;
     fsm_req_header_lo.payload.src_id = lce_id_i;
+    fsm_req_header_lo.payload.lru_way_id = lce_assoc_width_p'(cache_req_metadata_r.hit_or_repl_way);
+    fsm_req_header_lo.payload.non_exclusive =
+      (miss_load_v_r && (non_excl_reads_p == 1)) ? e_bedrock_req_non_excl : e_bedrock_req_excl;
+    fsm_req_header_lo.subop = req_subop;
     fsm_req_data_lo = cache_req_r.data;
 
-    unique case (state_r)
-
-      // LCE Request module stays in reset until the cache has been initialized
-      e_reset: begin
-        state_n = cache_init_done_i ? e_ready : state_r;
-      end
-
-      // Send request header when able
-      // requires valid cache request and possibly valid metadata (cached requests only)
-      e_ready: begin
-        unique case (cache_req_r.msg_type)
-          // TODO: For all supported caches, uncached requests have a single data beat
-          e_uc_store: begin
-            fsm_req_v_lo =  cache_req_v_r & (credit_count_lo < credits_p);
-            fsm_req_header_lo.msg_type.req = e_bedrock_req_uc_wr;
-            fsm_req_header_lo.subop = e_bedrock_store;
-            fsm_req_header_lo.size = bp_bedrock_msg_size_e'(cache_req_r.size);
-            fsm_req_header_lo.addr = cache_req_r.addr;
-          end
-          e_uc_load: begin
-            fsm_req_v_lo = cache_req_v_r & (credit_count_lo < credits_p);
-            fsm_req_header_lo.msg_type.req = e_bedrock_req_uc_rd;
-            fsm_req_header_lo.size = bp_bedrock_msg_size_e'(cache_req_r.size);
-            fsm_req_header_lo.addr = cache_req_r.addr;
-            // no data to send, stay in e_ready
-          end
-          e_uc_amo: begin
-            fsm_req_v_lo = cache_req_v_r & (credit_count_lo < credits_p);
-            fsm_req_header_lo.msg_type.req = e_bedrock_req_uc_amo;
-            fsm_req_header_lo.subop = req_subop;
-            fsm_req_header_lo.size = bp_bedrock_msg_size_e'(cache_req_r.size);
-            fsm_req_header_lo.addr = cache_req_r.addr;
-          end
-          e_miss_load: begin
-            fsm_req_v_lo = cache_req_v_r & (credit_count_lo < credits_p);
-            fsm_req_header_lo.size = bp_bedrock_msg_size_e'(cache_req_r.size);
-            fsm_req_header_lo.addr = cache_req_r.addr;
-            fsm_req_header_lo.msg_type.req = e_bedrock_req_rd_miss;
-            fsm_req_header_lo.payload.lru_way_id = lce_assoc_width_p'(cache_req_metadata_r.hit_or_repl_way);
-            fsm_req_header_lo.payload.non_exclusive = (non_excl_reads_p == 1)
-                                                          ? e_bedrock_req_non_excl
-                                                          : e_bedrock_req_excl;
-            // no data to send, stay in e_ready
-          end
-          e_miss_store: begin
-            fsm_req_v_lo = cache_req_v_r & (credit_count_lo < credits_p);
-            fsm_req_header_lo.size = bp_bedrock_msg_size_e'(cache_req_r.size);
-            fsm_req_header_lo.addr = cache_req_r.addr;
-            fsm_req_header_lo.msg_type.req = e_bedrock_req_wr_miss;
-            fsm_req_header_lo.payload.lru_way_id = lce_assoc_width_p'(cache_req_metadata_r.hit_or_repl_way);
-            fsm_req_header_lo.payload.non_exclusive = e_bedrock_req_excl;
-            // no data to send, stay in e_ready
-          end
-          default: begin
-          end
-        endcase
-      end
-
-      default: begin
-        state_n = e_reset;
-      end
+    fsm_req_v_lo = cache_req_v_r & ~backoff_v_r & (credit_count_lo < credits_p) & cache_init_done_i;
+  
+    // Send request header when able
+    // requires valid cache request and possibly valid metadata (cached requests only)
+    unique case (cache_req_r.msg_type)
+      e_uc_store  : fsm_req_header_lo.msg_type.req = e_bedrock_req_uc_wr;
+      e_uc_load   : fsm_req_header_lo.msg_type.req = e_bedrock_req_uc_rd;
+      e_uc_amo    : fsm_req_header_lo.msg_type.req = e_bedrock_req_uc_amo;
+      e_miss_load : fsm_req_header_lo.msg_type.req = e_bedrock_req_rd_miss;
+      e_miss_store: fsm_req_header_lo.msg_type.req = e_bedrock_req_wr_miss;
+      default: begin end
     endcase
-  end
 
-  // synopsys sync_set_reset "reset_i"
-  always_ff @ (posedge clk_i) begin
-    if (reset_i) begin
-      state_r <= e_reset;
-    end
-    else begin
-      state_r <= state_n;
-    end
+    // request finishes sending when last data sends
+    req_done = backoff_v_r || (fsm_req_yumi_li & fsm_req_last_lo);
+ 
+    // consume cache request if the previous request was issued or is being issued in the current cycle
+    cache_req_yumi_o = cache_req_v_i & (~cache_req_v_r | req_done);
   end
 
   // synopsys translate_off
@@ -325,3 +279,4 @@ module bp_lce_req
 endmodule
 
 `BSG_ABSTRACT_MODULE(bp_lce_req)
+

--- a/bp_me/src/v/network/bp_me_stream_pump_control.sv
+++ b/bp_me/src/v/network/bp_me_stream_pump_control.sv
@@ -28,6 +28,7 @@ module bp_me_stream_pump_control
    , parameter `BSG_INV_PARAM(block_width_p)
    , parameter `BSG_INV_PARAM(data_width_p)
    , parameter `BSG_INV_PARAM(stream_mask_p)
+   , parameter `BSG_INV_PARAM(widest_beat_size_p)
    `declare_bp_bedrock_if_widths(paddr_width_p, payload_width_p, xce)
    )
   (input                                          clk_i
@@ -70,7 +71,9 @@ module bp_me_stream_pump_control
         `BSG_MAX((1'b1 << header_cast_i.size) / bytes_lp, 1'b1) - 1'b1;
       wire stream = stream_mask_p[header_cast_i.msg_type];
       wire [width_lp-1:0] size_li = stream ? stream_size : '0;
-      wire [paddr_width_p-1:0] addr_mask = ~((1'b1 << header_cast_i.size) - 1'b1);
+      wire [paddr_width_p-1:0] req_mask = ~((1'b1 << header_cast_i.size) - 1'b1);
+      wire [paddr_width_p-1:0] max_mask = ~((1'b1 << widest_beat_size_p) - 1'b1);
+      wire [paddr_width_p-1:0] addr_mask = `BSG_MAX(req_mask, max_mask);
       wire [paddr_width_p-1:0] beat_mask = ~((1'b1 << beat_size) - 1'b1);
       wire [paddr_width_p-1:0] final_mask = `BSG_MAX(addr_mask, beat_mask);
 

--- a/bp_me/src/v/network/bp_me_stream_pump_in.sv
+++ b/bp_me/src/v/network/bp_me_stream_pump_in.sv
@@ -109,6 +109,10 @@ module bp_me_stream_pump_in
   wire nz_stream  = stream_size > '0;
   wire fsm_stream = fsm_stream_mask_p[msg_header_li.msg_type];
   wire msg_stream = msg_stream_mask_p[msg_header_li.msg_type];
+  // TODO: This could be dynamically adjusted depending on target
+  localparam widest_beat_width_lp =
+    `BSG_MAX(icache_fill_width_p, `BSG_MAX(dcache_fill_width_p, bedrock_fill_width_p));
+  localparam widest_beat_size_lp = `BSG_SAFE_CLOG2(widest_beat_width_lp)-1;
 
   logic cnt_up;
   bp_me_stream_pump_control
@@ -117,6 +121,7 @@ module bp_me_stream_pump_in
      ,.stream_mask_p(fsm_stream_mask_p)
      ,.data_width_p(fsm_data_width_p)
      ,.payload_width_p(payload_width_p)
+     ,.widest_beat_size_p(widest_beat_size_lp)
      )
    pump_control
     (.clk_i(clk_i)

--- a/bp_me/src/v/network/bp_me_stream_pump_out.sv
+++ b/bp_me/src/v/network/bp_me_stream_pump_out.sv
@@ -110,6 +110,10 @@ module bp_me_stream_pump_out
   wire fsm_stream = fsm_stream_mask_p[fsm_header_cast_i.msg_type];
   wire msg_stream = msg_stream_mask_p[fsm_header_cast_i.msg_type];
 
+  // TODO: This could be dynamically adjusted depending on target
+  localparam widest_beat_width_lp =
+    `BSG_MAX(icache_fill_width_p, `BSG_MAX(dcache_fill_width_p, bedrock_fill_width_p));
+  localparam widest_beat_size_lp = `BSG_SAFE_CLOG2(widest_beat_width_lp)-1;
   logic cnt_up;
   bp_me_stream_pump_control
    #(.bp_params_p(bp_params_p)
@@ -117,6 +121,7 @@ module bp_me_stream_pump_out
      ,.data_width_p(fsm_data_width_p)
      ,.block_width_p(block_width_p)
      ,.payload_width_p(payload_width_p)
+     ,.widest_beat_size_p(widest_beat_size_lp)
      )
    pump_control
     (.clk_i(clk_i)

--- a/bp_me/src/v/network/bp_me_xbar_stream.sv
+++ b/bp_me/src/v/network/bp_me_xbar_stream.sv
@@ -93,6 +93,7 @@ module bp_me_xbar_stream
     end
   for (genvar i = 0; i < num_sink_p; i++)
     begin : sink_comb
+      // We just use this to indicate the end of packets for unlocking
       logic msg_last_lo;
       bp_me_stream_pump_control
        #(.bp_params_p(bp_params_p)
@@ -100,6 +101,7 @@ module bp_me_xbar_stream
          ,.block_width_p(block_width_p)
          ,.data_width_p(data_width_p)
          ,.payload_width_p(payload_width_p)
+         ,.widest_beat_size_p(e_size_1B)
          )
        pump_control
         (.clk_i(clk_i)

--- a/bp_me/test/common/bp_me_nonsynth_cache.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cache.sv
@@ -71,6 +71,7 @@ module bp_me_nonsynth_cache
     , input                                                 cache_req_busy_i
     , output logic [cache_req_metadata_width_lp-1:0]        cache_req_metadata_o
     , output logic                                          cache_req_metadata_v_o
+    , input [paddr_width_p-1:0]                             cache_req_addr_i
     , input                                                 cache_req_critical_i
     , input                                                 cache_req_last_i
     , input                                                 cache_req_credits_full_i

--- a/bp_me/test/common/bp_me_nonsynth_cache.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cache.sv
@@ -67,7 +67,7 @@ module bp_me_nonsynth_cache
      // Cache-LCE interface
     , output logic [cache_req_width_lp-1:0]                 cache_req_o
     , output logic                                          cache_req_v_o
-    , input                                                 cache_req_ready_and_i
+    , input                                                 cache_req_yumi_i
     , input                                                 cache_req_busy_i
     , output logic [cache_req_metadata_width_lp-1:0]        cache_req_metadata_o
     , output logic                                          cache_req_metadata_v_o
@@ -494,7 +494,7 @@ module bp_me_nonsynth_cache
           cache_req_v_o = 1'b1;
           // metadata not used by LCE for uncached ops, but send it anyway
           cache_req_metadata_v_o = 1'b1;
-          state_n = (cache_req_ready_and_i & cache_req_v_o)
+          state_n = cache_req_yumi_i
                     ? tag_lookup_hit_lo
                       ? e_uc_hit_inv
                       : load_op
@@ -567,7 +567,7 @@ module bp_me_nonsynth_cache
         else begin
           cache_req_v_o = 1'b1;
           cache_req_metadata_v_o = 1'b1;
-          state_n = (cache_req_ready_and_i & cache_req_v_o) ? e_wait : state_r;
+          state_n = cache_req_yumi_i ? e_wait : state_r;
         end
       end // e_check_hit
 

--- a/bp_me/test/common/bp_me_nonsynth_cache.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cache.sv
@@ -72,7 +72,7 @@ module bp_me_nonsynth_cache
     , output logic [cache_req_metadata_width_lp-1:0]        cache_req_metadata_o
     , output logic                                          cache_req_metadata_v_o
     , input                                                 cache_req_critical_i
-    , input                                                 cache_req_complete_i
+    , input                                                 cache_req_last_i
     , input                                                 cache_req_credits_full_i
     , input                                                 cache_req_credits_empty_i
 
@@ -587,7 +587,7 @@ module bp_me_nonsynth_cache
       // then, return to ready and replay the current TR command
       // note: critical tag and data signals are ignored
       e_wait: begin
-        state_n = cache_req_complete_i ? e_ready : state_r;
+        state_n = cache_req_last_i ? e_ready : state_r;
       end
 
       // wait for UC load data

--- a/bp_me/test/common/bp_me_nonsynth_cfg_loader.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cfg_loader.sv
@@ -42,13 +42,13 @@ module bp_me_nonsynth_cfg_loader
    // BedRock Stream
    // TODO: convert yumi_i to ready_and_i
    , output logic [mem_fwd_header_width_lp-1:0]      mem_fwd_header_o
-   , output logic [dword_width_gp-1:0]               mem_fwd_data_o
+   , output logic [bedrock_fill_width_p-1:0]         mem_fwd_data_o
    , output logic                                    mem_fwd_v_o
    , input                                           mem_fwd_yumi_i
 
    // BedRock Stream
    , input [mem_rev_header_width_lp-1:0]             mem_rev_header_i
-   , input [dword_width_gp-1:0]                      mem_rev_data_i
+   , input [bedrock_fill_width_p-1:0]                mem_rev_data_i
    , input                                           mem_rev_v_i
    , output logic                                    mem_rev_ready_and_o
 
@@ -187,7 +187,7 @@ module bp_me_nonsynth_cfg_loader
       mem_fwd_payload                     = '0;
       mem_fwd_payload.lce_id              = lce_id_i;
       mem_fwd_cast_o.size                 = e_bedrock_msg_size_8;
-      mem_fwd_data_o                      = cfg_data_lo;
+      mem_fwd_data_o                      = {bedrock_fill_width_p/dword_width_gp{cfg_data_lo}};
       mem_fwd_cast_o.payload              = mem_fwd_payload;
     end
 

--- a/bp_me/test/common/bp_me_nonsynth_lce_tracer.sv
+++ b/bp_me/test/common/bp_me_nonsynth_lce_tracer.sv
@@ -70,7 +70,6 @@ module bp_me_nonsynth_lce_tracer
     ,input                                                  lce_resp_ready_and_i
 
     ,input                                                  cache_req_complete_i
-    ,input                                                  uc_store_req_complete_i
   );
 
   // LCE-CCE interface structs

--- a/bp_me/test/common/bp_me_nonsynth_lce_tracer.sv
+++ b/bp_me/test/common/bp_me_nonsynth_lce_tracer.sv
@@ -69,7 +69,7 @@ module bp_me_nonsynth_lce_tracer
     ,input                                                  lce_resp_v_i
     ,input                                                  lce_resp_ready_and_i
 
-    ,input                                                  cache_req_complete_i
+    ,input                                                  cache_req_last_i
   );
 
   // LCE-CCE interface structs
@@ -200,7 +200,7 @@ module bp_me_nonsynth_lce_tracer
       end
 
 
-      if (cache_req_complete_i) begin
+      if (cache_req_last_i) begin
         cnt_up <= 1'b0;
         $fdisplay(file, "%12t |: LCE[%0d] ReqLat: %d", $time, lce_id_i, req_cnt);
       end

--- a/bp_me/test/tb/bp_cce/testbench.sv
+++ b/bp_me/test/tb/bp_cce/testbench.sv
@@ -294,7 +294,7 @@ module testbench
   logic [num_lce_p-1:0] cache_req_v_lo, cache_req_yumi_li, cache_req_busy_li;
   bp_cache_req_metadata_s [num_lce_p-1:0] cache_req_metadata_lo;
   logic [num_lce_p-1:0] cache_req_metadata_v_lo;
-  logic [num_lce_p-1:0] cache_req_critical_li, cache_req_complete_li;
+  logic [num_lce_p-1:0] cache_req_critical_li, cache_req_last_li;
   logic [num_lce_p-1:0] cache_req_credits_full_li, cache_req_credits_empty_li;
 
   bp_cache_tag_mem_pkt_s [num_lce_p-1:0] tag_mem_pkt_li;
@@ -383,7 +383,7 @@ module testbench
        ,.cache_req_busy_i(cache_req_busy_li[i])
        ,.cache_req_metadata_o(cache_req_metadata_lo[i])
        ,.cache_req_metadata_v_o(cache_req_metadata_v_lo[i])
-       ,.cache_req_complete_i(cache_req_complete_li[i])
+       ,.cache_req_last_i(cache_req_last_li[i])
        ,.cache_req_critical_i(cache_req_critical_li[i])
        ,.cache_req_credits_full_i(cache_req_credits_full_li[i])
        ,.cache_req_credits_empty_i(cache_req_credits_empty_li[i])
@@ -435,7 +435,7 @@ module testbench
        ,.cache_req_metadata_i(cache_req_metadata_lo[i])
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo[i])
        ,.cache_req_critical_o(cache_req_critical_li[i])
-       ,.cache_req_complete_o(cache_req_complete_li[i])
+       ,.cache_req_last_o(cache_req_last_li[i])
        ,.cache_req_credits_full_o(cache_req_credits_full_li[i])
        ,.cache_req_credits_empty_o(cache_req_credits_empty_li[i])
 
@@ -670,7 +670,7 @@ module testbench
         ,.lce_resp_v_i(lce_resp_v_o)
         ,.lce_resp_ready_and_i(lce_resp_ready_and_i)
 
-        ,.cache_req_complete_i(cache_req_complete_o)
+        ,.cache_req_last_i(cache_req_last_o)
         ,.uc_store_req_complete_i(uc_store_req_complete_lo)
         );
 

--- a/bp_me/test/tb/bp_cce/testbench.sv
+++ b/bp_me/test/tb/bp_cce/testbench.sv
@@ -294,6 +294,7 @@ module testbench
   logic [num_lce_p-1:0] cache_req_v_lo, cache_req_yumi_li, cache_req_busy_li;
   bp_cache_req_metadata_s [num_lce_p-1:0] cache_req_metadata_lo;
   logic [num_lce_p-1:0] cache_req_metadata_v_lo;
+  logic [num_lce_p-1:0][paddr_width_p-1:0] cache_req_addr_li;
   logic [num_lce_p-1:0] cache_req_critical_li, cache_req_last_li;
   logic [num_lce_p-1:0] cache_req_credits_full_li, cache_req_credits_empty_li;
 
@@ -383,8 +384,9 @@ module testbench
        ,.cache_req_busy_i(cache_req_busy_li[i])
        ,.cache_req_metadata_o(cache_req_metadata_lo[i])
        ,.cache_req_metadata_v_o(cache_req_metadata_v_lo[i])
-       ,.cache_req_last_i(cache_req_last_li[i])
+       ,.cache_req_addr_i(cache_req_addr_li[i])
        ,.cache_req_critical_i(cache_req_critical_li[i])
+       ,.cache_req_last_i(cache_req_last_li[i])
        ,.cache_req_credits_full_i(cache_req_credits_full_li[i])
        ,.cache_req_credits_empty_i(cache_req_credits_empty_li[i])
 
@@ -434,6 +436,7 @@ module testbench
        ,.cache_req_busy_o(cache_req_busy_li[i])
        ,.cache_req_metadata_i(cache_req_metadata_lo[i])
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo[i])
+       ,.cache_req_addr_o(cache_req_addr_li[i])
        ,.cache_req_critical_o(cache_req_critical_li[i])
        ,.cache_req_last_o(cache_req_last_li[i])
        ,.cache_req_credits_full_o(cache_req_credits_full_li[i])
@@ -671,7 +674,6 @@ module testbench
         ,.lce_resp_ready_and_i(lce_resp_ready_and_i)
 
         ,.cache_req_last_i(cache_req_last_o)
-        ,.uc_store_req_complete_i(uc_store_req_complete_lo)
         );
 
   bind bp_me_nonsynth_cache
@@ -842,7 +844,7 @@ module testbench
 
   // Config
   bp_bedrock_mem_fwd_header_s cfg_mem_fwd_lo;
-  logic [dword_width_gp-1:0] cfg_mem_fwd_data_lo;
+  logic [bedrock_fill_width_p-1:0] cfg_mem_fwd_data_lo;
   logic cfg_mem_fwd_v_lo, cfg_mem_fwd_ready_and_li;
   logic cfg_mem_rev_v_lo;
 
@@ -877,7 +879,7 @@ module testbench
 
   logic [coh_noc_cord_width_p-1:0] cord_li = {{coh_noc_y_cord_width_p'(1'b1)}, {coh_noc_x_cord_width_p'('0)}};
   bp_me_cfg_slice
-   #(.bp_params_p(bp_params_p), .data_width_p(dword_width_gp))
+   #(.bp_params_p(bp_params_p))
    cfgs
     (.clk_i(clk_i)
      ,.reset_i(reset_i)

--- a/bp_me/test/tb/bp_cce/testbench.sv
+++ b/bp_me/test/tb/bp_cce/testbench.sv
@@ -291,7 +291,7 @@ module testbench
   `declare_bp_cache_engine_if(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, cache);
 
   bp_cache_req_s [num_lce_p-1:0] cache_req_lo;
-  logic [num_lce_p-1:0] cache_req_v_lo, cache_req_ready_and_li, cache_req_busy_li;
+  logic [num_lce_p-1:0] cache_req_v_lo, cache_req_yumi_li, cache_req_busy_li;
   bp_cache_req_metadata_s [num_lce_p-1:0] cache_req_metadata_lo;
   logic [num_lce_p-1:0] cache_req_metadata_v_lo;
   logic [num_lce_p-1:0] cache_req_critical_li, cache_req_complete_li;
@@ -379,7 +379,7 @@ module testbench
 
        ,.cache_req_o(cache_req_lo[i])
        ,.cache_req_v_o(cache_req_v_lo[i])
-       ,.cache_req_ready_and_i(cache_req_ready_and_li[i])
+       ,.cache_req_yumi_i(cache_req_yumi_li[i])
        ,.cache_req_busy_i(cache_req_busy_li[i])
        ,.cache_req_metadata_o(cache_req_metadata_lo[i])
        ,.cache_req_metadata_v_o(cache_req_metadata_v_lo[i])
@@ -430,7 +430,7 @@ module testbench
 
        ,.cache_req_i(cache_req_lo[i])
        ,.cache_req_v_i(cache_req_v_lo[i])
-       ,.cache_req_ready_and_o(cache_req_ready_and_li[i])
+       ,.cache_req_yumi_o(cache_req_yumi_li[i])
        ,.cache_req_busy_o(cache_req_busy_li[i])
        ,.cache_req_metadata_i(cache_req_metadata_lo[i])
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo[i])

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -112,7 +112,7 @@ module bp_cacc_vdp
   bp_acache_req_metadata_s acache_req_metadata_lo;
   logic acache_req_metadata_v_lo;
   logic [paddr_width_p-1:0] acache_req_addr_lo;
-  logic acache_req_complete_lo, acache_req_critical_lo;
+  logic acache_req_last_lo, acache_req_critical_lo;
   logic acache_req_credits_full_lo, acache_req_credits_empty_lo;
   bp_acache_data_mem_pkt_s acache_data_mem_pkt_li;
   logic acache_data_mem_pkt_v_li, acache_data_mem_pkt_yumi_lo;
@@ -173,7 +173,7 @@ module bp_cacc_vdp
      ,.cache_req_credits_empty_i(acache_req_credits_empty_lo)
      ,.cache_req_addr_i(acache_req_addr_lo)
      ,.cache_req_critical_i(acache_req_critical_lo)
-     ,.cache_req_complete_i(acache_req_complete_lo)
+     ,.cache_req_last_i(acache_req_last_lo)
 
      ,.data_mem_pkt_v_i(acache_data_mem_pkt_v_li)
      ,.data_mem_pkt_i(acache_data_mem_pkt_li)
@@ -218,7 +218,7 @@ module bp_cacc_vdp
      ,.cache_req_metadata_v_i(acache_req_metadata_v_lo)
      ,.cache_req_addr_o(acache_req_addr_lo)
      ,.cache_req_critical_o(acache_req_critical_lo)
-     ,.cache_req_complete_o(acache_req_complete_lo)
+     ,.cache_req_last_o(acache_req_last_lo)
      ,.cache_req_credits_full_o(acache_req_credits_full_lo)
      ,.cache_req_credits_empty_o(acache_req_credits_empty_lo)
 

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -160,7 +160,7 @@ module bp_cacc_vdp
      ,.ordered_o()
      ,.late_o()
      ,.rd_addr_o()
-     ,.tv_we_o()
+     ,.req_o()
 
      // D$-LCE Interface
      ,.cache_req_o(acache_req_lo)

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -108,7 +108,7 @@ module bp_cacc_vdp
 
   `declare_bp_cache_engine_if(paddr_width_p, acache_ctag_width_p, acache_sets_p, acache_assoc_p, dword_width_gp, acache_block_width_p, acache_fill_width_p, acache);
   bp_acache_req_s acache_req_lo;
-  logic acache_req_v_lo, acache_req_ready_and_li, acache_req_busy_li;
+  logic acache_req_v_lo, acache_req_yumi_li, acache_req_busy_li;
   bp_acache_req_metadata_s acache_req_metadata_lo;
   logic acache_req_metadata_v_lo;
   logic [paddr_width_p-1:0] acache_req_addr_lo;
@@ -165,7 +165,7 @@ module bp_cacc_vdp
      // D$-LCE Interface
      ,.cache_req_o(acache_req_lo)
      ,.cache_req_v_o(acache_req_v_lo)
-     ,.cache_req_ready_and_i(acache_req_ready_and_li)
+     ,.cache_req_yumi_i(acache_req_yumi_li)
      ,.cache_req_busy_i(acache_req_busy_li)
      ,.cache_req_metadata_o(acache_req_metadata_lo)
      ,.cache_req_metadata_v_o(acache_req_metadata_v_lo)
@@ -212,7 +212,7 @@ module bp_cacc_vdp
 
      ,.cache_req_i(acache_req_lo)
      ,.cache_req_v_i(acache_req_v_lo)
-     ,.cache_req_ready_and_o(acache_req_ready_and_li)
+     ,.cache_req_yumi_o(acache_req_yumi_li)
      ,.cache_req_busy_o(acache_req_busy_li)
      ,.cache_req_metadata_i(acache_req_metadata_lo)
      ,.cache_req_metadata_v_i(acache_req_metadata_v_lo)

--- a/bp_top/src/v/bp_core_lite.sv
+++ b/bp_top/src/v/bp_core_lite.sv
@@ -71,6 +71,7 @@ module bp_core_lite
   logic icache_req_v_lo, icache_req_ready_and_li, icache_req_busy_li;
   bp_icache_req_metadata_s icache_req_metadata_lo;
   logic icache_req_metadata_v_lo;
+  logic [paddr_width_p-1:0] icache_req_addr_li;
   logic icache_req_critical_li, icache_req_complete_li;
   logic icache_req_credits_full_li, icache_req_credits_empty_li;
 
@@ -78,6 +79,7 @@ module bp_core_lite
   logic dcache_req_v_lo, dcache_req_ready_and_li, dcache_req_busy_li;
   bp_dcache_req_metadata_s dcache_req_metadata_lo;
   logic dcache_req_metadata_v_lo;
+  logic [paddr_width_p-1:0] dcache_req_addr_li;
   logic dcache_req_critical_li, dcache_req_complete_li;
   logic dcache_req_credits_full_li, dcache_req_credits_empty_li;
 
@@ -127,8 +129,9 @@ module bp_core_lite
      ,.icache_req_busy_i(icache_req_busy_li)
      ,.icache_req_metadata_o(icache_req_metadata_lo)
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
-     ,.icache_req_complete_i(icache_req_complete_li)
+     ,.icache_req_addr_i(icache_req_addr_li)
      ,.icache_req_critical_i(icache_req_critical_li)
+     ,.icache_req_complete_i(icache_req_complete_li)
      ,.icache_req_credits_full_i(icache_req_credits_full_li)
      ,.icache_req_credits_empty_i(icache_req_credits_empty_li)
 
@@ -153,8 +156,9 @@ module bp_core_lite
      ,.dcache_req_busy_i(dcache_req_busy_li)
      ,.dcache_req_metadata_o(dcache_req_metadata_lo)
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
-     ,.dcache_req_complete_i(dcache_req_complete_li)
+     ,.dcache_req_addr_i(dcache_req_addr_li)
      ,.dcache_req_critical_i(dcache_req_critical_li)
+     ,.dcache_req_complete_i(dcache_req_complete_li)
      ,.dcache_req_credits_full_i(dcache_req_credits_full_li)
      ,.dcache_req_credits_empty_i(dcache_req_credits_empty_li)
 
@@ -205,6 +209,7 @@ module bp_core_lite
      ,.cache_req_busy_o(icache_req_busy_li)
      ,.cache_req_metadata_i(icache_req_metadata_lo)
      ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
+     ,.cache_req_addr_o(icache_req_addr_li)
      ,.cache_req_critical_o(icache_req_critical_li)
      ,.cache_req_complete_o(icache_req_complete_li)
      ,.cache_req_credits_full_o(icache_req_credits_full_li)
@@ -299,6 +304,7 @@ module bp_core_lite
      ,.cache_req_busy_o(dcache_req_busy_li)
      ,.cache_req_metadata_i(dcache_req_metadata_lo)
      ,.cache_req_metadata_v_i(dcache_req_metadata_v_lo)
+     ,.cache_req_addr_o(dcache_req_addr_li)
      ,.cache_req_critical_o(dcache_req_critical_li)
      ,.cache_req_complete_o(dcache_req_complete_li)
      ,.cache_req_credits_full_o(dcache_req_credits_full_li)

--- a/bp_top/src/v/bp_core_lite.sv
+++ b/bp_top/src/v/bp_core_lite.sv
@@ -68,7 +68,7 @@ module bp_core_lite
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
   bp_icache_req_s icache_req_lo;
-  logic icache_req_v_lo, icache_req_ready_and_li, icache_req_busy_li;
+  logic icache_req_v_lo, icache_req_yumi_li, icache_req_busy_li;
   bp_icache_req_metadata_s icache_req_metadata_lo;
   logic icache_req_metadata_v_lo;
   logic [paddr_width_p-1:0] icache_req_addr_li;
@@ -76,7 +76,7 @@ module bp_core_lite
   logic icache_req_credits_full_li, icache_req_credits_empty_li;
 
   bp_dcache_req_s dcache_req_lo;
-  logic dcache_req_v_lo, dcache_req_ready_and_li, dcache_req_busy_li;
+  logic dcache_req_v_lo, dcache_req_yumi_li, dcache_req_busy_li;
   bp_dcache_req_metadata_s dcache_req_metadata_lo;
   logic dcache_req_metadata_v_lo;
   logic [paddr_width_p-1:0] dcache_req_addr_li;
@@ -125,7 +125,7 @@ module bp_core_lite
 
      ,.icache_req_o(icache_req_lo)
      ,.icache_req_v_o(icache_req_v_lo)
-     ,.icache_req_ready_and_i(icache_req_ready_and_li)
+     ,.icache_req_yumi_i(icache_req_yumi_li)
      ,.icache_req_busy_i(icache_req_busy_li)
      ,.icache_req_metadata_o(icache_req_metadata_lo)
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
@@ -152,7 +152,7 @@ module bp_core_lite
 
      ,.dcache_req_o(dcache_req_lo)
      ,.dcache_req_v_o(dcache_req_v_lo)
-     ,.dcache_req_ready_and_i(dcache_req_ready_and_li)
+     ,.dcache_req_yumi_i(dcache_req_yumi_li)
      ,.dcache_req_busy_i(dcache_req_busy_li)
      ,.dcache_req_metadata_o(dcache_req_metadata_lo)
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
@@ -205,7 +205,7 @@ module bp_core_lite
 
      ,.cache_req_i(icache_req_lo)
      ,.cache_req_v_i(icache_req_v_lo)
-     ,.cache_req_ready_and_o(icache_req_ready_and_li)
+     ,.cache_req_yumi_o(icache_req_yumi_li)
      ,.cache_req_busy_o(icache_req_busy_li)
      ,.cache_req_metadata_i(icache_req_metadata_lo)
      ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
@@ -300,7 +300,7 @@ module bp_core_lite
 
      ,.cache_req_i(dcache_req_lo)
      ,.cache_req_v_i(dcache_req_v_lo)
-     ,.cache_req_ready_and_o(dcache_req_ready_and_li)
+     ,.cache_req_yumi_o(dcache_req_yumi_li)
      ,.cache_req_busy_o(dcache_req_busy_li)
      ,.cache_req_metadata_i(dcache_req_metadata_lo)
      ,.cache_req_metadata_v_i(dcache_req_metadata_v_lo)

--- a/bp_top/src/v/bp_core_lite.sv
+++ b/bp_top/src/v/bp_core_lite.sv
@@ -72,7 +72,7 @@ module bp_core_lite
   bp_icache_req_metadata_s icache_req_metadata_lo;
   logic icache_req_metadata_v_lo;
   logic [paddr_width_p-1:0] icache_req_addr_li;
-  logic icache_req_critical_li, icache_req_complete_li;
+  logic icache_req_critical_li, icache_req_last_li;
   logic icache_req_credits_full_li, icache_req_credits_empty_li;
 
   bp_dcache_req_s dcache_req_lo;
@@ -80,7 +80,7 @@ module bp_core_lite
   bp_dcache_req_metadata_s dcache_req_metadata_lo;
   logic dcache_req_metadata_v_lo;
   logic [paddr_width_p-1:0] dcache_req_addr_li;
-  logic dcache_req_critical_li, dcache_req_complete_li;
+  logic dcache_req_critical_li, dcache_req_last_li;
   logic dcache_req_credits_full_li, dcache_req_credits_empty_li;
 
   bp_icache_tag_mem_pkt_s icache_tag_mem_pkt_li;
@@ -131,7 +131,7 @@ module bp_core_lite
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
      ,.icache_req_addr_i(icache_req_addr_li)
      ,.icache_req_critical_i(icache_req_critical_li)
-     ,.icache_req_complete_i(icache_req_complete_li)
+     ,.icache_req_last_i(icache_req_last_li)
      ,.icache_req_credits_full_i(icache_req_credits_full_li)
      ,.icache_req_credits_empty_i(icache_req_credits_empty_li)
 
@@ -158,7 +158,7 @@ module bp_core_lite
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
      ,.dcache_req_addr_i(dcache_req_addr_li)
      ,.dcache_req_critical_i(dcache_req_critical_li)
-     ,.dcache_req_complete_i(dcache_req_complete_li)
+     ,.dcache_req_last_i(dcache_req_last_li)
      ,.dcache_req_credits_full_i(dcache_req_credits_full_li)
      ,.dcache_req_credits_empty_i(dcache_req_credits_empty_li)
 
@@ -211,7 +211,7 @@ module bp_core_lite
      ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
      ,.cache_req_addr_o(icache_req_addr_li)
      ,.cache_req_critical_o(icache_req_critical_li)
-     ,.cache_req_complete_o(icache_req_complete_li)
+     ,.cache_req_last_o(icache_req_last_li)
      ,.cache_req_credits_full_o(icache_req_credits_full_li)
      ,.cache_req_credits_empty_o(icache_req_credits_empty_li)
 
@@ -306,7 +306,7 @@ module bp_core_lite
      ,.cache_req_metadata_v_i(dcache_req_metadata_v_lo)
      ,.cache_req_addr_o(dcache_req_addr_li)
      ,.cache_req_critical_o(dcache_req_critical_li)
-     ,.cache_req_complete_o(dcache_req_complete_li)
+     ,.cache_req_last_o(dcache_req_last_li)
      ,.cache_req_credits_full_o(dcache_req_credits_full_li)
      ,.cache_req_credits_empty_o(dcache_req_credits_empty_li)
 

--- a/bp_top/src/v/bp_core_minimal.sv
+++ b/bp_top/src/v/bp_core_minimal.sv
@@ -23,7 +23,7 @@ module bp_core_minimal
 
    , output logic [icache_req_width_lp-1:0]          icache_req_o
    , output logic                                    icache_req_v_o
-   , input                                           icache_req_ready_and_i
+   , input                                           icache_req_yumi_i
    , input                                           icache_req_busy_i
    , output logic [icache_req_metadata_width_lp-1:0] icache_req_metadata_o
    , output logic                                    icache_req_metadata_v_o
@@ -52,7 +52,7 @@ module bp_core_minimal
    //   a negative-edge cache engine and synchronized before getting to the memory system
    , output logic [dcache_req_width_lp-1:0]          dcache_req_o
    , output logic                                    dcache_req_v_o
-   , input                                           dcache_req_ready_and_i
+   , input                                           dcache_req_yumi_i
    , input                                           dcache_req_busy_i
    , output logic [dcache_req_metadata_width_lp-1:0] dcache_req_metadata_o
    , output logic                                    dcache_req_metadata_v_o
@@ -112,7 +112,7 @@ module bp_core_minimal
 
      ,.cache_req_o(icache_req_o)
      ,.cache_req_v_o(icache_req_v_o)
-     ,.cache_req_ready_and_i(icache_req_ready_and_i)
+     ,.cache_req_yumi_i(icache_req_yumi_i)
      ,.cache_req_busy_i(icache_req_busy_i)
      ,.cache_req_metadata_o(icache_req_metadata_o)
      ,.cache_req_metadata_v_o(icache_req_metadata_v_o)
@@ -156,7 +156,7 @@ module bp_core_minimal
 
      ,.cache_req_o(dcache_req_o)
      ,.cache_req_v_o(dcache_req_v_o)
-     ,.cache_req_ready_and_i(dcache_req_ready_and_i)
+     ,.cache_req_yumi_i(dcache_req_yumi_i)
      ,.cache_req_busy_i(dcache_req_busy_i)
      ,.cache_req_metadata_o(dcache_req_metadata_o)
      ,.cache_req_metadata_v_o(dcache_req_metadata_v_o)

--- a/bp_top/src/v/bp_core_minimal.sv
+++ b/bp_top/src/v/bp_core_minimal.sv
@@ -29,7 +29,7 @@ module bp_core_minimal
    , output logic                                    icache_req_metadata_v_o
    , input [paddr_width_p-1:0]                       icache_req_addr_i
    , input                                           icache_req_critical_i
-   , input                                           icache_req_complete_i
+   , input                                           icache_req_last_i
    , input                                           icache_req_credits_full_i
    , input                                           icache_req_credits_empty_i
 
@@ -58,7 +58,7 @@ module bp_core_minimal
    , output logic                                    dcache_req_metadata_v_o
    , input [paddr_width_p-1:0]                       dcache_req_addr_i
    , input                                           dcache_req_critical_i
-   , input                                           dcache_req_complete_i
+   , input                                           dcache_req_last_i
    , input                                           dcache_req_credits_full_i
    , input                                           dcache_req_credits_empty_i
 
@@ -118,7 +118,7 @@ module bp_core_minimal
      ,.cache_req_metadata_v_o(icache_req_metadata_v_o)
      ,.cache_req_addr_i(icache_req_addr_i)
      ,.cache_req_critical_i(icache_req_critical_i)
-     ,.cache_req_complete_i(icache_req_complete_i)
+     ,.cache_req_last_i(icache_req_last_i)
      ,.cache_req_credits_full_i(icache_req_credits_full_i)
      ,.cache_req_credits_empty_i(icache_req_credits_empty_i)
 
@@ -162,7 +162,7 @@ module bp_core_minimal
      ,.cache_req_metadata_v_o(dcache_req_metadata_v_o)
      ,.cache_req_addr_i(dcache_req_addr_i)
      ,.cache_req_critical_i(dcache_req_critical_i)
-     ,.cache_req_complete_i(dcache_req_complete_i)
+     ,.cache_req_last_i(dcache_req_last_i)
      ,.cache_req_credits_full_i(dcache_req_credits_full_i)
      ,.cache_req_credits_empty_i(dcache_req_credits_empty_i)
 

--- a/bp_top/src/v/bp_core_minimal.sv
+++ b/bp_top/src/v/bp_core_minimal.sv
@@ -27,6 +27,7 @@ module bp_core_minimal
    , input                                           icache_req_busy_i
    , output logic [icache_req_metadata_width_lp-1:0] icache_req_metadata_o
    , output logic                                    icache_req_metadata_v_o
+   , input [paddr_width_p-1:0]                       icache_req_addr_i
    , input                                           icache_req_critical_i
    , input                                           icache_req_complete_i
    , input                                           icache_req_credits_full_i
@@ -55,6 +56,7 @@ module bp_core_minimal
    , input                                           dcache_req_busy_i
    , output logic [dcache_req_metadata_width_lp-1:0] dcache_req_metadata_o
    , output logic                                    dcache_req_metadata_v_o
+   , input [paddr_width_p-1:0]                       dcache_req_addr_i
    , input                                           dcache_req_critical_i
    , input                                           dcache_req_complete_i
    , input                                           dcache_req_credits_full_i
@@ -114,6 +116,7 @@ module bp_core_minimal
      ,.cache_req_busy_i(icache_req_busy_i)
      ,.cache_req_metadata_o(icache_req_metadata_o)
      ,.cache_req_metadata_v_o(icache_req_metadata_v_o)
+     ,.cache_req_addr_i(icache_req_addr_i)
      ,.cache_req_critical_i(icache_req_critical_i)
      ,.cache_req_complete_i(icache_req_complete_i)
      ,.cache_req_credits_full_i(icache_req_credits_full_i)
@@ -157,6 +160,7 @@ module bp_core_minimal
      ,.cache_req_busy_i(dcache_req_busy_i)
      ,.cache_req_metadata_o(dcache_req_metadata_o)
      ,.cache_req_metadata_v_o(dcache_req_metadata_v_o)
+     ,.cache_req_addr_i(dcache_req_addr_i)
      ,.cache_req_critical_i(dcache_req_critical_i)
      ,.cache_req_complete_i(dcache_req_complete_i)
      ,.cache_req_credits_full_i(dcache_req_credits_full_i)

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -47,6 +47,7 @@ module bp_unicore_lite
   bp_icache_req_s icache_req_lo;
   logic icache_req_v_lo, icache_req_ready_and_li, icache_req_busy_li, icache_req_metadata_v_lo;
   bp_icache_req_metadata_s icache_req_metadata_lo;
+  logic [paddr_width_p-1:0] icache_req_addr_li;
   logic icache_req_critical_li, icache_req_complete_li;
   logic icache_req_credits_full_li, icache_req_credits_empty_li;
 
@@ -63,6 +64,7 @@ module bp_unicore_lite
   bp_dcache_req_s dcache_req_lo;
   logic dcache_req_v_lo, dcache_req_ready_and_li, dcache_req_busy_li, dcache_req_metadata_v_lo;
   bp_dcache_req_metadata_s dcache_req_metadata_lo;
+  logic [paddr_width_p-1:0] dcache_req_addr_li;
   logic dcache_req_critical_li, dcache_req_complete_li;
   logic dcache_req_credits_full_li, dcache_req_credits_empty_li;
 
@@ -93,6 +95,7 @@ module bp_unicore_lite
      ,.icache_req_busy_i(icache_req_busy_li)
      ,.icache_req_metadata_o(icache_req_metadata_lo)
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
+     ,.icache_req_addr_i(icache_req_addr_li)
      ,.icache_req_critical_i(icache_req_critical_li)
      ,.icache_req_complete_i(icache_req_complete_li)
      ,.icache_req_credits_full_i(icache_req_credits_full_li)
@@ -119,6 +122,7 @@ module bp_unicore_lite
      ,.dcache_req_busy_i(dcache_req_busy_li)
      ,.dcache_req_metadata_o(dcache_req_metadata_lo)
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
+     ,.dcache_req_addr_i(dcache_req_addr_li)
      ,.dcache_req_critical_i(dcache_req_critical_li)
      ,.dcache_req_complete_i(dcache_req_complete_li)
      ,.dcache_req_credits_full_i(dcache_req_credits_full_li)
@@ -168,6 +172,7 @@ module bp_unicore_lite
      ,.cache_req_busy_o(icache_req_busy_li)
      ,.cache_req_metadata_i(icache_req_metadata_lo)
      ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
+     ,.cache_req_addr_o(icache_req_addr_li)
      ,.cache_req_critical_o(icache_req_critical_li)
      ,.cache_req_complete_o(icache_req_complete_li)
      ,.cache_req_credits_full_o(icache_req_credits_full_li)
@@ -227,6 +232,7 @@ module bp_unicore_lite
      ,.cache_req_busy_o(dcache_req_busy_li)
      ,.cache_req_metadata_i(dcache_req_metadata_lo)
      ,.cache_req_metadata_v_i(dcache_req_metadata_v_lo)
+     ,.cache_req_addr_o(dcache_req_addr_li)
      ,.cache_req_critical_o(dcache_req_critical_li)
      ,.cache_req_complete_o(dcache_req_complete_li)
      ,.cache_req_credits_full_o(dcache_req_credits_full_li)

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -48,7 +48,7 @@ module bp_unicore_lite
   logic icache_req_v_lo, icache_req_yumi_li, icache_req_busy_li, icache_req_metadata_v_lo;
   bp_icache_req_metadata_s icache_req_metadata_lo;
   logic [paddr_width_p-1:0] icache_req_addr_li;
-  logic icache_req_critical_li, icache_req_complete_li;
+  logic icache_req_critical_li, icache_req_last_li;
   logic icache_req_credits_full_li, icache_req_credits_empty_li;
 
   bp_icache_tag_mem_pkt_s icache_tag_mem_pkt_li;
@@ -65,7 +65,7 @@ module bp_unicore_lite
   logic dcache_req_v_lo, dcache_req_yumi_li, dcache_req_busy_li, dcache_req_metadata_v_lo;
   bp_dcache_req_metadata_s dcache_req_metadata_lo;
   logic [paddr_width_p-1:0] dcache_req_addr_li;
-  logic dcache_req_critical_li, dcache_req_complete_li;
+  logic dcache_req_critical_li, dcache_req_last_li;
   logic dcache_req_credits_full_li, dcache_req_credits_empty_li;
 
   bp_dcache_tag_mem_pkt_s dcache_tag_mem_pkt_li;
@@ -97,7 +97,7 @@ module bp_unicore_lite
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
      ,.icache_req_addr_i(icache_req_addr_li)
      ,.icache_req_critical_i(icache_req_critical_li)
-     ,.icache_req_complete_i(icache_req_complete_li)
+     ,.icache_req_last_i(icache_req_last_li)
      ,.icache_req_credits_full_i(icache_req_credits_full_li)
      ,.icache_req_credits_empty_i(icache_req_credits_empty_li)
 
@@ -124,7 +124,7 @@ module bp_unicore_lite
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
      ,.dcache_req_addr_i(dcache_req_addr_li)
      ,.dcache_req_critical_i(dcache_req_critical_li)
-     ,.dcache_req_complete_i(dcache_req_complete_li)
+     ,.dcache_req_last_i(dcache_req_last_li)
      ,.dcache_req_credits_full_i(dcache_req_credits_full_li)
      ,.dcache_req_credits_empty_i(dcache_req_credits_empty_li)
 
@@ -174,7 +174,7 @@ module bp_unicore_lite
      ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
      ,.cache_req_addr_o(icache_req_addr_li)
      ,.cache_req_critical_o(icache_req_critical_li)
-     ,.cache_req_complete_o(icache_req_complete_li)
+     ,.cache_req_last_o(icache_req_last_li)
      ,.cache_req_credits_full_o(icache_req_credits_full_li)
      ,.cache_req_credits_empty_o(icache_req_credits_empty_li)
 
@@ -234,7 +234,7 @@ module bp_unicore_lite
      ,.cache_req_metadata_v_i(dcache_req_metadata_v_lo)
      ,.cache_req_addr_o(dcache_req_addr_li)
      ,.cache_req_critical_o(dcache_req_critical_li)
-     ,.cache_req_complete_o(dcache_req_complete_li)
+     ,.cache_req_last_o(dcache_req_last_li)
      ,.cache_req_credits_full_o(dcache_req_credits_full_li)
      ,.cache_req_credits_empty_o(dcache_req_credits_empty_li)
 

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -45,7 +45,7 @@ module bp_unicore_lite
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
   bp_icache_req_s icache_req_lo;
-  logic icache_req_v_lo, icache_req_ready_and_li, icache_req_busy_li, icache_req_metadata_v_lo;
+  logic icache_req_v_lo, icache_req_yumi_li, icache_req_busy_li, icache_req_metadata_v_lo;
   bp_icache_req_metadata_s icache_req_metadata_lo;
   logic [paddr_width_p-1:0] icache_req_addr_li;
   logic icache_req_critical_li, icache_req_complete_li;
@@ -62,7 +62,7 @@ module bp_unicore_lite
   bp_icache_stat_info_s icache_stat_mem_lo;
 
   bp_dcache_req_s dcache_req_lo;
-  logic dcache_req_v_lo, dcache_req_ready_and_li, dcache_req_busy_li, dcache_req_metadata_v_lo;
+  logic dcache_req_v_lo, dcache_req_yumi_li, dcache_req_busy_li, dcache_req_metadata_v_lo;
   bp_dcache_req_metadata_s dcache_req_metadata_lo;
   logic [paddr_width_p-1:0] dcache_req_addr_li;
   logic dcache_req_critical_li, dcache_req_complete_li;
@@ -91,7 +91,7 @@ module bp_unicore_lite
 
      ,.icache_req_o(icache_req_lo)
      ,.icache_req_v_o(icache_req_v_lo)
-     ,.icache_req_ready_and_i(icache_req_ready_and_li)
+     ,.icache_req_yumi_i(icache_req_yumi_li)
      ,.icache_req_busy_i(icache_req_busy_li)
      ,.icache_req_metadata_o(icache_req_metadata_lo)
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
@@ -118,7 +118,7 @@ module bp_unicore_lite
 
      ,.dcache_req_o(dcache_req_lo)
      ,.dcache_req_v_o(dcache_req_v_lo)
-     ,.dcache_req_ready_and_i(dcache_req_ready_and_li)
+     ,.dcache_req_yumi_i(dcache_req_yumi_li)
      ,.dcache_req_busy_i(dcache_req_busy_li)
      ,.dcache_req_metadata_o(dcache_req_metadata_lo)
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
@@ -168,7 +168,7 @@ module bp_unicore_lite
 
      ,.cache_req_i(icache_req_lo)
      ,.cache_req_v_i(icache_req_v_lo)
-     ,.cache_req_ready_and_o(icache_req_ready_and_li)
+     ,.cache_req_yumi_o(icache_req_yumi_li)
      ,.cache_req_busy_o(icache_req_busy_li)
      ,.cache_req_metadata_i(icache_req_metadata_lo)
      ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
@@ -228,7 +228,7 @@ module bp_unicore_lite
 
      ,.cache_req_i(dcache_req_lo)
      ,.cache_req_v_i(dcache_req_v_lo)
-     ,.cache_req_ready_and_o(dcache_req_ready_and_li)
+     ,.cache_req_yumi_o(dcache_req_yumi_li)
      ,.cache_req_busy_o(dcache_req_busy_li)
      ,.cache_req_metadata_i(dcache_req_metadata_lo)
      ,.cache_req_metadata_v_i(dcache_req_metadata_v_lo)

--- a/bp_top/test/common/bp_nonsynth_cache_tracer.sv
+++ b/bp_top/test/common/bp_nonsynth_cache_tracer.sv
@@ -53,7 +53,7 @@ module bp_nonsynth_cache_tracer
    , input [cache_req_metadata_width_lp-1:0]               cache_req_metadata_o
    , input                                                 cache_req_metadata_v_o
 
-   , input                                                 cache_req_complete_i
+   , input                                                 cache_req_last_i
    // , input                                                 cache_req_critical_i
 
    // Cache data
@@ -209,7 +209,7 @@ module bp_nonsynth_cache_tracer
       if (cache_req_metadata_v_o)
         $fwrite(file, "%12t | lru_way: %x dirty: %x \n", $time, cache_req_metadata_cast_o.hit_or_repl_way, cache_req_metadata_cast_o.dirty);
 
-      if (cache_req_complete_i)
+      if (cache_req_last_i)
         $fwrite(file, "%12t | Cache request completed \n", $time);
 
       if (data_mem_pkt_v_i)

--- a/bp_top/test/common/bp_nonsynth_cosim.sv
+++ b/bp_top/test/common/bp_nonsynth_cosim.sv
@@ -46,10 +46,9 @@ module bp_nonsynth_cosim
     , input [rv64_reg_addr_width_gp-1:0]      frd_addr_i
     , input [dpath_width_gp-1:0]              frd_data_i
 
-    , input                                   cache_req_v_i
     , input                                   cache_req_yumi_i
-    , input                                   cache_req_last_i
     , input                                   cache_req_nonblocking_i
+    , input                                   cache_req_complete_i
 
     , input                                   cosim_clk_i
     , input                                   cosim_reset_i
@@ -93,7 +92,7 @@ module bp_nonsynth_cosim
      ,.data_o({is_debug_mode_r, commit_pkt_r})
      );
 
-  logic cache_req_last_r, cache_req_v_r;
+  logic cache_req_complete_r, cache_req_v_r;
   // We filter out for ready so that the request only tracks once
   wire cache_req_v_li = cache_req_yumi_i & ~cache_req_nonblocking_i;
   bsg_dff_chain
@@ -101,8 +100,8 @@ module bp_nonsynth_cosim
    cache_req_reg
     (.clk_i(negedge_clk)
 
-     ,.data_i({cache_req_last_i, cache_req_v_li})
-     ,.data_o({cache_req_last_r, cache_req_v_r})
+     ,.data_i({cache_req_complete_i, cache_req_v_li})
+     ,.data_o({cache_req_complete_r, cache_req_v_r})
      );
 
   logic                     commit_fifo_full_lo;
@@ -210,7 +209,7 @@ module bp_nonsynth_cosim
      ,.reset_i(reset_i | freeze_i)
 
      ,.up_i(cache_req_v_r)
-     ,.down_i(cache_req_last_r)
+     ,.down_i(cache_req_complete_r)
 
      ,.count_o(req_cnt_lo)
      );

--- a/bp_top/test/common/bp_nonsynth_cosim.sv
+++ b/bp_top/test/common/bp_nonsynth_cosim.sv
@@ -47,7 +47,7 @@ module bp_nonsynth_cosim
     , input [dpath_width_gp-1:0]              frd_data_i
 
     , input                                   cache_req_v_i
-    , input                                   cache_req_ready_and_i
+    , input                                   cache_req_yumi_i
     , input                                   cache_req_complete_i
     , input                                   cache_req_nonblocking_i
 
@@ -95,7 +95,7 @@ module bp_nonsynth_cosim
 
   logic cache_req_complete_r, cache_req_v_r;
   // We filter out for ready so that the request only tracks once
-  wire cache_req_v_li = cache_req_ready_and_i & cache_req_v_i & ~cache_req_nonblocking_i;
+  wire cache_req_v_li = cache_req_yumi_i & ~cache_req_nonblocking_i;
   bsg_dff_chain
    #(.width_p(2), .num_stages_p(2))
    cache_req_reg

--- a/bp_top/test/common/bp_nonsynth_cosim.sv
+++ b/bp_top/test/common/bp_nonsynth_cosim.sv
@@ -48,7 +48,7 @@ module bp_nonsynth_cosim
 
     , input                                   cache_req_v_i
     , input                                   cache_req_yumi_i
-    , input                                   cache_req_complete_i
+    , input                                   cache_req_last_i
     , input                                   cache_req_nonblocking_i
 
     , input                                   cosim_clk_i
@@ -93,7 +93,7 @@ module bp_nonsynth_cosim
      ,.data_o({is_debug_mode_r, commit_pkt_r})
      );
 
-  logic cache_req_complete_r, cache_req_v_r;
+  logic cache_req_last_r, cache_req_v_r;
   // We filter out for ready so that the request only tracks once
   wire cache_req_v_li = cache_req_yumi_i & ~cache_req_nonblocking_i;
   bsg_dff_chain
@@ -101,8 +101,8 @@ module bp_nonsynth_cosim
    cache_req_reg
     (.clk_i(negedge_clk)
 
-     ,.data_i({cache_req_complete_i, cache_req_v_li})
-     ,.data_o({cache_req_complete_r, cache_req_v_r})
+     ,.data_i({cache_req_last_i, cache_req_v_li})
+     ,.data_o({cache_req_last_r, cache_req_v_r})
      );
 
   logic                     commit_fifo_full_lo;
@@ -210,7 +210,7 @@ module bp_nonsynth_cosim
      ,.reset_i(reset_i | freeze_i)
 
      ,.up_i(cache_req_v_r)
-     ,.down_i(cache_req_complete_r)
+     ,.down_i(cache_req_last_r)
 
      ,.count_o(req_cnt_lo)
      );

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -381,9 +381,8 @@ module testbench
            ,.frd_data_i(scheduler.fwb_pkt_cast_i.rd_data)
 
            ,.cache_req_yumi_i(calculator.pipe_mem.dcache.cache_req_yumi_i)
-           ,.cache_req_v_i(calculator.pipe_mem.dcache.cache_req_v_o)
-           ,.cache_req_last_i(calculator.pipe_mem.dcache.cache_req_last_i)
            ,.cache_req_nonblocking_i(calculator.pipe_mem.dcache.nonblocking_req)
+           ,.cache_req_complete_i(calculator.pipe_mem.dcache.complete_recv)
 
            ,.cosim_clk_i(testbench.cosim_clk_i)
            ,.cosim_reset_i(testbench.cosim_reset_i)

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -380,7 +380,7 @@ module testbench
            ,.frd_addr_i(scheduler.fwb_pkt_cast_i.rd_addr)
            ,.frd_data_i(scheduler.fwb_pkt_cast_i.rd_data)
 
-           ,.cache_req_ready_and_i(calculator.pipe_mem.dcache.cache_req_ready_and_i)
+           ,.cache_req_yumi_i(calculator.pipe_mem.dcache.cache_req_yumi_i)
            ,.cache_req_v_i(calculator.pipe_mem.dcache.cache_req_v_o)
            ,.cache_req_complete_i(calculator.pipe_mem.dcache.cache_req_complete_i)
            ,.cache_req_nonblocking_i(calculator.pipe_mem.dcache.nonblocking_req)

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -382,7 +382,7 @@ module testbench
 
            ,.cache_req_yumi_i(calculator.pipe_mem.dcache.cache_req_yumi_i)
            ,.cache_req_v_i(calculator.pipe_mem.dcache.cache_req_v_o)
-           ,.cache_req_complete_i(calculator.pipe_mem.dcache.cache_req_complete_i)
+           ,.cache_req_last_i(calculator.pipe_mem.dcache.cache_req_last_i)
            ,.cache_req_nonblocking_i(calculator.pipe_mem.dcache.nonblocking_req)
 
            ,.cosim_clk_i(testbench.cosim_clk_i)
@@ -680,7 +680,7 @@ module testbench
               ,.lce_resp_v_i(lce_resp_v_o)
               ,.lce_resp_ready_and_i(lce_resp_ready_and_i)
 
-              ,.cache_req_complete_i(cache_req_complete_o)
+              ,.cache_req_last_i(cache_req_last_o)
               );
 
           bind bp_cce_pending_bits

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -681,7 +681,6 @@ module testbench
               ,.lce_resp_ready_and_i(lce_resp_ready_and_i)
 
               ,.cache_req_complete_i(cache_req_complete_o)
-              ,.uc_store_req_complete_i(uc_store_req_complete_lo)
               );
 
           bind bp_cce_pending_bits

--- a/docs/bedrock_guide.md
+++ b/docs/bedrock_guide.md
@@ -131,7 +131,6 @@ modules.  The BedRock protocol comprises the following signals:
 - data
 - valid
 - ready\_and
-- last
 
 The last signal is raised with data\_valid when the last beat of the message
 is being sent. The width of the data channel must be a power-of-two number of bits, in the inclusive

--- a/docs/interface_specification.md
+++ b/docs/interface_specification.md
@@ -237,7 +237,7 @@ The stat memory contains LRU and dirty data for a block, and the packet format i
 - Replacement index
 
 When the critical data of a transaction is being sent, cache_req_critical_o will go high.
-When a transaction is completed, cache_req_complete_o will go high for one cycle.
+When the last data of a transaction is sent, cache_req_complete_o will go high.
 
 There are additional signals for available credits in the engine, used for fencing. Empty credits
 signify all downstream transactions have completed, whereas full credits signify no more


### PR DESCRIPTION
This PR updates the cache engine interface to 
- Have exponential backoff commands
- be more ready/valid helpful
- be stateless in preparation for nonblocking
- cleans up the cache_req_complete/critical signals to remove double round trip 