### PR TITLE
Adding 1kB cache line megaparrot configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - megaparrot
   before_script:
       - git submodule update --init --checkout --recursive external/
       - cp -r $CI_RTL_INSTALL_DIR install/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - megaparrot
   before_script:
       - git submodule update --init --checkout --recursive external/
       - cp -r $CI_RTL_INSTALL_DIR install/

--- a/bp_common/src/include/bp_common_aviary_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_pkgdef.svh
@@ -20,25 +20,25 @@
       ,bht_row_els              : 4
       ,ghist_width              : 2
 
-      ,icache_sets        : 64
-      ,icache_assoc       : 8
-      ,icache_block_width : 512
-      ,icache_fill_width  : 512
+      ,icache_sets        : 32
+      ,icache_assoc       : 16
+      ,icache_block_width : 1024
+      ,icache_fill_width  : 1024
 
-      ,dcache_sets        : 64
-      ,dcache_assoc       : 8
-      ,dcache_block_width : 512
-      ,dcache_fill_width  : 512
+      ,dcache_sets        : 32
+      ,dcache_assoc       : 16
+      ,dcache_block_width : 1024
+      ,dcache_fill_width  : 1024
 
-      ,bedrock_block_width : 512
-      ,bedrock_fill_width  : 512
+      ,bedrock_block_width : 1024
+      ,bedrock_fill_width  : 1024
 
       ,l2_banks            : 8
-      ,l2_data_width       : 512
+      ,l2_data_width       : 1024
       ,l2_sets             : 128
       ,l2_assoc            : 8
-      ,l2_block_width      : 512
-      ,l2_fill_width       : 512
+      ,l2_block_width      : 1024
+      ,l2_fill_width       : 1024
       ,l2_outstanding_reqs : 32
 
       ,default : "inv"
@@ -162,35 +162,35 @@
       ,bht_row_els              : 4
       ,ghist_width              : 2
 
-      ,icache_sets        : 64
-      ,icache_assoc       : 8
-      ,icache_block_width : 512
-      ,icache_fill_width  : 512
+      ,icache_sets        : 32
+      ,icache_assoc       : 16
+      ,icache_block_width : 1024
+      ,icache_fill_width  : 1024
 
-      ,dcache_sets        : 64
-      ,dcache_assoc       : 8
-      ,dcache_block_width : 512
-      ,dcache_fill_width  : 512
+      ,dcache_sets        : 32
+      ,dcache_assoc       : 16
+      ,dcache_block_width : 1024
+      ,dcache_fill_width  : 1024
 
-      ,acache_sets        : 64
-      ,acache_assoc       : 8
-      ,acache_block_width : 512
-      ,acache_fill_width  : 512
+      ,acache_sets        : 32
+      ,acache_assoc       : 16
+      ,acache_block_width : 1024
+      ,acache_fill_width  : 1024
 
-      ,bedrock_fill_width  : 512
-      ,bedrock_block_width : 512
+      ,bedrock_fill_width  : 1024
+      ,bedrock_block_width : 1024
 
       ,l2_banks            : 8
-      ,l2_data_width       : 512
+      ,l2_data_width       : 1024
       ,l2_sets             : 128
       ,l2_assoc            : 8
-      ,l2_block_width      : 512
-      ,l2_fill_width       : 512
+      ,l2_block_width      : 1024
+      ,l2_fill_width       : 1024
       ,l2_outstanding_reqs : 32
 
-      ,dma_noc_flit_width  : 512
-      ,coh_noc_flit_width  : 512
-      ,mem_noc_flit_width  : 512
+      ,dma_noc_flit_width  : 1024
+      ,coh_noc_flit_width  : 1024
+      ,mem_noc_flit_width  : 1024
 
       ,default : "inv"
       };

--- a/bp_me/src/v/dev/bp_me_cce_to_cache.sv
+++ b/bp_me/src/v/dev/bp_me_cce_to_cache.sv
@@ -33,12 +33,12 @@ module bp_me_cce_to_cache
 
    // BedRock Stream interface
    , input [mem_fwd_header_width_lp-1:0]                   mem_fwd_header_i
-   , input [l2_data_width_p-1:0]                           mem_fwd_data_i
+   , input [bedrock_fill_width_p-1:0]                      mem_fwd_data_i
    , input                                                 mem_fwd_v_i
    , output logic                                          mem_fwd_ready_and_o
 
    , output logic [mem_rev_header_width_lp-1:0]            mem_rev_header_o
-   , output logic [l2_data_width_p-1:0]                    mem_rev_data_o
+   , output logic [bedrock_fill_width_p-1:0]               mem_rev_data_o
    , output logic                                          mem_rev_v_o
    , input                                                 mem_rev_ready_and_i
 
@@ -85,7 +85,7 @@ module bp_me_cce_to_cache
   bp_me_stream_pump_in
    #(.bp_params_p(bp_params_p)
      ,.fsm_data_width_p(l2_data_width_p)
-     ,.block_width_p(bedrock_block_width_p)
+     ,.block_width_p(l2_block_width_p)
      ,.payload_width_p(mem_fwd_payload_width_lp)
      ,.msg_stream_mask_p(mem_fwd_stream_mask_gp)
      ,.fsm_stream_mask_p(mem_fwd_stream_mask_gp | mem_rev_stream_mask_gp)
@@ -224,7 +224,7 @@ module bp_me_cce_to_cache
   bp_me_stream_pump_out
    #(.bp_params_p(bp_params_p)
      ,.fsm_data_width_p(l2_data_width_p)
-     ,.block_width_p(bedrock_block_width_p)
+     ,.block_width_p(l2_block_width_p)
      ,.payload_width_p(mem_rev_payload_width_lp)
      ,.msg_stream_mask_p(mem_rev_stream_mask_gp)
      ,.fsm_stream_mask_p(mem_fwd_stream_mask_gp | mem_rev_stream_mask_gp)
@@ -333,10 +333,11 @@ module bp_me_cce_to_cache
                   e_bedrock_msg_size_2: cache_pkt.opcode = LH;
                   e_bedrock_msg_size_4: cache_pkt.opcode = LW;
                   e_bedrock_msg_size_8: cache_pkt.opcode = LD;
-                  e_bedrock_msg_size_16
-                  ,e_bedrock_msg_size_32
-                  ,e_bedrock_msg_size_64: cache_pkt.opcode = LM;
-                  default: cache_pkt.opcode = LB;
+                  //e_bedrock_msg_size_16
+                  //,e_bedrock_msg_size_32
+                  //,e_bedrock_msg_size_64
+                  //,e_bedrock_msg_size_128
+                  default: cache_pkt.opcode = LM;
                 endcase
               e_bedrock_mem_uc_wr
               ,e_bedrock_mem_wr
@@ -358,10 +359,11 @@ module bp_me_cce_to_cache
                       e_bedrock_amomaxu: cache_pkt.opcode = is_word_op ? AMOMAXU_W : AMOMAXU_D;
                       default : begin end
                     endcase
-                  e_bedrock_msg_size_16
-                  ,e_bedrock_msg_size_32
-                  ,e_bedrock_msg_size_64: cache_pkt.opcode = SM;
-                  default: cache_pkt.opcode = LB;
+                  //e_bedrock_msg_size_16
+                  //,e_bedrock_msg_size_32
+                  //,e_bedrock_msg_size_64
+                  //,e_bedrock_msg_size_128
+                  default: cache_pkt.opcode = SM;
                 endcase
               default: cache_pkt.opcode = LB;
             endcase

--- a/bp_me/test/common/bp_nonsynth_dram.sv
+++ b/bp_me/test/common/bp_nonsynth_dram.sv
@@ -226,9 +226,9 @@ module bp_nonsynth_dram
     begin : axi
       localparam axi_id_width_p = 6;
       localparam axi_addr_width_p = 64;
-      localparam axi_data_width_p = 512;
+      localparam axi_data_width_p = l2_fill_width_p;
       localparam axi_strb_width_p = axi_data_width_p >> 3;
-      localparam axi_burst_len_p = 1;
+      localparam axi_burst_len_p = l2_block_width_p / l2_fill_width_p;
 
       localparam mem_els_lp = mem_bytes_p/(axi_data_width_p/8);
 

--- a/bp_me/test/common/bp_nonsynth_mem.sv
+++ b/bp_me/test/common/bp_nonsynth_mem.sv
@@ -23,12 +23,12 @@ module bp_nonsynth_mem
    , input                                          reset_i
 
    , input [mem_fwd_header_width_lp-1:0]            mem_fwd_header_i
-   , input [l2_data_width_p-1:0]                    mem_fwd_data_i
+   , input [bedrock_fill_width_p-1:0]               mem_fwd_data_i
    , input                                          mem_fwd_v_i
    , output logic                                   mem_fwd_ready_and_o
 
    , output logic [mem_rev_header_width_lp-1:0]     mem_rev_header_o
-   , output logic [l2_data_width_p-1:0]             mem_rev_data_o
+   , output logic [bedrock_fill_width_p-1:0]        mem_rev_data_o
    , output logic                                   mem_rev_v_o
    , input                                          mem_rev_ready_and_i
 

--- a/bp_top/test/common/bp_nonsynth_if_verif.sv
+++ b/bp_top/test/common/bp_nonsynth_if_verif.sv
@@ -101,8 +101,6 @@ module bp_nonsynth_if_verif
     $error("Error: L1 I$ requires fill width greater than bank width (block width / assoc)");
   if (dcache_fill_width_p < (dcache_block_width_p / dcache_assoc_p))
     $error("Error: L1 D$ requires fill width greater than bank width (block width / assoc)");
-  if (dcache_block_width_p > 512 || icache_block_width_p > 512 || acache_block_width_p > 512)
-    $error("Error: L1 caches can only support <=64B cache line size");
 
   // Address Widths
   if (vaddr_width_p != 39)
@@ -131,8 +129,6 @@ module bp_nonsynth_if_verif
     $error("Error: L2 banks must be a power of two");
 
   // Unicore
-  if ((cce_type_p == e_cce_uce) && (bedrock_fill_width_p != l2_data_width_p))
-    $error("Error: unicore requires L2-Cache data width same as UCE fill width");
   if ((cce_type_p == e_cce_uce) && (icache_fill_width_p != dcache_fill_width_p))
     $error("Error: unicore requires L1-Cache fill widths to match");
   if ((cce_type_p == e_cce_uce) && (num_core_p != 1))

--- a/ci/weird_config.sh
+++ b/ci/weird_config.sh
@@ -52,7 +52,8 @@ let JOBS=${#cfgs[@]}
 let CORES_PER_JOB=${N}/${JOBS}+1
 
 # Build configs
-cmd_base="make -C bp_top/syn build.${SUFFIX} COSIM_P=1 DRAM=axi"
+# DWP 7/20, weird vcs bug hangs when building without dump
+cmd_base="make -C bp_top/syn build_dump.${SUFFIX} COSIM_P=1 DRAM=axi"
 parallel --jobs ${JOBS} --results regress_logs --progress "$cmd_base CFG={}" ::: "${cfgs[@]}"
 
 # Run the regression in parallel on each configuration


### PR DESCRIPTION
### Summary
This PR adds support for 64kB caches. While this would likely impact critical path, it is a configuration which makes sense for some performance-focused applications

### Issue Fixed
#853 

### Area
Caches and fill path

### Reasoning (new feature, inefficient, verbose, etc.)
User requests

### Additional Changes Required (if any)
None

### Analysis
Minimal, since it's a non-default option

### Verification
Standard regression

### Additional Context
None

