### PR TITLE
2bit IDIV and FDIV

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
@@ -138,8 +138,12 @@ module bp_be_pipe_long
   logic sqrt_lo, invalid_exc, infinite_exc;
   logic [2:0] frm_lo;
   bp_hardfloat_raw_dp_s fdivsqrt_raw_lo;
-  divSqrtRecFNToRaw_small
-   #(.expWidth(dp_exp_width_gp), .sigWidth(dp_sig_width_gp))
+  localparam fdivsqrt_bits_per_iter_lp = fpu_support_p[e_fdivsqrt2b] ? 2'b10 : 2'b01;
+  divSqrtRecFNToRaw
+   #(.expWidth(dp_exp_width_gp)
+     ,.sigWidth(dp_sig_width_gp)
+     ,.bits_per_iter_p(fdivsqrt_bits_per_iter_lp)
+     )
    fdiv
     (.clock(clk_i)
      ,.nReset(~reset_i)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
@@ -85,8 +85,9 @@ module bp_be_pipe_long
   logic idiv_v_lo;
   wire idiv_v_li = v_li & (decode.fu_op inside {e_mul_op_div, e_mul_op_divu});
   wire irem_v_li = v_li & (decode.fu_op inside {e_mul_op_rem, e_mul_op_remu});
+  localparam idiv_bits_per_iter_lp = muldiv_support_p[e_idiv2b] ? 2'b10 : 2'b01;
   bsg_idiv_iterative
-   #(.width_p(dword_width_gp))
+   #(.width_p(dword_width_gp), .bits_per_iter_p(idiv_bits_per_iter_lp))
    idiv
     (.clk_i(clk_i)
      ,.reset_i(reset_i)

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -21,9 +21,10 @@
 
   typedef enum logic [1:0]
   {
-    e_div   = 2'b00
-    ,e_mul  = 2'b01
-    ,e_mulh = 2'b10
+    e_idiv    = 2'b00
+    ,e_imul   = 2'b01
+    ,e_imulh  = 2'b10
+    ,e_idiv2b = 2'b11
   } bp_muldiv_support_e;
 
   typedef enum logic [15:0]
@@ -175,7 +176,8 @@
     // MULDIV support in the system. It is a bitmask with:
     //   bit 0: div
     //   bit 1: mul
-    //   bit 2: mulh
+    //   bit 2: iterative mulh
+    //   bit 3: 2b iterative div
     integer unsigned muldiv_support;
     // Whether to emulate FPU
     //   bit 0: fpu enabled
@@ -302,7 +304,10 @@
 
       ,fe_queue_fifo_els : 8
       ,fe_cmd_fifo_els   : 4
-      ,muldiv_support    : (1 << e_div) | (1 << e_mul) | (1 << e_mulh)
+      ,muldiv_support    : (1 << e_idiv)
+                           | (1 << e_imul)
+                           | (1 << e_imulh)
+                           | (1 << e_idiv2b)
       ,fpu_support       : 1
       ,compressed_support: 1
 

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -27,6 +27,13 @@
     ,e_idiv2b = 2'b11
   } bp_muldiv_support_e;
 
+  typedef enum logic [1:0]
+  {
+    e_fma         = 2'b00
+    ,e_fdivsqrt   = 2'b01
+    ,e_fdivsqrt2b = 2'b10
+  } bp_fpu_support_e;
+
   typedef enum logic [15:0]
   {
     e_sacc_none = 0
@@ -180,7 +187,9 @@
     //   bit 3: 2b iterative div
     integer unsigned muldiv_support;
     // Whether to emulate FPU
-    //   bit 0: fpu enabled
+    //   bit 0: fma
+    //   bit 1: iterative fdivsqrt
+    //   bit 2: 2b iterative fdivsqrt
     integer unsigned fpu_support;
     // Whether to enable the "c" extension.
     integer unsigned compressed_support;
@@ -308,7 +317,7 @@
                            | (1 << e_imul)
                            | (1 << e_imulh)
                            | (1 << e_idiv2b)
-      ,fpu_support       : 1
+      ,fpu_support       : (1 << e_fma) | (1 << e_fdivsqrt) | (1 << e_fdivsqrt2b)
       ,compressed_support: 1
 
       ,async_coh_clk       : 0

--- a/bp_common/src/include/bp_common_aviary_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_pkgdef.svh
@@ -78,6 +78,8 @@
       ,l2_data_width : 64
       ,l2_fill_width : 64
 
+      ,muldiv_support: (1 << e_idiv) | (1 << e_imul)
+
       ,default : "inv"
       };
   `bp_aviary_derive_cfg(bp_unicore_tinyparrot_cfg_p

--- a/bp_common/src/include/bp_common_aviary_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_pkgdef.svh
@@ -79,6 +79,7 @@
       ,l2_fill_width : 64
 
       ,muldiv_support: (1 << e_idiv) | (1 << e_imul)
+      ,fpu_support   : (1 << e_fma) | (1 << e_fdivsqrt)
 
       ,default : "inv"
       };

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -180,6 +180,8 @@ $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.v
 # HardFloat files
 $HARDFLOAT_DIR/source/addRecFN.v
 $HARDFLOAT_DIR/source/compareRecFN.v
+$HARDFLOAT_DIR/source/divSqrtRecFN.v
+$HARDFLOAT_DIR/source/divSqrtRecFN_medium.v
 $HARDFLOAT_DIR/source/divSqrtRecFN_small.v
 $HARDFLOAT_DIR/source/fNToRecFN.v
 $HARDFLOAT_DIR/source/HardFloat_primitives.v

--- a/bp_top/test/common/bp_nonsynth_if_verif.sv
+++ b/bp_top/test/common/bp_nonsynth_if_verif.sv
@@ -74,8 +74,10 @@ module bp_nonsynth_if_verif
     $error("Error: RAS > 1 is not supported");
 
   // Core or Features
-  if (!muldiv_support_p[e_mul])
-    $error("MUL is not currently support in emulation");
+  if (!muldiv_support_p[e_imul])
+    $error("IMUL is not currently support in emulation");
+  if (!muldiv_support_p[e_idiv])
+    $error("IDIV is not currently support in emulation");
   if (!fpu_support_p)
     $error("FPU cannot currently be disabled");
   if (branch_metadata_fwd_width_p != $bits(bp_fe_branch_metadata_fwd_s))


### PR DESCRIPTION
### Summary
This PR adds support for 2bit per iteration IDIV and FDIV. This is configurable so that small configurations can ignore it, but performant configurations can leverage it.

### Issue Fixed
#1138 

### Area
Long latency pipe

### Reasoning (new feature, inefficient, verbose, etc.)
Most workloads do not care about IDIV/FDIV performance. But some do, and for those there's no getting around it

### Additional Changes Required (if any)
None

### Analysis
PPA and performance increase on large configurations, no change on smaller configurations

### Verification
None

### Additional Context
None

