### PR TITLE
Adding fifo to cache engines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,14 +59,6 @@ check-design:
   script:
     - $CI_PROJECT_DIR/ci/check_design.sh $CI_CORES
 
-surelog:
-  <<: *job_definition
-  stage: check
-  tags:
-    - bsg
-  script:
-    - $CI_PROJECT_DIR/ci/surelog.sh $CI_CORES
-
 yosys:
   <<: *job_definition
   stage: check
@@ -151,6 +143,14 @@ l2e-verilator:
     - verilator
   script:
     - $CI_PROJECT_DIR/ci/l2e_config.sh verilator $CI_CORES
+
+surelog:
+  <<: *job_definition
+  stage: test-medium
+  tags:
+    - bsg
+  script:
+    - $CI_PROJECT_DIR/ci/surelog.sh $CI_CORES
 
 me-regress-verilator:
   <<: *job_definition

--- a/bp_be/src/include/bp_be_ctl_pkgdef.svh
+++ b/bp_be/src/include/bp_be_ctl_pkgdef.svh
@@ -228,6 +228,7 @@
     logic dcache_replay;
     logic dtlb_load_miss;
     logic dtlb_store_miss;
+    logic fencei_dirty;
     logic itlb_fill;
     logic dtlb_fill;
     logic _interrupt;

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -117,7 +117,7 @@ module bp_be_calculator_top
 
   logic pipe_mem_dtlb_load_miss_lo, pipe_mem_dtlb_store_miss_lo;
   logic pipe_mem_dcache_load_miss_lo, pipe_mem_dcache_store_miss_lo, pipe_mem_dcache_replay_lo;
-  logic pipe_mem_fencei_clean_lo;
+  logic pipe_mem_fencei_clean_lo, pipe_mem_fencei_dirty_lo;
   logic pipe_mem_load_misaligned_lo, pipe_mem_load_access_fault_lo, pipe_mem_load_page_fault_lo;
   logic pipe_mem_store_misaligned_lo, pipe_mem_store_access_fault_lo, pipe_mem_store_page_fault_lo;
 
@@ -378,6 +378,7 @@ module bp_be_calculator_top
      ,.cache_load_miss_v_o(pipe_mem_dcache_load_miss_lo)
      ,.cache_store_miss_v_o(pipe_mem_dcache_store_miss_lo)
      ,.fencei_clean_v_o(pipe_mem_fencei_clean_lo)
+     ,.fencei_dirty_v_o(pipe_mem_fencei_dirty_lo)
      ,.load_misaligned_v_o(pipe_mem_load_misaligned_lo)
      ,.load_access_fault_v_o(pipe_mem_load_access_fault_lo)
      ,.load_page_fault_v_o(pipe_mem_load_page_fault_lo)
@@ -541,6 +542,7 @@ module bp_be_calculator_top
           exc_stage_n[2].exc.instr_misaligned   |= pipe_int_catchup_instr_misaligned_lo;
           exc_stage_n[2].exc.mispredict         |= pipe_int_catchup_mispredict_lo;
 
+          exc_stage_n[2].exc.fencei_dirty       |= pipe_mem_fencei_dirty_lo;
           exc_stage_n[2].exc.dcache_replay      |= pipe_mem_dcache_replay_lo;
           exc_stage_n[2].spec.dcache_load_miss  |= pipe_mem_dcache_load_miss_lo;
           exc_stage_n[2].spec.dcache_store_miss |= pipe_mem_dcache_store_miss_lo;

--- a/bp_be/src/v/bp_be_calculator/bp_be_ptw.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_ptw.sv
@@ -189,7 +189,7 @@ module bp_be_ptw
       e_idle      :  state_n = tlb_miss_v ? e_ordered : state_r;
       e_ordered   :  state_n = dcache_ordered_i ? e_send_load : state_r;
       e_send_load :  state_n = dcache_ready_and_i ? e_recv_load : state_r;
-      e_recv_load :  state_n = dcache_v_i ? e_check_load : e_send_load;
+      e_recv_load :  state_n = dcache_v_i ? e_check_load : e_ordered;
       e_check_load:  state_n = (pte_is_leaf | page_fault_v) ? e_writeback : e_send_load;
       default: // e_writeback
                      state_n = e_idle;

--- a/bp_be/test/common/bp_be_nonsynth_dcache_tracer.sv
+++ b/bp_be/test/common/bp_be_nonsynth_dcache_tracer.sv
@@ -190,29 +190,29 @@ module bp_be_nonsynth_dcache_tracer
       if (|data_mem_fast_read)
         $fwrite(mem_file, "%12t | data_mem_fast_read: %b\n", $time, data_mem_fast_read);
       if (|data_mem_fast_write)
-        $fwrite(mem_file, "%12t | data_mem_fast_read: %b\n", $time, data_mem_fast_write);
+        $fwrite(mem_file, "%12t | data_mem_fast_write: %b\n", $time, data_mem_fast_write);
       if (|data_mem_slow_read)
         $fwrite(mem_file, "%12t | data_mem_slow_read: %b\n", $time, data_mem_slow_read);
       if (|data_mem_slow_write)
-        $fwrite(mem_file, "%12t | data_mem_slow_read: %b\n", $time, data_mem_slow_write);
+        $fwrite(mem_file, "%12t | data_mem_slow_write: %b\n", $time, data_mem_slow_write);
 
       if (tag_mem_fast_read)
         $fwrite(mem_file, "%12t | tag_mem_fast_read : %b\n", $time, tag_mem_fast_read);
       if (tag_mem_fast_write)
-        $fwrite(mem_file, "%12t | tag_mem_fast_read : %b\n", $time, tag_mem_fast_write);
+        $fwrite(mem_file, "%12t | tag_mem_fast_write : %b\n", $time, tag_mem_fast_write);
       if (tag_mem_slow_read)
         $fwrite(mem_file, "%12t | tag_mem_slow_read : %b\n", $time, tag_mem_slow_read);
       if (tag_mem_slow_write)
-        $fwrite(mem_file, "%12t | tag_mem_slow_read : %b\n", $time, tag_mem_slow_write);
+        $fwrite(mem_file, "%12t | tag_mem_slow_write : %b\n", $time, tag_mem_slow_write);
 
       if (stat_mem_fast_read)
         $fwrite(mem_file, "%12t | stat_mem_fast_read: %b\n", $time, stat_mem_fast_read);
       if (stat_mem_fast_write)
-        $fwrite(mem_file, "%12t | stat_mem_fast_read: %b\n", $time, stat_mem_fast_write);
+        $fwrite(mem_file, "%12t | stat_mem_fast_write: %b\n", $time, stat_mem_fast_write);
       if (stat_mem_slow_read)
         $fwrite(mem_file, "%12t | stat_mem_slow_read: %b\n", $time, stat_mem_slow_read);
       if (stat_mem_slow_write)
-        $fwrite(mem_file, "%12t | stat_mem_slow_read: %b\n", $time, stat_mem_slow_write);
+        $fwrite(mem_file, "%12t | stat_mem_slow_write: %b\n", $time, stat_mem_slow_write);
     end
 
 endmodule

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -190,7 +190,6 @@ module wrapper
       ,.v_i(rolly_yumi_li[i])
       ,.ready_and_o(dcache_ready_and_lo[i])
 
-      ,.tv_we_o()
       ,.data_o(data_o[i])
       ,.v_o(v_o[i])
       ,.fencei_o()
@@ -200,6 +199,7 @@ module wrapper
       ,.ordered_o()
       ,.float_o()
       ,.store_o()
+      ,.req_o()
 
       ,.ptag_v_i(1'b1)
       ,.ptag_i(rolly_ptag_r[i])
@@ -247,7 +247,6 @@ module wrapper
              ,.fill_width_p(fill_width_p)
              ,.timeout_max_limit_p(4)
              ,.credits_p(coh_noc_max_credits_p)
-             ,.metadata_latency_p(1)
              ,.ctag_width_p(dcache_ctag_width_p)
              )
            dcache_lce
@@ -321,7 +320,6 @@ module wrapper
             ,.sets_p(sets_p)
             ,.block_width_p(block_width_p)
             ,.fill_width_p(fill_width_p)
-            ,.metadata_latency_p(1)
             ,.ctag_width_p(dcache_ctag_width_p)
             ,.writeback_p(!wt_p)
             )

--- a/bp_common/syn/Makefile.vcs
+++ b/bp_common/syn/Makefile.vcs
@@ -75,6 +75,7 @@ $(BUILD_DIR)/simv: | $(BUILD_COLLATERAL)
 build_dump.v: VCS_BUILD_OPTS += -debug_pp
 build_dump.v: VCS_BUILD_OPTS += +vcs+vcdpluson
 build_dump.v: VCS_BUILD_OPTS += +vcs+vcdplusautoflushon
+build_dump.v: VCS_BUILD_OPTS += +vpdfilesize+512
 build_dump.v: build.v
 
 build_cov.v: VCS_BUILD_OPTS += -cm line+tgl

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -184,7 +184,6 @@ module wrapper
        ,.credits_p(coh_noc_max_credits_p)
        ,.non_excl_reads_p(1)
        ,.ctag_width_p(icache_ctag_width_p)
-       ,.metadata_latency_p(1)
        )
      icache_lce
       (.clk_i(clk_i)
@@ -293,7 +292,6 @@ module wrapper
        ,.sets_p(icache_sets_p)
        ,.block_width_p(icache_block_width_p)
        ,.fill_width_p(icache_fill_width_p)
-       ,.metadata_latency_p(1)
        ,.ctag_width_p(icache_ctag_width_p)
        ,.writeback_p(icache_features_p[e_cfg_writeback])
        )

--- a/bp_me/src/v/dev/bp_me_bedrock_register.sv
+++ b/bp_me/src/v/dev/bp_me_bedrock_register.sv
@@ -95,7 +95,7 @@ module bp_me_bedrock_register
   logic v_r;
   wire wr_not_rd  = (mem_fwd_header_li.msg_type inside {e_bedrock_mem_wr, e_bedrock_mem_uc_wr});
   wire rd_not_wr  = (mem_fwd_header_li.msg_type inside {e_bedrock_mem_rd, e_bedrock_mem_uc_rd});
-  wire v_n = mem_fwd_v_li & ~v_r;
+  wire v_n = mem_rev_ready_and_i & mem_fwd_v_li & ~v_r;
   logic [els_p-1:0] r_v_r;
   bsg_dff_reset_set_clear
    #(.width_p(1+els_p), .clear_over_set_p(1))
@@ -119,9 +119,9 @@ module bp_me_bedrock_register
 
   for (genvar i = 0; i < els_p; i++)
     begin : dec
-      wire addr_match = mem_fwd_v_li & (mem_fwd_header_li.addr[0+:reg_addr_width_p] inside {base_addr_p[i]});
-      assign r_v_o[i] = ~v_r & addr_match & ~wr_not_rd;
-      assign w_v_o[i] = ~v_r & addr_match &  wr_not_rd;
+      wire addr_match = (mem_fwd_header_li.addr[0+:reg_addr_width_p] inside {base_addr_p[i]});
+      assign r_v_o[i] = v_n & addr_match & ~wr_not_rd;
+      assign w_v_o[i] = v_n & addr_match &  wr_not_rd;
     end
 
   assign addr_o = mem_fwd_header_li.addr[0+:reg_addr_width_p];

--- a/bp_me/src/v/lce/bp_lce.sv
+++ b/bp_me/src/v/lce/bp_lce.sv
@@ -28,9 +28,6 @@ module bp_lce
    , parameter credits_p = coh_noc_max_credits_p
    // issue non-exclusive read requests
    , parameter non_excl_reads_p = 0
-   // latency of request metadata in cycles, must be 0 or 1
-   // BP caches' metadata arrives cycle after request, by default
-   , parameter `BSG_INV_PARAM(metadata_latency_p)
    , parameter `BSG_INV_PARAM(ctag_width_p)
 
    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
@@ -45,7 +42,7 @@ module bp_lce
     , input bp_lce_mode_e                            lce_mode_i
 
     // Cache-LCE Interface
-    // valid->yumi; metadata is valid only at metadata_latency_p cycles after request valid
+    // valid->yumi; metadata is valid once after request valid
     // metadata arrives in the same cycle as req, or any cycle after, but before the next request
     // can arrive, as indicated by the metadata_v_i signal
     , input [cache_req_width_lp-1:0]                 cache_req_i
@@ -120,8 +117,6 @@ module bp_lce
   // LCE only supports single data beat for requests
   if (fill_width_p < dword_width_gp)
     $error("fill width must be greater or equal than cache request data width");
-  if ((metadata_latency_p > 1))
-    $error("metadata needs to arrive <2 cycles after the request");
 
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache);
   `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
@@ -142,7 +137,6 @@ module bp_lce
      ,.ctag_width_p(ctag_width_p)
      ,.credits_p(credits_p)
      ,.non_excl_reads_p(non_excl_reads_p)
-     ,.metadata_latency_p(metadata_latency_p)
      )
    request
     (.clk_i(clk_i)

--- a/bp_me/test/tb/bp_cce/testbench.sv
+++ b/bp_me/test/tb/bp_cce/testbench.sv
@@ -421,7 +421,6 @@ module testbench
        ,.timeout_max_limit_p(4)
        ,.credits_p(coh_noc_max_credits_p)
        ,.ctag_width_p(icache_ctag_width_p)
-       ,.metadata_latency_p(0)
        )
      lce
       (.clk_i(clk_i)

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -150,7 +150,6 @@ module bp_cacc_vdp
      ,.ptag_uncached_i(1'b0)
      ,.ptag_dram_i(1'b1)
      ,.st_data_i(acache_st_data_r)
-     ,.tv_we_o()
 
      ,.data_o(acache_data_lo)
      ,.v_o(acache_v_lo)
@@ -161,6 +160,7 @@ module bp_cacc_vdp
      ,.ordered_o()
      ,.late_o()
      ,.rd_addr_o()
+     ,.req_o()
 
      // D$-LCE Interface
      ,.cache_req_o(acache_req_lo)
@@ -199,7 +199,6 @@ module bp_cacc_vdp
      ,.block_width_p(acache_block_width_p)
      ,.fill_width_p(acache_fill_width_p)
      ,.ctag_width_p(acache_ctag_width_p)
-     ,.metadata_latency_p(1)
      ,.timeout_max_limit_p(4)
      ,.credits_p(coh_noc_max_credits_p)
      )

--- a/bp_top/src/v/bp_core_lite.sv
+++ b/bp_top/src/v/bp_core_lite.sv
@@ -194,7 +194,6 @@ module bp_core_lite
      ,.timeout_max_limit_p(4)
      ,.credits_p(coh_noc_max_credits_p)
      ,.non_excl_reads_p(1)
-     ,.metadata_latency_p(1)
      )
    fe_lce
     (.clk_i(posedge_clk)
@@ -289,7 +288,6 @@ module bp_core_lite
      ,.ctag_width_p(dcache_ctag_width_p)
      ,.timeout_max_limit_p(4)
      ,.credits_p(coh_noc_max_credits_p)
-     ,.metadata_latency_p(1)
      )
    be_lce
     (.clk_i(negedge_clk)

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -158,7 +158,6 @@ module bp_unicore_lite
      ,.fill_width_p(icache_fill_width_p)
      ,.ctag_width_p(icache_ctag_width_p)
      ,.writeback_p(icache_features_p[e_cfg_writeback])
-     ,.metadata_latency_p(1)
      )
    icache_uce
     (.clk_i(posedge_clk)
@@ -218,7 +217,6 @@ module bp_unicore_lite
      ,.fill_width_p(dcache_fill_width_p)
      ,.ctag_width_p(dcache_ctag_width_p)
      ,.writeback_p(dcache_features_p[e_cfg_writeback])
-     ,.metadata_latency_p(1)
      )
    dcache_uce
     (.clk_i(negedge_clk)


### PR DESCRIPTION
### Summary
This PR adds a fifo to local cache engines, which more elegantly handles back to back non-blocking requests. 

### Issue Fixed
Related to #1183 

### Area
UCE, LCE, D$

### Reasoning (new feature, inefficient, verbose, etc.)
Before, negedge synchronization could cause a ready signal from the cache engine to happen in the second half of a cycle. This could cause an error if the core pipeline inspects the signal in the first half of the cycle.

### Additional Changes Required (if any)
None

### Analysis
Slight area increase in cache engines, but reduction in cache size by getting rid of enables.

### Verification
Standard regression and linux boot.

### Additional Context
None