### PR TITLE
Miscellaneous hotfixes for unicore, address swizzling, and sipo passthrough dynamic

### DIFF
--- a/bp_common/src/v/bsg_serial_in_parallel_out_passthrough_dynamic.v
+++ b/bp_common/src/v/bsg_serial_in_parallel_out_passthrough_dynamic.v
@@ -31,7 +31,7 @@ module bsg_serial_in_parallel_out_passthrough_dynamic
   logic last_word;
 
   assign v_o = v_i & last_word;
-  assign ready_and_o = ~count_r[els_p-1] | ready_and_i; // have space, or we are dequeing; (one gate delay in-to-out)
+  assign ready_and_o = ready_and_i;
 
   wire sending   = v_o & ready_and_i;  // we have all the items, and downstream is ready
   wire receiving = v_i & ready_and_o;  // data is coming in, and we have space

--- a/bp_me/src/v/dev/bp_me_cache_slice.sv
+++ b/bp_me/src/v/dev/bp_me_cache_slice.sv
@@ -60,6 +60,9 @@ module bp_me_cache_slice
   logic [l2_banks_p-1:0][l2_data_width_p-1:0] cache_data_lo;
   logic [l2_banks_p-1:0] cache_data_v_lo, cache_data_yumi_li;
 
+  `declare_bsg_cache_dma_pkt_s(daddr_width_p, l2_block_size_in_words_p);
+  bsg_cache_dma_pkt_s [l2_banks_p-1:0] dma_pkt_lo, dma_pkt_cast_o;
+
   // TODO: Buffering can be reduced by only saving headers per stream
   bp_bedrock_mem_fwd_header_s mem_fwd_header_li;
   logic [bedrock_fill_width_p-1:0] mem_fwd_data_li;
@@ -140,7 +143,7 @@ module bp_me_cache_slice
          ,.v_o(cache_data_v_lo[i])
          ,.yumi_i(cache_data_yumi_li[i])
 
-         ,.dma_pkt_o(dma_pkt_o[i])
+         ,.dma_pkt_o(dma_pkt_lo[i])
          ,.dma_pkt_v_o(dma_pkt_v_o[i])
          ,.dma_pkt_yumi_i(dma_pkt_ready_and_i[i] & dma_pkt_v_o[i])
 
@@ -154,6 +157,16 @@ module bp_me_cache_slice
 
          ,.v_we_o()
          );
+
+      bp_me_dram_hash_decode
+        #(.bp_params_p(bp_params_p))
+        dma_addr_hash_decode
+         (.daddr_i(dma_pkt_lo[i].addr)
+          ,.daddr_o(dma_pkt_cast_o[i].addr)
+          );
+      assign dma_pkt_cast_o[i].write_not_read = dma_pkt_lo[i].write_not_read;
+      assign dma_pkt_cast_o[i].mask = dma_pkt_lo[i].mask;
+      assign dma_pkt_o[i] = dma_pkt_cast_o[i];
     end
 
 endmodule

--- a/bp_me/src/v/dev/bp_me_dram_hash_decode.sv
+++ b/bp_me/src/v/dev/bp_me_dram_hash_decode.sv
@@ -5,6 +5,8 @@
  * Description:
  *   This module reverses the bit swizzling applied by bp_me_dram_hash_encode.
  *
+ *   Unicore designs do not swizzle addresses.
+ *
  *   Encode takes an address of form {A, b...bb, c...cc, D} and outputs
  *   address of {A, c...cc, b...bb, D}. The bit widths of b and c bits may differ and are
  *   specified by the offset_widths_p parameter.
@@ -24,23 +26,27 @@ module bp_me_dram_hash_decode
    , output logic [daddr_width_p-1:0] daddr_o
    );
 
-  localparam l2_block_offset_width_lp = `BSG_SAFE_CLOG2(l2_block_width_p/8);
-  localparam lg_l2_sets_lp            = `BSG_SAFE_CLOG2(l2_sets_p);
-  localparam lg_l2_banks_lp           = `BSG_SAFE_CLOG2(l2_banks_p);
-  localparam lg_num_cce_lp            = `BSG_SAFE_CLOG2(num_cce_p);
-  localparam int hash_offset_widths_lp[2:0] = '{(lg_l2_sets_lp-lg_num_cce_lp), lg_num_cce_lp, l2_block_offset_width_lp};
-  localparam offset_width_lp = hash_offset_widths_lp[0] + hash_offset_widths_lp[1] + hash_offset_widths_lp[2];
+  if (cce_type_p == e_cce_uce) begin : unicore
+    assign daddr_o = daddr_i;
+  end else begin : multicore
+    localparam l2_block_offset_width_lp = `BSG_SAFE_CLOG2(l2_block_width_p/8);
+    localparam lg_l2_sets_lp            = `BSG_SAFE_CLOG2(l2_sets_p);
+    localparam lg_l2_banks_lp           = `BSG_SAFE_CLOG2(l2_banks_p);
+    localparam lg_num_cce_lp            = `BSG_SAFE_CLOG2(num_cce_p);
+    localparam int hash_offset_widths_lp[2:0] = '{(lg_l2_sets_lp-lg_num_cce_lp), lg_num_cce_lp, l2_block_offset_width_lp};
+    localparam offset_width_lp = hash_offset_widths_lp[0] + hash_offset_widths_lp[1] + hash_offset_widths_lp[2];
 
-  wire [hash_offset_widths_lp[2]+hash_offset_widths_lp[1]-1:0] decoded_bits =
-    {daddr_i[hash_offset_widths_lp[0]+:hash_offset_widths_lp[2]]
-     ,daddr_i[(hash_offset_widths_lp[0]+hash_offset_widths_lp[2])+:hash_offset_widths_lp[1]]
-     };
+    wire [hash_offset_widths_lp[2]+hash_offset_widths_lp[1]-1:0] decoded_bits =
+      {daddr_i[hash_offset_widths_lp[0]+:hash_offset_widths_lp[2]]
+       ,daddr_i[(hash_offset_widths_lp[0]+hash_offset_widths_lp[2])+:hash_offset_widths_lp[1]]
+       };
 
-  assign daddr_o =
-    {daddr_i[daddr_width_p-1:offset_width_lp]
-     ,decoded_bits
-     ,daddr_i[0+:hash_offset_widths_lp[0]]
-     };
+    assign daddr_o =
+      {daddr_i[daddr_width_p-1:offset_width_lp]
+       ,decoded_bits
+       ,daddr_i[0+:hash_offset_widths_lp[0]]
+       };
+  end
 
 endmodule
 

--- a/bp_me/src/v/dev/bp_me_dram_hash_encode.sv
+++ b/bp_me/src/v/dev/bp_me_dram_hash_encode.sv
@@ -6,6 +6,8 @@
  *   This module swizzles bits in an address, primarily to enable uniform access to L2/memory
  *   in a BlackParrot multicore.
  *
+ *   Unicore designs do not swizzle addresses.
+ *
  *   Encode takes an address of form {A, b...bb, c...cc, D} and outputs
  *   address of {A, c...cc, b...bb, D}. The bit widths of b and c bits may differ and are
  *   specified by the offset_widths_p parameter.
@@ -28,22 +30,32 @@ module bp_me_dram_hash_encode
 
   localparam l2_block_offset_width_lp = `BSG_SAFE_CLOG2(l2_block_width_p/8);
   localparam lg_l2_sets_lp            = `BSG_SAFE_CLOG2(l2_sets_p);
-  localparam lg_num_cce_lp            = `BSG_SAFE_CLOG2(num_cce_p);
-  localparam l2_bank_offset_width_lp  = (num_cce_p > 1) ? l2_block_offset_width_lp+lg_num_cce_lp : l2_block_offset_width_lp;
-  localparam int hash_offset_widths_lp[2:0] = '{(lg_l2_sets_lp-lg_num_cce_lp), lg_num_cce_lp, l2_block_offset_width_lp};
-  localparam offset_width_lp = hash_offset_widths_lp[0] + hash_offset_widths_lp[1] + hash_offset_widths_lp[2];
 
-  wire [hash_offset_widths_lp[2]+hash_offset_widths_lp[1]-1:0] encoded_bits =
-    {daddr_i[hash_offset_widths_lp[0]+:hash_offset_widths_lp[1]]
-     ,daddr_i[(hash_offset_widths_lp[0]+hash_offset_widths_lp[1])+:hash_offset_widths_lp[2]]
-     };
-
-  assign daddr_o =
-    {daddr_i[daddr_width_p-1:offset_width_lp]
-     ,encoded_bits
-     ,daddr_i[0+:hash_offset_widths_lp[0]]
-     };
-  assign bank_o = (l2_banks_p > 1) ? daddr_i[l2_bank_offset_width_lp+:lg_l2_banks_lp] : '0;
+  if (cce_type_p == e_cce_uce) begin : unicore
+    // unicore does not apply an address swizzle
+    assign daddr_o = daddr_i;
+    // bank selection uses the low order tag bits
+    localparam l2_bank_offset_width_lp  = l2_block_offset_width_lp+lg_l2_sets_lp;
+    assign bank_o = (l2_banks_p > 1) ? daddr_i[l2_bank_offset_width_lp+:lg_l2_banks_lp] : '0;
+  end
+  else begin : multicore
+    localparam lg_num_cce_lp            = `BSG_SAFE_CLOG2(num_cce_p);
+    localparam int hash_offset_widths_lp[2:0] = '{(lg_l2_sets_lp-lg_num_cce_lp), lg_num_cce_lp, l2_block_offset_width_lp};
+    localparam offset_width_lp = hash_offset_widths_lp[0] + hash_offset_widths_lp[1] + hash_offset_widths_lp[2];
+    // swizzle the address
+    wire [hash_offset_widths_lp[2]+hash_offset_widths_lp[1]-1:0] encoded_bits =
+      {daddr_i[hash_offset_widths_lp[0]+:hash_offset_widths_lp[1]]
+       ,daddr_i[(hash_offset_widths_lp[0]+hash_offset_widths_lp[1])+:hash_offset_widths_lp[2]]
+       };
+    assign daddr_o =
+      {daddr_i[daddr_width_p-1:offset_width_lp]
+       ,encoded_bits
+       ,daddr_i[0+:hash_offset_widths_lp[0]]
+       };
+    // bank selection
+    localparam l2_bank_offset_width_lp  = (num_cce_p > 1) ? l2_block_offset_width_lp+lg_num_cce_lp : l2_block_offset_width_lp;
+    assign bank_o = (l2_banks_p > 1) ? daddr_i[l2_bank_offset_width_lp+:lg_l2_banks_lp] : '0;
+  end
 
 endmodule
 


### PR DESCRIPTION
Miscellaneous hotfixes for unicore and sipo_passthrough_dynamic.

- fix UCE to properly handle back-to-back non-blocking requests from the cache. Due to the negedge to posedge crossing out of the UCE (mem_fwd), it is possible for an uncached store to be mishandled if the receiver stops accepting the mem_fwd messages by lowering ready_and_i. This happens due to the half cycle clock crossing and the dlatch extension of the handshake between the two clock edges. The UCE will see ready_and_i high in the back half of its clock cycle, which it views as a valid handshake, but the posedge clocked logic has already lowered the ready signal and does not actually accept the message.
- remove address swizzling from unicore designs
- add address unswizzling before the dma packet leaves the L2 cache slice for multicore designs
- bug fix sipo_passthrough_dynamic to properly handle non-full length transactions. The sipo now directly connects the ready_i|o signals. This requires the consumer to be ready for the SIPO to accept data. This fix also resolves an issue with stream gearbox where we would otherwise need to buffer a header if the SIPO were allowed to consume the last data word before the consumer can consume the parallel output. In effect, this makes the last word of every transaction, regardless of length, conform to the passthrough behavior.

These fixes have not yet been thoroughly tested.
