### PR TITLE
FMD disable

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -257,22 +257,20 @@ module bp_be_calculator_top
      );
 
   // Aux pipe: 2 cycle latency
-  if(fpu_support_p)begin
-    bp_be_pipe_aux
-     #(.bp_params_p(bp_params_p))
-     pipe_aux
-      (.clk_i(clk_i)
-       ,.reset_i(reset_i)
+  bp_be_pipe_aux
+   #(.bp_params_p(bp_params_p))
+   pipe_aux
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
 
-      ,.reservation_i(reservation_r)
-      ,.flush_i(commit_pkt_cast_o.npc_w_v)
-      ,.frm_dyn_i(frm_dyn_lo)
+     ,.reservation_i(reservation_r)
+     ,.flush_i(commit_pkt_cast_o.npc_w_v)
+     ,.frm_dyn_i(frm_dyn_lo)
 
-      ,.data_o(pipe_aux_data_lo)
-      ,.fflags_o(pipe_aux_fflags_lo)
-      ,.v_o(pipe_aux_data_lo_v)
-      );
-  end
+     ,.data_o(pipe_aux_data_lo)
+     ,.fflags_o(pipe_aux_fflags_lo)
+     ,.v_o(pipe_aux_data_lo_v)
+     );
 
   // Memory pipe: 2/3 cycle latency
   bp_be_pipe_mem
@@ -350,50 +348,44 @@ module bp_be_calculator_top
      );
 
   // Floating point pipe: 3/4 cycle latency
-  if(muldiv_support_p)
-   begin
-    bp_be_pipe_fma
-     #(.bp_params_p(bp_params_p))
-      pipe_fma
-       (.clk_i(clk_i)
-        ,.reset_i(reset_i)
+  bp_be_pipe_fma
+   #(.bp_params_p(bp_params_p))
+   pipe_fma
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
 
-        ,.reservation_i(reservation_r)
-        ,.flush_i(commit_pkt_cast_o.npc_w_v)
-        ,.frm_dyn_i(frm_dyn_lo)
+     ,.reservation_i(reservation_r)
+     ,.flush_i(commit_pkt_cast_o.npc_w_v)
+     ,.frm_dyn_i(frm_dyn_lo)
 
-        ,.imul_data_o(pipe_mul_data_lo)
-        ,.imul_v_o(pipe_mul_data_lo_v)
-        ,.fma_data_o(pipe_fma_data_lo)
-        ,.fma_fflags_o(pipe_fma_fflags_lo)
-        ,.fma_v_o(pipe_fma_data_lo_v)
-      );
-  end
+     ,.imul_data_o(pipe_mul_data_lo)
+     ,.imul_v_o(pipe_mul_data_lo_v)
+     ,.fma_data_o(pipe_fma_data_lo)
+     ,.fma_fflags_o(pipe_fma_fflags_lo)
+     ,.fma_v_o(pipe_fma_data_lo_v)
+     );
 
   // Variable length pipeline, used for long (potentially scoreboarded operations)
-  if(fpu_support_p)
-   begin
-    bp_be_pipe_long
-     #(.bp_params_p(bp_params_p))
-      pipe_long
-      (.clk_i(clk_i)
-       ,.reset_i(reset_i)
+  bp_be_pipe_long
+   #(.bp_params_p(bp_params_p))
+   pipe_long
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
 
-       ,.reservation_i(reservation_r)
-       ,.flush_i(commit_pkt_cast_o.npc_w_v)
-       ,.ibusy_o(idiv_busy_o)
-       ,.fbusy_o(fdiv_busy_o)
-       ,.frm_dyn_i(frm_dyn_lo)
+     ,.reservation_i(reservation_r)
+     ,.flush_i(commit_pkt_cast_o.npc_w_v)
+     ,.ibusy_o(idiv_busy_o)
+     ,.fbusy_o(fdiv_busy_o)
+     ,.frm_dyn_i(frm_dyn_lo)
 
-       ,.iwb_pkt_o(long_iwb_pkt)
-       ,.iwb_v_o(pipe_long_idata_lo_v)
-       ,.iwb_yumi_i(pipe_long_idata_lo_yumi)
+     ,.iwb_pkt_o(long_iwb_pkt)
+     ,.iwb_v_o(pipe_long_idata_lo_v)
+     ,.iwb_yumi_i(pipe_long_idata_lo_yumi)
 
-       ,.fwb_pkt_o(long_fwb_pkt)
-       ,.fwb_v_o(pipe_long_fdata_lo_v)
-       ,.fwb_yumi_i(pipe_long_fdata_lo_yumi)
-       );
-  end
+     ,.fwb_pkt_o(long_fwb_pkt)
+     ,.fwb_v_o(pipe_long_fdata_lo_v)
+     ,.fwb_yumi_i(pipe_long_fdata_lo_yumi)
+     );
 
   // If a pipeline has completed an instruction (pipe_xxx_v), then mux in the calculated result.
   // Else, mux in the previous stage of the completion pipe. Since we are single issue and have
@@ -418,13 +410,13 @@ module bp_be_calculator_top
       comp_stage_n[1].rd_data    |= pipe_ctl_data_lo_v       ? pipe_ctl_data_lo         : '0;
       comp_stage_n[1].rd_data    |= pipe_sys_data_lo_v       ? pipe_sys_data_lo         : '0;
       comp_stage_n[2].rd_data    |= pipe_mem_early_data_lo_v ? pipe_mem_early_data_lo   : '0;
-      comp_stage_n[2].rd_data    |= fpu_support_p            ? (pipe_aux_data_lo_v       ? pipe_aux_data_lo         : '0):'0;
+      comp_stage_n[2].rd_data    |= pipe_aux_data_lo_v       ? pipe_aux_data_lo         : '0;
       comp_stage_n[3].rd_data    |= pipe_mem_final_data_lo_v ? pipe_mem_final_data_lo   : '0;
-      comp_stage_n[3].rd_data    |= muldiv_support_p         ? (pipe_mul_data_lo_v       ? pipe_mul_data_lo         : '0):'0;
-      comp_stage_n[4].rd_data    |= muldiv_support_p         ? (pipe_fma_data_lo_v       ? pipe_fma_data_lo         : '0):'0;
+      comp_stage_n[3].rd_data    |= pipe_mul_data_lo_v       ? pipe_mul_data_lo         : '0;
+      comp_stage_n[4].rd_data    |= pipe_fma_data_lo_v       ? pipe_fma_data_lo         : '0;
 
-      comp_stage_n[2].fflags     |= fpu_support_p            ? (pipe_aux_data_lo_v       ? pipe_aux_fflags_lo       : '0):'0;
-      comp_stage_n[4].fflags     |= muldiv_support_p         ? (pipe_fma_data_lo_v       ? pipe_fma_fflags_lo       : '0):'0;
+      comp_stage_n[2].fflags     |= pipe_aux_data_lo_v       ? pipe_aux_fflags_lo       : '0;
+      comp_stage_n[4].fflags     |= pipe_fma_data_lo_v       ? pipe_fma_fflags_lo       : '0;
 
       comp_stage_n[0].ird_w_v    &= exc_stage_n[0].v;
       comp_stage_n[1].ird_w_v    &= exc_stage_n[1].v;

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -350,47 +350,49 @@ module bp_be_calculator_top
      );
 
   // Floating point pipe: 3/4 cycle latency
-  if(muldiv_support_p)begin
-  bp_be_pipe_fma
-   #(.bp_params_p(bp_params_p))
-   pipe_fma
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+  if(muldiv_support_p)
+   begin
+    bp_be_pipe_fma
+     #(.bp_params_p(bp_params_p))
+      pipe_fma
+       (.clk_i(clk_i)
+        ,.reset_i(reset_i)
 
-     ,.reservation_i(reservation_r)
-     ,.flush_i(commit_pkt_cast_o.npc_w_v)
-     ,.frm_dyn_i(frm_dyn_lo)
+        ,.reservation_i(reservation_r)
+        ,.flush_i(commit_pkt_cast_o.npc_w_v)
+        ,.frm_dyn_i(frm_dyn_lo)
 
-     ,.imul_data_o(pipe_mul_data_lo)
-     ,.imul_v_o(pipe_mul_data_lo_v)
-     ,.fma_data_o(pipe_fma_data_lo)
-     ,.fma_fflags_o(pipe_fma_fflags_lo)
-     ,.fma_v_o(pipe_fma_data_lo_v)
-     );
+        ,.imul_data_o(pipe_mul_data_lo)
+        ,.imul_v_o(pipe_mul_data_lo_v)
+        ,.fma_data_o(pipe_fma_data_lo)
+        ,.fma_fflags_o(pipe_fma_fflags_lo)
+        ,.fma_v_o(pipe_fma_data_lo_v)
+      );
   end
 
   // Variable length pipeline, used for long (potentially scoreboarded operations)
-  if(fpu_support_p)begin
-  bp_be_pipe_long
-   #(.bp_params_p(bp_params_p))
-   pipe_long
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+  if(fpu_support_p)
+   begin
+    bp_be_pipe_long
+     #(.bp_params_p(bp_params_p))
+      pipe_long
+      (.clk_i(clk_i)
+       ,.reset_i(reset_i)
 
-     ,.reservation_i(reservation_r)
-     ,.flush_i(commit_pkt_cast_o.npc_w_v)
-     ,.ibusy_o(idiv_busy_o)
-     ,.fbusy_o(fdiv_busy_o)
-     ,.frm_dyn_i(frm_dyn_lo)
+       ,.reservation_i(reservation_r)
+       ,.flush_i(commit_pkt_cast_o.npc_w_v)
+       ,.ibusy_o(idiv_busy_o)
+       ,.fbusy_o(fdiv_busy_o)
+       ,.frm_dyn_i(frm_dyn_lo)
 
-     ,.iwb_pkt_o(long_iwb_pkt)
-     ,.iwb_v_o(pipe_long_idata_lo_v)
-     ,.iwb_yumi_i(pipe_long_idata_lo_yumi)
+       ,.iwb_pkt_o(long_iwb_pkt)
+       ,.iwb_v_o(pipe_long_idata_lo_v)
+       ,.iwb_yumi_i(pipe_long_idata_lo_yumi)
 
-     ,.fwb_pkt_o(long_fwb_pkt)
-     ,.fwb_v_o(pipe_long_fdata_lo_v)
-     ,.fwb_yumi_i(pipe_long_fdata_lo_yumi)
-     );
+       ,.fwb_pkt_o(long_fwb_pkt)
+       ,.fwb_v_o(pipe_long_fdata_lo_v)
+       ,.fwb_yumi_i(pipe_long_fdata_lo_yumi)
+       );
   end
 
   // If a pipeline has completed an instruction (pipe_xxx_v), then mux in the calculated result.

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_aux.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_aux.sv
@@ -45,26 +45,24 @@ module bp_be_pipe_aux
   wire [dword_width_gp-1:0] rs1 = reservation.rs1;
   wire [dword_width_gp-1:0] rs2 = reservation.rs2;
 
-  generate
-    if(|fpu_support_p)
-      begin
-        bp_be_nan_unbox
-         #(.bp_params_p(bp_params_p))
-         frs1_unbox
-          (.reg_i(reservation.rs1)
-           ,.unbox_i(decode.ops_v & !(decode.fu_op inside {e_aux_op_fmvi}))
-           ,.reg_o(frs1)
-           );
+  if(|fpu_support_p)
+    begin
+      bp_be_nan_unbox
+       #(.bp_params_p(bp_params_p))
+       frs1_unbox
+        (.reg_i(reservation.rs1)
+         ,.unbox_i(decode.ops_v & !(decode.fu_op inside {e_aux_op_fmvi}))
+         ,.reg_o(frs1)
+         );
 
-        bp_be_nan_unbox
-         #(.bp_params_p(bp_params_p))
-         frs2_unbox
-          (.reg_i(reservation.rs2)
-           ,.unbox_i(decode.ops_v)
-           ,.reg_o(frs2)
-           );
-      end
-    endgenerate
+      bp_be_nan_unbox
+       #(.bp_params_p(bp_params_p))
+       frs2_unbox
+        (.reg_i(reservation.rs2)
+         ,.unbox_i(decode.ops_v)
+         ,.reg_o(frs2)
+         );
+    end
 
   //
   // Control bits for the FPU
@@ -79,24 +77,22 @@ module bp_be_pipe_aux
   //
   logic [dword_width_gp-1:0] frs1_raw;
   logic [dword_width_gp-1:0] frs2_raw;
-  generate
-    if(|fpu_support_p)
-      begin
-        bp_be_reg_to_fp
-         #(.bp_params_p(bp_params_p))
-         frs1_rec2raw
-          (.reg_i(frs1)
-           ,.raw_o(frs1_raw)
-           );
-        
-        bp_be_reg_to_fp
-         #(.bp_params_p(bp_params_p))
-         frs2_rec2raw
-          (.reg_i(frs2)
-           ,.raw_o(frs2_raw)
-           );
-      end
-    endgenerate
+  if(|fpu_support_p)
+    begin
+      bp_be_reg_to_fp
+       #(.bp_params_p(bp_params_p))
+       frs1_rec2raw
+        (.reg_i(frs1)
+         ,.raw_o(frs1_raw)
+         );
+      
+      bp_be_reg_to_fp
+       #(.bp_params_p(bp_params_p))
+       frs2_rec2raw
+        (.reg_i(frs2)
+         ,.raw_o(frs2_raw)
+         );
+  end
 
   //
   // Move Float -> Int
@@ -117,17 +113,15 @@ module bp_be_pipe_aux
 
   bp_be_fp_reg_s imvf_result;
   rv64_fflags_s imvf_fflags;
-  generate
-    if(|fpu_support_p)
-      begin
-        bp_be_fp_to_reg
-         #(.bp_params_p(bp_params_p))
-         fp_to_reg
-          (.raw_i(imvf_src)
-           ,.reg_o(imvf_result)
-           );
-      end
-    endgenerate
+  if(|fpu_support_p)
+    begin
+      bp_be_fp_to_reg
+       #(.bp_params_p(bp_params_p))
+       fp_to_reg
+        (.raw_i(imvf_src)
+         ,.reg_o(imvf_result)
+         );
+  end
   assign imvf_fflags = '0;
 
   //
@@ -141,62 +135,56 @@ module bp_be_pipe_aux
 
   logic [dp_rec_width_gp-1:0] i2d_out;
   rv64_fflags_s i2d_fflags;
-  generate
-    if(|fpu_support_p)
-      begin
-        iNToRecFN
-         #(.intWidth(dword_width_gp)
-           ,.expWidth(dp_exp_width_gp)
-           ,.sigWidth(dp_sig_width_gp)
-           )
-         i2d
-          (.control(control_li)
-           ,.signedIn(signed_i2f)
-           ,.in(i2f_src)
-           ,.roundingMode(frm_li)
-           ,.out(i2d_out)
-           ,.exceptionFlags(i2d_fflags)
-           );
-      end
-    endgenerate
+  if(|fpu_support_p)
+    begin
+      iNToRecFN
+       #(.intWidth(dword_width_gp)
+         ,.expWidth(dp_exp_width_gp)
+         ,.sigWidth(dp_sig_width_gp)
+         )
+       i2d
+        (.control(control_li)
+         ,.signedIn(signed_i2f)
+         ,.in(i2f_src)
+         ,.roundingMode(frm_li)
+         ,.out(i2d_out)
+         ,.exceptionFlags(i2d_fflags)
+         );
+  end
 
   logic [sp_rec_width_gp-1:0] i2s_out;
   rv64_fflags_s i2s_fflags;
-  generate
-    if(|fpu_support_p)
-      begin
-        iNToRecFN
-         #(.intWidth(dword_width_gp)
-           ,.expWidth(sp_exp_width_gp)
-           ,.sigWidth(sp_sig_width_gp)
-           )
-         i2s
-          (.control(control_li)
-           ,.signedIn(signed_i2f)
-           ,.in(i2f_src)
-           ,.roundingMode(frm_li)
-           ,.out(i2s_out)
-           ,.exceptionFlags(i2s_fflags)
-           );
-      end
-    endgenerate
+  if(|fpu_support_p)
+    begin
+      iNToRecFN
+       #(.intWidth(dword_width_gp)
+         ,.expWidth(sp_exp_width_gp)
+         ,.sigWidth(sp_sig_width_gp)
+         )
+       i2s
+        (.control(control_li)
+         ,.signedIn(signed_i2f)
+         ,.in(i2f_src)
+         ,.roundingMode(frm_li)
+         ,.out(i2s_out)
+         ,.exceptionFlags(i2s_fflags)
+         );
+  end
 
   logic [dp_rec_width_gp-1:0] i2s2d_out;
-  generate
-    if(|fpu_support_p)
-      begin
-        recFNToRecFN_unsafe
-         #(.inExpWidth(sp_exp_width_gp)
-           ,.inSigWidth(sp_sig_width_gp)
-           ,.outExpWidth(dp_exp_width_gp)
-           ,.outSigWidth(dp_sig_width_gp)
-           )
-         i2s2d
-          (.in(i2s_out)
-           ,.out(i2s2d_out)
-           );
-      end
-    endgenerate
+  if(|fpu_support_p)
+    begin
+      recFNToRecFN_unsafe
+       #(.inExpWidth(sp_exp_width_gp)
+         ,.inSigWidth(sp_sig_width_gp)
+         ,.outExpWidth(dp_exp_width_gp)
+         ,.outSigWidth(dp_sig_width_gp)
+         )
+       i2s2d
+        (.in(i2s_out)
+         ,.out(i2s2d_out)
+         );
+  end
 
   assign i2f_result = '{tag: decode.ops_v ? e_fp_sp : e_fp_full, rec: decode.ops_v ? i2s2d_out : i2d_out};
   assign i2f_fflags = decode.ops_v ? i2s_fflags : i2d_fflags;
@@ -211,41 +199,37 @@ module bp_be_pipe_aux
   logic [dword_width_gp-1:0] f2dw_out;
   rv64_iflags_s f2dw_iflags;
   wire signed_f2i = (decode.fu_op inside {e_aux_op_f2i, e_aux_op_fmvi});
-  generate
-    if(|fpu_support_p)
-      begin
-        recFNToIN
-         #(.expWidth(dp_exp_width_gp), .sigWidth(dp_sig_width_gp), .intWidth(dword_width_gp))
-         f2dw
-          (.control(control_li)
-           ,.in(frs1.rec)
-           ,.roundingMode(frm_li)
-           ,.signedOut(signed_f2i)
-           ,.out(f2dw_out)
-           ,.intExceptionFlags(f2dw_iflags)
-           );
-      end
-    endgenerate
+  if(|fpu_support_p)
+    begin
+      recFNToIN
+       #(.expWidth(dp_exp_width_gp), .sigWidth(dp_sig_width_gp), .intWidth(dword_width_gp))
+       f2dw
+        (.control(control_li)
+         ,.in(frs1.rec)
+         ,.roundingMode(frm_li)
+         ,.signedOut(signed_f2i)
+         ,.out(f2dw_out)
+         ,.intExceptionFlags(f2dw_iflags)
+         );
+  end
 
   // It's possible we can do away with this int converter and manually
   //   check for inexact exceptions.
   logic [word_width_gp-1:0] f2w_out;
   rv64_iflags_s f2w_iflags;
-  generate
-    if(|fpu_support_p)
-      begin
-        recFNToIN
-         #(.expWidth(dp_exp_width_gp), .sigWidth(dp_sig_width_gp), .intWidth(word_width_gp))
-         f2w
-          (.control(control_li)
-           ,.in(frs1.rec)
-           ,.roundingMode(frm_li)
-           ,.signedOut(signed_f2i)
-           ,.out(f2w_out)
-           ,.intExceptionFlags(f2w_iflags)
-           );
-      end
-    endgenerate
+  if(|fpu_support_p)
+    begin
+      recFNToIN
+       #(.expWidth(dp_exp_width_gp), .sigWidth(dp_sig_width_gp), .intWidth(word_width_gp))
+       f2w
+        (.control(control_li)
+         ,.in(frs1.rec)
+         ,.roundingMode(frm_li)
+         ,.signedOut(signed_f2i)
+         ,.out(f2w_out)
+         ,.intExceptionFlags(f2w_iflags)
+         );
+  end
 
   assign f2i_result = decode.opw_v
                       ? {{word_width_gp{f2w_out[word_width_gp-1]}}, f2w_out}
@@ -272,78 +256,70 @@ module bp_be_pipe_aux
   logic frs1_sign;
   logic [dp_exp_width_gp+1:0] frs1_sexp;
   logic [dp_sig_width_gp:0] frs1_sig;
-  generate
-    if(|fpu_support_p)
-      begin
-        recFNToRawFN
-         #(.expWidth(dp_exp_width_gp) ,.sigWidth(dp_sig_width_gp))
-         frs1_class
-          (.in(frs1.rec)
-           ,.isNaN(frs1_is_nan)
-           ,.isInf(frs1_is_inf)
-           ,.isZero(frs1_is_zero)
-           ,.sign(frs1_sign)
-           ,.sExp(frs1_sexp)
-           ,.sig(frs1_sig)
-           );
-      end
-    endgenerate
+  if(|fpu_support_p)
+    begin
+      recFNToRawFN
+       #(.expWidth(dp_exp_width_gp) ,.sigWidth(dp_sig_width_gp))
+       frs1_class
+        (.in(frs1.rec)
+         ,.isNaN(frs1_is_nan)
+         ,.isInf(frs1_is_inf)
+         ,.isZero(frs1_is_zero)
+         ,.sign(frs1_sign)
+         ,.sExp(frs1_sexp)
+         ,.sig(frs1_sig)
+         );
+  end
   wire frs1_is_sub = decode.ops_v
                      ? ~|frs1_raw[sp_sig_width_gp-1+:sp_exp_width_gp] & |frs1_raw[0+:sp_sig_width_gp-1]
                      : ~|frs1_raw[dp_sig_width_gp-1+:dp_exp_width_gp] & |frs1_raw[0+:dp_sig_width_gp-1];
 
   logic frs1_is_snan;
-  generate
-    if(|fpu_support_p)
-      begin
-        isSigNaNRecFN
-         #(.expWidth(dp_exp_width_gp)
-           ,.sigWidth(dp_sig_width_gp)
-           )
-         frs1_sig_nan
-          (.in(frs1.rec)
-           ,.isSigNaN(frs1_is_snan)
-           );
-      end
-    endgenerate
+  if(|fpu_support_p)
+    begin
+      isSigNaNRecFN
+       #(.expWidth(dp_exp_width_gp)
+         ,.sigWidth(dp_sig_width_gp)
+         )
+       frs1_sig_nan
+        (.in(frs1.rec)
+         ,.isSigNaN(frs1_is_snan)
+         );
+  end
 
   logic frs2_is_nan, frs2_is_inf, frs2_is_zero;
   logic frs2_sign;
   logic [dp_exp_width_gp+1:0] frs2_sexp;
-  generate
-    if(|fpu_support_p)
-      begin
-        recFNToRawFN
-         #(.expWidth(dp_exp_width_gp) ,.sigWidth(dp_sig_width_gp))
-         frs2_class
-          (.in(frs2.rec)
-           ,.isNaN(frs2_is_nan)
-           ,.isInf(frs2_is_inf)
-           ,.isZero(frs2_is_zero)
-           ,.sign(frs2_sign)
-           ,.sExp(frs2_sexp)
-           ,.sig()
-           );
-      end
-    endgenerate
+  if(|fpu_support_p)
+    begin
+      recFNToRawFN
+       #(.expWidth(dp_exp_width_gp) ,.sigWidth(dp_sig_width_gp))
+       frs2_class
+        (.in(frs2.rec)
+         ,.isNaN(frs2_is_nan)
+         ,.isInf(frs2_is_inf)
+         ,.isZero(frs2_is_zero)
+         ,.sign(frs2_sign)
+         ,.sExp(frs2_sexp)
+         ,.sig()
+         );
+  end
   wire frs2_is_sub = decode.ops_v
                      ? ~|frs2_raw[sp_sig_width_gp-1+:sp_exp_width_gp] & |frs2_raw[0+:sp_sig_width_gp-1]
                      : ~|frs2_raw[dp_sig_width_gp-1+:dp_exp_width_gp] & |frs2_raw[0+:dp_sig_width_gp-1];
 
   logic frs2_is_snan;
-  generate
-    if(|fpu_support_p)
-      begin
-        isSigNaNRecFN
-         #(.expWidth(dp_exp_width_gp)
-           ,.sigWidth(dp_sig_width_gp)
-           )
-         frs2_sig_nan
-          (.in(frs2.rec)
-           ,.isSigNaN(frs2_is_snan)
-           );
-      end
-    endgenerate
+  if(|fpu_support_p)
+    begin
+      isSigNaNRecFN
+       #(.expWidth(dp_exp_width_gp)
+         ,.sigWidth(dp_sig_width_gp)
+         )
+       frs2_sig_nan
+        (.in(frs2.rec)
+         ,.isSigNaN(frs2_is_snan)
+         );
+  end
 
   rv64_fclass_s fclass_result;
   rv64_fflags_s fclass_fflags;
@@ -370,41 +346,37 @@ module bp_be_pipe_aux
   // DP->SP conversion is a rounding operation
   logic [sp_rec_width_gp-1:0] dp2sp_round;
   rv64_fflags_s dp2sp_fflags;
-  generate
-    if(|fpu_support_p)
-      begin
-        recFNToRecFN
-         #(.inExpWidth(dp_exp_width_gp)
-           ,.inSigWidth(dp_sig_width_gp)
-           ,.outExpWidth(sp_exp_width_gp)
-           ,.outSigWidth(sp_sig_width_gp)
-           )
-         f2f_round
-          (.control(control_li)
-           ,.in(frs1.rec)
-           ,.roundingMode(frm_li)
-           ,.out(dp2sp_round)
-           ,.exceptionFlags(dp2sp_fflags)
-           );
-      end
-    endgenerate
+  if(|fpu_support_p)
+    begin
+      recFNToRecFN
+       #(.inExpWidth(dp_exp_width_gp)
+         ,.inSigWidth(dp_sig_width_gp)
+         ,.outExpWidth(sp_exp_width_gp)
+         ,.outSigWidth(sp_sig_width_gp)
+         )
+       f2f_round
+        (.control(control_li)
+         ,.in(frs1.rec)
+         ,.roundingMode(frm_li)
+         ,.out(dp2sp_round)
+         ,.exceptionFlags(dp2sp_fflags)
+         );
+    end
 
   logic [dp_rec_width_gp-1:0] dp2sp_result;
-  generate
-    if(|fpu_support_p)
-      begin
-        recFNToRecFN_unsafe
-         #(.inExpWidth(sp_exp_width_gp)
-           ,.inSigWidth(sp_sig_width_gp)
-           ,.outExpWidth(dp_exp_width_gp)
-           ,.outSigWidth(dp_sig_width_gp)
-           )
-         f2f_recover
-          (.in(dp2sp_round)
-           ,.out(dp2sp_result)
-           );
-      end
-    endgenerate
+  if(|fpu_support_p)
+    begin
+      recFNToRecFN_unsafe
+       #(.inExpWidth(sp_exp_width_gp)
+         ,.inSigWidth(sp_sig_width_gp)
+         ,.outExpWidth(dp_exp_width_gp)
+         ,.outSigWidth(dp_sig_width_gp)
+         )
+       f2f_recover
+        (.in(dp2sp_round)
+         ,.out(dp2sp_result)
+         );
+  end
 
   // SP->DP conversion is a NOP, except for canonicalizing NaNs
   logic [dp_rec_width_gp-1:0] sp2dp_result;
@@ -442,17 +414,15 @@ module bp_be_pipe_aux
       fsgnj_raw[frd_signbit] = sgn_lo;
     end
 
-  generate
-    if(|fpu_support_p)
-      begin    
-        bp_be_fp_to_reg
-         #(.bp_params_p(bp_params_p))
-         fsgnj_fp_to_reg
-          (.raw_i(fsgnj_raw)
-           ,.reg_o(fsgnj_result)
-           );
-      end
-    endgenerate
+  if(|fpu_support_p)
+    begin    
+      bp_be_fp_to_reg
+       #(.bp_params_p(bp_params_p))
+       fsgnj_fp_to_reg
+        (.raw_i(fsgnj_raw)
+         ,.reg_o(fsgnj_result)
+         );
+    end
   assign fsgnj_fflags = '0;
 
   //
@@ -468,23 +438,21 @@ module bp_be_pipe_aux
   wire is_fmax_li = (decode.fu_op == e_aux_op_fmax);
   wire is_fmin_li = (decode.fu_op == e_aux_op_fmin);
   wire signaling_li = is_flt_li | is_fle_li;
-  generate
-    if(|fpu_support_p)
-      begin
-        compareRecFN
-         #(.expWidth(dp_exp_width_gp), .sigWidth(dp_sig_width_gp))
-         fcmp
-          (.a(frs1.rec)
-           ,.b(frs2.rec)
-           ,.signaling(signaling_li)
-           ,.lt(flt_lo)
-           ,.eq(feq_lo)
-           ,.gt(fgt_lo)
-           ,.unordered(unordered_lo)
-           ,.exceptionFlags(fcmp_fflags)
-           );
-      end
-    endgenerate
+  if(|fpu_support_p)
+    begin
+      compareRecFN
+       #(.expWidth(dp_exp_width_gp), .sigWidth(dp_sig_width_gp))
+       fcmp
+        (.a(frs1.rec)
+         ,.b(frs2.rec)
+         ,.signaling(signaling_li)
+         ,.lt(flt_lo)
+         ,.eq(feq_lo)
+         ,.gt(fgt_lo)
+         ,.unordered(unordered_lo)
+         ,.exceptionFlags(fcmp_fflags)
+         );
+  end
   wire fle_lo = ~fgt_lo;
   wire fcmp_out = (is_feq_li & feq_lo) | (is_flt_li & flt_lo) | (is_fle_li & (flt_lo | feq_lo));
   assign fcmp_result = '{tag: decode.ops_v ? e_fp_sp : e_fp_full, rec: fcmp_out};
@@ -575,23 +543,21 @@ module bp_be_pipe_aux
     end
 
   wire faux_v_li = reservation.v & reservation.decode.pipe_aux_v;
-  generate
-    if(|fpu_support_p)
-      begin
-        bsg_dff_chain
-         #(.width_p($bits(bp_be_fp_reg_s)+$bits(rv64_fflags_s)+1), .num_stages_p(1))
-         retiming_chain
-          (.clk_i(clk_i)
+  if(|fpu_support_p)
+    begin
+      bsg_dff_chain
+       #(.width_p($bits(bp_be_fp_reg_s)+$bits(rv64_fflags_s)+1), .num_stages_p(1))
+       retiming_chain
+        (.clk_i(clk_i)
 
-           ,.data_i({faux_fflags, faux_result, faux_v_li})
-           ,.data_o({fflags_o, data_o, v_o})
-           );
-      end
-    endgenerate
+         ,.data_i({faux_fflags, faux_result, faux_v_li})
+         ,.data_o({fflags_o, data_o, v_o})
+         );
+  end
 
     always_comb
       begin
-        if(!fpu_support_p)
+        if(~|fpu_support_p)
           begin
             fflags_o  =   'b0;
             data_o    =   'b0;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_aux.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_aux.sv
@@ -45,21 +45,26 @@ module bp_be_pipe_aux
   wire [dword_width_gp-1:0] rs1 = reservation.rs1;
   wire [dword_width_gp-1:0] rs2 = reservation.rs2;
 
-  bp_be_nan_unbox
-   #(.bp_params_p(bp_params_p))
-   frs1_unbox
-    (.reg_i(reservation.rs1)
-     ,.unbox_i(decode.ops_v & !(decode.fu_op inside {e_aux_op_fmvi}))
-     ,.reg_o(frs1)
-     );
+  generate
+    if(|fpu_support_p)
+      begin
+        bp_be_nan_unbox
+         #(.bp_params_p(bp_params_p))
+         frs1_unbox
+          (.reg_i(reservation.rs1)
+           ,.unbox_i(decode.ops_v & !(decode.fu_op inside {e_aux_op_fmvi}))
+           ,.reg_o(frs1)
+           );
 
-  bp_be_nan_unbox
-   #(.bp_params_p(bp_params_p))
-   frs2_unbox
-    (.reg_i(reservation.rs2)
-     ,.unbox_i(decode.ops_v)
-     ,.reg_o(frs2)
-     );
+        bp_be_nan_unbox
+         #(.bp_params_p(bp_params_p))
+         frs2_unbox
+          (.reg_i(reservation.rs2)
+           ,.unbox_i(decode.ops_v)
+           ,.reg_o(frs2)
+           );
+      end
+    endgenerate
 
   //
   // Control bits for the FPU
@@ -73,20 +78,25 @@ module bp_be_pipe_aux
   // Convert recoded registers to raw
   //
   logic [dword_width_gp-1:0] frs1_raw;
-  bp_be_reg_to_fp
-   #(.bp_params_p(bp_params_p))
-   frs1_rec2raw
-    (.reg_i(frs1)
-     ,.raw_o(frs1_raw)
-     );
-
   logic [dword_width_gp-1:0] frs2_raw;
-  bp_be_reg_to_fp
-   #(.bp_params_p(bp_params_p))
-   frs2_rec2raw
-    (.reg_i(frs2)
-     ,.raw_o(frs2_raw)
-     );
+  generate
+    if(|fpu_support_p)
+      begin
+        bp_be_reg_to_fp
+         #(.bp_params_p(bp_params_p))
+         frs1_rec2raw
+          (.reg_i(frs1)
+           ,.raw_o(frs1_raw)
+           );
+        
+        bp_be_reg_to_fp
+         #(.bp_params_p(bp_params_p))
+         frs2_rec2raw
+          (.reg_i(frs2)
+           ,.raw_o(frs2_raw)
+           );
+      end
+    endgenerate
 
   //
   // Move Float -> Int
@@ -107,12 +117,17 @@ module bp_be_pipe_aux
 
   bp_be_fp_reg_s imvf_result;
   rv64_fflags_s imvf_fflags;
-  bp_be_fp_to_reg
-   #(.bp_params_p(bp_params_p))
-   fp_to_reg
-    (.raw_i(imvf_src)
-     ,.reg_o(imvf_result)
-     );
+  generate
+    if(|fpu_support_p)
+      begin
+        bp_be_fp_to_reg
+         #(.bp_params_p(bp_params_p))
+         fp_to_reg
+          (.raw_i(imvf_src)
+           ,.reg_o(imvf_result)
+           );
+      end
+    endgenerate
   assign imvf_fflags = '0;
 
   //
@@ -126,47 +141,62 @@ module bp_be_pipe_aux
 
   logic [dp_rec_width_gp-1:0] i2d_out;
   rv64_fflags_s i2d_fflags;
-  iNToRecFN
-   #(.intWidth(dword_width_gp)
-     ,.expWidth(dp_exp_width_gp)
-     ,.sigWidth(dp_sig_width_gp)
-     )
-   i2d
-    (.control(control_li)
-     ,.signedIn(signed_i2f)
-     ,.in(i2f_src)
-     ,.roundingMode(frm_li)
-     ,.out(i2d_out)
-     ,.exceptionFlags(i2d_fflags)
-     );
+  generate
+    if(|fpu_support_p)
+      begin
+        iNToRecFN
+         #(.intWidth(dword_width_gp)
+           ,.expWidth(dp_exp_width_gp)
+           ,.sigWidth(dp_sig_width_gp)
+           )
+         i2d
+          (.control(control_li)
+           ,.signedIn(signed_i2f)
+           ,.in(i2f_src)
+           ,.roundingMode(frm_li)
+           ,.out(i2d_out)
+           ,.exceptionFlags(i2d_fflags)
+           );
+      end
+    endgenerate
 
   logic [sp_rec_width_gp-1:0] i2s_out;
   rv64_fflags_s i2s_fflags;
-  iNToRecFN
-   #(.intWidth(dword_width_gp)
-     ,.expWidth(sp_exp_width_gp)
-     ,.sigWidth(sp_sig_width_gp)
-     )
-   i2s
-    (.control(control_li)
-     ,.signedIn(signed_i2f)
-     ,.in(i2f_src)
-     ,.roundingMode(frm_li)
-     ,.out(i2s_out)
-     ,.exceptionFlags(i2s_fflags)
-     );
+  generate
+    if(|fpu_support_p)
+      begin
+        iNToRecFN
+         #(.intWidth(dword_width_gp)
+           ,.expWidth(sp_exp_width_gp)
+           ,.sigWidth(sp_sig_width_gp)
+           )
+         i2s
+          (.control(control_li)
+           ,.signedIn(signed_i2f)
+           ,.in(i2f_src)
+           ,.roundingMode(frm_li)
+           ,.out(i2s_out)
+           ,.exceptionFlags(i2s_fflags)
+           );
+      end
+    endgenerate
 
   logic [dp_rec_width_gp-1:0] i2s2d_out;
-  recFNToRecFN_unsafe
-   #(.inExpWidth(sp_exp_width_gp)
-     ,.inSigWidth(sp_sig_width_gp)
-     ,.outExpWidth(dp_exp_width_gp)
-     ,.outSigWidth(dp_sig_width_gp)
-     )
-   i2s2d
-    (.in(i2s_out)
-     ,.out(i2s2d_out)
-     );
+  generate
+    if(|fpu_support_p)
+      begin
+        recFNToRecFN_unsafe
+         #(.inExpWidth(sp_exp_width_gp)
+           ,.inSigWidth(sp_sig_width_gp)
+           ,.outExpWidth(dp_exp_width_gp)
+           ,.outSigWidth(dp_sig_width_gp)
+           )
+         i2s2d
+          (.in(i2s_out)
+           ,.out(i2s2d_out)
+           );
+      end
+    endgenerate
 
   assign i2f_result = '{tag: decode.ops_v ? e_fp_sp : e_fp_full, rec: decode.ops_v ? i2s2d_out : i2d_out};
   assign i2f_fflags = decode.ops_v ? i2s_fflags : i2d_fflags;
@@ -181,31 +211,41 @@ module bp_be_pipe_aux
   logic [dword_width_gp-1:0] f2dw_out;
   rv64_iflags_s f2dw_iflags;
   wire signed_f2i = (decode.fu_op inside {e_aux_op_f2i, e_aux_op_fmvi});
-  recFNToIN
-   #(.expWidth(dp_exp_width_gp), .sigWidth(dp_sig_width_gp), .intWidth(dword_width_gp))
-   f2dw
-    (.control(control_li)
-     ,.in(frs1.rec)
-     ,.roundingMode(frm_li)
-     ,.signedOut(signed_f2i)
-     ,.out(f2dw_out)
-     ,.intExceptionFlags(f2dw_iflags)
-     );
+  generate
+    if(|fpu_support_p)
+      begin
+        recFNToIN
+         #(.expWidth(dp_exp_width_gp), .sigWidth(dp_sig_width_gp), .intWidth(dword_width_gp))
+         f2dw
+          (.control(control_li)
+           ,.in(frs1.rec)
+           ,.roundingMode(frm_li)
+           ,.signedOut(signed_f2i)
+           ,.out(f2dw_out)
+           ,.intExceptionFlags(f2dw_iflags)
+           );
+      end
+    endgenerate
 
   // It's possible we can do away with this int converter and manually
   //   check for inexact exceptions.
   logic [word_width_gp-1:0] f2w_out;
   rv64_iflags_s f2w_iflags;
-  recFNToIN
-   #(.expWidth(dp_exp_width_gp), .sigWidth(dp_sig_width_gp), .intWidth(word_width_gp))
-   f2w
-    (.control(control_li)
-     ,.in(frs1.rec)
-     ,.roundingMode(frm_li)
-     ,.signedOut(signed_f2i)
-     ,.out(f2w_out)
-     ,.intExceptionFlags(f2w_iflags)
-     );
+  generate
+    if(|fpu_support_p)
+      begin
+        recFNToIN
+         #(.expWidth(dp_exp_width_gp), .sigWidth(dp_sig_width_gp), .intWidth(word_width_gp))
+         f2w
+          (.control(control_li)
+           ,.in(frs1.rec)
+           ,.roundingMode(frm_li)
+           ,.signedOut(signed_f2i)
+           ,.out(f2w_out)
+           ,.intExceptionFlags(f2w_iflags)
+           );
+      end
+    endgenerate
 
   assign f2i_result = decode.opw_v
                       ? {{word_width_gp{f2w_out[word_width_gp-1]}}, f2w_out}
@@ -232,58 +272,78 @@ module bp_be_pipe_aux
   logic frs1_sign;
   logic [dp_exp_width_gp+1:0] frs1_sexp;
   logic [dp_sig_width_gp:0] frs1_sig;
-  recFNToRawFN
-   #(.expWidth(dp_exp_width_gp) ,.sigWidth(dp_sig_width_gp))
-   frs1_class
-    (.in(frs1.rec)
-     ,.isNaN(frs1_is_nan)
-     ,.isInf(frs1_is_inf)
-     ,.isZero(frs1_is_zero)
-     ,.sign(frs1_sign)
-     ,.sExp(frs1_sexp)
-     ,.sig(frs1_sig)
-     );
+  generate
+    if(|fpu_support_p)
+      begin
+        recFNToRawFN
+         #(.expWidth(dp_exp_width_gp) ,.sigWidth(dp_sig_width_gp))
+         frs1_class
+          (.in(frs1.rec)
+           ,.isNaN(frs1_is_nan)
+           ,.isInf(frs1_is_inf)
+           ,.isZero(frs1_is_zero)
+           ,.sign(frs1_sign)
+           ,.sExp(frs1_sexp)
+           ,.sig(frs1_sig)
+           );
+      end
+    endgenerate
   wire frs1_is_sub = decode.ops_v
                      ? ~|frs1_raw[sp_sig_width_gp-1+:sp_exp_width_gp] & |frs1_raw[0+:sp_sig_width_gp-1]
                      : ~|frs1_raw[dp_sig_width_gp-1+:dp_exp_width_gp] & |frs1_raw[0+:dp_sig_width_gp-1];
 
   logic frs1_is_snan;
-  isSigNaNRecFN
-   #(.expWidth(dp_exp_width_gp)
-     ,.sigWidth(dp_sig_width_gp)
-     )
-   frs1_sig_nan
-    (.in(frs1.rec)
-     ,.isSigNaN(frs1_is_snan)
-     );
+  generate
+    if(|fpu_support_p)
+      begin
+        isSigNaNRecFN
+         #(.expWidth(dp_exp_width_gp)
+           ,.sigWidth(dp_sig_width_gp)
+           )
+         frs1_sig_nan
+          (.in(frs1.rec)
+           ,.isSigNaN(frs1_is_snan)
+           );
+      end
+    endgenerate
 
   logic frs2_is_nan, frs2_is_inf, frs2_is_zero;
   logic frs2_sign;
   logic [dp_exp_width_gp+1:0] frs2_sexp;
-  recFNToRawFN
-   #(.expWidth(dp_exp_width_gp) ,.sigWidth(dp_sig_width_gp))
-   frs2_class
-    (.in(frs2.rec)
-     ,.isNaN(frs2_is_nan)
-     ,.isInf(frs2_is_inf)
-     ,.isZero(frs2_is_zero)
-     ,.sign(frs2_sign)
-     ,.sExp(frs2_sexp)
-     ,.sig()
-     );
+  generate
+    if(|fpu_support_p)
+      begin
+        recFNToRawFN
+         #(.expWidth(dp_exp_width_gp) ,.sigWidth(dp_sig_width_gp))
+         frs2_class
+          (.in(frs2.rec)
+           ,.isNaN(frs2_is_nan)
+           ,.isInf(frs2_is_inf)
+           ,.isZero(frs2_is_zero)
+           ,.sign(frs2_sign)
+           ,.sExp(frs2_sexp)
+           ,.sig()
+           );
+      end
+    endgenerate
   wire frs2_is_sub = decode.ops_v
                      ? ~|frs2_raw[sp_sig_width_gp-1+:sp_exp_width_gp] & |frs2_raw[0+:sp_sig_width_gp-1]
                      : ~|frs2_raw[dp_sig_width_gp-1+:dp_exp_width_gp] & |frs2_raw[0+:dp_sig_width_gp-1];
 
   logic frs2_is_snan;
-  isSigNaNRecFN
-   #(.expWidth(dp_exp_width_gp)
-     ,.sigWidth(dp_sig_width_gp)
-     )
-   frs2_sig_nan
-    (.in(frs2.rec)
-     ,.isSigNaN(frs2_is_snan)
-     );
+  generate
+    if(|fpu_support_p)
+      begin
+        isSigNaNRecFN
+         #(.expWidth(dp_exp_width_gp)
+           ,.sigWidth(dp_sig_width_gp)
+           )
+         frs2_sig_nan
+          (.in(frs2.rec)
+           ,.isSigNaN(frs2_is_snan)
+           );
+      end
+    endgenerate
 
   rv64_fclass_s fclass_result;
   rv64_fflags_s fclass_fflags;
@@ -310,31 +370,41 @@ module bp_be_pipe_aux
   // DP->SP conversion is a rounding operation
   logic [sp_rec_width_gp-1:0] dp2sp_round;
   rv64_fflags_s dp2sp_fflags;
-  recFNToRecFN
-   #(.inExpWidth(dp_exp_width_gp)
-     ,.inSigWidth(dp_sig_width_gp)
-     ,.outExpWidth(sp_exp_width_gp)
-     ,.outSigWidth(sp_sig_width_gp)
-     )
-   f2f_round
-    (.control(control_li)
-     ,.in(frs1.rec)
-     ,.roundingMode(frm_li)
-     ,.out(dp2sp_round)
-     ,.exceptionFlags(dp2sp_fflags)
-     );
+  generate
+    if(|fpu_support_p)
+      begin
+        recFNToRecFN
+         #(.inExpWidth(dp_exp_width_gp)
+           ,.inSigWidth(dp_sig_width_gp)
+           ,.outExpWidth(sp_exp_width_gp)
+           ,.outSigWidth(sp_sig_width_gp)
+           )
+         f2f_round
+          (.control(control_li)
+           ,.in(frs1.rec)
+           ,.roundingMode(frm_li)
+           ,.out(dp2sp_round)
+           ,.exceptionFlags(dp2sp_fflags)
+           );
+      end
+    endgenerate
 
   logic [dp_rec_width_gp-1:0] dp2sp_result;
-  recFNToRecFN_unsafe
-   #(.inExpWidth(sp_exp_width_gp)
-     ,.inSigWidth(sp_sig_width_gp)
-     ,.outExpWidth(dp_exp_width_gp)
-     ,.outSigWidth(dp_sig_width_gp)
-     )
-   f2f_recover
-    (.in(dp2sp_round)
-     ,.out(dp2sp_result)
-     );
+  generate
+    if(|fpu_support_p)
+      begin
+        recFNToRecFN_unsafe
+         #(.inExpWidth(sp_exp_width_gp)
+           ,.inSigWidth(sp_sig_width_gp)
+           ,.outExpWidth(dp_exp_width_gp)
+           ,.outSigWidth(dp_sig_width_gp)
+           )
+         f2f_recover
+          (.in(dp2sp_round)
+           ,.out(dp2sp_result)
+           );
+      end
+    endgenerate
 
   // SP->DP conversion is a NOP, except for canonicalizing NaNs
   logic [dp_rec_width_gp-1:0] sp2dp_result;
@@ -372,12 +442,17 @@ module bp_be_pipe_aux
       fsgnj_raw[frd_signbit] = sgn_lo;
     end
 
-  bp_be_fp_to_reg
-   #(.bp_params_p(bp_params_p))
-   fsgnj_fp_to_reg
-    (.raw_i(fsgnj_raw)
-     ,.reg_o(fsgnj_result)
-     );
+  generate
+    if(|fpu_support_p)
+      begin    
+        bp_be_fp_to_reg
+         #(.bp_params_p(bp_params_p))
+         fsgnj_fp_to_reg
+          (.raw_i(fsgnj_raw)
+           ,.reg_o(fsgnj_result)
+           );
+      end
+    endgenerate
   assign fsgnj_fflags = '0;
 
   //
@@ -393,18 +468,23 @@ module bp_be_pipe_aux
   wire is_fmax_li = (decode.fu_op == e_aux_op_fmax);
   wire is_fmin_li = (decode.fu_op == e_aux_op_fmin);
   wire signaling_li = is_flt_li | is_fle_li;
-  compareRecFN
-   #(.expWidth(dp_exp_width_gp), .sigWidth(dp_sig_width_gp))
-   fcmp
-    (.a(frs1.rec)
-     ,.b(frs2.rec)
-     ,.signaling(signaling_li)
-     ,.lt(flt_lo)
-     ,.eq(feq_lo)
-     ,.gt(fgt_lo)
-     ,.unordered(unordered_lo)
-     ,.exceptionFlags(fcmp_fflags)
-     );
+  generate
+    if(|fpu_support_p)
+      begin
+        compareRecFN
+         #(.expWidth(dp_exp_width_gp), .sigWidth(dp_sig_width_gp))
+         fcmp
+          (.a(frs1.rec)
+           ,.b(frs2.rec)
+           ,.signaling(signaling_li)
+           ,.lt(flt_lo)
+           ,.eq(feq_lo)
+           ,.gt(fgt_lo)
+           ,.unordered(unordered_lo)
+           ,.exceptionFlags(fcmp_fflags)
+           );
+      end
+    endgenerate
   wire fle_lo = ~fgt_lo;
   wire fcmp_out = (is_feq_li & feq_lo) | (is_flt_li & flt_lo) | (is_fle_li & (flt_lo | feq_lo));
   assign fcmp_result = '{tag: decode.ops_v ? e_fp_sp : e_fp_full, rec: fcmp_out};
@@ -495,14 +575,29 @@ module bp_be_pipe_aux
     end
 
   wire faux_v_li = reservation.v & reservation.decode.pipe_aux_v;
-  bsg_dff_chain
-   #(.width_p($bits(bp_be_fp_reg_s)+$bits(rv64_fflags_s)+1), .num_stages_p(1))
-   retiming_chain
-    (.clk_i(clk_i)
+  generate
+    if(|fpu_support_p)
+      begin
+        bsg_dff_chain
+         #(.width_p($bits(bp_be_fp_reg_s)+$bits(rv64_fflags_s)+1), .num_stages_p(1))
+         retiming_chain
+          (.clk_i(clk_i)
 
-     ,.data_i({faux_fflags, faux_result, faux_v_li})
-     ,.data_o({fflags_o, data_o, v_o})
-     );
+           ,.data_i({faux_fflags, faux_result, faux_v_li})
+           ,.data_o({fflags_o, data_o, v_o})
+           );
+      end
+    endgenerate
+
+    always_comb
+      begin
+        if(!fpu_support_p)
+          begin
+            fflags_o  =   'b0;
+            data_o    =   'b0;
+            v_o       =   'b0;
+          end
+      end
 
 endmodule
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_fma.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_fma.sv
@@ -59,29 +59,35 @@ module bp_be_pipe_fma
   assign instr = reservation.instr;
   wire [dword_width_gp-1:0] rs1 = decode.opw_v ? (reservation.rs1 << word_width_gp) : reservation.rs1;
   wire [dword_width_gp-1:0] rs2 = reservation.rs2;
-  bp_be_nan_unbox
-   #(.bp_params_p(bp_params_p))
-   frs1_unbox
-    (.reg_i(reservation.rs1)
-     ,.unbox_i(decode.ops_v)
-     ,.reg_o(frs1)
-     );
 
-  bp_be_nan_unbox
-   #(.bp_params_p(bp_params_p))
-   frs2_unbox
-    (.reg_i(reservation.rs2)
-     ,.unbox_i(decode.ops_v)
-     ,.reg_o(frs2)
-     );
+  generate
+    if(|fpu_support_p)
+      begin
+        bp_be_nan_unbox
+         #(.bp_params_p(bp_params_p))
+         frs1_unbox
+          (.reg_i(reservation.rs1)
+           ,.unbox_i(decode.ops_v)
+           ,.reg_o(frs1)
+           );
 
-  bp_be_nan_unbox
-   #(.bp_params_p(bp_params_p))
-   frs3_unbox
-    (.reg_i(reservation.imm)
-     ,.unbox_i(decode.ops_v)
-     ,.reg_o(frs3)
-     );
+        bp_be_nan_unbox
+         #(.bp_params_p(bp_params_p))
+         frs2_unbox
+          (.reg_i(reservation.rs2)
+           ,.unbox_i(decode.ops_v)
+           ,.reg_o(frs2)
+           );
+
+        bp_be_nan_unbox
+         #(.bp_params_p(bp_params_p))
+         frs3_unbox
+          (.reg_i(reservation.imm)
+           ,.unbox_i(decode.ops_v)
+           ,.reg_o(frs3)
+           );
+    end
+  endgenerate
 
   //
   // Control bits for the FPU
@@ -155,50 +161,69 @@ module bp_be_pipe_fma
 
   rv64_frm_e frm_r;
   logic ops_v_r;
-  bsg_dff_chain
-   #(.width_p($bits(rv64_frm_e)+1), .num_stages_p(fma_pipeline_stages_lp[0]+fma_pipeline_stages_lp[1]))
-   fma_info_chain
-    (.clk_i(clk_i)
-     ,.data_i({frm_li, decode.ops_v})
-     ,.data_o({frm_r, ops_v_r})
-     );
+
+  generate
+    if(fpu_support_p[e_fma])
+      begin
+        bsg_dff_chain
+         #(.width_p($bits(rv64_frm_e)+1), .num_stages_p(fma_pipeline_stages_lp[0]+fma_pipeline_stages_lp[1]))
+         fma_info_chain
+          (.clk_i(clk_i)
+           ,.data_i({frm_li, decode.ops_v})
+           ,.data_o({frm_r, ops_v_r})
+           );
+      end
+    endgenerate
 
   logic opw_v_r;
-  bsg_dff_chain
-   #(.width_p(1), .num_stages_p(fma_pipeline_stages_lp[0]))
-   mul_info_chain
-    (.clk_i(clk_i)
-     ,.data_i(decode.opw_v)
-     ,.data_o(opw_v_r)
-     );
+
+  generate
+    if(muldiv_support_p[e_imul])
+      begin
+        bsg_dff_chain
+         #(.width_p(1), .num_stages_p(fma_pipeline_stages_lp[0]))
+         mul_info_chain
+          (.clk_i(clk_i)
+           ,.data_i(decode.opw_v)
+           ,.data_o(opw_v_r)
+           );
+      end
+    endgenerate
 
   logic invalid_exc, is_nan, is_inf, is_zero, fma_out_sign;
   logic [dword_width_gp-1:0] imul_out;
   bp_hardfloat_raw_dp_s fma_raw_lo;
-  mulAddRecFNToRaw
-   #(.expWidth(dp_exp_width_gp)
-     ,.sigWidth(dp_sig_width_gp)
-     ,.pipelineStages(fma_pipeline_stages_lp[0])
-     ,.imulEn(1)
-     )
-   fma
-    (.clock(clk_i),
-     .control(control_li)
-     ,.op(fma_op_li)
-     ,.a(fma_a_li)
-     ,.b(fma_b_li)
-     ,.c(fma_c_li)
-     ,.roundingMode(frm_li)
 
-     ,.invalidExc(invalid_exc)
-     ,.out_isNaN(fma_raw_lo.is_nan)
-     ,.out_isInf(fma_raw_lo.is_inf)
-     ,.out_isZero(fma_raw_lo.is_zero)
-     ,.out_sign(fma_raw_lo.sign)
-     ,.out_sExp(fma_raw_lo.sexp)
-     ,.out_sig(fma_raw_lo.sig)
-     ,.out_imul(imul_out)
-     );
+  generate
+    if(muldiv_support_p[e_imul])
+      begin
+        mulAddRecFNToRaw
+         #(.expWidth(dp_exp_width_gp)
+           ,.sigWidth(dp_sig_width_gp)
+           ,.pipelineStages(fma_pipeline_stages_lp[0])
+           ,.imulEn(1)
+           )
+         fma
+          (.clock(clk_i),
+           .control(control_li)
+           ,.op(fma_op_li)
+           ,.a(fma_a_li)
+           ,.b(fma_b_li)
+           ,.c(fma_c_li)
+           ,.roundingMode(frm_li)
+
+           ,.invalidExc(invalid_exc)
+           ,.out_isNaN(fma_raw_lo.is_nan)
+           ,.out_isInf(fma_raw_lo.is_inf)
+           ,.out_isZero(fma_raw_lo.is_zero)
+           ,.out_sign(fma_raw_lo.sign)
+           ,.out_sExp(fma_raw_lo.sexp)
+           ,.out_sig(fma_raw_lo.sig)
+           ,.out_imul(imul_out)
+           );
+      end
+    endgenerate
+
   wire [dpath_width_gp-1:0] imulw_out    = $signed(imul_out) >>> word_width_gp;
   wire [dpath_width_gp-1:0] imul_result = opw_v_r ? imulw_out : imul_out;
 
@@ -214,30 +239,36 @@ module bp_be_pipe_fma
 
   logic [dp_rec_width_gp-1:0] fma_result_dp, fma_result_sp;
   rv64_fflags_s fma_fflags_dp, fma_fflags_sp;
-  roundRawFNtoRecFN_mixed
-   #(.fullExpWidth(dp_exp_width_gp)
-     ,.fullSigWidth(dp_sig_width_gp)
-     ,.midExpWidth(sp_exp_width_gp)
-     ,.midSigWidth(sp_sig_width_gp)
-     ,.outExpWidth(dp_exp_width_gp)
-     ,.outSigWidth(dp_sig_width_gp)
-     )
-   round_mixed
-    (.control(control_li)
-     ,.invalidExc(invalid_exc_r)
-     ,.infiniteExc('0)
-     ,.in_isNaN(fma_raw_r.is_nan)
-     ,.in_isInf(fma_raw_r.is_inf)
-     ,.in_isZero(fma_raw_r.is_zero)
-     ,.in_sign(fma_raw_r.sign)
-     ,.in_sExp(fma_raw_r.sexp)
-     ,.in_sig(fma_raw_r.sig)
-     ,.roundingMode(frm_r)
-     ,.fullOut(fma_result_dp)
-     ,.fullExceptionFlags(fma_fflags_dp)
-     ,.midOut(fma_result_sp)
-     ,.midExceptionFlags(fma_fflags_sp)
-     );
+
+  generate
+    if(fpu_support_p[e_fma])
+      begin
+        roundRawFNtoRecFN_mixed
+         #(.fullExpWidth(dp_exp_width_gp)
+           ,.fullSigWidth(dp_sig_width_gp)
+           ,.midExpWidth(sp_exp_width_gp)
+           ,.midSigWidth(sp_sig_width_gp)
+           ,.outExpWidth(dp_exp_width_gp)
+           ,.outSigWidth(dp_sig_width_gp)
+           )
+         round_mixed
+          (.control(control_li)
+           ,.invalidExc(invalid_exc_r)
+           ,.infiniteExc('0)
+           ,.in_isNaN(fma_raw_r.is_nan)
+           ,.in_isInf(fma_raw_r.is_inf)
+           ,.in_isZero(fma_raw_r.is_zero)
+           ,.in_sign(fma_raw_r.sign)
+           ,.in_sExp(fma_raw_r.sexp)
+           ,.in_sig(fma_raw_r.sig)
+           ,.roundingMode(frm_r)
+           ,.fullOut(fma_result_dp)
+           ,.fullExceptionFlags(fma_fflags_dp)
+           ,.midOut(fma_result_sp)
+           ,.midExceptionFlags(fma_fflags_sp)
+           );
+      end
+    endgenerate
 
   bp_be_fp_reg_s fma_sp_reg_lo, fma_dp_reg_lo, frd_data_lo;
   rv64_fflags_s fflags_lo;
@@ -250,43 +281,75 @@ module bp_be_pipe_fma
       {fflags_lo, frd_data_lo} = {fma_fflags_dp, fma_dp_reg_lo};
 
   // TODO: Can combine the registers here if DC doesn't do it automatically
-  bsg_dff_chain
-   #(.width_p(dpath_width_gp), .num_stages_p(imul_retime_latency_lp-1))
-   imul_retiming_chain
-    (.clk_i(clk_i)
+  generate
+    if(muldiv_support_p[e_imul])
+      begin
+        bsg_dff_chain
+         #(.width_p(dpath_width_gp), .num_stages_p(imul_retime_latency_lp-1))
+         imul_retiming_chain
+          (.clk_i(clk_i)
 
-     ,.data_i({imul_result})
-     ,.data_o({imul_data_o})
-     );
+           ,.data_i({imul_result})
+           ,.data_o({imul_data_o})
+           );
+      end
+    endgenerate
 
-  bsg_dff_chain
-   #(.width_p($bits(bp_be_fp_reg_s)+$bits(rv64_fflags_s)), .num_stages_p(fma_retime_latency_lp-1))
-   fma_retiming_chain
-    (.clk_i(clk_i)
+  generate
+    if(fpu_support_p[e_fma])
+      begin
+        bsg_dff_chain
+         #(.width_p($bits(bp_be_fp_reg_s)+$bits(rv64_fflags_s)), .num_stages_p(fma_retime_latency_lp-1))
+         fma_retiming_chain
+          (.clk_i(clk_i)
 
-     ,.data_i({fflags_lo, frd_data_lo})
-     ,.data_o({fma_fflags_o, fma_data_o})
-     );
+           ,.data_i({fflags_lo, frd_data_lo})
+           ,.data_o({fma_fflags_o, fma_data_o})
+           );
+      end
+    endgenerate
 
   wire imul_v_li = reservation.v & reservation.decode.pipe_mul_v;
-  bsg_dff_chain
-   #(.width_p(1), .num_stages_p(imul_latency_lp-1))
-   imul_v_chain
-    (.clk_i(clk_i)
+  generate
+    if(muldiv_support_p[e_imul])
+      begin
+        bsg_dff_chain
+         #(.width_p(1), .num_stages_p(imul_latency_lp-1))
+         imul_v_chain
+          (.clk_i(clk_i)
 
-     ,.data_i(imul_v_li)
-     ,.data_o(imul_v_o)
-     );
+           ,.data_i(imul_v_li)
+           ,.data_o(imul_v_o)
+           );
+      end
+    endgenerate
 
   wire fma_v_li = reservation.v & reservation.decode.pipe_fma_v;
-  bsg_dff_chain
-   #(.width_p(1), .num_stages_p(fma_latency_lp-1))
-   fma_v_chain
-    (.clk_i(clk_i)
+  generate
+    if(fpu_support_p[e_fma])
+      begin
+        bsg_dff_chain
+         #(.width_p(1), .num_stages_p(fma_latency_lp-1))
+         fma_v_chain
+          (.clk_i(clk_i)
 
-     ,.data_i(fma_v_li)
-     ,.data_o(fma_v_o)
-     );
+           ,.data_i(fma_v_li)
+           ,.data_o(fma_v_o)
+           );
+      end
+    endgenerate
+
+  always_comb
+    begin
+      if(!fpu_support_p)
+        begin
+          imul_data_o   =  'b0;
+          imul_v_o      =  'b0;
+          fma_data_o    =  'b0;
+          fma_fflags_o  =  'b0;
+          fma_v_o       =  'b0;
+        end
+    end
 
 endmodule
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
@@ -63,27 +63,25 @@ module bp_be_pipe_long
   logic imulh_ready_lo, imulh_v_lo;
   wire imulh_v_li = v_li & (decode.fu_op inside {e_mul_op_mulh, e_mul_op_mulhsu, e_mul_op_mulhu});
 
-  generate
-    if(muldiv_support_p[e_imulh])
-      begin
-        bsg_imul_iterative
-         #(.width_p(dword_width_gp))
-         imulh
-          (.clk_i(clk_i)
-          ,.reset_i(reset_i)
-          ,.v_i(imulh_v_li)
-          ,.ready_o(imulh_ready_lo)
-          ,.opA_i(op_a)
-          ,.signed_opA_i(signed_opA_li)
-          ,.opB_i(op_b)
-          ,.signed_opB_i(signed_opB_li)
-          ,.gets_high_part_i(1'b1)
-          ,.v_o(imulh_v_lo)
-          ,.result_o(imulh_result_lo)
-          ,.yumi_i(imulh_v_lo & iwb_yumi_i)
-          );
-      end
-  endgenerate
+  if(muldiv_support_p[e_imulh])
+    begin
+      bsg_imul_iterative
+       #(.width_p(dword_width_gp))
+       imulh
+        (.clk_i(clk_i)
+        ,.reset_i(reset_i)
+        ,.v_i(imulh_v_li)
+        ,.ready_o(imulh_ready_lo)
+        ,.opA_i(op_a)
+        ,.signed_opA_i(signed_opA_li)
+        ,.opB_i(op_b)
+        ,.signed_opB_i(signed_opB_li)
+        ,.gets_high_part_i(1'b1)
+        ,.v_o(imulh_v_lo)
+        ,.result_o(imulh_result_lo)
+        ,.yumi_i(imulh_v_lo & iwb_yumi_i)
+        );
+    end
 
   // We actual could exit early here
   logic [dword_width_gp-1:0] quotient_lo, remainder_lo;
@@ -92,53 +90,49 @@ module bp_be_pipe_long
   wire idiv_v_li = v_li & (decode.fu_op inside {e_mul_op_div, e_mul_op_divu});
   wire irem_v_li = v_li & (decode.fu_op inside {e_mul_op_rem, e_mul_op_remu});
 
-  generate
-    if(muldiv_support_p[e_idiv])
-      begin
-        bsg_idiv_iterative
-        #(.width_p(dword_width_gp))
-        idiv
-         (.clk_i(clk_i)
-          ,.reset_i(reset_i)
+  if(muldiv_support_p[e_idiv])
+    begin
+      bsg_idiv_iterative
+      #(.width_p(dword_width_gp))
+      idiv
+       (.clk_i(clk_i)
+        ,.reset_i(reset_i)
 
-          ,.dividend_i(op_a)
-          ,.divisor_i(op_b)
-          ,.signed_div_i(signed_div_li)
-          ,.v_i(idiv_v_li | irem_v_li)
-          ,.ready_and_o(idiv_ready_and_lo)
+        ,.dividend_i(op_a)
+        ,.divisor_i(op_b)
+        ,.signed_div_i(signed_div_li)
+        ,.v_i(idiv_v_li | irem_v_li)
+        ,.ready_and_o(idiv_ready_and_lo)
 
-          ,.quotient_o(quotient_lo)
-          ,.remainder_o(remainder_lo)
-          ,.v_o(idiv_v_lo)
-          ,.yumi_i(idiv_v_lo & iwb_yumi_i)
-          );
-      end
-  endgenerate
+        ,.quotient_o(quotient_lo)
+        ,.remainder_o(remainder_lo)
+        ,.v_o(idiv_v_lo)
+        ,.yumi_i(idiv_v_lo & iwb_yumi_i)
+        );
+    end
 
   wire [word_width_gp-1:0] quotient_w_lo = quotient_lo[0+:word_width_gp];
   wire [word_width_gp-1:0] remainder_w_lo = remainder_lo[0+:word_width_gp];
 
   bp_be_fp_reg_s frs1, frs2;
-  generate
-    if(|muldiv_support_p)
-      begin
-        bp_be_nan_unbox
-         #(.bp_params_p(bp_params_p))
-         frs1_unbox
-          (.reg_i(reservation.rs1)
-           ,.unbox_i(decode.ops_v)
-           ,.reg_o(frs1)
-           );
+  if(|muldiv_support_p)
+    begin
+      bp_be_nan_unbox
+       #(.bp_params_p(bp_params_p))
+       frs1_unbox
+        (.reg_i(reservation.rs1)
+         ,.unbox_i(decode.ops_v)
+         ,.reg_o(frs1)
+         );
 
-        bp_be_nan_unbox
-         #(.bp_params_p(bp_params_p))
-         frs2_unbox
-          (.reg_i(reservation.rs2)
-           ,.unbox_i(decode.ops_v)
-           ,.reg_o(frs2)
-           );
-    end
-  endgenerate
+      bp_be_nan_unbox
+       #(.bp_params_p(bp_params_p))
+       frs2_unbox
+        (.reg_i(reservation.rs2)
+         ,.unbox_i(decode.ops_v)
+         ,.reg_o(frs2)
+         );
+  end
 
   //
   // Control bits for the FPU
@@ -156,108 +150,100 @@ module bp_be_pipe_long
   logic [2:0] frm_lo;
   bp_hardfloat_raw_dp_s fdivsqrt_raw_lo;
 
-  generate
-    if(fpu_support_p[e_fdivsqrt])
-      begin
-        divSqrtRecFNToRaw_small
-         #(.expWidth(dp_exp_width_gp), .sigWidth(dp_sig_width_gp))
-         fdiv
-          (.clock(clk_i)
-           ,.nReset(~reset_i)
-           ,.control(control_li)
+  if(fpu_support_p[e_fdivsqrt])
+    begin
+      divSqrtRecFNToRaw_small
+       #(.expWidth(dp_exp_width_gp), .sigWidth(dp_sig_width_gp))
+       fdiv
+        (.clock(clk_i)
+         ,.nReset(~reset_i)
+         ,.control(control_li)
+        
+         ,.inReady(fdiv_ready_and_lo)
+         ,.inValid(fdiv_v_li | fsqrt_v_li)
+         ,.sqrtOp(fsqrt_v_li)
+         ,.a(frs1.rec)
+         ,.b(frs2.rec)
+         ,.roundingMode(frm_li)
+       
+         ,.outValid(fdivsqrt_v_lo)
+         ,.sqrtOpOut(sqrt_lo)
+         ,.roundingModeOut(frm_lo)
+         ,.invalidExc(invalid_exc)
+         ,.infiniteExc(infinite_exc)
 
-           ,.inReady(fdiv_ready_and_lo)
-           ,.inValid(fdiv_v_li | fsqrt_v_li)
-           ,.sqrtOp(fsqrt_v_li)
-           ,.a(frs1.rec)
-           ,.b(frs2.rec)
-           ,.roundingMode(frm_li)
-
-           ,.outValid(fdivsqrt_v_lo)
-           ,.sqrtOpOut(sqrt_lo)
-           ,.roundingModeOut(frm_lo)
-           ,.invalidExc(invalid_exc)
-           ,.infiniteExc(infinite_exc)
-
-           ,.out_isNaN(fdivsqrt_raw_lo.is_nan)
-           ,.out_isInf(fdivsqrt_raw_lo.is_inf)
-           ,.out_isZero(fdivsqrt_raw_lo.is_zero)
-           ,.out_sign(fdivsqrt_raw_lo.sign)
-           ,.out_sExp(fdivsqrt_raw_lo.sexp)
-           ,.out_sig(fdivsqrt_raw_lo.sig)
-           );
-      end
-  endgenerate
+         ,.out_isNaN(fdivsqrt_raw_lo.is_nan)
+         ,.out_isInf(fdivsqrt_raw_lo.is_inf)
+         ,.out_isZero(fdivsqrt_raw_lo.is_zero)
+         ,.out_sign(fdivsqrt_raw_lo.sign)
+         ,.out_sExp(fdivsqrt_raw_lo.sexp)
+         ,.out_sig(fdivsqrt_raw_lo.sig)
+         );
+    end
 
   logic opw_v_r, ops_v_r;
   bp_be_fu_op_s fu_op_r;
   logic [reg_addr_width_gp-1:0] rd_addr_r;
   rv64_frm_e frm_r;
-  generate
-    if(|muldiv_support_p)
-      begin
-        bsg_dff_reset_en
-         #(.width_p($bits(rv64_frm_e)+reg_addr_width_gp+$bits(bp_be_fu_op_s)+2))
-         wb_reg
-          (.clk_i(clk_i)
-           ,.reset_i(reset_i)
-           ,.en_i(v_li)
-
-           ,.data_i({frm_li, instr.t.fmatype.rd_addr, decode.fu_op, decode.opw_v, decode.ops_v})
-           ,.data_o({frm_r, rd_addr_r, fu_op_r, opw_v_r, ops_v_r})
-           );
-    end
-  endgenerate
+  if(|muldiv_support_p)
+    begin
+      bsg_dff_reset_en
+       #(.width_p($bits(rv64_frm_e)+reg_addr_width_gp+$bits(bp_be_fu_op_s)+2))
+       wb_reg
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+         ,.en_i(v_li)
+        
+         ,.data_i({frm_li, instr.t.fmatype.rd_addr, decode.fu_op, decode.opw_v, decode.ops_v})
+         ,.data_o({frm_r, rd_addr_r, fu_op_r, opw_v_r, ops_v_r})
+         );
+  end
 
   logic [dp_rec_width_gp-1:0] fdivsqrt_result_dp, fdivsqrt_result_sp;
   rv64_fflags_s fdivsqrt_fflags_dp, fdivsqrt_fflags_sp;
 
-  generate
-    if(fpu_support_p)
-      begin
-        roundRawFNtoRecFN_mixed
-         #(.fullExpWidth(dp_exp_width_gp)
-           ,.fullSigWidth(dp_sig_width_gp)
-           ,.midExpWidth(sp_exp_width_gp)
-           ,.midSigWidth(sp_sig_width_gp)
-           ,.outExpWidth(dp_exp_width_gp)
-           ,.outSigWidth(dp_sig_width_gp)
-           )
-         round_mixed
-          (.control(control_li)
-           ,.invalidExc(invalid_exc)
-           ,.infiniteExc(infinite_exc)
-           ,.in_isNaN(fdivsqrt_raw_lo.is_nan)
-           ,.in_isInf(fdivsqrt_raw_lo.is_inf)
-           ,.in_isZero(fdivsqrt_raw_lo.is_zero)
-           ,.in_sign(fdivsqrt_raw_lo.sign)
-           ,.in_sExp(fdivsqrt_raw_lo.sexp)
-           ,.in_sig(fdivsqrt_raw_lo.sig)
-           ,.roundingMode(frm_r)
-           ,.fullOut(fdivsqrt_result_dp)
-           ,.fullExceptionFlags(fdivsqrt_fflags_dp)
-           ,.midOut(fdivsqrt_result_sp)
-           ,.midExceptionFlags(fdivsqrt_fflags_sp)
-           );
-      end
-  endgenerate
+  if(fpu_support_p)
+    begin
+      roundRawFNtoRecFN_mixed
+       #(.fullExpWidth(dp_exp_width_gp)
+         ,.fullSigWidth(dp_sig_width_gp)
+         ,.midExpWidth(sp_exp_width_gp)
+         ,.midSigWidth(sp_sig_width_gp)
+         ,.outExpWidth(dp_exp_width_gp)
+         ,.outSigWidth(dp_sig_width_gp)
+         )
+       round_mixed
+        (.control(control_li)
+         ,.invalidExc(invalid_exc)
+         ,.infiniteExc(infinite_exc)
+         ,.in_isNaN(fdivsqrt_raw_lo.is_nan)
+         ,.in_isInf(fdivsqrt_raw_lo.is_inf)
+         ,.in_isZero(fdivsqrt_raw_lo.is_zero)
+         ,.in_sign(fdivsqrt_raw_lo.sign)
+         ,.in_sExp(fdivsqrt_raw_lo.sexp)
+         ,.in_sig(fdivsqrt_raw_lo.sig)
+         ,.roundingMode(frm_r)
+         ,.fullOut(fdivsqrt_result_dp)
+         ,.fullExceptionFlags(fdivsqrt_fflags_dp)
+         ,.midOut(fdivsqrt_result_sp)
+         ,.midExceptionFlags(fdivsqrt_fflags_sp)
+         );
+    end
 
   logic imulh_done_v_r, idiv_done_v_r, fdiv_done_v_r, rd_w_v_r;
-  generate
-    if(|muldiv_support_p)
-      begin
-        bsg_dff_reset_set_clear
-         #(.width_p(4))
-         wb_v_reg
-          (.clk_i(clk_i)
-           ,.reset_i(reset_i)
-
-           ,.set_i({imulh_v_lo, idiv_v_lo, fdivsqrt_v_lo, v_li})
-           ,.clear_i({v_li, v_li, v_li, (iwb_yumi_i | fwb_yumi_i)})
-           ,.data_o({imulh_done_v_r, idiv_done_v_r, fdiv_done_v_r, rd_w_v_r})
-           );
-    end
-  endgenerate 
+  if(|muldiv_support_p)
+    begin
+      bsg_dff_reset_set_clear
+       #(.width_p(4))
+       wb_v_reg
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+      
+         ,.set_i({imulh_v_lo, idiv_v_lo, fdivsqrt_v_lo, v_li})
+         ,.clear_i({v_li, v_li, v_li, (iwb_yumi_i | fwb_yumi_i)})
+         ,.data_o({imulh_done_v_r, idiv_done_v_r, fdiv_done_v_r, rd_w_v_r})
+         );
+  end
 
   bp_be_fp_reg_s fdivsqrt_sp_reg_lo, fdivsqrt_dp_reg_lo, frd_data_lo;
   rv64_fflags_s fflags_lo;
@@ -283,8 +269,8 @@ module bp_be_pipe_long
       ird_data_lo = remainder_lo;
 
   // Actually a busy signal
-  assign ibusy_o = ~imulh_ready_lo | ~idiv_ready_and_lo | rd_w_v_r;
-  assign fbusy_o = ~fdiv_ready_and_lo | rd_w_v_r;
+  //assign ibusy_o = ~imulh_ready_lo | ~idiv_ready_and_lo | rd_w_v_r;
+  //assign fbusy_o = ~fdiv_ready_and_lo | rd_w_v_r;
 
   assign iwb_pkt.ird_w_v    = rd_w_v_r;
   assign iwb_pkt.frd_w_v    = 1'b0;
@@ -313,7 +299,7 @@ module bp_be_pipe_long
 
   always_comb
     begin
-      if(!fpu_support_p)
+      if(~fpu_support_p)
         begin
           ibusy_o     =   'b0;
           fbusy_o     =   'b0;
@@ -321,6 +307,11 @@ module bp_be_pipe_long
           iwb_v_o     =   'b0;
           fwb_pkt_o   =   'b0;
           fwb_v_o     =   'b0;
+        end
+        else begin
+          // Actually a busy signal
+          assign ibusy_o = ~imulh_ready_lo | ~idiv_ready_and_lo | rd_w_v_r;
+          assign fbusy_o = ~fdiv_ready_and_lo | rd_w_v_r;
         end
     end
 

--- a/bp_be/src/v/bp_be_checker/bp_be_instr_decoder.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_instr_decoder.sv
@@ -211,6 +211,7 @@ module bp_be_instr_decoder
             decode_cast_o.ops_v      = instr inside {`RV64_FL_W};
 
             illegal_instr_o = ~decode_info_cast_i.fpu_en;
+            illegal_instr_o = ~fpu_support_p;
 
             unique casez (instr)
               `RV64_FL_W: decode_cast_o.fu_op = e_dcache_op_flw;
@@ -240,6 +241,7 @@ module bp_be_instr_decoder
             decode_cast_o.fflags_w_v = 1'b1;
 
             illegal_instr_o = ~decode_info_cast_i.fpu_en;
+            illegal_instr_o = ~fpu_support_p;
 
             unique casez (instr)
               `RV64_FS_W : decode_cast_o.fu_op = e_dcache_op_fsw;
@@ -325,6 +327,7 @@ module bp_be_instr_decoder
         `RV64_FP_OP:
           begin
             illegal_instr_o = ~decode_info_cast_i.fpu_en;
+            illegal_instr_o = ~fpu_support_p;
             unique casez (instr)
               `RV64_FCVT_SD, `RV64_FCVT_DS:
                 begin
@@ -551,6 +554,7 @@ module bp_be_instr_decoder
             endcase
 
             illegal_instr_o = ~decode_info_cast_i.fpu_en;
+            illegal_instr_o = ~fpu_support_p;
           end
 
         `RV64_AMO_OP:

--- a/bp_be/src/v/bp_be_checker/bp_be_instr_decoder.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_instr_decoder.sv
@@ -77,7 +77,10 @@ module bp_be_instr_decoder
         `RV64_OP_OP, `RV64_OP_32_OP:
           begin
             if (instr inside {`RV64_MUL, `RV64_MULW})
+            begin
               decode_cast_o.pipe_mul_v = 1'b1;
+              illegal_instr_o = (|muldiv_support_p) ? illegal_instr_o : 1'b1;
+            end
             else if (instr inside {`RV64_MULH, `RV64_MULHSU, `RV64_MULHU
                                    ,`RV64_DIV, `RV64_DIVU, `RV64_DIVW, `RV64_DIVUW
                                    ,`RV64_REM, `RV64_REMU, `RV64_REMW, `RV64_REMUW
@@ -85,6 +88,7 @@ module bp_be_instr_decoder
               begin
                 decode_cast_o.pipe_long_v = 1'b1;
                 decode_cast_o.late_iwb_v  = (instr.rd_addr != '0);
+                illegal_instr_o = (|muldiv_support_p) ? illegal_instr_o : 1'b1;
               end
             else
               decode_cast_o.pipe_int_v = 1'b1;

--- a/bp_be/src/v/bp_be_checker/bp_be_instr_decoder.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_instr_decoder.sv
@@ -211,7 +211,6 @@ module bp_be_instr_decoder
             decode_cast_o.ops_v      = instr inside {`RV64_FL_W};
 
             illegal_instr_o = ~decode_info_cast_i.fpu_en;
-            illegal_instr_o = ~fpu_support_p;
 
             unique casez (instr)
               `RV64_FL_W: decode_cast_o.fu_op = e_dcache_op_flw;
@@ -241,7 +240,6 @@ module bp_be_instr_decoder
             decode_cast_o.fflags_w_v = 1'b1;
 
             illegal_instr_o = ~decode_info_cast_i.fpu_en;
-            illegal_instr_o = ~fpu_support_p;
 
             unique casez (instr)
               `RV64_FS_W : decode_cast_o.fu_op = e_dcache_op_fsw;
@@ -327,7 +325,6 @@ module bp_be_instr_decoder
         `RV64_FP_OP:
           begin
             illegal_instr_o = ~decode_info_cast_i.fpu_en;
-            illegal_instr_o = ~fpu_support_p;
             unique casez (instr)
               `RV64_FCVT_SD, `RV64_FCVT_DS:
                 begin
@@ -554,7 +551,6 @@ module bp_be_instr_decoder
             endcase
 
             illegal_instr_o = ~decode_info_cast_i.fpu_en;
-            illegal_instr_o = ~fpu_support_p;
           end
 
         `RV64_AMO_OP:

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -119,6 +119,7 @@ module bp_be_scheduler
      );
 
   logic [dpath_width_gp-1:0] frf_rs1, frf_rs2, frf_rs3;
+  if(fpu_support_p)begin
   bp_be_regfile
   #(.bp_params_p(bp_params_p), .read_ports_p(3), .zero_x0_p(0), .data_width_p(dpath_width_gp))
    fp_regfile
@@ -133,6 +134,7 @@ module bp_be_scheduler
      ,.rs_addr_i({preissue_instr.rs3_addr, preissue_instr.rs2_addr, preissue_instr.rs1_addr})
      ,.rs_data_o({frf_rs3, frf_rs2, frf_rs1})
      );
+  end
 
   // Decode the dispatched instruction
   bp_be_decode_s decoded_instr_lo;

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -119,22 +119,23 @@ module bp_be_scheduler
      );
 
   logic [dpath_width_gp-1:0] frf_rs1, frf_rs2, frf_rs3;
-  if(fpu_support_p)begin
-  bp_be_regfile
-  #(.bp_params_p(bp_params_p), .read_ports_p(3), .zero_x0_p(0), .data_width_p(dpath_width_gp))
-   fp_regfile
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+  if(fpu_support_p)
+    begin
+      bp_be_regfile
+      #(.bp_params_p(bp_params_p), .read_ports_p(3), .zero_x0_p(0), .data_width_p(dpath_width_gp))
+       fp_regfile
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
 
-     ,.rd_w_v_i(fwb_pkt_cast_i.frd_w_v)
-     ,.rd_addr_i(fwb_pkt_cast_i.rd_addr)
-     ,.rd_data_i(fwb_pkt_cast_i.rd_data)
+        ,.rd_w_v_i(fwb_pkt_cast_i.frd_w_v)
+        ,.rd_addr_i(fwb_pkt_cast_i.rd_addr)
+        ,.rd_data_i(fwb_pkt_cast_i.rd_data)
 
-     ,.rs_r_v_i({preissue_pkt.frs3_v, preissue_pkt.frs2_v, preissue_pkt.frs1_v})
-     ,.rs_addr_i({preissue_instr.rs3_addr, preissue_instr.rs2_addr, preissue_instr.rs1_addr})
-     ,.rs_data_o({frf_rs3, frf_rs2, frf_rs1})
-     );
-  end
+        ,.rs_r_v_i({preissue_pkt.frs3_v, preissue_pkt.frs2_v, preissue_pkt.frs1_v})
+        ,.rs_addr_i({preissue_instr.rs3_addr, preissue_instr.rs2_addr, preissue_instr.rs1_addr})
+        ,.rs_data_o({frf_rs3, frf_rs2, frf_rs1})
+        );
+    end
 
   // Decode the dispatched instruction
   bp_be_decode_s decoded_instr_lo;

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -311,8 +311,8 @@
 
       ,fe_queue_fifo_els : 8
       ,fe_cmd_fifo_els   : 4
-      ,muldiv_support    : (1 << e_idiv) | (1 << e_imul) | (1 << e_imulh) | (1 << e_idiv2b)
-      ,fpu_support       : (1 << e_fma) | (1 << e_fdivsqrt) | (1 << e_fdivsqrt2b)
+      ,muldiv_support    : 0//(1 << e_idiv) | (1 << e_imul) | (1 << e_imulh) | (1 << e_idiv2b)
+      ,fpu_support       : 0//(1 << e_fma) | (1 << e_fdivsqrt) | (1 << e_fdivsqrt2b)
       ,compressed_support: 1
 
       ,async_coh_clk       : 0

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -311,8 +311,8 @@
 
       ,fe_queue_fifo_els : 8
       ,fe_cmd_fifo_els   : 4
-      ,muldiv_support    : 0//(1 << e_idiv) | (1 << e_imul) | (1 << e_imulh) | (1 << e_idiv2b)
-      ,fpu_support       : 0//(1 << e_fma) | (1 << e_fdivsqrt) | (1 << e_fdivsqrt2b)
+      ,muldiv_support    : (1 << e_idiv) | (1 << e_imul) | (1 << e_imulh) | (1 << e_idiv2b)
+      ,fpu_support       : (1 << e_fma) | (1 << e_fdivsqrt) | (1 << e_fdivsqrt2b)
       ,compressed_support: 1
 
       ,async_coh_clk       : 0

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -21,10 +21,18 @@
 
   typedef enum logic [1:0]
   {
-    e_div   = 2'b00
-    ,e_mul  = 2'b01
-    ,e_mulh = 2'b10
+    e_idiv   = 2'b00
+    ,e_imul  = 2'b01
+    ,e_imulh = 2'b10
+    ,e_idiv2b = 2'b11
   } bp_muldiv_support_e;
+
+  typedef enum logic [1:0]
+  {
+    e_fma         = 2'b00
+    ,e_fdivsqrt   = 2'b01
+    ,e_fdivsqrt2b = 2'b10
+  } bp_fpu_support_e;
 
   typedef enum logic [15:0]
   {
@@ -303,8 +311,8 @@
 
       ,fe_queue_fifo_els : 8
       ,fe_cmd_fifo_els   : 4
-      ,muldiv_support    : (1 << e_div) | (1 << e_mul) | (1 << e_mulh)
-      ,fpu_support       : 1
+      ,muldiv_support    : (1 << e_idiv) | (1 << e_imul) | (1 << e_imulh) | (1 << e_idiv2b)
+      ,fpu_support       : (1 << e_fma) | (1 << e_fdivsqrt) | (1 << e_fdivsqrt2b)
       ,compressed_support: 1
 
       ,async_coh_clk       : 0


### PR DESCRIPTION
Summary:
Parameterize the F, M, and D extensions in BlackParrot to enable/disable them, reducing FPGA area requirements and enabling access to the design on smaller FPGAs for academic purposes.

Issue Fixed:
This change addresses an issue with the F, M, and D extensions in BlackParrot related to FPGA area requirements and accessibility for academic purposes.

Area:
BlackParrot module.

Reasoning:
The change is required to parameterize the F, M, and D extensions, allowing them to be enabled or disabled. This is done to reduce the FPGA area requirements of BlackParrot, making it accessible on smaller FPGAs. By disabling these extensions, the design can fit into smaller devices, which is particularly beneficial for academic purposes where resources may be limited.

Additional Changes Required:
No additional changes are required.

Analysis:
The impact of this change is that it allows users to enable or disable the F, M, and D extensions in BlackParrot, reducing the FPGA area requirements. This enables the use of BlackParrot on smaller FPGAs, making it more accessible for academic purposes. The reduction in area requirements may also have benefits in terms of resource utilization and performance.

Verification:
To verify the change, the following steps can be taken:

Set the parameters to enable the F, M, and D extensions.
Verify that the design requires a larger FPGA area.
Set the parameters to disable the F, M, and D extensions.
Verify that the design now fits into a smaller FPGA.
Run any relevant tests or benchmarks to ensure the functionality is preserved despite the disabled extensions.

Additional Context:
The motivation behind disabling the F, M, and D extensions is to reduce the FPGA area requirements of BlackParrot, allowing it to be used on smaller FPGAs. This enhances accessibility, particularly in academic settings where resources may be limited. It is important to consider the trade-off between FPGA area reduction and potential impact on performance or functionality. Logs or additional context about the problem and its impact may be helpful for further investigation.
