### PR TITLE
Adding Xcelium support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ install/
 regress_logs/
 stack.info.*
 *.swp
+.simvision/

--- a/bp_be/syn/Makefile
+++ b/bp_be/syn/Makefile
@@ -25,4 +25,5 @@ include $(BP_COMMON_DIR)/syn/Makefile.common
 include $(BP_COMMON_DIR)/syn/Makefile.dc
 include $(BP_COMMON_DIR)/syn/Makefile.verilator
 include $(BP_COMMON_DIR)/syn/Makefile.vcs
+include $(BP_COMMON_DIR)/syn/Makefile.xcelium
 

--- a/bp_be/test/tb/bp_be_dcache/Makefile.xcelium
+++ b/bp_be/test/tb/bp_be_dcache/Makefile.xcelium
@@ -1,0 +1,5 @@
+exit_simx_job:
+	@echo "Xcelium is not supported for this testbench"
+	exit 1
+
+SIM_COLLATERAL = exit_simx_job

--- a/bp_common/syn/Makefile.xcelium
+++ b/bp_common/syn/Makefile.xcelium
@@ -1,0 +1,116 @@
+override TOOL := xcelium
+
+override LOG_DIR     := $(LOG_PATH)/$(TOOL)
+override RESULTS_DIR := $(RESULTS_PATH)/$(TOOL)
+override REPORT_DIR  := $(REPORT_PATH)/$(TOOL)
+override TOUCH_DIR   := $(TOUCH_PATH)/$(TOOL)
+
+override LINT_DIR  := $(RESULTS_DIR)/$(TB).$(CFG).$(TAG).lint
+override BUILD_DIR := $(RESULTS_DIR)/$(TB).$(CFG).$(TAG).build
+override SIM_DIR   := $(RESULTS_DIR)/$(TB).$(CFG).$(TAG).sim.$(SUITE).$(PROG)
+override COV_DIR   := $(RESULTS_DIR)/$(TB).$(CFG).$(TAG).cov
+$(TOUCH_DIR) $(RESULTS_DIR) $(LOG_DIR) $(REPORT_DIR) $(LINT_DIR) $(BUILD_DIR) $(SIM_DIR) $(COV_DIR):
+	mkdir -p $@
+
+.PHONY: clean.x lint.x build.x sim.x cov.x
+
+include $(TB_PATH)/$(TB)/Makefile.xcelium
+
+## Tool specific options
+LINT_XMSIM_OPTIONS = +lint=all,noSVA-UA,noSVA-NSVU,noNS,noVCDE
+
+XMSIM_OPTIONS += -64BIT
+XMSIM_OPTIONS += testbench
+XMSIM_OPTIONS += +libext+.v+.vlib+.vh       # Find library files with these extensions
+XMSIM_OPTIONS += -SV_ROOT $(BP_RTL_INSTALL_DIR)/lib -SV_LIB libdramsim3
+XMSIM_OPTIONS += -SV_ROOT $(BP_TOOLS_INSTALL_DIR)/lib -SV_LIB libdromajo_cosim
+
+XRUN_BUILD_OPTS  = -64bit # Compile a 64-bit executable
+XRUN_BUILD_OPTS += -sv # Enable SystemVerilog
+XRUN_BUILD_OPTS += -assert # Enable elaboration system tasks
+XRUN_BUILD_OPTS += -timescale 1ps/1ps  # Set timescale
+XRUN_BUILD_OPTS += -elaborate -notimingchecks
+XRUN_BUILD_OPTS += "-I$(BP_TOOLS_DIR)/dromajo/include"
+XRUN_BUILD_OPTS += "-I$(BP_TOOLS_INSTALL_DIR)/include -I $(BASEJUMP_STL_DIR)/bsg_test"
+#XRUN_BUILD_OPTS += "-L$(BP_RTL_INSTALL_DIR)/lib -ldramsim3 -Wl,-rpath=$(BP_RTL_INSTALL_DIR)/lib"
+#XRUN_BUILD_OPTS += "-L$(BP_TOOLS_INSTALL_DIR)/lib -ldromajo_cosim -Wl,-rpath=$(BP_TOOLS_INSTALL_DIR)/lib"
+XRUN_BUILD_OPTS += -top testbench
+XRUN_BUILD_OPTS += -f flist.vcs
+
+XMSIM_PLUSARGS  =
+
+lint.x: $(LINT_DIR)/lintx
+lint.x: LINT_LOG     := $(LOG_DIR)/$(TB).$(CFG).$(TAG).lint.log
+lint.x: LINT_REPORT  := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).lint.rpt
+lint.x: LINT_ERROR   := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).lint.err
+$(LINT_COLLATERAL): | $(TOUCH_DIR) $(RESULTS_DIR) $(LOG_DIR) $(REPORT_DIR) $(LINT_DIR)
+$(LINT_DIR)/lintx: | $(LINT_COLLATERAL)
+	cd $(@D); \
+		$(XRUN) $(XRUN_BUILD_OPTS) $(LINT_XMSIM_OPTIONS) $(subst pvalue+,defparam testbench.,$(HDL_PARAMS)) $(HDL_DEFINES) 2>&1 | tee -i $(LINT_LOG)
+	-@grep -A5 "Lint" $(LINT_LOG) > $(LINT_REPORT)
+
+build.x: $(BUILD_DIR)/xcelium.d
+build.x: BUILD_LOG    := $(LOG_DIR)/$(TB).$(CFG).$(TAG).build.log
+build.x: BUILD_REPORT := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).build.rpt
+build.x: BUILD_ERROR  := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).build.err
+$(BUILD_COLLATERAL): | $(TOUCH_DIR) $(RESULTS_DIR) $(LOG_DIR) $(REPORT_DIR) $(BUILD_DIR)
+$(BUILD_DIR)/xcelium.d: | $(BUILD_COLLATERAL)
+	cd $(@D); \
+		$(XRUN) $(XRUN_BUILD_OPTS) $(subst pvalue+,defparam testbench.,$(HDL_PARAMS)) $(HDL_DEFINES) 2>&1 | tee -i $(BUILD_LOG)
+	-@grep "Error" -A5 $(BUILD_LOG) > $(BUILD_ERROR)
+	-@tail -n3 $(BUILD_LOG) > $(BUILD_REPORT)
+	-@test -s $(BUILD_ERROR) && echo "FAILED" >> $(BUILD_REPORT) || rm $(BUILD_ERROR)
+
+build_dump.x: XRUN_BUILD_OPTS += -access rc
+build_dump.x: build.x
+
+build_cov.x: build.x
+	$(error Coverage is currently unsupported for xcelium)
+
+sim.x: build.x
+sim.x: $(SIM_DIR)/run_simx
+sim.x: SIM_LOG    := $(LOG_DIR)/$(TB).$(CFG).$(TAG).sim.$(SUITE).$(PROG).log
+sim.x: SIM_REPORT := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).sim.$(SUITE).$(PROG).rpt
+sim.x: SIM_ERROR  := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).sim.$(SUITE).$(PROG).err
+$(SIM_COLLATERAL): | $(TOUCH_DIR) $(RESULTS_DIR) $(LOG_DIR) $(REPORT_DIR) $(SIM_DIR)
+$(SIM_DIR)/run_simx: | $(SIM_COLLATERAL)
+	cd $(@D); $(XMSIM) $(XMSIM_OPTIONS) $(XMSIM_PLUSARGS) 2>&1 | tee -i $(SIM_LOG)
+	-@grep "FAIL" $(SIM_LOG) && echo "FAILED" > $(SIM_ERROR)
+	-@grep "PASS" $(SIM_LOG) || echo "FAILED" > $(SIM_ERROR)
+	-@grep "finish called from file" $(SIM_LOG) || echo "FAILED" > $(SIM_ERROR)
+	-@grep "STATS" -A 3 $(SIM_LOG) > $(SIM_REPORT)
+
+sim_dump.x: XMSIM_OPTIONS += -input $(TB_PATH)/$(TB)/xcelium_dump.tcl
+sim_dump.x: sim.x
+
+sim_cov.x: sim.x
+	$(error Coverage is currently unsupported for xcelium)
+
+cov.x: $(COV_DIR)/covv
+cov.x: COV_LOG     := $(LOG_DIR)/$(TB).$(CFG).$(TAG).cov.log
+cov.x: COV_REPORT  := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).cov
+cov.x: COV_HREPORT := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).cov.hier.rpt
+cov.x: COV_TREPORT := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).cov.test.rpt
+cov.x: COV_ERROR   := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).cov.err
+$(COV_COLLATERAL): | $(TOUCH_DIR) $(RESULTS_DIR) $(LOG_DIR) $(REPORT_DIR) $(COV_DIR)
+$(COV_DIR)/cov.x: | $(COV_COLLATERAL)
+	$(error Coverage is currently unsupported for xcelium)
+
+wave.x: $(SIM_DIR)/wavex
+$(SIM_DIR)/wavex:
+	$(SIMVISION) -64BIT $(@D)/dump.shm &
+
+# TODO: Make compatible with multi-core
+BLOODGRAPH ?= $(BP_COMMON_DIR)/software/py/blood_graph.py --generate --generate-key
+blood.x: $(SIM_DIR)/bloodx
+$(SIM_DIR)/bloodx:
+	cd $(@D); $(PYTHON) $(BLOODGRAPH) --trace stall_0.trace
+
+clean.x:
+	@-rm -rf touchfiles/vcs
+	@-rm -rf results/vcs
+	@-rm -rf reports/vcs
+	@-rm -rf logs/vcs
+	@-rm -rf DVEfiles
+	@-rm -rf stack.info*
+

--- a/bp_fe/syn/Makefile
+++ b/bp_fe/syn/Makefile
@@ -26,4 +26,5 @@ include $(BP_COMMON_DIR)/syn/Makefile.common
 include $(BP_COMMON_DIR)/syn/Makefile.dc
 include $(BP_COMMON_DIR)/syn/Makefile.verilator
 include $(BP_COMMON_DIR)/syn/Makefile.vcs
+include $(BP_COMMON_DIR)/syn/Makefile.xcelium
 

--- a/bp_fe/test/tb/bp_fe_icache/Makefile.xcelium
+++ b/bp_fe/test/tb/bp_fe_icache/Makefile.xcelium
@@ -1,0 +1,5 @@
+exit_simx_job:
+	@echo "Xcelium is not supported for this testbench"
+	exit 1
+
+SIM_COLLATERAL = exit_simx_job

--- a/bp_me/syn/Makefile
+++ b/bp_me/syn/Makefile
@@ -26,4 +26,5 @@ include $(BP_COMMON_DIR)/syn/Makefile.common
 include $(BP_COMMON_DIR)/syn/Makefile.dc
 include $(BP_COMMON_DIR)/syn/Makefile.verilator
 include $(BP_COMMON_DIR)/syn/Makefile.vcs
+include $(BP_COMMON_DIR)/syn/Makefile.xcelium
 

--- a/bp_me/test/tb/bp_cce/Makefile.xcelium
+++ b/bp_me/test/tb/bp_cce/Makefile.xcelium
@@ -1,0 +1,5 @@
+exit_simx_job:
+	@echo "Xcelium is not supported for this testbench"
+	exit 1
+
+SIM_COLLATERAL = exit_simx_job

--- a/bp_top/syn/Makefile
+++ b/bp_top/syn/Makefile
@@ -28,5 +28,6 @@ include $(BP_COMMON_DIR)/syn/Makefile.sv2v
 include $(BP_COMMON_DIR)/syn/Makefile.verilator
 include $(BP_COMMON_DIR)/syn/Makefile.vcs
 include $(BP_COMMON_DIR)/syn/Makefile.vivado
+include $(BP_COMMON_DIR)/syn/Makefile.xcelium
 include $(BP_COMMON_DIR)/syn/Makefile.yosys
 

--- a/bp_top/test/common/bp_nonsynth_branch_profiler.sv
+++ b/bp_top/test/common/bp_nonsynth_branch_profiler.sv
@@ -23,6 +23,8 @@ module bp_nonsynth_branch_profiler
     , input                       commit_v_i
     );
 
+`ifndef XCELIUM
+
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
   `declare_bp_fe_branch_metadata_fwd_s(ras_idx_width_p, btb_tag_width_p, btb_idx_width_p, bht_idx_width_p, ghist_width_p, bht_row_els_p);
   bp_fe_cmd_s fe_cmd;
@@ -138,6 +140,8 @@ module bp_nonsynth_branch_profiler
       foreach (branch_histo[key])
         $fwrite(file, "[%x] %d %d %d\n", key, branch_histo[key], miss_histo[key], (miss_histo[key]*100)/branch_histo[key]);
     end
+
+`endif
 
 endmodule
 

--- a/bp_top/test/common/bp_nonsynth_core_profiler.sv
+++ b/bp_top/test/common/bp_nonsynth_core_profiler.sv
@@ -134,6 +134,7 @@ module bp_nonsynth_core_profiler
     , input [commit_pkt_width_lp-1:0] commit_pkt_i
     );
 
+`ifndef XCELIUM
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 
   localparam num_stages_p = 7;
@@ -316,6 +317,7 @@ module bp_nonsynth_core_profiler
     end
   `endif
   // synopsys translate_on
+`endif
 
 endmodule
 

--- a/bp_top/test/common/bp_nonsynth_cosim.sv
+++ b/bp_top/test/common/bp_nonsynth_cosim.sv
@@ -65,6 +65,8 @@ module bp_nonsynth_cosim
   import "DPI-C" context function void set_finish(int hartid);
   import "DPI-C" context function bit check_terminate();
 
+`ifndef XCELIUM
+
   wire posedge_clk =  clk_i;
   wire negedge_clk = ~clk_i;
 
@@ -314,6 +316,8 @@ module bp_nonsynth_cosim
         $display("COSIM_FAIL: commit fifo overrun, core %x", mhartid_i);
         $finish();
       end
+
+`endif
 
 endmodule
 

--- a/bp_top/test/common/bp_nonsynth_pc_profiler.sv
+++ b/bp_top/test/common/bp_nonsynth_pc_profiler.sv
@@ -22,6 +22,8 @@ module bp_nonsynth_pc_profiler
     , input [commit_pkt_width_lp-1:0] commit_pkt
     );
 
+`ifndef XCELIUM
+
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
   bp_be_commit_pkt_s commit_pkt_cast_i;
   assign commit_pkt_cast_i = commit_pkt;
@@ -55,6 +57,7 @@ module bp_nonsynth_pc_profiler
   final
    foreach (histogram[key])
      $fwrite(file, "[%x] %x\n", key, histogram[key]);
+`endif
 
 endmodule
 

--- a/bp_top/test/tb/bp_tethered/Makefile.xcelium
+++ b/bp_top/test/tb/bp_tethered/Makefile.xcelium
@@ -1,0 +1,112 @@
+
+$(LINT_DIR)/testbench.sv $(LINT_DIR)/wrapper.sv:
+	@sed "s/BP_CFG_FLOWVAR/$(CFG)/g" $(TB_PATH)/$(TB)/$(@F) > $@
+	@sed -i 's/BP_DRAM_FLOWVAR/"$(DRAM)"/g' $@
+
+$(LINT_DIR)/bsg_tag_boot_rom.v: $(TB_PATH)/$(TB)/bsg_tag_boot.tr
+	@python $(BASEJUMP_STL_DIR)/bsg_mem/bsg_ascii_to_rom.py $< bsg_tag_boot_rom > $@
+
+$(LINT_DIR)/flist.vcs:
+	@grep -v -e "^\#" $(SYN_PATH)/flist.vcs          > $@
+	@grep -v -e "^\#" $(TB_PATH)/$(TB)/flist.vcs    >> $@
+	@echo wrapper.sv                                >> $@
+	@echo testbench.sv                              >> $@
+	@echo bsg_tag_boot_rom.v                        >> $@
+	@echo "$(BP_ME_DIR)/test/common/bp_ddr.sv"      >> $@
+	@echo "$(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_reset_gen.v" >> $@
+	@echo "$(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_clock_gen.v" >> $@
+	@echo "$(BASEJUMP_STL_DIR)/bsg_clk_gen/bsg_dly_line.v"        >> $@
+	@echo "$(BASEJUMP_STL_DIR)/bsg_dmc/bsg_dmc_clk_rst_gen.v"     >> $@
+	@echo "$(BASEJUMP_STL_DIR)/testing/bsg_dmc/lpddr_verilog_model/mobile_ddr.v" >> $@
+
+LINT_COLLATERAL = $(addprefix $(LINT_DIR)/, flist.vcs wrapper.sv testbench.sv bsg_tag_boot_rom.v)
+
+$(BUILD_DIR)/testbench.sv:
+	@sed "s/BP_CFG_FLOWVAR/$(CFG)/g" $(TB_PATH)/$(TB)/$(@F) > $@
+	@sed -i 's/BP_DRAM_FLOWVAR/"$(DRAM)"/g' $@
+
+$(BUILD_DIR)/wrapper.sv:
+	if [ "$(SIM_SYNTH_VIVADO_P)" = "1" ]; then \
+		cp $(SYN_PATH)/results/vivado/bp_tethered.$(CFG).$(TAG).build/wrapper_synth.sv $@; \
+	elif [ "$(SIM_SYNTH_YOSYS_P)" = "1" ]; then \
+		cp $(SYN_PATH)/results/yosys/bp_tethered.$(CFG).$(TAG).synth/wrapper.synth.v $@; \
+	else \
+		sed "s/BP_CFG_FLOWVAR/$(CFG)/g" $(TB_PATH)/$(TB)/$(@F) > $@; \
+		sed -i 's/BP_DRAM_FLOWVAR/"$(DRAM)"/g' $@; \
+	fi
+
+$(BUILD_DIR)/bsg_tag_boot_rom.v: $(TB_PATH)/$(TB)/bsg_tag_boot.tr
+	@python $(BASEJUMP_STL_DIR)/bsg_mem/bsg_ascii_to_rom.py $< bsg_tag_boot_rom > $@
+
+$(BUILD_DIR)/flist.vcs:
+	@grep -v -e "^\#" $(SYN_PATH)/flist.vcs          > $@
+	@grep -v -e "^\#" $(TB_PATH)/$(TB)/flist.vcs    >> $@
+	@echo wrapper.sv                                >> $@
+	@echo testbench.sv                              >> $@
+	@echo bsg_tag_boot_rom.v                        >> $@
+	@echo "$(BP_ME_DIR)/test/common/bp_ddr.sv"      >> $@
+	@echo "$(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_reset_gen.v" >> $@
+	@echo "$(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_clock_gen.v" >> $@
+	@echo "$(BASEJUMP_STL_DIR)/bsg_clk_gen/bsg_dly_line.v"        >> $@
+	@echo "$(BASEJUMP_STL_DIR)/bsg_dmc/bsg_dmc_clk_rst_gen.v"     >> $@
+	@echo "$(BASEJUMP_STL_DIR)/testing/bsg_dmc/lpddr_verilog_model/mobile_ddr.v" >> $@
+
+BUILD_COLLATERAL = $(addprefix $(BUILD_DIR)/, flist.vcs wrapper.sv testbench.sv bsg_tag_boot_rom.v)
+
+$(SIM_DIR)/xcelium.d: $(BUILD_DIR)/xcelium.d
+	@ln -nsf $(<D)/$(@F) $@
+
+$(SIM_DIR)/prog.riscv: $(BP_SDK_PROG_DIR)/$(SUITE)/$(PROG).riscv
+	cp $^ $@
+
+$(SIM_DIR)/prog.elf: $(SIM_DIR)/prog.riscv
+	cp $^ $@
+
+ifeq ($(UCODE), 1)
+CCE_UCODE_FILE ?= $(BP_SDK_UCODE_DIR)/$(CCE_MEM)
+else
+CCE_UCODE_FILE ?=
+endif
+
+$(SIM_DIR)/cce_ucode.mem: $(CCE_UCODE_FILE)
+ifeq ($(UCODE), 1)
+	cp $< $@
+endif
+
+NBF_INPUTS ?= --ncpus=$(NCPUS)
+ifeq ($(UCODE), 1)
+NBF_INPUTS += --config --ucode=cce_ucode.mem
+else ifeq ($(NBF_CONFIG_P), 1)
+NBF_INPUTS += --config
+endif
+ifeq ($(PRELOAD_MEM_P), 0)
+NBF_INPUTS += --mem=prog.mem --mem_size=$(NBF_MEM_SIZE)
+ifeq ($(NBF_SKIP_ZEROS), 1)
+NBF_INPUTS += --skip_zeros
+endif
+endif
+NBF_INPUTS += --addr_width=$(PADDR_WIDTH)
+NBF_INPUTS += --debug
+
+$(SIM_DIR)/prog.nbf: $(SIM_DIR)/cce_ucode.mem $(SIM_DIR)/prog.mem
+	cd $(@D); python $(MEM2NBF) $(NBF_INPUTS) > $@
+
+$(SIM_DIR)/bootrom.riscv: $(BP_SDK_PROG_DIR)/bootrom/bootrom.riscv
+	cp $< $@
+
+$(SIM_DIR)/bootrom.mem: $(SIM_DIR)/bootrom.riscv
+	$(RISCV_OBJCOPY) -O verilog --verilog-data-width=8 $< $@
+	$(SED) -i "s/@0011/@0000/g" $@
+
+SIM_COLLATERAL  = $(addprefix $(SIM_DIR)/, xcelium.d)
+SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, prog.riscv prog.elf prog.mem prog.nbf prog.dump)
+SIM_COLLATERAL += $(addprefix $(SIM_DIR)/, bootrom.riscv bootrom.mem bootrom.dump)
+
+sim_sample.x: build.x
+sim_sample.x: $(SIM_DIR)/run_samplex
+sim_sample.x: SIM_LOG    := $(LOG_DIR)/$(TB).$(CFG).$(TAG).sim.$(SUITE).$(PROG).log
+sim_sample.x: SIM_REPORT := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).sim.$(SUITE).$(PROG).rpt
+sim_sample.x: SIM_ERROR  := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).sim.$(SUITE).$(PROG).err
+$(SIM_DIR)/run_samplex: $(SIM_COLLATERAL)
+	$(error Sampling is currently unsupported for xcelium)
+

--- a/bp_top/test/tb/bp_tethered/xcelium_dump.tcl
+++ b/bp_top/test/tb/bp_tethered/xcelium_dump.tcl
@@ -1,0 +1,4 @@
+database -open dump -shm
+probe -create testbench.wrapper.processor -depth all -all -shm -database dump
+run
+exit


### PR DESCRIPTION
### Summary
This PR adds support for xcelium simulation. It's preliminary and does not support many TB features, but should allow users to run standard regressions.

### Issue Fixed
None

### Area
Simulation makefiles

### Reasoning (new feature, inefficient, verbose, etc.)
Some shops / labs are Cadence only and we don't want to exclude them

### Additional Changes Required (if any)
None

### Analysis
No design impact

### Verification
Smoke test of a few programs. Users can raise alarms if certain flows are unsupported

### Additional Context
None

