### PR TITLE
Catchup ALU

### DIFF
--- a/bp_be/src/include/bp_be_ctl_pkgdef.svh
+++ b/bp_be/src/include/bp_be_ctl_pkgdef.svh
@@ -232,6 +232,7 @@
     logic dtlb_fill;
     logic _interrupt;
     logic cmd_full;
+    logic mispredict;
   }  bp_be_exception_s;
 
   typedef struct packed
@@ -252,6 +253,7 @@
   {
     logic v;
     logic queue_v;
+    logic ispec_v;
 
     bp_be_exception_s exc;
     bp_be_special_s   spec;

--- a/bp_be/src/include/bp_be_ctl_pkgdef.svh
+++ b/bp_be/src/include/bp_be_ctl_pkgdef.svh
@@ -175,11 +175,17 @@
     logic                             pipe_fma_v;
     logic                             pipe_long_v;
 
+    logic                             irs1_r_v;
+    logic                             irs2_r_v;
+    logic                             frs1_r_v;
+    logic                             frs2_r_v;
+    logic                             frs3_r_v;
     logic                             irf_w_v;
     logic                             frf_w_v;
     logic                             fflags_w_v;
     logic                             branch_v;
     logic                             jump_v;
+    logic                             fence_v;
     logic                             dcache_r_v;
     logic                             dcache_w_v;
     logic                             late_iwb_v;

--- a/bp_be/src/include/bp_be_defines.svh
+++ b/bp_be/src/include/bp_be_defines.svh
@@ -63,6 +63,7 @@
       logic                                    v;                                                  \
       logic                                    queue_v;                                            \
       logic                                    instr_v;                                            \
+      logic                                    ispec_v;                                            \
       logic [vaddr_width_mp-1:0]               pc;                                                 \
       rv64_instr_s                             instr;                                              \
       logic                                    compressed;                                         \
@@ -79,18 +80,21 @@
     typedef struct packed                                                                          \
     {                                                                                              \
       logic                              v;                                                        \
-      logic                              fflags_w_v;                                               \
-      logic                              ctl_iwb_v;                                                \
       logic                              aux_iwb_v;                                                \
       logic                              aux_fwb_v;                                                \
-      logic                              int_iwb_v;                                                \
-      logic                              int_fwb_v;                                                \
+      logic                              eint_iwb_v;                                               \
+      logic                              eint_fwb_v;                                               \
+      logic                              fint_iwb_v;                                               \
+      logic                              fint_fwb_v;                                               \
       logic                              emem_iwb_v;                                               \
       logic                              emem_fwb_v;                                               \
       logic                              fmem_iwb_v;                                               \
       logic                              fmem_fwb_v;                                               \
       logic                              mul_iwb_v;                                                \
+      logic                              mul_fwb_v;                                                \
+      logic                              fma_iwb_v;                                                \
       logic                              fma_fwb_v;                                                \
+      logic                              fflags_w_v;                                               \
                                                                                                    \
       logic [rv64_reg_addr_width_gp-1:0] rd_addr;                                                  \
     }  bp_be_dep_status_s;                                                                         \
@@ -100,6 +104,7 @@
       logic                     v;                                                                 \
       logic                     branch;                                                            \
       logic                     btaken;                                                            \
+      logic                     bspec;                                                             \
       logic [vaddr_width_p-1:0] npc;                                                               \
     }  bp_be_branch_pkt_s;                                                                         \
                                                                                                    \
@@ -236,7 +241,7 @@
     (7+vaddr_width_mp+instr_width_gp+$bits(bp_be_decode_s)+dpath_width_gp+branch_metadata_fwd_width_mp+12)
 
   `define bp_be_dispatch_pkt_width(vaddr_width_mp) \
-    (3                                                                                             \
+    (4                                                                                             \
      + vaddr_width_mp                                                                              \
      + rv64_instr_width_gp                                                                         \
      + 1                                                                                           \
@@ -248,10 +253,10 @@
      )
 
   `define bp_be_dep_status_width \
-    (13 + rv64_reg_addr_width_gp)
+    (15 + rv64_reg_addr_width_gp)
 
   `define bp_be_branch_pkt_width(vaddr_width_mp) \
-    (3 + vaddr_width_mp)
+    (4 + vaddr_width_mp)
 
   `define bp_be_retire_pkt_width(vaddr_width_mp) \
     (4 + dpath_width_gp + 2*vaddr_width_mp + instr_width_gp + 1 + $bits(bp_be_exception_s) + $bits(bp_be_special_s))

--- a/bp_be/src/include/bp_be_defines.svh
+++ b/bp_be/src/include/bp_be_defines.svh
@@ -33,26 +33,29 @@
     {                                                                                              \
       logic                                    v;                                                  \
       logic                                    instr_v;                                            \
-      logic                                    itlb_miss_v;                                        \
-      logic                                    instr_access_fault_v;                               \
-      logic                                    instr_page_fault_v;                                 \
-      logic                                    icache_miss_v;                                      \
+      logic                                    itlb_miss;                                          \
+      logic                                    instr_access_fault;                                 \
+      logic                                    instr_page_fault;                                   \
+      logic                                    icache_miss;                                        \
+      logic                                    illegal_instr;                                      \
+      logic                                    ecall_m;                                            \
+      logic                                    ecall_s;                                            \
+      logic                                    ecall_u;                                            \
+      logic                                    ebreak;                                             \
+      logic                                    dbreak;                                             \
+      logic                                    dret;                                               \
+      logic                                    mret;                                               \
+      logic                                    sret;                                               \
+      logic                                    wfi;                                                \
+      logic                                    sfence_vma;                                         \
+                                                                                                   \
       logic [vaddr_width_mp-1:0]               pc;                                                 \
       rv64_instr_s                             instr;                                              \
-      logic                                    partial;                                            \
       logic                                    compressed;                                         \
+      logic                                    partial;                                            \
+      bp_be_decode_s                           decode;                                             \
+      logic [dpath_width_gp-1:0]               imm;                                                \
       logic [branch_metadata_fwd_width_mp-1:0] branch_metadata_fwd;                                \
-      logic                                    csr_v;                                              \
-      logic                                    mem_v;                                              \
-      logic                                    fence_v;                                            \
-      logic                                    long_v;                                             \
-      logic                                    irs1_v;                                             \
-      logic                                    irs2_v;                                             \
-      logic                                    frs1_v;                                             \
-      logic                                    frs2_v;                                             \
-      logic                                    frs3_v;                                             \
-      logic                                    iwb_v;                                              \
-      logic                                    fwb_v;                                              \
     }  bp_be_issue_pkt_s;                                                                          \
                                                                                                    \
     typedef struct packed                                                                          \
@@ -60,18 +63,12 @@
       logic                                    v;                                                  \
       logic                                    queue_v;                                            \
       logic                                    instr_v;                                            \
-      logic                                    compressed;                                         \
-      logic                                    partial;                                            \
       logic [vaddr_width_mp-1:0]               pc;                                                 \
       rv64_instr_s                             instr;                                              \
+      logic                                    compressed;                                         \
+      logic                                    partial;                                            \
       bp_be_decode_s                           decode;                                             \
                                                                                                    \
-      logic                                    irs1_v;                                             \
-      logic                                    frs1_v;                                             \
-      logic                                    irs2_v;                                             \
-      logic                                    frs2_v;                                             \
-      logic                                    irs3_v;                                             \
-      logic                                    frs3_v;                                             \
       logic [dpath_width_gp-1:0]               rs1;                                                \
       logic [dpath_width_gp-1:0]               rs2;                                                \
       logic [dpath_width_gp-1:0]               imm;                                                \
@@ -236,13 +233,13 @@
     (6+rv64_instr_width_gp)
 
   `define bp_be_issue_pkt_width(vaddr_width_mp, branch_metadata_fwd_width_mp) \
-    (7+vaddr_width_mp+instr_width_gp+branch_metadata_fwd_width_mp+12)
+    (7+vaddr_width_mp+instr_width_gp+$bits(bp_be_decode_s)+dpath_width_gp+branch_metadata_fwd_width_mp+12)
 
   `define bp_be_dispatch_pkt_width(vaddr_width_mp) \
     (3                                                                                             \
      + vaddr_width_mp                                                                              \
      + rv64_instr_width_gp                                                                         \
-     + 7                                                                                           \
+     + 1                                                                                           \
      + 3 * dpath_width_gp                                                                          \
      + $bits(bp_be_decode_s)                                                                       \
      + 1                                                                                           \

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -141,11 +141,11 @@ module bp_be_calculator_top
   logic [pipe_stage_els_lp-1:0][dpath_width_gp-1:0] forward_data;
   for (genvar i = 0; i < pipe_stage_els_lp; i++)
     begin : forward_match
-      assign match_rs[0][i] = ((i < 4) & dispatch_pkt_cast_i.irs1_v & comp_stage_r[i].ird_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs1_addr == comp_stage_r[i].rd_addr))
-                              || ((i > 0) & dispatch_pkt_cast_i.frs1_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs1_addr == comp_stage_r[i].rd_addr));
-      assign match_rs[1][i] = ((i < 4) & dispatch_pkt_cast_i.irs2_v & comp_stage_r[i].ird_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs2_addr == comp_stage_r[i].rd_addr))
-                              || ((i > 0) & dispatch_pkt_cast_i.frs2_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs2_addr == comp_stage_r[i].rd_addr));
-      assign match_rs[2][i] = ((i > 0) & dispatch_pkt_cast_i.frs3_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs3_addr == comp_stage_r[i].rd_addr));
+      assign match_rs[0][i] = ((i < 4) & dispatch_pkt_cast_i.decode.irs1_r_v & comp_stage_r[i].ird_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs1_addr == comp_stage_r[i].rd_addr))
+                              || ((i > 0) & dispatch_pkt_cast_i.decode.frs1_r_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs1_addr == comp_stage_r[i].rd_addr));
+      assign match_rs[1][i] = ((i < 4) & dispatch_pkt_cast_i.decode.irs2_r_v & comp_stage_r[i].ird_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs2_addr == comp_stage_r[i].rd_addr))
+                              || ((i > 0) & dispatch_pkt_cast_i.decode.frs2_r_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs2_addr == comp_stage_r[i].rd_addr));
+      assign match_rs[2][i] = ((i > 0) & dispatch_pkt_cast_i.decode.frs3_r_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs3_addr == comp_stage_r[i].rd_addr));
 
       assign forward_data[i] = comp_stage_n[i+1].rd_data;
     end

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -98,7 +98,6 @@ module bp_be_calculator_top
   `bp_cast_o(bp_be_commit_pkt_s, commit_pkt);
   `bp_cast_o(bp_be_branch_pkt_s, br_pkt);
 
-
   // Pipeline stage registers
   localparam pipe_stage_els_lp = 5;
   bp_be_exc_stage_s [pipe_stage_els_lp  :0] exc_stage_n;
@@ -114,6 +113,7 @@ module bp_be_calculator_top
   bp_be_wb_pkt_s long_iwb_pkt, long_fwb_pkt;
 
   logic pipe_int_early_instr_misaligned_lo;
+  logic pipe_int_catchup_instr_misaligned_lo, pipe_int_catchup_mispredict_lo;
 
   logic pipe_mem_dtlb_load_miss_lo, pipe_mem_dtlb_store_miss_lo;
   logic pipe_mem_dcache_load_miss_lo, pipe_mem_dcache_store_miss_lo, pipe_mem_dcache_replay_lo;
@@ -123,13 +123,16 @@ module bp_be_calculator_top
 
   logic pipe_sys_illegal_instr_lo, pipe_sys_csrw_lo;
 
-  logic pipe_int_early_data_lo_v, pipe_aux_data_lo_v, pipe_mem_early_data_lo_v, pipe_mem_final_data_lo_v, pipe_sys_data_lo_v, pipe_mul_data_lo_v, pipe_fma_data_lo_v;
+  logic pipe_int_early_data_lo_v, pipe_int_catchup_data_lo_v, pipe_aux_data_lo_v, pipe_mem_early_data_lo_v, pipe_mem_final_data_lo_v, pipe_sys_data_lo_v, pipe_mul_data_lo_v, pipe_fma_data_lo_v;
   logic pipe_long_idata_lo_v, pipe_long_idata_lo_yumi, pipe_long_fdata_lo_v, pipe_long_fdata_lo_yumi;
-  logic [dpath_width_gp-1:0] pipe_int_early_data_lo, pipe_aux_data_lo, pipe_mem_early_data_lo, pipe_mem_final_data_lo, pipe_sys_data_lo, pipe_mul_data_lo, pipe_fma_data_lo;
+  logic [dpath_width_gp-1:0] pipe_int_early_data_lo, pipe_int_catchup_data_lo, pipe_aux_data_lo, pipe_mem_early_data_lo, pipe_mem_final_data_lo, pipe_sys_data_lo, pipe_mul_data_lo, pipe_fma_data_lo;
   rv64_fflags_s pipe_aux_fflags_lo, pipe_fma_fflags_lo;
 
   logic [vaddr_width_p-1:0] pipe_int_early_npc_lo;
   logic pipe_int_early_branch_lo, pipe_int_early_btaken_lo;
+
+  logic [vaddr_width_p-1:0] pipe_int_catchup_npc_lo;
+  logic pipe_int_catchup_branch_lo, pipe_int_catchup_btaken_lo;
 
   bp_be_wb_pkt_s pipe_mem_late_iwb_pkt;
   logic pipe_mem_late_iwb_pkt_v, pipe_mem_late_iwb_pkt_yumi;
@@ -233,10 +236,11 @@ module bp_be_calculator_top
   // Integer pipe: 1 cycle latency
   bp_be_pipe_int
    #(.bp_params_p(bp_params_p))
-   pipe_int
+   pipe_int_early
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
+     ,.en_i(~exc_stage_r[0].ispec_v)
      ,.reservation_i(reservation_r)
      ,.flush_i(commit_pkt_cast_o.npc_w_v)
 
@@ -247,10 +251,62 @@ module bp_be_calculator_top
      ,.btaken_o(pipe_int_early_btaken_lo)
      ,.instr_misaligned_v_o(pipe_int_early_instr_misaligned_lo)
      );
+
   assign br_pkt_cast_o.v      = reservation_r.v & reservation_r.queue_v & ~commit_pkt_cast_o.npc_w_v;
   assign br_pkt_cast_o.branch = br_pkt_cast_o.v & pipe_int_early_branch_lo;
   assign br_pkt_cast_o.btaken = br_pkt_cast_o.v & pipe_int_early_btaken_lo;
+  assign br_pkt_cast_o.bspec  = br_pkt_cast_o.v & exc_stage_r[0].ispec_v;
   assign br_pkt_cast_o.npc    = pipe_int_early_npc_lo;
+
+  if (integer_support_p[e_catchup])
+    begin : catchup
+      bp_be_dispatch_pkt_s catchup_reservation_n, catchup_reservation_r;
+      bsg_dff
+       #(.width_p(dispatch_pkt_width_lp))
+       catchup_reservation_reg
+        (.clk_i(clk_i)
+         ,.data_i(catchup_reservation_n)
+         ,.data_o(catchup_reservation_r)
+         );
+
+      always_comb
+        begin
+          catchup_reservation_n = reservation_r;
+
+          catchup_reservation_n.rs1 = (reservation_r.decode.irs1_r_v && comp_stage_r[1].ird_w_v && (comp_stage_r[1].rd_addr == reservation_r.instr.t.rtype.rs1_addr))
+            ? comp_stage_n[2].rd_data
+            : catchup_reservation_n.rs1;
+          catchup_reservation_n.rs2 = (reservation_r.decode.irs2_r_v && comp_stage_r[1].ird_w_v && (comp_stage_r[1].rd_addr == reservation_r.instr.t.rtype.rs2_addr))
+            ? comp_stage_n[2].rd_data
+            : catchup_reservation_n.rs2;
+        end
+
+      // Late integer pipe: 1 cycle latency, starts at EX2
+      bp_be_pipe_int
+       #(.bp_params_p(bp_params_p))
+       pipe_int_catchup
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+
+         ,.en_i(exc_stage_r[1].ispec_v)
+         ,.reservation_i(catchup_reservation_r)
+         ,.flush_i(commit_pkt_cast_o.npc_w_v)
+
+         ,.data_o(pipe_int_catchup_data_lo)
+         ,.v_o(pipe_int_catchup_data_lo_v)
+         ,.npc_o(pipe_int_catchup_npc_lo)
+         ,.branch_o(pipe_int_catchup_branch_lo)
+         ,.btaken_o(pipe_int_catchup_btaken_lo)
+         ,.instr_misaligned_v_o(pipe_int_catchup_instr_misaligned_lo)
+         );
+      assign pipe_int_catchup_mispredict_lo = exc_stage_r[1].ispec_v & (pipe_int_catchup_npc_lo != reservation_r.pc);
+    end
+  else
+    begin : no_catchup
+      assign pipe_int_catchup_data_lo = '0;
+      assign pipe_int_catchup_data_lo_v = '0;
+      assign pipe_int_catchup_mispredict_lo = '0;
+    end
 
   // Aux pipe: 2 cycle latency
   bp_be_pipe_aux
@@ -402,17 +458,18 @@ module bp_be_calculator_top
             : comp_stage_r[i-1];
         end
       // Injected instructions can carry a payload in rs2
-      comp_stage_n[0].rd_data    |= injection                ? dispatch_pkt_cast_i.rs2  : '0;
-      comp_stage_n[1].rd_data    |= pipe_int_early_data_lo_v ? pipe_int_early_data_lo   : '0;
-      comp_stage_n[1].rd_data    |= pipe_sys_data_lo_v       ? pipe_sys_data_lo         : '0;
-      comp_stage_n[2].rd_data    |= pipe_mem_early_data_lo_v ? pipe_mem_early_data_lo   : '0;
-      comp_stage_n[2].rd_data    |= pipe_aux_data_lo_v       ? pipe_aux_data_lo         : '0;
-      comp_stage_n[3].rd_data    |= pipe_mem_final_data_lo_v ? pipe_mem_final_data_lo   : '0;
-      comp_stage_n[3].rd_data    |= pipe_mul_data_lo_v       ? pipe_mul_data_lo         : '0;
-      comp_stage_n[4].rd_data    |= pipe_fma_data_lo_v       ? pipe_fma_data_lo         : '0;
+      comp_stage_n[0].rd_data    |= injection                  ? dispatch_pkt_cast_i.rs2  : '0;
+      comp_stage_n[1].rd_data    |= pipe_int_early_data_lo_v   ? pipe_int_early_data_lo   : '0;
+      comp_stage_n[1].rd_data    |= pipe_sys_data_lo_v         ? pipe_sys_data_lo         : '0;
+      comp_stage_n[2].rd_data    |= pipe_mem_early_data_lo_v   ? pipe_mem_early_data_lo   : '0;
+      comp_stage_n[2].rd_data    |= pipe_aux_data_lo_v         ? pipe_aux_data_lo         : '0;
+      comp_stage_n[2].rd_data    |= pipe_int_catchup_data_lo_v ? pipe_int_catchup_data_lo : '0;
+      comp_stage_n[3].rd_data    |= pipe_mem_final_data_lo_v   ? pipe_mem_final_data_lo   : '0;
+      comp_stage_n[3].rd_data    |= pipe_mul_data_lo_v         ? pipe_mul_data_lo         : '0;
+      comp_stage_n[4].rd_data    |= pipe_fma_data_lo_v         ? pipe_fma_data_lo         : '0;
 
-      comp_stage_n[2].fflags     |= pipe_aux_data_lo_v       ? pipe_aux_fflags_lo       : '0;
-      comp_stage_n[4].fflags     |= pipe_fma_data_lo_v       ? pipe_fma_fflags_lo       : '0;
+      comp_stage_n[2].fflags     |= pipe_aux_data_lo_v         ? pipe_aux_fflags_lo       : '0;
+      comp_stage_n[4].fflags     |= pipe_fma_data_lo_v         ? pipe_fma_fflags_lo       : '0;
 
       comp_stage_n[0].ird_w_v    &= exc_stage_n[0].v;
       comp_stage_n[1].ird_w_v    &= exc_stage_n[1].v;
@@ -450,25 +507,26 @@ module bp_be_calculator_top
           // Normally, shift down in the pipe
           exc_stage_n[i] = (i == 0) ? '0 : exc_stage_r[i-1];
         end
-          exc_stage_n[0].v                       = reservation_n.v;
+          exc_stage_n[0].v                      |= reservation_n.v;
+          exc_stage_n[0].queue_v                |= reservation_n.queue_v;
+          exc_stage_n[0].ispec_v                |= reservation_n.ispec_v;
+          exc_stage_n[0].spec                   |= reservation_n.special;
+          exc_stage_n[0].exc                    |= reservation_n.exception;
+
           exc_stage_n[0].v                      &= ~commit_pkt_cast_o.npc_w_v;
           exc_stage_n[1].v                      &= ~commit_pkt_cast_o.npc_w_v;
           exc_stage_n[2].v                      &= ~commit_pkt_cast_o.npc_w_v;
           exc_stage_n[3].v                      &= commit_pkt_cast_o.instret;
 
-          exc_stage_n[0].queue_v                 = reservation_n.queue_v;
           exc_stage_n[0].queue_v                &= ~commit_pkt_cast_o.npc_w_v;
           exc_stage_n[1].queue_v                &= ~commit_pkt_cast_o.npc_w_v;
           exc_stage_n[2].queue_v                &= ~commit_pkt_cast_o.npc_w_v;
           exc_stage_n[3].queue_v                &= ~commit_pkt_cast_o.npc_w_v;
 
-          exc_stage_n[0].spec                   |= reservation_n.special;
-          exc_stage_n[0].exc                    |= reservation_n.exception;
-
           exc_stage_n[1].exc.illegal_instr      |= pipe_sys_illegal_instr_lo;
           exc_stage_n[1].spec.csrw              |= pipe_sys_csrw_lo;
 
-          exc_stage_n[1].exc.instr_misaligned   |= pipe_int_early_instr_misaligned_lo;
+          exc_stage_n[1].exc.instr_misaligned   |= pipe_int_early_instr_misaligned_lo & ~exc_stage_r[0].ispec_v;
 
           exc_stage_n[1].exc.dtlb_store_miss    |= pipe_mem_dtlb_store_miss_lo;
           exc_stage_n[1].exc.dtlb_load_miss     |= pipe_mem_dtlb_load_miss_lo;
@@ -478,6 +536,9 @@ module bp_be_calculator_top
           exc_stage_n[1].exc.store_misaligned   |= pipe_mem_store_misaligned_lo;
           exc_stage_n[1].exc.store_access_fault |= pipe_mem_store_access_fault_lo;
           exc_stage_n[1].exc.store_page_fault   |= pipe_mem_store_page_fault_lo;
+
+          exc_stage_n[2].exc.instr_misaligned   |= pipe_int_catchup_instr_misaligned_lo;
+          exc_stage_n[2].exc.mispredict         |= pipe_int_catchup_mispredict_lo;
 
           exc_stage_n[2].exc.dcache_replay      |= pipe_mem_dcache_replay_lo;
           exc_stage_n[2].spec.dcache_load_miss  |= pipe_mem_dcache_load_miss_lo;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_int.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_int.sv
@@ -23,6 +23,7 @@ module bp_be_pipe_int
   (input                                    clk_i
    , input                                  reset_i
 
+   , input                                  en_i
    , input [dispatch_pkt_width_lp-1:0]      reservation_i
    , input                                  flush_i
 
@@ -101,13 +102,13 @@ module bp_be_pipe_int
   // Shift back the ALU result from the top field for word width operations
   wire [dword_width_gp-1:0] opw_result = $signed(alu_result) >>> word_width_gp;
   assign data_o = decode.branch_v ? br_result : decode.opw_v ? opw_result : alu_result;
-  assign v_o    = reservation.v & reservation.decode.pipe_int_v;
+  assign v_o    = en_i & reservation.v & reservation.decode.pipe_int_v;
+
+  assign instr_misaligned_v_o = en_i & btaken_o & (taken_tgt[1:0] != 2'b00) & !compressed_support_p;
 
   assign branch_o = decode.branch_v;
   assign btaken_o = decode.branch_v & (decode.jump_v | alu_result[0]);
   assign npc_o = btaken_o ? taken_tgt : ntaken_tgt;
-
-  assign instr_misaligned_v_o = btaken_o & (taken_tgt[1:0] != 2'b00) & !compressed_support_p;
 
 endmodule
 

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -142,66 +142,66 @@ module bp_be_detector
         end
 
       // Detect scoreboard hazards
-      irs1_sb_raw_haz_v = (issue_pkt_cast_i.irs1_v & irs_match_lo[0]);
-      irs2_sb_raw_haz_v = (issue_pkt_cast_i.irs2_v & irs_match_lo[1]);
-      ird_sb_waw_haz_v = (issue_pkt_cast_i.iwb_v & ird_match_lo);
+      irs1_sb_raw_haz_v = (issue_pkt_cast_i.decode.irs1_r_v & irs_match_lo[0]);
+      irs2_sb_raw_haz_v = (issue_pkt_cast_i.decode.irs2_r_v & irs_match_lo[1]);
+      ird_sb_waw_haz_v = (issue_pkt_cast_i.decode.irf_w_v & ird_match_lo);
 
-      frs1_sb_raw_haz_v = (issue_pkt_cast_i.frs1_v & frs_match_lo[0]);
-      frs2_sb_raw_haz_v = (issue_pkt_cast_i.frs2_v & frs_match_lo[1]);
-      frs3_sb_raw_haz_v = (issue_pkt_cast_i.frs3_v & frs_match_lo[2]);
+      frs1_sb_raw_haz_v = (issue_pkt_cast_i.decode.frs1_r_v & frs_match_lo[0]);
+      frs2_sb_raw_haz_v = (issue_pkt_cast_i.decode.frs2_r_v & frs_match_lo[1]);
+      frs3_sb_raw_haz_v = (issue_pkt_cast_i.decode.frs3_r_v & frs_match_lo[2]);
 
-      frd_sb_waw_haz_v = (issue_pkt_cast_i.fwb_v & frd_match_lo);
+      frd_sb_waw_haz_v = (issue_pkt_cast_i.decode.frf_w_v & frd_match_lo);
 
       // Detect integer and float data hazards for EX1
-      irs1_data_haz_v[0] = (issue_pkt_cast_i.irs1_v & rs1_match_vector[0])
+      irs1_data_haz_v[0] = (issue_pkt_cast_i.decode.irs1_r_v & rs1_match_vector[0])
                            & (dep_status_r[0].aux_iwb_v | dep_status_r[0].mul_iwb_v | dep_status_r[0].emem_iwb_v | dep_status_r[0].fmem_iwb_v);
 
-      irs2_data_haz_v[0] = (issue_pkt_cast_i.irs2_v & rs2_match_vector[0])
+      irs2_data_haz_v[0] = (issue_pkt_cast_i.decode.irs2_r_v & rs2_match_vector[0])
                            & (dep_status_r[0].aux_iwb_v | dep_status_r[0].mul_iwb_v | dep_status_r[0].emem_iwb_v | dep_status_r[0].fmem_iwb_v);
 
-      frs1_data_haz_v[0] = (issue_pkt_cast_i.frs1_v & rs1_match_vector[0])
+      frs1_data_haz_v[0] = (issue_pkt_cast_i.decode.frs1_r_v & rs1_match_vector[0])
                            & (dep_status_r[0].aux_fwb_v | dep_status_r[0].emem_fwb_v | dep_status_r[0].fmem_fwb_v | dep_status_r[0].fma_fwb_v);
 
-      frs2_data_haz_v[0] = (issue_pkt_cast_i.frs2_v & rs2_match_vector[0])
+      frs2_data_haz_v[0] = (issue_pkt_cast_i.decode.frs2_r_v & rs2_match_vector[0])
                            & (dep_status_r[0].aux_fwb_v | dep_status_r[0].emem_fwb_v | dep_status_r[0].fmem_fwb_v | dep_status_r[0].fma_fwb_v);
 
-      frs3_data_haz_v[0] = (issue_pkt_cast_i.frs3_v & rs3_match_vector[0])
+      frs3_data_haz_v[0] = (issue_pkt_cast_i.decode.frs3_r_v & rs3_match_vector[0])
                            & (dep_status_r[0].aux_fwb_v | dep_status_r[0].emem_fwb_v | dep_status_r[0].fmem_fwb_v | dep_status_r[0].fma_fwb_v);
 
       // Detect integer and float data hazards for EX2
-      irs1_data_haz_v[1] = (issue_pkt_cast_i.irs1_v & rs1_match_vector[1])
+      irs1_data_haz_v[1] = (issue_pkt_cast_i.decode.irs1_r_v & rs1_match_vector[1])
                            & (dep_status_r[1].fmem_iwb_v | dep_status_r[1].mul_iwb_v);
 
-      irs2_data_haz_v[1] = (issue_pkt_cast_i.irs2_v & rs2_match_vector[1])
+      irs2_data_haz_v[1] = (issue_pkt_cast_i.decode.irs2_r_v & rs2_match_vector[1])
                            & (dep_status_r[1].fmem_iwb_v | dep_status_r[1].mul_iwb_v);
 
-      frs1_data_haz_v[1] = (issue_pkt_cast_i.frs1_v & rs1_match_vector[1])
+      frs1_data_haz_v[1] = (issue_pkt_cast_i.decode.frs1_r_v & rs1_match_vector[1])
                            & (dep_status_r[1].fmem_fwb_v | dep_status_r[1].fma_fwb_v);
 
-      frs2_data_haz_v[1] = (issue_pkt_cast_i.frs2_v & rs2_match_vector[1])
+      frs2_data_haz_v[1] = (issue_pkt_cast_i.decode.frs2_r_v & rs2_match_vector[1])
                            & (dep_status_r[1].fmem_fwb_v | dep_status_r[1].fma_fwb_v);
 
-      frs3_data_haz_v[1] = (issue_pkt_cast_i.frs3_v & rs3_match_vector[1])
+      frs3_data_haz_v[1] = (issue_pkt_cast_i.decode.frs3_r_v & rs3_match_vector[1])
                            & (dep_status_r[1].fmem_fwb_v | dep_status_r[1].fma_fwb_v);
 
       irs1_data_haz_v[2] = '0;
 
       irs2_data_haz_v[2] = '0;
 
-      frs1_data_haz_v[2] = (issue_pkt_cast_i.frs1_v & rs1_match_vector[2])
+      frs1_data_haz_v[2] = (issue_pkt_cast_i.decode.frs1_r_v & rs1_match_vector[2])
                            & (dep_status_r[2].fma_fwb_v);
 
-      frs2_data_haz_v[2] = (issue_pkt_cast_i.frs2_v & rs2_match_vector[2])
+      frs2_data_haz_v[2] = (issue_pkt_cast_i.decode.frs2_r_v & rs2_match_vector[2])
                            & (dep_status_r[2].fma_fwb_v);
 
-      frs3_data_haz_v[2] = (issue_pkt_cast_i.frs3_v & rs3_match_vector[2])
+      frs3_data_haz_v[2] = (issue_pkt_cast_i.decode.frs3_r_v & rs3_match_vector[2])
                            & (dep_status_r[2].fma_fwb_v);
 
-      fence_haz_v        = issue_pkt_cast_i.fence_v & ~mem_ordered_i;
+      fence_haz_v        = issue_pkt_cast_i.decode.fence_v & ~mem_ordered_i;
       cmd_haz_v          = cmd_full_i;
 
       // TODO: Pessimistic, could have a separate fflags r/w_v
-      fflags_haz_v = issue_pkt_cast_i.csr_v
+      fflags_haz_v = (issue_pkt_cast_i.decode.csr_r_v | issue_pkt_cast_i.decode.csr_w_v)
                      & ((dep_status_r[0].fflags_w_v)
                         | (dep_status_r[1].fflags_w_v)
                         | (dep_status_r[2].fflags_w_v)
@@ -213,13 +213,13 @@ module bp_be_detector
       //   executing instructions on trap, and only pause on dependency in
       //   EX4, rather than any instruction. Most likely not a huge
       //   performance problem at the moment.
-      long_haz_v = issue_pkt_cast_i.long_v
+      long_haz_v = issue_pkt_cast_i.decode.pipe_long_v
                    & ((dep_status_r[0].v)
                       | (dep_status_r[1].v)
                       | (dep_status_r[2].v)
                       );
 
-      csr_haz_v     = issue_pkt_cast_i.csr_v
+      csr_haz_v     = (issue_pkt_cast_i.decode.csr_r_v | issue_pkt_cast_i.decode.csr_w_v)
                       & ((dep_status_r[0].v)
                          | (dep_status_r[1].v)
                          | (dep_status_r[2].v)
@@ -242,9 +242,10 @@ module bp_be_detector
       // Combine all structural hazard information
       struct_haz_v = ptw_busy_i
                      | cmd_haz_v
-                     | (mem_busy_i & issue_pkt_cast_i.mem_v)
-                     | (fdiv_busy_i & issue_pkt_cast_i.long_v)
-                     | (idiv_busy_i & issue_pkt_cast_i.long_v);
+                     | (mem_busy_i & issue_pkt_cast_i.decode.pipe_mem_early_v)
+                     | (mem_busy_i & issue_pkt_cast_i.decode.pipe_mem_final_v)
+                     | (fdiv_busy_i & issue_pkt_cast_i.decode.pipe_long_v)
+                     | (idiv_busy_i & issue_pkt_cast_i.decode.pipe_long_v);
     end
 
   // Dispatch if we have a valid issue. Don't stall on data hazards for exceptions

--- a/bp_be/src/v/bp_be_checker/bp_be_director.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.sv
@@ -80,8 +80,9 @@ module bp_be_director
   // Update the NPC on a valid instruction in ex1 or upon commit
   logic [vaddr_width_p-1:0] npc_n, npc_r;
   wire npc_w_v = commit_pkt_cast_i.npc_w_v | br_pkt_cast_i.v;
-  assign npc_n = commit_pkt_cast_i.npc_w_v ? commit_pkt_cast_i.npc : br_pkt_cast_i.npc;
-  bsg_dff_reset_en
+
+  assign npc_n = commit_pkt_cast_i.npc_w_v ? commit_pkt_cast_i.npc : br_pkt_cast_i.bspec ? issue_pkt_cast_i.pc : br_pkt_cast_i.npc;
+  bsg_dff_reset_en_bypass
    #(.width_p(vaddr_width_p))
    npc_reg
     (.clk_i(clk_i)
@@ -91,7 +92,7 @@ module bp_be_director
      ,.data_i(npc_n)
      ,.data_o(npc_r)
      );
-  assign expected_npc_o = npc_w_v ? npc_n : npc_r;
+  assign expected_npc_o = npc_r;
 
   wire npc_mismatch_v = dispatch_v_i & (expected_npc_o != issue_pkt_cast_i.pc);
   wire npc_match_v    = dispatch_v_i & (expected_npc_o == issue_pkt_cast_i.pc);

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -41,6 +41,7 @@ module bp_be_scheduler
    , input [decode_info_width_lp-1:0]         decode_info_i
    , input                                    dispatch_v_i
    , input                                    interrupt_v_i
+   , input                                    ispec_v_i
 
    // Fetch interface
    , input [fe_queue_width_lp-1:0]            fe_queue_i
@@ -169,7 +170,8 @@ module bp_be_scheduler
       dispatch_pkt_cast_o.v          = fe_queue_read_li || be_exc_not_instr_li;
       dispatch_pkt_cast_o.queue_v    = fe_queue_read_li;
       dispatch_pkt_cast_o.instr_v    = fe_instr_not_exc_li;
-      dispatch_pkt_cast_o.pc         = fe_queue_read_li ? issue_pkt_cast_o.pc : expected_npc_i;
+      dispatch_pkt_cast_o.ispec_v    = ispec_v_i;
+      dispatch_pkt_cast_o.pc         = expected_npc_i;
       dispatch_pkt_cast_o.instr      = issue_pkt_cast_o.instr;
       dispatch_pkt_cast_o.compressed = issue_pkt_cast_o.compressed;
       dispatch_pkt_cast_o.partial    = be_exc_not_instr_li ? be_partial : fe_partial;

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -96,6 +96,7 @@ module bp_be_scheduler
      ,.fe_queue_v_i(fe_queue_v_i)
      ,.fe_queue_ready_and_o(fe_queue_ready_and_o)
 
+     ,.decode_info_i(decode_info_i)
      ,.preissue_pkt_o(preissue_pkt)
      ,.issue_pkt_o(issue_pkt_cast_o)
      );
@@ -134,36 +135,6 @@ module bp_be_scheduler
      ,.rs_data_o({frf_rs3, frf_rs2, frf_rs1})
      );
 
-  // Decode the dispatched instruction
-  bp_be_decode_s decoded_instr_lo;
-  logic [dword_width_gp-1:0] decoded_imm_lo;
-  logic illegal_instr_lo;
-  logic ecall_m_lo, ecall_s_lo, ecall_u_lo;
-  logic ebreak_lo, dbreak_lo;
-  logic dret_lo, mret_lo, sret_lo;
-  logic wfi_lo, sfence_vma_lo;
-  bp_be_instr_decoder
-   #(.bp_params_p(bp_params_p))
-   instr_decoder
-    (.instr_i(issue_pkt_cast_o.instr)
-     ,.decode_info_i(decode_info_i)
-
-     ,.decode_o(decoded_instr_lo)
-     ,.imm_o(decoded_imm_lo)
-
-     ,.illegal_instr_o(illegal_instr_lo)
-     ,.ecall_m_o(ecall_m_lo)
-     ,.ecall_s_o(ecall_s_lo)
-     ,.ecall_u_o(ecall_u_lo)
-     ,.ebreak_o(ebreak_lo)
-     ,.dbreak_o(dbreak_lo)
-     ,.dret_o(dret_lo)
-     ,.mret_o(mret_lo)
-     ,.sret_o(sret_lo)
-     ,.wfi_o(wfi_lo)
-     ,.sfence_vma_o(sfence_vma_lo)
-     );
-
   // Prioritization is:
   //   1) ptw_fill_pkt, since there is no backpressure
   //   3) unfreeze request
@@ -198,21 +169,15 @@ module bp_be_scheduler
       dispatch_pkt_cast_o.v          = fe_queue_read_li || be_exc_not_instr_li;
       dispatch_pkt_cast_o.queue_v    = fe_queue_read_li;
       dispatch_pkt_cast_o.instr_v    = fe_instr_not_exc_li;
-      dispatch_pkt_cast_o.partial    = be_exc_not_instr_li ? be_partial : fe_partial;
-      dispatch_pkt_cast_o.compressed = issue_pkt_cast_o.compressed;
       dispatch_pkt_cast_o.pc         = fe_queue_read_li ? issue_pkt_cast_o.pc : expected_npc_i;
       dispatch_pkt_cast_o.instr      = issue_pkt_cast_o.instr;
+      dispatch_pkt_cast_o.compressed = issue_pkt_cast_o.compressed;
+      dispatch_pkt_cast_o.partial    = be_exc_not_instr_li ? be_partial : fe_partial;
       // If register injection is critical, can be done after bypass
-      dispatch_pkt_cast_o.frs1_v     = issue_pkt_cast_o.frs1_v;
-      dispatch_pkt_cast_o.irs1_v     = issue_pkt_cast_o.irs1_v;
-      dispatch_pkt_cast_o.rs1        = be_exc_not_instr_li ? be_exc_vaddr_li : fe_exc_not_instr_li ? fe_exc_vaddr_li : issue_pkt_cast_o.frs1_v ? frf_rs1 : irf_rs1;
-      dispatch_pkt_cast_o.frs2_v     = issue_pkt_cast_o.frs2_v;
-      dispatch_pkt_cast_o.irs2_v     = issue_pkt_cast_o.irs2_v;
-      dispatch_pkt_cast_o.rs2        = be_exc_not_instr_li ? be_exc_data_li  : fe_exc_not_instr_li ? '0 : issue_pkt_cast_o.frs2_v ? frf_rs2 : irf_rs2;
-      dispatch_pkt_cast_o.frs3_v     = issue_pkt_cast_o.frs3_v;
-      dispatch_pkt_cast_o.irs3_v     = 1'b0;
-      dispatch_pkt_cast_o.imm        = (fe_exc_not_instr_li | be_exc_not_instr_li) ? '0 : issue_pkt_cast_o.frs3_v ? frf_rs3 : decoded_imm_lo;
-      dispatch_pkt_cast_o.decode     = (fe_exc_not_instr_li | be_exc_not_instr_li | illegal_instr_lo) ? '0 : decoded_instr_lo;
+      dispatch_pkt_cast_o.rs1        = be_exc_not_instr_li ? be_exc_vaddr_li : fe_exc_not_instr_li ? fe_exc_vaddr_li : issue_pkt_cast_o.decode.frs1_r_v ? frf_rs1 : irf_rs1;
+      dispatch_pkt_cast_o.rs2        = be_exc_not_instr_li ? be_exc_data_li  : fe_exc_not_instr_li ? '0 : issue_pkt_cast_o.decode.frs2_r_v ? frf_rs2 : irf_rs2;
+      dispatch_pkt_cast_o.imm        = (fe_exc_not_instr_li | be_exc_not_instr_li) ? '0 : issue_pkt_cast_o.decode.frs3_r_v ? frf_rs3 : issue_pkt_cast_o.imm;
+      dispatch_pkt_cast_o.decode     = (fe_exc_not_instr_li | be_exc_not_instr_li) ? '0 : issue_pkt_cast_o.decode;
 
       dispatch_pkt_cast_o.exception.instr_page_fault |= be_exc_not_instr_li & ptw_instr_page_fault_v;
       dispatch_pkt_cast_o.exception.load_page_fault  |= be_exc_not_instr_li & ptw_load_page_fault_v;
@@ -222,22 +187,22 @@ module bp_be_scheduler
       dispatch_pkt_cast_o.exception.unfreeze         |= be_exc_not_instr_li & unfreeze_v;
       dispatch_pkt_cast_o.exception._interrupt       |= be_exc_not_instr_li & interrupt_v;
 
-      dispatch_pkt_cast_o.exception.instr_access_fault |= fe_exc_not_instr_li & issue_pkt_cast_o.instr_access_fault_v;
-      dispatch_pkt_cast_o.exception.instr_page_fault   |= fe_exc_not_instr_li & issue_pkt_cast_o.instr_page_fault_v;
-      dispatch_pkt_cast_o.exception.itlb_miss          |= fe_exc_not_instr_li & issue_pkt_cast_o.itlb_miss_v;
-      dispatch_pkt_cast_o.exception.icache_miss        |= fe_exc_not_instr_li & issue_pkt_cast_o.icache_miss_v;
+      dispatch_pkt_cast_o.exception.instr_access_fault |= fe_exc_not_instr_li & issue_pkt_cast_o.instr_access_fault;
+      dispatch_pkt_cast_o.exception.instr_page_fault   |= fe_exc_not_instr_li & issue_pkt_cast_o.instr_page_fault;
+      dispatch_pkt_cast_o.exception.itlb_miss          |= fe_exc_not_instr_li & issue_pkt_cast_o.itlb_miss;
+      dispatch_pkt_cast_o.exception.icache_miss        |= fe_exc_not_instr_li & issue_pkt_cast_o.icache_miss;
 
-      dispatch_pkt_cast_o.exception.illegal_instr |= fe_instr_not_exc_li & illegal_instr_lo;
-      dispatch_pkt_cast_o.exception.ecall_m       |= fe_instr_not_exc_li & ecall_m_lo;
-      dispatch_pkt_cast_o.exception.ecall_s       |= fe_instr_not_exc_li & ecall_s_lo;
-      dispatch_pkt_cast_o.exception.ecall_u       |= fe_instr_not_exc_li & ecall_u_lo;
-      dispatch_pkt_cast_o.exception.ebreak        |= fe_instr_not_exc_li & ebreak_lo;
-      dispatch_pkt_cast_o.special.dbreak          |= fe_instr_not_exc_li & dbreak_lo;
-      dispatch_pkt_cast_o.special.dret            |= fe_instr_not_exc_li & dret_lo;
-      dispatch_pkt_cast_o.special.mret            |= fe_instr_not_exc_li & mret_lo;
-      dispatch_pkt_cast_o.special.sret            |= fe_instr_not_exc_li & sret_lo;
-      dispatch_pkt_cast_o.special.wfi             |= fe_instr_not_exc_li & wfi_lo;
-      dispatch_pkt_cast_o.special.sfence_vma      |= fe_instr_not_exc_li & sfence_vma_lo;
+      dispatch_pkt_cast_o.exception.illegal_instr |= fe_instr_not_exc_li & issue_pkt_cast_o.illegal_instr;
+      dispatch_pkt_cast_o.exception.ecall_m       |= fe_instr_not_exc_li & issue_pkt_cast_o.ecall_m;
+      dispatch_pkt_cast_o.exception.ecall_s       |= fe_instr_not_exc_li & issue_pkt_cast_o.ecall_s;
+      dispatch_pkt_cast_o.exception.ecall_u       |= fe_instr_not_exc_li & issue_pkt_cast_o.ecall_u;
+      dispatch_pkt_cast_o.exception.ebreak        |= fe_instr_not_exc_li & issue_pkt_cast_o.ebreak;
+      dispatch_pkt_cast_o.special.dbreak          |= fe_instr_not_exc_li & issue_pkt_cast_o.dbreak;
+      dispatch_pkt_cast_o.special.dret            |= fe_instr_not_exc_li & issue_pkt_cast_o.dret;
+      dispatch_pkt_cast_o.special.mret            |= fe_instr_not_exc_li & issue_pkt_cast_o.mret;
+      dispatch_pkt_cast_o.special.sret            |= fe_instr_not_exc_li & issue_pkt_cast_o.sret;
+      dispatch_pkt_cast_o.special.wfi             |= fe_instr_not_exc_li & issue_pkt_cast_o.wfi;
+      dispatch_pkt_cast_o.special.sfence_vma      |= fe_instr_not_exc_li & issue_pkt_cast_o.sfence_vma;
     end
 
 endmodule

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -82,7 +82,7 @@ module bp_be_top
   bp_be_dispatch_pkt_s dispatch_pkt;
   bp_be_branch_pkt_s   br_pkt;
 
-  logic dispatch_v, interrupt_v;
+  logic dispatch_v, interrupt_v, ispec_v;
   logic irq_pending_lo, irq_waiting_lo;
 
   bp_be_commit_pkt_s commit_pkt;
@@ -143,6 +143,7 @@ module bp_be_top
      ,.ptw_busy_i(ptw_busy_lo)
      ,.irq_pending_i(irq_pending_lo)
 
+     ,.ispec_v_o(ispec_v)
      ,.dispatch_v_o(dispatch_v)
      ,.interrupt_v_o(interrupt_v)
      ,.dispatch_pkt_i(dispatch_pkt)
@@ -157,6 +158,8 @@ module bp_be_top
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
+     ,.unfreeze_i(unfreeze_lo)
+     ,.decode_info_i(decode_info_lo)
      ,.issue_pkt_o(issue_pkt)
      ,.poison_isd_i(poison_isd_lo)
      ,.suppress_iss_i(suppress_iss_lo)
@@ -164,8 +167,7 @@ module bp_be_top
      ,.expected_npc_i(expected_npc_lo)
      ,.dispatch_v_i(dispatch_v)
      ,.interrupt_v_i(interrupt_v)
-     ,.unfreeze_i(unfreeze_lo)
-     ,.decode_info_i(decode_info_lo)
+     ,.ispec_v_i(ispec_v)
 
      ,.fe_queue_i(fe_queue_i)
      ,.fe_queue_v_i(fe_queue_v_i)

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -19,6 +19,12 @@
     ,e_cfg_amo_fetch_arithmetic = 3'b111
   } bp_cache_features_e;
 
+  typedef enum logic
+  {
+    e_basic = 1'b0
+    ,e_catchup = 1'b1
+  } bp_integer_support_e;
+
   typedef enum logic [1:0]
   {
     e_idiv    = 2'b00
@@ -180,6 +186,10 @@
     integer unsigned fe_queue_fifo_els;
     // Size of the cmd queue
     integer unsigned fe_cmd_fifo_els;
+    // Integer support in the system. It is a bitmask with:
+    //   bit 0: basic alu
+    //   bit 1: catchup alu
+    integer unsigned integer_support;
     // MULDIV support in the system. It is a bitmask with:
     //   bit 0: div
     //   bit 1: mul
@@ -313,6 +323,7 @@
 
       ,fe_queue_fifo_els : 8
       ,fe_cmd_fifo_els   : 4
+      ,integer_support   : (1 << e_basic) | (1 << e_catchup)
       ,muldiv_support    : (1 << e_idiv)
                            | (1 << e_imul)
                            | (1 << e_imulh)
@@ -371,6 +382,7 @@
 
       ,`bp_aviary_define_override(fe_queue_fifo_els, BP_FE_QUEUE_WIDTH, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(fe_cmd_fifo_els, BP_FE_CMD_WIDTH, `BP_CUSTOM_BASE_CFG)
+      ,`bp_aviary_define_override(integer_support, BP_INTEGER_SUPPORT, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(muldiv_support, BP_MULDIV_SUPPORT, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(fpu_support, BP_FPU_SUPPORT, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(compressed_support, BP_COMPRESSED_SUPPORT, `BP_CUSTOM_BASE_CFG)

--- a/bp_common/src/include/bp_common_aviary_defines.svh
+++ b/bp_common/src/include/bp_common_aviary_defines.svh
@@ -107,6 +107,7 @@
                                                                                                    \
     , localparam fe_queue_fifo_els_p  = proc_param_lp.fe_queue_fifo_els                            \
     , localparam fe_cmd_fifo_els_p    = proc_param_lp.fe_cmd_fifo_els                              \
+    , localparam integer_support_p    = proc_param_lp.integer_support                              \
     , localparam muldiv_support_p     = proc_param_lp.muldiv_support                               \
     , localparam fpu_support_p        = proc_param_lp.fpu_support                                  \
     , localparam compressed_support_p = proc_param_lp.compressed_support                           \
@@ -206,6 +207,7 @@
                                                                                                    \
           ,`bp_aviary_parameter_override(fe_queue_fifo_els, override_cfg_mp, default_cfg_mp)       \
           ,`bp_aviary_parameter_override(fe_cmd_fifo_els, override_cfg_mp, default_cfg_mp)         \
+          ,`bp_aviary_parameter_override(integer_support, override_cfg_mp, default_cfg_mp)         \
           ,`bp_aviary_parameter_override(muldiv_support, override_cfg_mp, default_cfg_mp)          \
           ,`bp_aviary_parameter_override(fpu_support, override_cfg_mp, default_cfg_mp)             \
           ,`bp_aviary_parameter_override(compressed_support, override_cfg_mp, default_cfg_mp)      \

--- a/bp_common/src/include/bp_common_aviary_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_pkgdef.svh
@@ -78,8 +78,9 @@
       ,l2_data_width : 64
       ,l2_fill_width : 64
 
-      ,muldiv_support: (1 << e_idiv) | (1 << e_imul)
-      ,fpu_support   : (1 << e_fma) | (1 << e_fdivsqrt)
+      ,integer_support: (1 << e_basic)
+      ,muldiv_support : (1 << e_idiv) | (1 << e_imul)
+      ,fpu_support    : (1 << e_fma) | (1 << e_fdivsqrt)
 
       ,default : "inv"
       };

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -507,8 +507,8 @@ module testbench
           ,.sb_iwaw_dep_i(be.detector.ird_sb_waw_haz_v & be.detector.data_haz_v)
           ,.sb_fwaw_dep_i(be.detector.frd_sb_waw_haz_v & be.detector.data_haz_v)
           ,.struct_haz_i(be.detector.struct_haz_v)
-          ,.idiv_haz_i(be.detector.idiv_busy_i & be.detector.issue_pkt_cast_i.long_v)
-          ,.fdiv_haz_i(be.detector.fdiv_busy_i & be.detector.issue_pkt_cast_i.long_v)
+          ,.idiv_haz_i(be.detector.idiv_busy_i & be.detector.issue_pkt_cast_i.decode.pipe_long_v)
+          ,.fdiv_haz_i(be.detector.fdiv_busy_i & be.detector.issue_pkt_cast_i.decode.pipe_long_v)
           ,.ptw_busy_i(be.detector.ptw_busy_i)
 
           ,.retire_pkt_i(be.calculator.pipe_sys.retire_pkt)


### PR DESCRIPTION
### Summary
This PR adds an optional, secondary "catchup" ALU which is used to unblock the pipeline in the case of a load->int/load->branch dependency. With perfect branch prediction, this eliminates all load-use stalls in the pipeline.

### Issue Fixed
None

### Area
BE decoder and hazard detection

### Reasoning (new feature, inefficient, verbose, etc.)
Performance enhancement, mainly Coremark

### Additional Changes Required (if any)
None

### Analysis
PPA has not been analyzed for this feature, but it is unlikely to impact critical path. Area is estimated to be ~2% based on other ALU size.

### Verification
Standard regression and Linux Boot

### Additional Context
None

