### PR TITLE
Hit under single miss for D$

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - nonblocking
   before_script:
       - git submodule update --init --checkout --recursive external/
       - cp -r $CI_RTL_INSTALL_DIR install/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - nonblocking
   before_script:
       - git submodule update --init --checkout --recursive external/
       - cp -r $CI_RTL_INSTALL_DIR install/

--- a/bp_be/src/include/bp_be_dcache_defines.svh
+++ b/bp_be/src/include/bp_be_dcache_defines.svh
@@ -13,6 +13,7 @@
   `define declare_bp_be_dcache_wbuf_entry_s(caddr_width_mp, ways_mp) \
     typedef struct packed                           \
     {                                               \
+      logic                                snoop;   \
       logic [caddr_width_mp-1:0]           caddr;   \
       logic [dword_width_gp-1:0]           data;    \
       logic [(dword_width_gp>>3)-1:0]      mask;    \
@@ -23,7 +24,7 @@
     (vaddr_width_mp+$bits(bp_be_dcache_fu_op_e)+reg_addr_width_gp)
 
   `define bp_be_dcache_wbuf_entry_width(caddr_width_mp, ways_mp) \
-    (caddr_width_mp+dword_width_gp+(dword_width_gp>>3)+`BSG_SAFE_CLOG2(ways_mp))
+    (1+caddr_width_mp+dword_width_gp+(dword_width_gp>>3)+`BSG_SAFE_CLOG2(ways_mp))
 
 `endif
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -65,7 +65,7 @@ module bp_be_calculator_top
    , output logic [dcache_req_width_lp-1:0]          cache_req_o
    , output logic                                    cache_req_v_o
    , input                                           cache_req_yumi_i
-   , input                                           cache_req_busy_i
+   , input                                           cache_req_lock_i
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
    , input [paddr_width_p-1:0]                       cache_req_addr_i
@@ -349,7 +349,7 @@ module bp_be_calculator_top
      ,.cache_req_o(cache_req_o)
      ,.cache_req_v_o(cache_req_v_o)
      ,.cache_req_yumi_i(cache_req_yumi_i)
-     ,.cache_req_busy_i(cache_req_busy_i)
+     ,.cache_req_lock_i(cache_req_lock_i)
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
      ,.cache_req_addr_i(cache_req_addr_i)

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -32,63 +32,64 @@ module bp_be_calculator_top
    , localparam wb_pkt_width_lp         = `bp_be_wb_pkt_width(vaddr_width_p)
    , localparam decode_info_width_lp    = `bp_be_decode_info_width
    )
- (input                                             clk_i
-  , input                                           reset_i
+  (input                                             clk_i
+   , input                                           reset_i
 
-  , input [cfg_bus_width_lp-1:0]                    cfg_bus_i
+   , input [cfg_bus_width_lp-1:0]                    cfg_bus_i
 
-  // Calculator - Checker interface
-  , input [dispatch_pkt_width_lp-1:0]               dispatch_pkt_i
+   // Calculator - Checker interface
+   , input [dispatch_pkt_width_lp-1:0]               dispatch_pkt_i
 
-  , output logic                                    idiv_busy_o
-  , output logic                                    fdiv_busy_o
-  , output logic                                    mem_busy_o
-  , output logic                                    mem_ordered_o
-  , output logic                                    ptw_busy_o
-  , output logic [decode_info_width_lp-1:0]         decode_info_o
-  , input                                           cmd_full_n_i
+   , output logic                                    idiv_busy_o
+   , output logic                                    fdiv_busy_o
+   , output logic                                    mem_busy_o
+   , output logic                                    mem_ordered_o
+   , output logic                                    ptw_busy_o
+   , output logic [decode_info_width_lp-1:0]         decode_info_o
+   , input                                           cmd_full_n_i
 
-  , output logic [commit_pkt_width_lp-1:0]          commit_pkt_o
-  , output logic [branch_pkt_width_lp-1:0]          br_pkt_o
-  , output logic [wb_pkt_width_lp-1:0]              iwb_pkt_o
-  , output logic [wb_pkt_width_lp-1:0]              fwb_pkt_o
-  , output logic [ptw_fill_pkt_width_lp-1:0]        ptw_fill_pkt_o
+   , output logic [commit_pkt_width_lp-1:0]          commit_pkt_o
+   , output logic [branch_pkt_width_lp-1:0]          br_pkt_o
+   , output logic [wb_pkt_width_lp-1:0]              iwb_pkt_o
+   , output logic [wb_pkt_width_lp-1:0]              fwb_pkt_o
+   , output logic [ptw_fill_pkt_width_lp-1:0]        ptw_fill_pkt_o
 
-  , input                                           debug_irq_i
-  , input                                           timer_irq_i
-  , input                                           software_irq_i
-  , input                                           m_external_irq_i
-  , input                                           s_external_irq_i
-  , output logic                                    irq_waiting_o
-  , output logic                                    irq_pending_o
+   , input                                           debug_irq_i
+   , input                                           timer_irq_i
+   , input                                           software_irq_i
+   , input                                           m_external_irq_i
+   , input                                           s_external_irq_i
+   , output logic                                    irq_waiting_o
+   , output logic                                    irq_pending_o
 
-  , output logic [dcache_req_width_lp-1:0]          cache_req_o
-  , output logic                                    cache_req_v_o
-  , input                                           cache_req_yumi_i
-  , input                                           cache_req_busy_i
-  , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
-  , output logic                                    cache_req_metadata_v_o
-  , input [paddr_width_p-1:0]                       cache_req_addr_i
-  , input                                           cache_req_critical_i
-  , input                                           cache_req_last_i
-  , input                                           cache_req_credits_full_i
-  , input                                           cache_req_credits_empty_i
+   , output logic [dcache_req_width_lp-1:0]          cache_req_o
+   , output logic                                    cache_req_v_o
+   , input                                           cache_req_yumi_i
+   , input                                           cache_req_busy_i
+   , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
+   , output logic                                    cache_req_metadata_v_o
+   , input [paddr_width_p-1:0]                       cache_req_addr_i
+   , input [dword_width_gp-1:0]                      cache_req_data_i
+   , input                                           cache_req_critical_i
+   , input                                           cache_req_last_i
+   , input                                           cache_req_credits_full_i
+   , input                                           cache_req_credits_empty_i
 
-  , input                                           data_mem_pkt_v_i
-  , input [dcache_data_mem_pkt_width_lp-1:0]        data_mem_pkt_i
-  , output logic                                    data_mem_pkt_yumi_o
-  , output logic [dcache_block_width_p-1:0]         data_mem_o
+   , input                                           data_mem_pkt_v_i
+   , input [dcache_data_mem_pkt_width_lp-1:0]        data_mem_pkt_i
+   , output logic                                    data_mem_pkt_yumi_o
+   , output logic [dcache_block_width_p-1:0]         data_mem_o
 
-  , input                                           tag_mem_pkt_v_i
-  , input [dcache_tag_mem_pkt_width_lp-1:0]         tag_mem_pkt_i
-  , output logic                                    tag_mem_pkt_yumi_o
-  , output logic [dcache_tag_info_width_lp-1:0]     tag_mem_o
+   , input                                           tag_mem_pkt_v_i
+   , input [dcache_tag_mem_pkt_width_lp-1:0]         tag_mem_pkt_i
+   , output logic                                    tag_mem_pkt_yumi_o
+   , output logic [dcache_tag_info_width_lp-1:0]     tag_mem_o
 
-  , input                                           stat_mem_pkt_v_i
-  , input [dcache_stat_mem_pkt_width_lp-1:0]        stat_mem_pkt_i
-  , output logic                                    stat_mem_pkt_yumi_o
-  , output logic [dcache_stat_info_width_lp-1:0]    stat_mem_o
-  );
+   , input                                           stat_mem_pkt_v_i
+   , input [dcache_stat_mem_pkt_width_lp-1:0]        stat_mem_pkt_i
+   , output logic                                    stat_mem_pkt_yumi_o
+   , output logic [dcache_stat_info_width_lp-1:0]    stat_mem_o
+   );
 
   // Declare parameterizable structs
   `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
@@ -352,6 +353,7 @@ module bp_be_calculator_top
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
      ,.cache_req_addr_i(cache_req_addr_i)
+     ,.cache_req_data_i(cache_req_data_i)
      ,.cache_req_critical_i(cache_req_critical_i)
      ,.cache_req_last_i(cache_req_last_i)
      ,.cache_req_credits_full_i(cache_req_credits_full_i)

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -436,20 +436,20 @@ module bp_be_csr
                 {1'b1, `CSR_ADDR_SIP          }: csr_data_lo = mip_lo & sip_rmask_li;
                 {1'b1, `CSR_ADDR_SATP         }: csr_data_lo = satp_lo;
                 // We have no vendorid currently
-                {1'b1, `CSR_ADDR_MVENDORID    }: csr_data_lo = '0;
+                {1'b1, `CSR_ADDR_MVENDORID    }: csr_data_lo = 64'h5e5;
                 // https://github.com/riscv/riscv-isa-manual/blob/master/marchid.md
                 //   Lucky 13 (*v*)
-                {1'b1, `CSR_ADDR_MARCHID      }: csr_data_lo = 64'd13;
+                {1'b1, `CSR_ADDR_MARCHID      }: csr_data_lo = 64'h8000000000000002; 
                 // 0: Tapeout 0, July 2019
                 // 1: Tapeout 1, June 2021
                 // 2: Tapeout 2, Sept 2022
                 // 3: Current
-                {1'b1, `CSR_ADDR_MIMPID       }: csr_data_lo = 64'd3;
+                {1'b1, `CSR_ADDR_MIMPID       }: csr_data_lo = 64'd1;
                 {1'b1, `CSR_ADDR_MHARTID      }: csr_data_lo = cfg_bus_cast_i.core_id;
                 {1'b1, `CSR_ADDR_MSTATUS      }: csr_data_lo = mstatus_lo;
                 // MISA is optionally read-write, but all fields are read-only in BlackParrot
                 //   64 bit MXLEN, IMACFDSU extensions
-                {1'b1, `CSR_ADDR_MISA         }: csr_data_lo = {2'b10, 36'b0, 26'h14112d};
+                {1'b1, `CSR_ADDR_MISA         }: csr_data_lo = {2'b10, 36'b0, 26'h141129};
                 {1'b1, `CSR_ADDR_MEDELEG      }: csr_data_lo = medeleg_lo;
                 {1'b1, `CSR_ADDR_MIDELEG      }: csr_data_lo = mideleg_lo;
                 {1'b1, `CSR_ADDR_MIE          }: csr_data_lo = mie_lo;

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -436,20 +436,20 @@ module bp_be_csr
                 {1'b1, `CSR_ADDR_SIP          }: csr_data_lo = mip_lo & sip_rmask_li;
                 {1'b1, `CSR_ADDR_SATP         }: csr_data_lo = satp_lo;
                 // We have no vendorid currently
-                {1'b1, `CSR_ADDR_MVENDORID    }: csr_data_lo = 64'h5e5;
+                {1'b1, `CSR_ADDR_MVENDORID    }: csr_data_lo = '0;
                 // https://github.com/riscv/riscv-isa-manual/blob/master/marchid.md
                 //   Lucky 13 (*v*)
-                {1'b1, `CSR_ADDR_MARCHID      }: csr_data_lo = 64'h8000000000000002; 
+                {1'b1, `CSR_ADDR_MARCHID      }: csr_data_lo = 64'd13;
                 // 0: Tapeout 0, July 2019
                 // 1: Tapeout 1, June 2021
                 // 2: Tapeout 2, Sept 2022
                 // 3: Current
-                {1'b1, `CSR_ADDR_MIMPID       }: csr_data_lo = 64'd1;
+                {1'b1, `CSR_ADDR_MIMPID       }: csr_data_lo = 64'd3;
                 {1'b1, `CSR_ADDR_MHARTID      }: csr_data_lo = cfg_bus_cast_i.core_id;
                 {1'b1, `CSR_ADDR_MSTATUS      }: csr_data_lo = mstatus_lo;
                 // MISA is optionally read-write, but all fields are read-only in BlackParrot
                 //   64 bit MXLEN, IMACFDSU extensions
-                {1'b1, `CSR_ADDR_MISA         }: csr_data_lo = {2'b10, 36'b0, 26'h141129};
+                {1'b1, `CSR_ADDR_MISA         }: csr_data_lo = {2'b10, 36'b0, 26'h14112d};
                 {1'b1, `CSR_ADDR_MEDELEG      }: csr_data_lo = medeleg_lo;
                 {1'b1, `CSR_ADDR_MIDELEG      }: csr_data_lo = mideleg_lo;
                 {1'b1, `CSR_ADDR_MIE          }: csr_data_lo = mie_lo;

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -76,7 +76,7 @@ module bp_be_pipe_mem
    , output logic [dcache_req_width_lp-1:0]          cache_req_o
    , output logic                                    cache_req_v_o
    , input                                           cache_req_yumi_i
-   , input                                           cache_req_busy_i
+   , input                                           cache_req_lock_i
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
    , input [paddr_width_p-1:0]                       cache_req_addr_i
@@ -328,7 +328,7 @@ module bp_be_pipe_mem
       ,.cache_req_o(cache_req_cast_o)
       ,.cache_req_v_o(cache_req_v_o)
       ,.cache_req_yumi_i(cache_req_yumi_i)
-      ,.cache_req_busy_i(cache_req_busy_i)
+      ,.cache_req_lock_i(cache_req_lock_i)
       ,.cache_req_metadata_o(cache_req_metadata_o)
       ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
       ,.cache_req_addr_i(cache_req_addr_i)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -80,6 +80,7 @@ module bp_be_pipe_mem
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
    , input [paddr_width_p-1:0]                       cache_req_addr_i
+   , input [dword_width_gp-1:0]                      cache_req_data_i
    , input                                           cache_req_critical_i
    , input                                           cache_req_last_i
    , input                                           cache_req_credits_full_i
@@ -331,6 +332,7 @@ module bp_be_pipe_mem
       ,.cache_req_metadata_o(cache_req_metadata_o)
       ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
       ,.cache_req_addr_i(cache_req_addr_i)
+      ,.cache_req_data_i(cache_req_data_i)
       ,.cache_req_critical_i(cache_req_critical_i)
       ,.cache_req_last_i(cache_req_last_i)
       ,.cache_req_credits_full_i(cache_req_credits_full_i)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -166,8 +166,9 @@ module bp_be_pipe_mem
 
   logic [dword_width_gp-1:0] dcache_data;
   logic [reg_addr_width_gp-1:0] dcache_rd_addr;
-  logic                     dcache_ret, dcache_store, dcache_late, dcache_fencei, dcache_v, dcache_req;
+  logic                     dcache_ret, dcache_store, dcache_late, dcache_fencei, dcache_v;
   logic                     dcache_float;
+  logic                     dcache_req;
 
   logic load_access_fault_v, store_access_fault_v;
   logic load_page_fault_v, store_page_fault_v;
@@ -286,10 +287,9 @@ module bp_be_pipe_mem
      ,.dcache_pkt_o(ptw_dcache_pkt)
      ,.dcache_ptag_o(ptw_dcache_ptag)
      ,.dcache_ptag_v_o(ptw_dcache_ptag_v)
-     ,.dcache_ordered_i(dcache_ordered_lo)
      ,.dcache_ready_and_i(dcache_ready_and_lo)
 
-     ,.dcache_v_i(dcache_v)
+     ,.dcache_v_i(dcache_v & ~dcache_late)
      ,.dcache_data_i(dcache_data)
      );
 

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -158,13 +158,12 @@ module bp_be_detector
       // Detect scoreboard hazards
       irs1_sb_raw_haz_v = (issue_pkt_cast_i.decode.irs1_r_v & irs_match_lo[0]);
       irs2_sb_raw_haz_v = (issue_pkt_cast_i.decode.irs2_r_v & irs_match_lo[1]);
-      ird_sb_waw_haz_v = (issue_pkt_cast_i.decode.irf_w_v & ird_match_lo);
+      ird_sb_waw_haz_v = ((issue_pkt_cast_i.decode.irf_w_v | issue_pkt_cast_i.decode.late_iwb_v) & ird_match_lo);
 
       frs1_sb_raw_haz_v = (issue_pkt_cast_i.decode.frs1_r_v & frs_match_lo[0]);
       frs2_sb_raw_haz_v = (issue_pkt_cast_i.decode.frs2_r_v & frs_match_lo[1]);
       frs3_sb_raw_haz_v = (issue_pkt_cast_i.decode.frs3_r_v & frs_match_lo[2]);
-
-      frd_sb_waw_haz_v = (issue_pkt_cast_i.decode.frf_w_v & frd_match_lo);
+      frd_sb_waw_haz_v = ((issue_pkt_cast_i.decode.frf_w_v | issue_pkt_cast_i.decode.late_fwb_v) & frd_match_lo);
 
       // Detect integer and float data hazards for EX1
       irs1_data_haz_v[0] = (issue_pkt_cast_i.decode.irs1_r_v & rs1_match_vector[0])

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -1218,15 +1218,19 @@ module bp_be_dcache
          );
 
       logic [assoc_p-1:0] fill_bank_mask_n, fill_hit_n;
-      wire [assoc_p-1:0] fill_bank_mask_nn = (fill_bank_mask_n | data_mem_pkt_fill_mask_expanded);
-      wire [assoc_p-1:0] fill_hit_nn = (1'b1 << data_mem_pkt_cast_i.way_id);
       wire fill_v = data_mem_pkt_yumi_o & data_mem_pkt_cast_i.opcode == e_cache_data_mem_write;
+      wire [assoc_p-1:0] fill_bank_mask_nn = fill_v
+        ? (fill_bank_mask_n | data_mem_pkt_fill_mask_expanded)
+        : '0;
+      wire [assoc_p-1:0] fill_hit_nn = fill_v
+        ? (1'b1 << data_mem_pkt_cast_i.way_id)
+        : '1;
       bsg_dff_reset_en
        #(.width_p(2*assoc_p))
        fill_reg
         (.clk_i(clk_i)
-         ,.reset_i(reset_i | blocking_sent)
-         ,.en_i(fill_v)
+         ,.reset_i(reset_i)
+         ,.en_i(fill_v | blocking_sent)
          ,.data_i({fill_bank_mask_nn, fill_hit_nn})
          ,.data_o({fill_bank_mask_n, fill_hit_n})
          );

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -564,7 +564,7 @@ module bp_be_dcache
   logic wbuf_v_li, wbuf_v_lo, wbuf_force_lo, wbuf_snoop_match_lo, wbuf_yumi_li;
 
   assign wbuf_v_li = v_tv_r
-    & decode_tv_r.store_op & ~sc_fail_tv & ~uncached_op_tv_r
+    & decode_tv_r.store_op & store_hit_tv & ~sc_fail_tv & ~uncached_op_tv_r
     & ~any_miss_tv;
 
   //

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -989,7 +989,7 @@ module bp_be_dcache
       & ~{|data_mem_fast_write & (data_mem_pkt_cast_i.opcode == e_cache_data_mem_read)}
       & ~|{data_mem_fast_read & data_mem_write_bank_mask}
       & ~|{data_mem_fast_write & data_mem_write_bank_mask}
-      & ~(v_tl_r & decode_tl_r.store_op)
+      & ~(v_tl_r & cache_req_critical_i)
       & ~(wbuf_snoop_match_lo);
 
   logic [lg_assoc_lp-1:0] data_mem_pkt_way_r;

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -95,6 +95,7 @@ module bp_be_dcache
                                         | ((dcache_features_p[e_cfg_amo_fetch_arithmetic]) << e_dcache_subop_amominu)
                                         | ((dcache_features_p[e_cfg_amo_fetch_arithmetic]) << e_dcache_subop_amomaxu)
                                         )
+   , parameter hit_under_miss_p = dcache_features_p[e_cfg_hit_under_miss]
    , parameter sets_p         = dcache_sets_p
    , parameter assoc_p        = dcache_assoc_p
    , parameter block_width_p  = dcache_block_width_p
@@ -189,18 +190,14 @@ module bp_be_dcache
     ? (bindex_width_lp+byte_offset_width_lp)
     : byte_offset_width_lp;
 
-  // State machine declaration
-  enum logic {e_ready, e_miss} state_n, state_r;
-  wire is_ready  = (state_r == e_ready);
-  wire is_miss   = (state_r == e_miss);
-
   // Global signals
   logic tl_we, tv_we;
   logic safe_tl_we, safe_tv_we;
   logic v_tl_r, v_tv_r;
   logic gdirty_r;
   logic tag_mem_write_hazard, data_mem_write_hazard, blocking_hazard, engine_hazard;
-  logic blocking_sent, nonblocking_sent;
+  logic blocking_req, blocking_sent;
+  logic nonblocking_req, nonblocking_sent;
 
   wire flush_self = flush_i | tag_mem_write_hazard | data_mem_write_hazard | blocking_hazard | engine_hazard;
   wire critical_recv = cache_req_critical_i
@@ -213,13 +210,18 @@ module bp_be_dcache
     & (~data_mem_pkt_v_i | data_mem_pkt_yumi_o);
 
   // Snoop signals
-  logic snoop_uncached_op_r;
-  logic [dword_width_gp-1:0] snoop_st_data_r;
-  bp_be_dcache_decode_s snoop_decode_r;
   logic [block_width_p-1:0] snoop_data;
   logic [paddr_width_p-1:0] snoop_addr;
   logic [2:0][assoc_p-1:0] snoop_hit;
   logic [assoc_p-1:0] snoop_bank_sel_one_hot;
+
+  // Fill signals
+  logic fill_snoop_v, fill_pending_r, fill_secondary_r, fill_uncached_r;
+  logic [dword_width_gp-1:0] fill_st_data_r;
+  bp_be_dcache_decode_s fill_decode_r;
+  logic [sindex_width_lp-1:0] fill_index_r;
+  logic [assoc_p-1:0] fill_hit_r;
+  logic [assoc_p-1:0] fill_bank_mask_r;
 
   /////////////////////////////////////////////////////////////////////////////
   // Decode Stage
@@ -359,13 +361,14 @@ module bp_be_dcache
   /////////////////////////////////////////////////////////////////////////////
   // TV Stage
   /////////////////////////////////////////////////////////////////////////////
-  logic uncached_op_tv_r, snoop_tv_r;
+  logic uncached_op_tv_r, snoop_tv_r, pending_tv_r;
   logic [paddr_width_p-1:0] paddr_tv_r;
   logic [dword_width_gp-1:0] st_data_tv_r;
   logic [assoc_p-1:0][bank_width_lp-1:0] ld_data_tv_r;
   logic [assoc_p-1:0] load_hit_v_tv_r, store_hit_v_tv_r, way_v_tv_r, bank_sel_one_hot_tv_r;
   bp_be_dcache_decode_s decode_tv_r;
   logic sc_success_tv, sc_fail_tv;
+
   wire [bindex_width_lp-1:0] paddr_bank_tv  = paddr_tv_r[byte_offset_width_lp+:bindex_width_lp];
   wire [sindex_width_lp-1:0] paddr_index_tv = paddr_tv_r[block_offset_width_lp+:sindex_width_lp];
   wire [ctag_width_p-1:0]    paddr_tag_tv   = paddr_tv_r[block_offset_width_lp+sindex_width_lp+:ctag_width_p];
@@ -392,24 +395,25 @@ module bp_be_dcache
   bsg_mux
    #(.width_p(3*assoc_p+block_width_p+paddr_width_p+dword_width_gp+assoc_p+1+$bits(bp_be_dcache_decode_s)), .els_p(2))
    tv_snoop_mux
-    (.data_i({{snoop_hit, snoop_data, snoop_addr
-               ,snoop_st_data_r, snoop_bank_sel_one_hot, snoop_uncached_op_r, snoop_decode_r}
-              ,{way_v_tl, store_hit_tl, load_hit_tl, data_mem_data_lo, paddr_tl
-                ,st_data_tl, bank_sel_one_hot_tl, uncached_op_tl, decode_tl_r}
+    (.data_i({{snoop_hit, snoop_data, snoop_addr, snoop_bank_sel_one_hot
+               ,fill_st_data_r, fill_uncached_r, fill_decode_r}
+              ,{way_v_tl, store_hit_tl, load_hit_tl, data_mem_data_lo, paddr_tl, bank_sel_one_hot_tl
+                ,st_data_tl, uncached_op_tl, decode_tl_r}
               })
-     ,.sel_i(critical_recv)
-     ,.data_o({way_v_tv_n, store_hit_tv_n, load_hit_tv_n, ld_data_tv_n, paddr_tv_n
-               ,st_data_tv_n, bank_sel_one_hot_tv_n, uncached_op_tv_n, decode_tv_n})
+     ,.sel_i(fill_snoop_v)
+     ,.data_o({way_v_tv_n, store_hit_tv_n, load_hit_tv_n, ld_data_tv_n, paddr_tv_n, bank_sel_one_hot_tv_n
+               ,st_data_tv_n, uncached_op_tv_n, decode_tv_n})
      );
 
+  wire pending_tv_n = fill_pending_r;
   wire snoop_tv_n = critical_recv;
   bsg_dff
-   #(.width_p(1+3*assoc_p+paddr_width_p+block_width_p+dword_width_gp+assoc_p+1+$bits(bp_be_dcache_decode_s)))
+   #(.width_p(2+3*assoc_p+paddr_width_p+block_width_p+dword_width_gp+assoc_p+1+$bits(bp_be_dcache_decode_s)))
    tv_stage_reg
     (.clk_i(clk_i)
-     ,.data_i({snoop_tv_n, way_v_tv_n, store_hit_tv_n, load_hit_tv_n, paddr_tv_n, ld_data_tv_n
+     ,.data_i({pending_tv_n, snoop_tv_n, way_v_tv_n, store_hit_tv_n, load_hit_tv_n, paddr_tv_n, ld_data_tv_n
                ,st_data_tv_n, bank_sel_one_hot_tv_n, uncached_op_tv_n, decode_tv_n})
-     ,.data_o({snoop_tv_r, way_v_tv_r, store_hit_v_tv_r, load_hit_v_tv_r, paddr_tv_r, ld_data_tv_r
+     ,.data_o({pending_tv_r, snoop_tv_r, way_v_tv_r, store_hit_v_tv_r, load_hit_v_tv_r, paddr_tv_r, ld_data_tv_r
                ,st_data_tv_r, bank_sel_one_hot_tv_r, uncached_op_tv_r, decode_tv_r})
      );
 
@@ -495,13 +499,16 @@ module bp_be_dcache
      );
 
   // Store no-allocate, so keep going if we have a store miss on a writethrough cache
-  wire store_miss_tv    = ~uncached_op_tv_r & (decode_tv_r.store_op | decode_tv_r.lr_op) & ~store_hit_tv & ~sc_fail_tv & writeback_p;
-  wire load_miss_tv     = ~uncached_op_tv_r & decode_tv_r.load_op & ~load_hit_tv & ~sc_fail_tv;
+  wire store_miss_tv    = (decode_tv_r.store_op | decode_tv_r.lr_op) & ~store_hit_tv & ~sc_fail_tv & ~nonblocking_req & writeback_p;
+  wire load_miss_tv     = decode_tv_r.load_op & ~load_hit_tv & ~sc_fail_tv & ~nonblocking_req;
   wire ldst_miss_tv     = load_miss_tv | store_miss_tv;
   wire fencei_miss_tv   = decode_tv_r.fencei_op & gdirty_r;
-  wire uncached_miss_tv = uncached_op_tv_r & decode_tv_r.ret_op & ~snoop_tv_r;
   wire engine_miss_tv   = cache_req_v_o & ~cache_req_yumi_i;
-  wire any_miss_tv      = ldst_miss_tv | fencei_miss_tv | uncached_miss_tv | engine_miss_tv;
+  wire fill_miss_tv     = pending_tv_r & ~snoop_tv_r
+    &   (fill_index_r == paddr_index_tv)
+    &   (fill_hit_r == load_hit_v_tv_r)
+    & ~|(fill_bank_mask_r & bank_sel_one_hot_tv_r);
+  wire any_miss_tv      = ldst_miss_tv | fencei_miss_tv | engine_miss_tv | fill_miss_tv;
 
   assign data_o = sc_success_tv ? 1'b0 : sc_fail_tv ? 1'b1 : final_data;
 
@@ -554,7 +561,7 @@ module bp_be_dcache
   ///////////////////////////
   `declare_bp_be_dcache_wbuf_entry_s(caddr_width_p, assoc_p);
   bp_be_dcache_wbuf_entry_s wbuf_entry_in, wbuf_entry_out;
-  logic wbuf_v_li, wbuf_v_lo, wbuf_force_lo, wbuf_yumi_li;
+  logic wbuf_v_li, wbuf_v_lo, wbuf_force_lo, wbuf_snoop_match_lo, wbuf_yumi_li;
 
   assign wbuf_v_li = v_tv_r
     & decode_tv_r.store_op & ~uncached_op_tv_r
@@ -655,10 +662,17 @@ module bp_be_dcache
      );
   assign wbuf_entry_in.caddr = paddr_tv_r;
   assign wbuf_entry_in.way_id = store_hit_way_tv;
+  assign wbuf_entry_in.snoop = snoop_tv_r;
 
   wire [caddr_width_p-1:0] ld_addr_tl = {ptag_i, vaddr_tl_r[0+:page_offset_width_gp]};
   bp_be_dcache_wbuf
-   #(.bp_params_p(bp_params_p))
+   #(.bp_params_p(bp_params_p)
+     ,.sets_p(dcache_sets_p)
+     ,.assoc_p(dcache_assoc_p)
+     ,.block_width_p(dcache_block_width_p)
+     ,.fill_width_p(dcache_fill_width_p)
+     ,.ctag_width_p(dcache_ctag_width_p)
+     )
    wbuf
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
@@ -671,8 +685,17 @@ module bp_be_dcache
      ,.yumi_i(wbuf_yumi_li)
      ,.wbuf_entry_o(wbuf_entry_out)
 
-     ,.load_addr_i(ld_addr_tl)
-     ,.load_data_i(ld_data_dword_raw)
+     ,.tag_mem_pkt_i(tag_mem_pkt_i)
+     ,.tag_mem_pkt_v_i(tag_mem_pkt_v_i)
+     ,.data_mem_pkt_i(data_mem_pkt_i)
+     ,.data_mem_pkt_v_i(data_mem_pkt_v_i)
+     ,.stat_mem_pkt_i(stat_mem_pkt_i)
+     ,.stat_mem_pkt_v_i(stat_mem_pkt_v_i)
+     ,.snoop_match_o(wbuf_snoop_match_lo)
+
+     ,.v_tl_i(v_tl_r)
+     ,.addr_tl_i(ld_addr_tl)
+     ,.data_tv_i(ld_data_dword_raw)
      ,.data_merged_o(ld_data_dword_merged)
      );
   wire [bindex_width_lp-1:0] wbuf_entry_out_bank_offset = wbuf_entry_out.caddr[byte_offset_width_lp+:bindex_width_lp];
@@ -695,12 +718,12 @@ module bp_be_dcache
   wire wt_req              = ~uncached_op_tv_r & decode_tv_r.store_op & ~sc_fail_tv & !writeback_p;
 
   // Uncached stores and writethrough requests are non-blocking
-  wire nonblocking_req     = (uncached_store_req | wt_req | backoff_req);
-  wire blocking_req        = (fencei_req | load_req | store_req | uncached_amo_req | uncached_load_req);
+  assign nonblocking_req   = (uncached_store_req | wt_req | backoff_req);
+  assign blocking_req      = (fencei_req | load_req | store_req | uncached_amo_req | uncached_load_req);
   assign nonblocking_sent  = nonblocking_req & cache_req_yumi_i;
   assign blocking_sent     = blocking_req & cache_req_yumi_i;
 
-  assign cache_req_v_o = v_tv_r & (blocking_req | nonblocking_req);
+  assign cache_req_v_o = v_tv_r & ~fill_pending_r & (blocking_req | nonblocking_req);
 
   assign blocking_hazard = cache_req_v_o & blocking_req;
   assign engine_hazard   = cache_req_v_o & ~cache_req_yumi_i;
@@ -762,14 +785,14 @@ module bp_be_dcache
         cache_req_cast_o.msg_type = e_wt_store;
     end
 
-  wire cache_req_metadata_v = cache_req_yumi_i;
+  wire cache_req_metadata_v_n = cache_req_yumi_i;
   bsg_dff_reset
    #(.width_p(1))
    cache_req_v_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.data_i(cache_req_metadata_v)
+     ,.data_i(cache_req_metadata_v_n)
      ,.data_o(cache_req_metadata_v_o)
      );
 
@@ -800,27 +823,8 @@ module bp_be_dcache
   assign cache_req_metadata_cast_o.hit_or_repl_way = hit_or_repl_way;
   assign cache_req_metadata_cast_o.dirty = stat_mem_data_lo.dirty[hit_or_repl_way];
 
-  /////////////////////////////////////////////////////////////////////////////
-  // State machine
-  //   e_ready  : Cache is ready to accept requests
-  //   e_miss   : Cache is waiting for a miss to be serviced
-  /////////////////////////////////////////////////////////////////////////////
-  always_comb
-    case (state_r)
-      e_ready : state_n = blocking_sent ? e_miss : e_ready;
-      e_miss  : state_n = complete_recv ? e_ready : e_miss;
-      default: state_n = e_ready;
-    endcase
-
-  // synopsys sync_set_reset "reset_i"
-  always_ff @(posedge clk_i)
-    if (reset_i)
-      state_r <= e_ready;
-    else
-      state_r <= state_n;
-
-  assign ready_and_o = is_ready & ~cache_req_busy_i;
-  assign ordered_o = is_ready & ~v_tl_r & ~v_tv_r & cache_req_credits_empty_i;
+  assign ready_and_o = ~cache_req_busy_i & ~fill_secondary_r;
+  assign ordered_o = ~v_tl_r & ~v_tv_r & cache_req_credits_empty_i;
 
   /////////////////////////////////////////////////////////////////////////////
   // SRAM Control
@@ -842,7 +846,10 @@ module bp_be_dcache
     : tag_mem_fast_read
       ? vaddr_index
       : tag_mem_pkt_cast_i.index;
-  assign tag_mem_pkt_yumi_o = tag_mem_pkt_v_i & ~tag_mem_fast_read & ~tag_mem_fast_write;
+  assign tag_mem_pkt_yumi_o = tag_mem_pkt_v_i
+    & ~tag_mem_fast_read
+    & ~tag_mem_fast_write
+    & ~wbuf_snoop_match_lo;
 
   logic [assoc_p-1:0] tag_mem_way_one_hot;
   bsg_decode
@@ -948,7 +955,7 @@ module bp_be_dcache
         & (data_mem_pkt_cast_i.opcode == e_cache_data_mem_write) & data_mem_write_bank_mask[i];
       assign data_mem_slow_read[i] = data_mem_pkt_yumi_o
         & (data_mem_pkt_cast_i.opcode == e_cache_data_mem_read);
-      assign data_mem_fast_read[i] = safe_tl_we & decode_lo.load_op & ~data_mem_force_write[i];
+      assign data_mem_fast_read[i] = safe_tl_we & decode_lo.load_op;
       assign data_mem_fast_write[i] = wbuf_yumi_li & wbuf_bank_sel_one_hot[i];
 
       assign data_mem_v_li[i] = data_mem_fast_read[i]
@@ -973,20 +980,17 @@ module bp_be_dcache
         ? {num_dwords_per_bank_lp{wbuf_entry_out.data}}
         : data_mem_pkt_data_li[i];
     end
-  assign wbuf_yumi_li = wbuf_v_lo & |{~data_mem_fast_read & wbuf_bank_sel_one_hot};
+  assign wbuf_yumi_li = wbuf_v_lo && (~|{data_mem_fast_read & wbuf_bank_sel_one_hot} || wbuf_force_lo);
   // If we didn't read all banks, this could be more efficient
-  assign data_mem_write_hazard = (safe_tl_we & decode_lo.load_op) & |data_mem_force_write;
+  assign data_mem_write_hazard = |{data_mem_fast_read & data_mem_force_write};
 
-  // As an optimization, we could snoop the data_mem_pkt to see if there are any matching entries
-  //   in the write buffer, so that the write buffer will only drain if it is full, or if there is
-  //   a snoop match. However, this is a critical path, so we drain the write buffer on invalidations.
-  // A similar scheme could be adopted for a non-blocking version, where we snoop the bank
-  // TODO: With blocking TL and TV, we really should implement snooping for performance
-  assign data_mem_pkt_yumi_o = (data_mem_pkt_cast_i.opcode == e_cache_data_mem_uncached)
-    ? data_mem_pkt_v_i
-    : data_mem_pkt_v_i & ~|data_mem_fast_read
+  assign data_mem_pkt_yumi_o = data_mem_pkt_v_i
+      & ~{|data_mem_fast_read & (data_mem_pkt_cast_i.opcode == e_cache_data_mem_read)}
+      & ~{|data_mem_fast_write & (data_mem_pkt_cast_i.opcode == e_cache_data_mem_read)}
+      & ~|{data_mem_fast_read & data_mem_write_bank_mask}
+      & ~|{data_mem_fast_write & data_mem_write_bank_mask}
       & ~(v_tl_r & decode_tl_r.store_op)
-      & ~(wbuf_v_lo & ~snoop_tv_r);
+      & ~(wbuf_snoop_match_lo);
 
   logic [lg_assoc_lp-1:0] data_mem_pkt_way_r;
   bsg_dff
@@ -1009,7 +1013,7 @@ module bp_be_dcache
   ///////////////////////////
   // Stat Mem Control
   ///////////////////////////
-  wire stat_mem_fast_read  = (v_tv_r & any_miss_tv) | tag_mem_write_hazard;
+  wire stat_mem_fast_read  = (v_tv_r & any_miss_tv & cache_req_metadata_v_n) | tag_mem_write_hazard;
   wire stat_mem_fast_write = (v_tv_r & load_hit_tv & ~decode_tv_r.fencei_op & ~uncached_op_tv_r);
   wire stat_mem_slow_write = stat_mem_pkt_yumi_o & (stat_mem_pkt_cast_i.opcode != e_cache_stat_mem_read);
   wire stat_mem_slow_read  = stat_mem_pkt_yumi_o & (stat_mem_pkt_cast_i.opcode == e_cache_stat_mem_read);
@@ -1019,7 +1023,11 @@ module bp_be_dcache
   assign stat_mem_addr_li = (stat_mem_fast_write | stat_mem_fast_read)
     ? paddr_tv_r[block_offset_width_lp+:sindex_width_lp]
     : stat_mem_pkt_cast_i.index;
-  assign stat_mem_pkt_yumi_o = stat_mem_pkt_v_i & ~stat_mem_fast_read & ~stat_mem_fast_write;
+  assign stat_mem_pkt_yumi_o =
+    stat_mem_pkt_v_i
+    & ~stat_mem_fast_read
+    & ~stat_mem_fast_write
+    & ~(wbuf_snoop_match_lo & (stat_mem_pkt_cast_i.opcode == e_cache_stat_mem_read));
 
   logic [`BSG_SAFE_MINUS(assoc_p, 2):0] lru_decode_data_lo;
   logic [`BSG_SAFE_MINUS(assoc_p, 2):0] lru_decode_mask_lo;
@@ -1065,7 +1073,7 @@ module bp_be_dcache
       // For a non-coherent writethrough write-no-allocate cache, we set the dirty regardless of hit
       // For a coherent cache, we never set the dirty bit as the coherence system should handle it
       wire set_dirty = wbuf_v_li;
-      wire clear_dirty = complete_recv & snoop_decode_r.fencei_op;
+      wire clear_dirty = complete_recv & fill_decode_r.fencei_op;
       bsg_dff_reset_set_clear
        #(.width_p(1))
        gdirty_reg
@@ -1170,15 +1178,6 @@ module bp_be_dcache
   /////////////////////////////////////////////////////////////////////////////
   // Snoop Logic
   /////////////////////////////////////////////////////////////////////////////
-  bsg_dff_en
-   #(.width_p(1+dword_width_gp+$bits(bp_be_dcache_decode_s)))
-   snoop_metadata_reg
-    (.clk_i(clk_i)
-     ,.en_i(blocking_sent)
-     ,.data_i({uncached_op_tv_r, st_data_tv_r, decode_tv_r})
-     ,.data_o({snoop_uncached_op_r, snoop_st_data_r, snoop_decode_r})
-     );
-
   wire [assoc_p-1:0] pseudo_hit =
     (data_mem_pkt_v_i << data_mem_pkt_cast_i.way_id) | (tag_mem_pkt_v_i << tag_mem_pkt_cast_i.way_id);
   assign snoop_hit = {3{pseudo_hit}};
@@ -1192,6 +1191,93 @@ module bp_be_dcache
     (.i(snoop_bank)
      ,.o(snoop_bank_sel_one_hot)
      );
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Nonblocking Fill Logic
+  /////////////////////////////////////////////////////////////////////////////
+  if (hit_under_miss_p)
+    begin : hum
+      bsg_dff_reset_set_clear
+       #(.width_p(1))
+       fill_pending_reg
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+         ,.set_i(blocking_sent)
+         ,.clear_i(complete_recv)
+         ,.data_o(fill_pending_r)
+         );
+
+      bsg_dff_reset_set_clear
+       #(.width_p(1), .clear_over_set_p(1))
+       fill_secondary_reg
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+         ,.set_i(fill_pending_r & any_miss_tv)
+         ,.clear_i(complete_recv)
+         ,.data_o(fill_secondary_r)
+         );
+
+      logic [assoc_p-1:0] fill_bank_mask_n, fill_hit_n;
+      wire [assoc_p-1:0] fill_bank_mask_nn = (fill_bank_mask_n | data_mem_pkt_fill_mask_expanded);
+      wire [assoc_p-1:0] fill_hit_nn = (1'b1 << data_mem_pkt_cast_i.way_id);
+      wire fill_v = data_mem_pkt_yumi_o & data_mem_pkt_cast_i.opcode == e_cache_data_mem_write;
+      bsg_dff_reset_en
+       #(.width_p(2*assoc_p))
+       fill_reg
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i | blocking_sent)
+         ,.en_i(fill_v)
+         ,.data_i({fill_bank_mask_nn, fill_hit_nn})
+         ,.data_o({fill_bank_mask_n, fill_hit_n})
+         );
+
+      // Could instead determine fill_hit during load_hit/store_hit calculation
+      bsg_dff_chain
+       #(.width_p(2*assoc_p), .num_stages_p(2))
+       fill_buffer_reg
+        (.clk_i(clk_i)
+         ,.data_i({fill_bank_mask_n, fill_hit_n})
+         ,.data_o({fill_bank_mask_r, fill_hit_r})
+         );
+
+      wire fill_uncached_n = uncached_op_tv_r;
+      wire [dword_width_gp-1:0] fill_st_data_n = st_data_tv_r;
+      wire [$bits(bp_be_dcache_decode_s)-1:0] fill_decode_n = decode_tv_r;
+      wire [sindex_width_lp-1:0] fill_index_n = paddr_tv_r[block_offset_width_lp+:sindex_width_lp];
+      bsg_dff_en
+       #(.width_p(sindex_width_lp+1+dword_width_gp+$bits(bp_be_dcache_decode_s)))
+       fill_metadata_reg
+        (.clk_i(clk_i)
+         ,.en_i(blocking_sent)
+         ,.data_i({fill_index_n, fill_uncached_n, fill_st_data_n, fill_decode_n})
+         ,.data_o({fill_index_r, fill_uncached_r, fill_st_data_r, fill_decode_r})
+         );
+
+      assign fill_snoop_v = critical_recv;
+    end
+  else
+    begin : nhum
+      bsg_dff_reset_set_clear
+       #(.width_p(1))
+       fill_pending_reg
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+         ,.set_i(blocking_sent)
+         ,.clear_i(complete_recv)
+         ,.data_o(fill_pending_r)
+         );
+      assign fill_secondary_r = fill_pending_r;
+
+      assign fill_bank_mask_r = '0;
+      assign fill_hit_r = '0;
+      assign fill_index_r = '0;
+
+      assign fill_uncached_r = uncached_op_tv_r;
+      assign fill_st_data_r = st_data_tv_r;
+      assign fill_decode_r = decode_tv_r;
+
+      assign fill_snoop_v = blocking_sent | fill_pending_r;
+    end
 
   // synopsys translate_off
   `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -564,9 +564,8 @@ module bp_be_dcache
   logic wbuf_v_li, wbuf_v_lo, wbuf_force_lo, wbuf_snoop_match_lo, wbuf_yumi_li;
 
   assign wbuf_v_li = v_tv_r
-    & decode_tv_r.store_op & ~uncached_op_tv_r
-    & store_hit_tv & ~sc_fail_tv
-    & (writeback_p | cache_req_yumi_i);
+    & decode_tv_r.store_op & ~sc_fail_tv & ~uncached_op_tv_r
+    & ~any_miss_tv;
 
   //
   // Atomic operations
@@ -1212,7 +1211,7 @@ module bp_be_dcache
        fill_secondary_reg
         (.clk_i(clk_i)
          ,.reset_i(reset_i)
-         ,.set_i(fill_pending_r & any_miss_tv)
+         ,.set_i(v_tv_r & fill_pending_r & any_miss_tv)
          ,.clear_i(complete_recv)
          ,.data_o(fill_secondary_r)
          );

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -148,7 +148,7 @@ module bp_be_dcache
    , output logic [dcache_req_width_lp-1:0]          cache_req_o
    , output logic                                    cache_req_v_o
    , input                                           cache_req_yumi_i
-   , input                                           cache_req_busy_i
+   , input                                           cache_req_lock_i
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
    , input [paddr_width_p-1:0]                       cache_req_addr_i
@@ -821,7 +821,7 @@ module bp_be_dcache
   assign cache_req_metadata_cast_o.hit_or_repl_way = hit_or_repl_way;
   assign cache_req_metadata_cast_o.dirty = stat_mem_data_lo.dirty[hit_or_repl_way];
 
-  assign ready_and_o = ~cache_req_busy_i & ~fill_secondary_r;
+  assign ready_and_o = ~cache_req_lock_i & ~fill_secondary_r;
   assign ordered_o = ~v_tl_r & ~v_tv_r & cache_req_credits_empty_i;
 
   /////////////////////////////////////////////////////////////////////////////

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache_wbuf.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache_wbuf.sv
@@ -148,9 +148,9 @@ module bp_be_dcache_wbuf
   wire tag_hit1_n = bypass_word_addr == wbuf_entry_el1_r.caddr[byte_offset_width_lp+:word_addr_width_lp];
   wire tag_hit2_n = bypass_word_addr == wbuf_entry_cast_i.caddr[byte_offset_width_lp+:word_addr_width_lp];
 
-  wire tag_hit0 = tag_hit0_n & el0_valid;
-  wire tag_hit1 = tag_hit1_n & el1_valid;
-  wire tag_hit2 = tag_hit2_n & v_i;
+  wire tag_hit0 = v_tl_i & tag_hit0_n & el0_valid;
+  wire tag_hit1 = v_tl_i & tag_hit1_n & el1_valid;
+  wire tag_hit2 = v_tl_i & tag_hit2_n & v_i;
 
   wire [data_mask_width_lp-1:0] tag_hit0x4 = {data_mask_width_lp{tag_hit0}};
   wire [data_mask_width_lp-1:0] tag_hit1x4 = {data_mask_width_lp{tag_hit1}};

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache_wbuf.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache_wbuf.sv
@@ -14,49 +14,67 @@ module bp_be_dcache_wbuf
  import bp_be_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
+   , parameter sets_p         = dcache_sets_p
+   , parameter assoc_p        = dcache_assoc_p
+   , parameter block_width_p  = dcache_block_width_p
+   , parameter fill_width_p   = dcache_fill_width_p
+   , parameter ctag_width_p   = dcache_ctag_width_p
 
-   , localparam data_mask_width_lp   = (dword_width_gp>>3)
-   , localparam byte_offset_width_lp = `BSG_SAFE_CLOG2(dword_width_gp>>3)
+   `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, dcache)
 
-   , localparam wbuf_entry_width_lp=`bp_be_dcache_wbuf_entry_width(caddr_width_p,dcache_assoc_p)
+   , localparam wbuf_entry_width_lp=`bp_be_dcache_wbuf_entry_width(caddr_width_p, dcache_assoc_p)
    )
-  (input                                    clk_i
-   , input                                  reset_i
+  (input                                      clk_i
+   , input                                    reset_i
 
-   , input [wbuf_entry_width_lp-1:0]        wbuf_entry_i
-   , input                                  v_i
+   , input [wbuf_entry_width_lp-1:0]          wbuf_entry_i
+   , input                                    v_i
 
-   , output logic [wbuf_entry_width_lp-1:0] wbuf_entry_o
-   , output logic                           v_o
-   , output logic                           force_o
-   , input                                  yumi_i
+   , output logic [wbuf_entry_width_lp-1:0]   wbuf_entry_o
+   , output logic                             v_o
+   , output logic                             force_o
+   , input                                    yumi_i
 
-   , input [caddr_width_p-1:0]              load_addr_i
-   , input [dword_width_gp-1:0]             load_data_i
-   , output logic [dword_width_gp-1:0]      data_merged_o
+   , input [dcache_data_mem_pkt_width_lp-1:0] data_mem_pkt_i
+   , input                                    data_mem_pkt_v_i
+   , input [dcache_tag_mem_pkt_width_lp-1:0]  tag_mem_pkt_i
+   , input                                    tag_mem_pkt_v_i
+   , input [dcache_stat_mem_pkt_width_lp-1:0] stat_mem_pkt_i
+   , input                                    stat_mem_pkt_v_i
+   , output logic                             snoop_match_o
+
+   , input                                    v_tl_i
+   , input [caddr_width_p-1:0]                addr_tl_i
+   , input [dword_width_gp-1:0]               data_tv_i
+   , output logic [dword_width_gp-1:0]        data_merged_o
    );
 
   `declare_bp_be_dcache_wbuf_entry_s(caddr_width_p, dcache_assoc_p);
-  bp_be_dcache_wbuf_entry_s wbuf_entry_in;
-  assign wbuf_entry_in = wbuf_entry_i;
+  `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, dcache);
+  `bp_cast_i(bp_be_dcache_wbuf_entry_s, wbuf_entry);
+  `bp_cast_i(bp_dcache_data_mem_pkt_s, data_mem_pkt);
+  `bp_cast_i(bp_dcache_tag_mem_pkt_s, tag_mem_pkt);
+  `bp_cast_i(bp_dcache_stat_mem_pkt_s, stat_mem_pkt);
+
+  localparam data_mask_width_lp    = dword_width_gp >> 3;
+  localparam byte_offset_width_lp  = `BSG_SAFE_CLOG2(data_mask_width_lp);
+  localparam bindex_width_lp       = `BSG_SAFE_CLOG2(assoc_p);
+  localparam sindex_width_lp       = `BSG_SAFE_CLOG2(sets_p);
+  localparam block_offset_width_lp = (assoc_p > 1)
+    ? (bindex_width_lp+byte_offset_width_lp)
+    : byte_offset_width_lp;
 
   logic [1:0] num_els_r;
-  // Negedge shenanigans cause this counter to fire a faulty assertion
-  //bsg_counter_up_down
-  // #(.max_val_p(3), .init_val_p(0), .max_step_p(1))
-  // num_els_counter
-  //  (.clk_i(clk_i)
-  //   ,.reset_i(reset_i)
+  bsg_counter_up_down
+   #(.max_val_p(2), .init_val_p(0), .max_step_p(1))
+   num_els_counter
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
 
-  //   ,.up_i(v_i)
-  //   ,.down_i(yumi_i)
-  //   ,.count_o(num_els_r)
-  //   );
-  always_ff @(posedge clk_i)
-    if (reset_i)
-      num_els_r <= '0;
-    else
-      num_els_r <= num_els_r + v_i - yumi_i;
+     ,.up_i(v_i)
+     ,.down_i(yumi_i)
+     ,.count_o(num_els_r)
+     );
 
   logic el0_valid, el1_valid;
   logic el0_enable, el1_enable;
@@ -101,7 +119,7 @@ module bp_be_dcache_wbuf
   bp_be_dcache_wbuf_entry_s wbuf_entry_el0_n, wbuf_entry_el0_r;
   bp_be_dcache_wbuf_entry_s wbuf_entry_el1_n, wbuf_entry_el1_r;
 
-  assign wbuf_entry_el0_n = wbuf_entry_in;
+  assign wbuf_entry_el0_n = wbuf_entry_cast_i;
   bsg_dff_en
    #(.width_p($bits(bp_be_dcache_wbuf_entry_s)))
    wbuf_entry0_reg
@@ -111,7 +129,7 @@ module bp_be_dcache_wbuf
      ,.data_o(wbuf_entry_el0_r)
      );
 
-  assign wbuf_entry_el1_n = mux0_sel ? wbuf_entry_el0_r : wbuf_entry_in;
+  assign wbuf_entry_el1_n = mux0_sel ? wbuf_entry_el0_r : wbuf_entry_cast_i;
   bsg_dff_en
    #(.width_p($bits(bp_be_dcache_wbuf_entry_s)))
    wbuf_entry1_reg
@@ -120,15 +138,15 @@ module bp_be_dcache_wbuf
      ,.data_i(wbuf_entry_el1_n)
      ,.data_o(wbuf_entry_el1_r)
      );
-  assign wbuf_entry_o = mux1_sel ? wbuf_entry_el1_r : wbuf_entry_in;
+  assign wbuf_entry_o = mux1_sel ? wbuf_entry_el1_r : wbuf_entry_cast_i;
 
   // bypassing
   //
   localparam word_addr_width_lp = caddr_width_p-byte_offset_width_lp;
-  wire [word_addr_width_lp-1:0] bypass_word_addr = load_addr_i[byte_offset_width_lp+:word_addr_width_lp];
+  wire [word_addr_width_lp-1:0] bypass_word_addr = addr_tl_i[byte_offset_width_lp+:word_addr_width_lp];
   wire tag_hit0_n = bypass_word_addr == wbuf_entry_el0_r.caddr[byte_offset_width_lp+:word_addr_width_lp];
   wire tag_hit1_n = bypass_word_addr == wbuf_entry_el1_r.caddr[byte_offset_width_lp+:word_addr_width_lp];
-  wire tag_hit2_n = bypass_word_addr == wbuf_entry_in.caddr[byte_offset_width_lp+:word_addr_width_lp];
+  wire tag_hit2_n = bypass_word_addr == wbuf_entry_cast_i.caddr[byte_offset_width_lp+:word_addr_width_lp];
 
   wire tag_hit0 = tag_hit0_n & el0_valid;
   wire tag_hit1 = tag_hit1_n & el1_valid;
@@ -153,14 +171,14 @@ module bp_be_dcache_wbuf
    #(.segments_p(data_mask_width_lp), .segment_width_p(byte_width_gp))
    mux_segmented_merge1
     (.data0_i(el0or1_data)
-     ,.data1_i(wbuf_entry_in.data)
-     ,.sel_i(tag_hit2x4 & wbuf_entry_in.mask)
+     ,.data1_i(wbuf_entry_cast_i.data)
+     ,.sel_i(tag_hit2x4 & wbuf_entry_cast_i.mask)
      ,.data_o(bypass_data_n)
      );
 
   wire [data_mask_width_lp-1:0] bypass_mask_n = (tag_hit0x4 & wbuf_entry_el0_r.mask)
                                                 | (tag_hit1x4 & wbuf_entry_el1_r.mask)
-                                                | (tag_hit2x4 & wbuf_entry_in.mask);
+                                                | (tag_hit2x4 & wbuf_entry_cast_i.mask);
 
   logic [dword_width_gp-1:0] bypass_data_r;
   logic [data_mask_width_lp-1:0] bypass_mask_r;
@@ -177,11 +195,29 @@ module bp_be_dcache_wbuf
   bsg_mux_segmented
    #(.segments_p(data_mask_width_lp), .segment_width_p(byte_width_gp))
    bypass_mux_segmented
-    (.data0_i(load_data_i)
+    (.data0_i(data_tv_i)
      ,.data1_i(bypass_data_r)
      ,.sel_i(bypass_mask_r)
      ,.data_o(data_merged_o)
      );
+
+  // This is slightly pessimistic because it blocks all ways. However, putting the SRAM read
+  //   and tag match on the slow path seems like a bad idea.
+  wire snoop_tag_match = v_tl_i & tag_mem_pkt_v_i
+    & (addr_tl_i[block_offset_width_lp+:sindex_width_lp] == tag_mem_pkt_cast_i.index);
+  wire snoop_stat_match = v_tl_i & stat_mem_pkt_v_i
+    & (addr_tl_i[block_offset_width_lp+:sindex_width_lp] == stat_mem_pkt_cast_i.index);
+  wire snoop_el0_match = el0_valid & ~wbuf_entry_cast_i.snoop & data_mem_pkt_v_i
+    & (wbuf_entry_el0_r.caddr[block_offset_width_lp+:sindex_width_lp] == data_mem_pkt_cast_i.index)
+    & (wbuf_entry_el0_r.way_id == data_mem_pkt_cast_i.way_id);
+  wire snoop_el1_match = el1_valid & ~wbuf_entry_el1_r.snoop & data_mem_pkt_v_i
+    & (wbuf_entry_el1_r.caddr[block_offset_width_lp+:sindex_width_lp] == data_mem_pkt_cast_i.index)
+    & (wbuf_entry_el1_r.way_id == data_mem_pkt_cast_i.way_id);
+  wire snoop_el2_match = v_i & ~wbuf_entry_cast_i.snoop & data_mem_pkt_v_i
+    & (wbuf_entry_cast_i.caddr[block_offset_width_lp+:sindex_width_lp] == data_mem_pkt_cast_i.index)
+    & (wbuf_entry_cast_i.way_id == data_mem_pkt_cast_i.way_id);
+
+  assign snoop_match_o = snoop_tag_match | snoop_stat_match | snoop_el0_match | snoop_el1_match | snoop_el2_match;
 
   // synopsys translate_off
   always_ff @(negedge clk_i) begin

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -44,6 +44,7 @@ module bp_be_top
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
    , input [paddr_width_p-1:0]                       cache_req_addr_i
+   , input [dword_width_gp-1:0]                      cache_req_data_i
    , input                                           cache_req_critical_i
    , input                                           cache_req_last_i
    , input                                           cache_req_credits_full_i
@@ -210,6 +211,7 @@ module bp_be_top
      ,.cache_req_busy_i(cache_req_busy_i)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
      ,.cache_req_addr_i(cache_req_addr_i)
+     ,.cache_req_data_i(cache_req_data_i)
      ,.cache_req_critical_i(cache_req_critical_i)
      ,.cache_req_last_i(cache_req_last_i)
      ,.cache_req_credits_full_i(cache_req_credits_full_i)

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -40,7 +40,7 @@ module bp_be_top
    , output logic [dcache_req_width_lp-1:0]          cache_req_o
    , output logic                                    cache_req_v_o
    , input                                           cache_req_yumi_i
-   , input                                           cache_req_busy_i
+   , input                                           cache_req_lock_i
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
    , input [paddr_width_p-1:0]                       cache_req_addr_i
@@ -208,7 +208,7 @@ module bp_be_top
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_v_o(cache_req_v_o)
      ,.cache_req_yumi_i(cache_req_yumi_i)
-     ,.cache_req_busy_i(cache_req_busy_i)
+     ,.cache_req_lock_i(cache_req_lock_i)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
      ,.cache_req_addr_i(cache_req_addr_i)
      ,.cache_req_data_i(cache_req_data_i)

--- a/bp_be/test/common/bp_be_nonsynth_dcache_tracer.sv
+++ b/bp_be/test/common/bp_be_nonsynth_dcache_tracer.sv
@@ -36,7 +36,7 @@ module bp_be_nonsynth_dcache_tracer
    , input [cache_req_width_lp-1:0]                       cache_req_o
    , input                                                cache_req_v_o
    , input                                                cache_req_yumi_i
-   , input                                                cache_req_busy_i
+   , input                                                cache_req_lock_i
    , input [cache_req_metadata_width_lp-1:0]              cache_req_metadata_o
    , input                                                cache_req_metadata_v_o
    , input                                                cache_req_critical_i

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -72,7 +72,7 @@ module wrapper
   // D$ - LCE Interface signals
   // Miss, Management Interfaces
   logic [num_caches_p-1:0] cache_req_v_lo, cache_req_metadata_v_lo;
-  logic [num_caches_p-1:0] cache_req_yumi_lo, cache_req_busy_lo;
+  logic [num_caches_p-1:0] cache_req_yumi_lo, cache_req_lock_lo;
   logic [num_caches_p-1:0] cache_req_last_lo, cache_req_critical_lo;
   logic [num_caches_p-1:0][paddr_width_p-1:0] cache_req_addr_lo;
   logic [num_caches_p-1:0][dcache_req_width_lp-1:0] cache_req_lo;
@@ -214,7 +214,7 @@ module wrapper
       ,.cache_req_metadata_o(cache_req_metadata_lo[i])
       ,.cache_req_metadata_v_o(cache_req_metadata_v_lo[i])
       ,.cache_req_yumi_i(cache_req_yumi_lo[i])
-      ,.cache_req_busy_i(cache_req_busy_lo[i])
+      ,.cache_req_lock_i(cache_req_lock_lo[i])
       ,.cache_req_addr_i(cache_req_addr_lo[i])
       ,.cache_req_critical_i(cache_req_critical_lo[i])
       ,.cache_req_last_i(cache_req_last_lo[i])
@@ -259,7 +259,7 @@ module wrapper
              ,.cache_req_i(cache_req_lo[i])
              ,.cache_req_v_i(cache_req_v_lo[i])
              ,.cache_req_yumi_o(cache_req_yumi_lo[i])
-             ,.cache_req_busy_o(cache_req_busy_lo[i])
+             ,.cache_req_lock_o(cache_req_lock_lo[i])
              ,.cache_req_metadata_i(cache_req_metadata_lo[i])
              ,.cache_req_metadata_v_i(cache_req_metadata_v_lo[i])
              ,.cache_req_addr_o(cache_req_addr_lo[i])
@@ -332,7 +332,7 @@ module wrapper
             ,.cache_req_i(cache_req_lo)
             ,.cache_req_v_i(cache_req_v_lo)
             ,.cache_req_yumi_o(cache_req_yumi_lo)
-            ,.cache_req_busy_o(cache_req_busy_lo)
+            ,.cache_req_lock_o(cache_req_lock_lo)
             ,.cache_req_metadata_i(cache_req_metadata_lo)
             ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
             ,.cache_req_addr_o(cache_req_addr_lo)

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -7,16 +7,17 @@
   localparam lg_max_cfgs = $clog2(max_cfgs);
 
   // Configuration enums
-  typedef enum logic [2:0]
+  typedef enum logic [3:0]
   {
-    e_cfg_enabled               = 3'b000
-    ,e_cfg_coherent             = 3'b001
-    ,e_cfg_writeback            = 3'b010
-    ,e_cfg_word_tracking        = 3'b011
-    ,e_cfg_lr_sc                = 3'b100
-    ,e_cfg_amo_swap             = 3'b101
-    ,e_cfg_amo_fetch_logic      = 3'b110
-    ,e_cfg_amo_fetch_arithmetic = 3'b111
+    e_cfg_enabled               = 4'b0000
+    ,e_cfg_coherent             = 4'b0001
+    ,e_cfg_writeback            = 4'b0010
+    ,e_cfg_word_tracking        = 4'b0011
+    ,e_cfg_lr_sc                = 4'b0100
+    ,e_cfg_amo_swap             = 4'b0101
+    ,e_cfg_amo_fetch_logic      = 4'b0110
+    ,e_cfg_amo_fetch_arithmetic = 4'b0111
+    ,e_cfg_hit_under_miss       = 4'b1000
   } bp_cache_features_e;
 
   typedef enum logic
@@ -285,6 +286,7 @@
                               | (1 << e_cfg_amo_swap)
                               | (1 << e_cfg_amo_fetch_logic)
                               | (1 << e_cfg_amo_fetch_arithmetic)
+                              | (1 << e_cfg_hit_under_miss)
       ,dcache_sets          : 64
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -104,7 +104,7 @@ module bp_fe_icache
    , output logic [icache_req_width_lp-1:0]           cache_req_o
    , output logic                                     cache_req_v_o
    , input                                            cache_req_yumi_i
-   , input                                            cache_req_busy_i
+   , input                                            cache_req_lock_i
    , output logic [icache_req_metadata_width_lp-1:0]  cache_req_metadata_o
    , output logic                                     cache_req_metadata_v_o
    , input [paddr_width_p-1:0]                        cache_req_addr_i
@@ -247,7 +247,7 @@ module bp_fe_icache
 
   // Accept requests when we're in ready state and there's no blocked request in TL
   // Also accept request when 'forced'
-  assign safe_tl_we = is_ready & v_i & (~v_tl_r | safe_tv_we | force_i) & ~cache_req_busy_i;
+  assign safe_tl_we = is_ready & v_i & (~v_tl_r | safe_tv_we | force_i) & ~cache_req_lock_i;
   assign tl_we = safe_tl_we | poison_tl_i;
   assign v_tl_n = yumi_o & ~poison_tl_i;
   bsg_dff_reset_en

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -108,6 +108,7 @@ module bp_fe_icache
    , output logic [icache_req_metadata_width_lp-1:0]  cache_req_metadata_o
    , output logic                                     cache_req_metadata_v_o
    , input [paddr_width_p-1:0]                        cache_req_addr_i
+   , input [dword_width_gp-1:0]                       cache_req_data_i
    , input                                            cache_req_critical_i
    , input                                            cache_req_last_i
    , input                                            cache_req_credits_full_i

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -350,7 +350,7 @@ module bp_fe_icache
   wire uncached_op_tv_n = critical_recv ? uncached_op_tv_r : fetch_uncached_tl;
   bsg_dff_reset_en
    #(.width_p(block_width_p+1+3*assoc_p+paddr_width_p+4))
-   hit_tv_reg
+   tv_stage_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
      ,.en_i(tv_we | critical_recv)

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -32,7 +32,7 @@ module bp_fe_top
    , output logic [icache_req_width_lp-1:0]           cache_req_o
    , output logic                                     cache_req_v_o
    , input                                            cache_req_yumi_i
-   , input                                            cache_req_busy_i
+   , input                                            cache_req_lock_i
    , output logic [icache_req_metadata_width_lp-1:0]  cache_req_metadata_o
    , output logic                                     cache_req_metadata_v_o
    , input [paddr_width_p-1:0]                        cache_req_addr_i
@@ -253,7 +253,7 @@ module bp_fe_top
      ,.cache_req_o(cache_req_o)
      ,.cache_req_v_o(cache_req_v_o)
      ,.cache_req_yumi_i(cache_req_yumi_i)
-     ,.cache_req_busy_i(cache_req_busy_i)
+     ,.cache_req_lock_i(cache_req_lock_i)
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
      ,.cache_req_addr_i(cache_req_addr_i)

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -36,6 +36,7 @@ module bp_fe_top
    , output logic [icache_req_metadata_width_lp-1:0]  cache_req_metadata_o
    , output logic                                     cache_req_metadata_v_o
    , input [paddr_width_p-1:0]                        cache_req_addr_i
+   , input [dword_width_gp-1:0]                       cache_req_data_i
    , input                                            cache_req_critical_i
    , input                                            cache_req_last_i
    , input                                            cache_req_credits_full_i
@@ -256,6 +257,7 @@ module bp_fe_top
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
      ,.cache_req_addr_i(cache_req_addr_i)
+     ,.cache_req_data_i(cache_req_data_i)
      ,.cache_req_critical_i(cache_req_critical_i)
      ,.cache_req_last_i(cache_req_last_i)
      ,.cache_req_credits_full_i(cache_req_credits_full_i)

--- a/bp_fe/test/common/bp_fe_nonsynth_icache_tracer.sv
+++ b/bp_fe/test/common/bp_fe_nonsynth_icache_tracer.sv
@@ -37,7 +37,7 @@ module bp_fe_nonsynth_icache_tracer
    , input [cache_req_width_lp-1:0]                       cache_req_o
    , input                                                cache_req_v_o
    , input                                                cache_req_yumi_i
-   , input                                                cache_req_busy_i
+   , input                                                cache_req_lock_i
    , input [cache_req_metadata_width_lp-1:0]              cache_req_metadata_o
    , input                                                cache_req_metadata_v_o
    , input                                                cache_req_critical_i

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -52,7 +52,7 @@ module wrapper
 
   // I$-LCE Interface signals
   // Miss, Management Interfaces
-  logic cache_req_yumi_li, cache_req_busy_li;
+  logic cache_req_yumi_li, cache_req_lock_li;
   logic [icache_req_width_lp-1:0] cache_req_lo;
   logic cache_req_v_lo;
   logic [icache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
@@ -127,7 +127,7 @@ module wrapper
      ,.cache_req_o(cache_req_lo)
      ,.cache_req_v_o(cache_req_v_lo)
      ,.cache_req_yumi_i(cache_req_yumi_li)
-     ,.cache_req_busy_i(cache_req_busy_li)
+     ,.cache_req_lock_i(cache_req_lock_li)
      ,.cache_req_metadata_o(cache_req_metadata_lo)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_lo)
      ,.cache_req_addr_i(cache_req_addr_li)
@@ -195,7 +195,7 @@ module wrapper
        ,.cache_req_v_i(cache_req_v_lo)
        ,.cache_req_i(cache_req_lo)
        ,.cache_req_yumi_o(cache_req_yumi_li)
-       ,.cache_req_busy_o(cache_req_busy_li)
+       ,.cache_req_lock_o(cache_req_lock_li)
        ,.cache_req_metadata_i(cache_req_metadata_lo)
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
        ,.cache_req_addr_o(cache_req_addr_li)
@@ -304,7 +304,7 @@ module wrapper
        ,.cache_req_i(cache_req_lo)
        ,.cache_req_v_i(cache_req_v_lo)
        ,.cache_req_yumi_o(cache_req_yumi_li)
-       ,.cache_req_busy_o(cache_req_busy_li)
+       ,.cache_req_lock_o(cache_req_lock_li)
        ,.cache_req_metadata_i(cache_req_metadata_lo)
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
        ,.cache_req_addr_o(cache_req_addr_li)

--- a/bp_me/src/v/cce/bp_uce.sv
+++ b/bp_me/src/v/cce/bp_uce.sv
@@ -646,7 +646,7 @@ module bp_uce
             tag_mem_pkt_cast_o.way_id = fsm_rev_header_li.payload.way_id[0+:`BSG_SAFE_CLOG2(assoc_p)];
             tag_mem_pkt_cast_o.state  = e_COH_M;
             tag_mem_pkt_cast_o.tag    = fsm_rev_addr_li[block_offset_width_lp+index_width_lp+:ctag_width_p];
-            tag_mem_pkt_v_o = load_resp_v_li & fsm_rev_new_li;
+            tag_mem_pkt_v_o = load_resp_v_li & fsm_rev_last_li;
 
             data_mem_pkt_cast_o.opcode     = e_cache_data_mem_write;
             data_mem_pkt_cast_o.index      = fsm_rev_addr_li[block_offset_width_lp+:index_width_lp];
@@ -685,7 +685,7 @@ module bp_uce
             tag_mem_pkt_cast_o.way_id = fsm_rev_header_li.payload.way_id[0+:`BSG_SAFE_CLOG2(assoc_p)];
             tag_mem_pkt_cast_o.state  = e_COH_M;
             tag_mem_pkt_cast_o.tag    = fsm_rev_addr_li[block_offset_width_lp+index_width_lp+:ctag_width_p];
-            tag_mem_pkt_v_o = load_resp_v_li & fsm_rev_new_li;
+            tag_mem_pkt_v_o = load_resp_v_li & fsm_rev_last_li;
 
             data_mem_pkt_cast_o.opcode = e_cache_data_mem_write;
             data_mem_pkt_cast_o.index  = fsm_rev_addr_li[block_offset_width_lp+:index_width_lp];

--- a/bp_me/src/v/cce/bp_uce.sv
+++ b/bp_me/src/v/cce/bp_uce.sv
@@ -38,6 +38,7 @@ module bp_uce
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
     , output logic [paddr_width_p-1:0]               cache_req_addr_o
+    , output logic [dword_width_gp-1:0]              cache_req_data_o
     , output logic                                   cache_req_critical_o
     , output logic                                   cache_req_last_o
     , output logic                                   cache_req_credits_full_o
@@ -280,7 +281,8 @@ module bp_uce
      ,.fsm_critical_o(fsm_rev_critical_li)
      ,.fsm_last_o(fsm_rev_last_li)
      );
-  assign cache_req_addr_o = fsm_rev_header_li.addr;
+  assign cache_req_addr_o = cache_req_r.addr;
+  assign cache_req_data_o = cache_req_r.data;
 
   // We check for uncached stores ealier than other requests, because they get sent out in ready
   wire flush_v_li         = cache_req_v_i & cache_req_cast_i.msg_type inside {e_cache_flush};

--- a/bp_me/src/v/cce/bp_uce.sv
+++ b/bp_me/src/v/cce/bp_uce.sv
@@ -34,7 +34,7 @@ module bp_uce
     , input [cache_req_width_lp-1:0]                 cache_req_i
     , input                                          cache_req_v_i
     , output logic                                   cache_req_yumi_o
-    , output logic                                   cache_req_busy_o
+    , output logic                                   cache_req_lock_o
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
     , output logic [paddr_width_p-1:0]               cache_req_addr_o
@@ -403,7 +403,7 @@ module bp_uce
   // We ack mem_revs for stores no matter what, so load_resp_yumi_lo is for other responses
   logic load_resp_yumi_lo;
   assign fsm_rev_yumi_lo = load_resp_yumi_lo | store_resp_v_li;
-  assign cache_req_busy_o = is_reset | is_init;
+  assign cache_req_lock_o = is_reset | is_init | flush_v_r | clear_v_r;
   always_comb
     begin
       cache_req_yumi_o = '0;

--- a/bp_me/src/v/lce/bp_lce.sv
+++ b/bp_me/src/v/lce/bp_lce.sv
@@ -48,7 +48,7 @@ module bp_lce
     , input [cache_req_width_lp-1:0]                 cache_req_i
     , input                                          cache_req_v_i
     , output logic                                   cache_req_yumi_o
-    , output logic                                   cache_req_busy_o
+    , output logic                                   cache_req_lock_o
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
     , output logic [paddr_width_p-1:0]               cache_req_addr_o
@@ -310,7 +310,7 @@ module bp_lce
   // - timout signal is low, indicating LCE isn't blocked on using data/tag/stat mem
   // This signal acts as a hint to the cache that the LCE is not ready for a request.
   // The cache_req_yumi_o signal actually controls whether the LCE accepts a request.
-  assign cache_req_busy_o = timeout | req_busy_lo | ~cache_init_done_lo;
+  assign cache_req_lock_o = timeout | req_busy_lo | ~cache_init_done_lo;
 
 endmodule
 

--- a/bp_me/src/v/lce/bp_lce.sv
+++ b/bp_me/src/v/lce/bp_lce.sv
@@ -52,6 +52,7 @@ module bp_lce
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
     , output logic [paddr_width_p-1:0]               cache_req_addr_o
+    , output logic [dword_width_gp-1:0]              cache_req_data_o
     , output logic                                   cache_req_critical_o
     , output logic                                   cache_req_last_o
     , output logic                                   cache_req_credits_full_o
@@ -158,6 +159,8 @@ module bp_lce
      ,.credits_empty_o(cache_req_credits_empty_o)
      ,.credit_return_i(credit_return_lo)
      ,.cache_req_done_i(cache_req_done_lo)
+     ,.cache_req_addr_o(cache_req_addr_o)
+     ,.cache_req_data_o(cache_req_data_o)
      ,.backoff_o(backoff_lo)
 
      ,.lce_req_header_o(lce_req_header_o)
@@ -237,7 +240,6 @@ module bp_lce
 
      ,.cache_init_done_o(cache_init_done_lo)
      ,.sync_done_o(sync_done_lo)
-     ,.cache_req_addr_o(cache_req_addr_o)
      ,.cache_req_critical_o(cache_req_critical_o)
      ,.cache_req_last_o(cache_req_last_o)
      ,.credit_return_o(credit_return_lo)

--- a/bp_me/src/v/lce/bp_lce_cmd.sv
+++ b/bp_me/src/v/lce/bp_lce_cmd.sv
@@ -60,7 +60,6 @@ module bp_lce_cmd
     // request complete signals
     // cached requests and uncached loads block in the caches, but uncached stores do not
     // cache_req_last_o is routed to the cache to indicate a blocking request is complete
-    , output logic [paddr_width_p-1:0]               cache_req_addr_o
     , output logic                                   cache_req_critical_o
     , output logic                                   cache_req_last_o
 
@@ -337,7 +336,6 @@ module bp_lce_cmd
     // raised request is fully resolved
     cache_req_last_o = 1'b0;
     cache_req_critical_o = 1'b0;
-    cache_req_addr_o = fsm_cmd_header_li.addr;
 
     // LCE-CCE Interface signals
     fsm_cmd_yumi_lo = 1'b0;

--- a/bp_me/src/v/lce/bp_lce_cmd.sv
+++ b/bp_me/src/v/lce/bp_lce_cmd.sv
@@ -492,7 +492,7 @@ module bp_lce_cmd
             tag_mem_pkt_cast_o.state = fsm_cmd_header_li.payload.state;
             tag_mem_pkt_cast_o.tag = fsm_cmd_header_li.addr[tag_offset_lp+:ctag_width_p];
             tag_mem_pkt_cast_o.opcode = e_cache_tag_mem_set_tag;
-            tag_mem_pkt_v_o = fsm_cmd_v_li & fsm_cmd_last_li;
+            tag_mem_pkt_v_o = fsm_cmd_v_li & fsm_cmd_new_li;
 
             data_mem_pkt_cast_o.index = fsm_cmd_header_li.addr[block_byte_offset_lp+:lg_sets_lp];
             data_mem_pkt_cast_o.way_id = fsm_cmd_header_li.payload.way_id[0+:lg_assoc_lp];

--- a/bp_me/src/v/lce/bp_lce_cmd.sv
+++ b/bp_me/src/v/lce/bp_lce_cmd.sv
@@ -492,7 +492,7 @@ module bp_lce_cmd
             tag_mem_pkt_cast_o.state = fsm_cmd_header_li.payload.state;
             tag_mem_pkt_cast_o.tag = fsm_cmd_header_li.addr[tag_offset_lp+:ctag_width_p];
             tag_mem_pkt_cast_o.opcode = e_cache_tag_mem_set_tag;
-            tag_mem_pkt_v_o = fsm_cmd_v_li & fsm_cmd_new_li;
+            tag_mem_pkt_v_o = fsm_cmd_v_li & fsm_cmd_last_li;
 
             data_mem_pkt_cast_o.index = fsm_cmd_header_li.addr[block_byte_offset_lp+:lg_sets_lp];
             data_mem_pkt_cast_o.way_id = fsm_cmd_header_li.payload.way_id[0+:lg_assoc_lp];

--- a/bp_me/src/v/lce/bp_lce_req.sv
+++ b/bp_me/src/v/lce/bp_lce_req.sv
@@ -61,6 +61,8 @@ module bp_lce_req
     , output logic                                   cache_req_yumi_o
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
+    , output logic [paddr_width_p-1:0]               cache_req_addr_o
+    , output logic [dword_width_gp-1:0]              cache_req_data_o
 
     // LCE-Cache Interface
     , output logic                                   credits_full_o
@@ -110,6 +112,8 @@ module bp_lce_req
      ,.v_o(cache_req_v_r)
      ,.yumi_i(cache_req_done)
      );
+  assign cache_req_addr_o = cache_req_r.addr;
+  assign cache_req_data_o = cache_req_r.data;
 
   bp_cache_req_metadata_s cache_req_metadata, cache_req_metadata_r;
   logic cache_req_metadata_v_r;

--- a/bp_me/test/common/bp_me_nonsynth_cache.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cache.sv
@@ -68,7 +68,7 @@ module bp_me_nonsynth_cache
     , output logic [cache_req_width_lp-1:0]                 cache_req_o
     , output logic                                          cache_req_v_o
     , input                                                 cache_req_yumi_i
-    , input                                                 cache_req_busy_i
+    , input                                                 cache_req_lock_i
     , output logic [cache_req_metadata_width_lp-1:0]        cache_req_metadata_o
     , output logic                                          cache_req_metadata_v_o
     , input [paddr_width_p-1:0]                             cache_req_addr_i
@@ -108,7 +108,7 @@ module bp_me_nonsynth_cache
   // Automatically consume new packet if register doesn't hold valid packet
   // Clear register when TR response sends
   // do not accept new TR packets if LCE busy signal asserted
-  wire tr_pkt_v_li = tr_pkt_v_i & ~cache_req_busy_i;
+  wire tr_pkt_v_li = tr_pkt_v_i & ~cache_req_lock_i;
   bp_me_nonsynth_tr_pkt_s tr_pkt_r;
   bsg_dff_reset_en
     #(.width_p($bits(bp_me_nonsynth_tr_pkt_s)+1))

--- a/bp_me/test/common/bp_me_nonsynth_cache.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cache.sv
@@ -72,6 +72,7 @@ module bp_me_nonsynth_cache
     , output logic [cache_req_metadata_width_lp-1:0]        cache_req_metadata_o
     , output logic                                          cache_req_metadata_v_o
     , input [paddr_width_p-1:0]                             cache_req_addr_i
+    , input [dword_width_gp-1:0]                            cache_req_data_i
     , input                                                 cache_req_critical_i
     , input                                                 cache_req_last_i
     , input                                                 cache_req_credits_full_i

--- a/bp_me/test/tb/bp_cce/testbench.sv
+++ b/bp_me/test/tb/bp_cce/testbench.sv
@@ -295,6 +295,7 @@ module testbench
   bp_cache_req_metadata_s [num_lce_p-1:0] cache_req_metadata_lo;
   logic [num_lce_p-1:0] cache_req_metadata_v_lo;
   logic [num_lce_p-1:0][paddr_width_p-1:0] cache_req_addr_li;
+  logic [num_lce_p-1:0][dword_width_gp-1:0] cache_req_data_li;
   logic [num_lce_p-1:0] cache_req_critical_li, cache_req_last_li;
   logic [num_lce_p-1:0] cache_req_credits_full_li, cache_req_credits_empty_li;
 
@@ -385,6 +386,7 @@ module testbench
        ,.cache_req_metadata_o(cache_req_metadata_lo[i])
        ,.cache_req_metadata_v_o(cache_req_metadata_v_lo[i])
        ,.cache_req_addr_i(cache_req_addr_li[i])
+       ,.cache_req_data_i(cache_req_data_li[i])
        ,.cache_req_critical_i(cache_req_critical_li[i])
        ,.cache_req_last_i(cache_req_last_li[i])
        ,.cache_req_credits_full_i(cache_req_credits_full_li[i])
@@ -436,6 +438,7 @@ module testbench
        ,.cache_req_metadata_i(cache_req_metadata_lo[i])
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo[i])
        ,.cache_req_addr_o(cache_req_addr_li[i])
+       ,.cache_req_data_o(cache_req_data_li[i])
        ,.cache_req_critical_o(cache_req_critical_li[i])
        ,.cache_req_last_o(cache_req_last_li[i])
        ,.cache_req_credits_full_o(cache_req_credits_full_li[i])

--- a/bp_me/test/tb/bp_cce/testbench.sv
+++ b/bp_me/test/tb/bp_cce/testbench.sv
@@ -291,7 +291,7 @@ module testbench
   `declare_bp_cache_engine_if(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, cache);
 
   bp_cache_req_s [num_lce_p-1:0] cache_req_lo;
-  logic [num_lce_p-1:0] cache_req_v_lo, cache_req_yumi_li, cache_req_busy_li;
+  logic [num_lce_p-1:0] cache_req_v_lo, cache_req_yumi_li, cache_req_lock_li;
   bp_cache_req_metadata_s [num_lce_p-1:0] cache_req_metadata_lo;
   logic [num_lce_p-1:0] cache_req_metadata_v_lo;
   logic [num_lce_p-1:0][paddr_width_p-1:0] cache_req_addr_li;
@@ -382,7 +382,7 @@ module testbench
        ,.cache_req_o(cache_req_lo[i])
        ,.cache_req_v_o(cache_req_v_lo[i])
        ,.cache_req_yumi_i(cache_req_yumi_li[i])
-       ,.cache_req_busy_i(cache_req_busy_li[i])
+       ,.cache_req_lock_i(cache_req_lock_li[i])
        ,.cache_req_metadata_o(cache_req_metadata_lo[i])
        ,.cache_req_metadata_v_o(cache_req_metadata_v_lo[i])
        ,.cache_req_addr_i(cache_req_addr_li[i])
@@ -434,7 +434,7 @@ module testbench
        ,.cache_req_i(cache_req_lo[i])
        ,.cache_req_v_i(cache_req_v_lo[i])
        ,.cache_req_yumi_o(cache_req_yumi_li[i])
-       ,.cache_req_busy_o(cache_req_busy_li[i])
+       ,.cache_req_lock_o(cache_req_lock_li[i])
        ,.cache_req_metadata_i(cache_req_metadata_lo[i])
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo[i])
        ,.cache_req_addr_o(cache_req_addr_li[i])

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -108,7 +108,7 @@ module bp_cacc_vdp
 
   `declare_bp_cache_engine_if(paddr_width_p, acache_ctag_width_p, acache_sets_p, acache_assoc_p, dword_width_gp, acache_block_width_p, acache_fill_width_p, acache);
   bp_acache_req_s acache_req_lo;
-  logic acache_req_v_lo, acache_req_yumi_li, acache_req_busy_li;
+  logic acache_req_v_lo, acache_req_yumi_li, acache_req_lock_li;
   bp_acache_req_metadata_s acache_req_metadata_lo;
   logic acache_req_metadata_v_lo;
   logic [paddr_width_p-1:0] acache_req_addr_lo;
@@ -167,7 +167,7 @@ module bp_cacc_vdp
      ,.cache_req_o(acache_req_lo)
      ,.cache_req_v_o(acache_req_v_lo)
      ,.cache_req_yumi_i(acache_req_yumi_li)
-     ,.cache_req_busy_i(acache_req_busy_li)
+     ,.cache_req_lock_i(acache_req_lock_li)
      ,.cache_req_metadata_o(acache_req_metadata_lo)
      ,.cache_req_metadata_v_o(acache_req_metadata_v_lo)
      ,.cache_req_credits_full_i(acache_req_credits_full_lo)
@@ -214,7 +214,7 @@ module bp_cacc_vdp
      ,.cache_req_i(acache_req_lo)
      ,.cache_req_v_i(acache_req_v_lo)
      ,.cache_req_yumi_o(acache_req_yumi_li)
-     ,.cache_req_busy_o(acache_req_busy_li)
+     ,.cache_req_lock_o(acache_req_lock_li)
      ,.cache_req_metadata_i(acache_req_metadata_lo)
      ,.cache_req_metadata_v_i(acache_req_metadata_v_lo)
      ,.cache_req_addr_o(acache_req_addr_lo)

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -112,6 +112,7 @@ module bp_cacc_vdp
   bp_acache_req_metadata_s acache_req_metadata_lo;
   logic acache_req_metadata_v_lo;
   logic [paddr_width_p-1:0] acache_req_addr_lo;
+  logic [dword_width_gp-1:0] acache_req_data_lo;
   logic acache_req_last_lo, acache_req_critical_lo;
   logic acache_req_credits_full_lo, acache_req_credits_empty_lo;
   bp_acache_data_mem_pkt_s acache_data_mem_pkt_li;
@@ -172,6 +173,7 @@ module bp_cacc_vdp
      ,.cache_req_credits_full_i(acache_req_credits_full_lo)
      ,.cache_req_credits_empty_i(acache_req_credits_empty_lo)
      ,.cache_req_addr_i(acache_req_addr_lo)
+     ,.cache_req_data_i(acache_req_data_lo)
      ,.cache_req_critical_i(acache_req_critical_lo)
      ,.cache_req_last_i(acache_req_last_lo)
 
@@ -216,6 +218,7 @@ module bp_cacc_vdp
      ,.cache_req_metadata_i(acache_req_metadata_lo)
      ,.cache_req_metadata_v_i(acache_req_metadata_v_lo)
      ,.cache_req_addr_o(acache_req_addr_lo)
+     ,.cache_req_data_o(acache_req_data_lo)
      ,.cache_req_critical_o(acache_req_critical_lo)
      ,.cache_req_last_o(acache_req_last_lo)
      ,.cache_req_credits_full_o(acache_req_credits_full_lo)

--- a/bp_top/src/v/bp_core_lite.sv
+++ b/bp_top/src/v/bp_core_lite.sv
@@ -72,6 +72,7 @@ module bp_core_lite
   bp_icache_req_metadata_s icache_req_metadata_lo;
   logic icache_req_metadata_v_lo;
   logic [paddr_width_p-1:0] icache_req_addr_li;
+  logic [dword_width_gp-1:0] icache_req_data_li;
   logic icache_req_critical_li, icache_req_last_li;
   logic icache_req_credits_full_li, icache_req_credits_empty_li;
 
@@ -80,6 +81,7 @@ module bp_core_lite
   bp_dcache_req_metadata_s dcache_req_metadata_lo;
   logic dcache_req_metadata_v_lo;
   logic [paddr_width_p-1:0] dcache_req_addr_li;
+  logic [dword_width_gp-1:0] dcache_req_data_li;
   logic dcache_req_critical_li, dcache_req_last_li;
   logic dcache_req_credits_full_li, dcache_req_credits_empty_li;
 
@@ -130,6 +132,7 @@ module bp_core_lite
      ,.icache_req_metadata_o(icache_req_metadata_lo)
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
      ,.icache_req_addr_i(icache_req_addr_li)
+     ,.icache_req_data_i(icache_req_data_li)
      ,.icache_req_critical_i(icache_req_critical_li)
      ,.icache_req_last_i(icache_req_last_li)
      ,.icache_req_credits_full_i(icache_req_credits_full_li)
@@ -157,6 +160,7 @@ module bp_core_lite
      ,.dcache_req_metadata_o(dcache_req_metadata_lo)
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
      ,.dcache_req_addr_i(dcache_req_addr_li)
+     ,.dcache_req_data_i(dcache_req_data_li)
      ,.dcache_req_critical_i(dcache_req_critical_li)
      ,.dcache_req_last_i(dcache_req_last_li)
      ,.dcache_req_credits_full_i(dcache_req_credits_full_li)
@@ -209,6 +213,7 @@ module bp_core_lite
      ,.cache_req_metadata_i(icache_req_metadata_lo)
      ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
      ,.cache_req_addr_o(icache_req_addr_li)
+     ,.cache_req_data_o(icache_req_data_li)
      ,.cache_req_critical_o(icache_req_critical_li)
      ,.cache_req_last_o(icache_req_last_li)
      ,.cache_req_credits_full_o(icache_req_credits_full_li)
@@ -303,6 +308,7 @@ module bp_core_lite
      ,.cache_req_metadata_i(dcache_req_metadata_lo)
      ,.cache_req_metadata_v_i(dcache_req_metadata_v_lo)
      ,.cache_req_addr_o(dcache_req_addr_li)
+     ,.cache_req_data_o(dcache_req_data_li)
      ,.cache_req_critical_o(dcache_req_critical_li)
      ,.cache_req_last_o(dcache_req_last_li)
      ,.cache_req_credits_full_o(dcache_req_credits_full_li)

--- a/bp_top/src/v/bp_core_lite.sv
+++ b/bp_top/src/v/bp_core_lite.sv
@@ -68,7 +68,7 @@ module bp_core_lite
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
   bp_icache_req_s icache_req_lo;
-  logic icache_req_v_lo, icache_req_yumi_li, icache_req_busy_li;
+  logic icache_req_v_lo, icache_req_yumi_li, icache_req_lock_li;
   bp_icache_req_metadata_s icache_req_metadata_lo;
   logic icache_req_metadata_v_lo;
   logic [paddr_width_p-1:0] icache_req_addr_li;
@@ -77,7 +77,7 @@ module bp_core_lite
   logic icache_req_credits_full_li, icache_req_credits_empty_li;
 
   bp_dcache_req_s dcache_req_lo;
-  logic dcache_req_v_lo, dcache_req_yumi_li, dcache_req_busy_li;
+  logic dcache_req_v_lo, dcache_req_yumi_li, dcache_req_lock_li;
   bp_dcache_req_metadata_s dcache_req_metadata_lo;
   logic dcache_req_metadata_v_lo;
   logic [paddr_width_p-1:0] dcache_req_addr_li;
@@ -128,7 +128,7 @@ module bp_core_lite
      ,.icache_req_o(icache_req_lo)
      ,.icache_req_v_o(icache_req_v_lo)
      ,.icache_req_yumi_i(icache_req_yumi_li)
-     ,.icache_req_busy_i(icache_req_busy_li)
+     ,.icache_req_lock_i(icache_req_lock_li)
      ,.icache_req_metadata_o(icache_req_metadata_lo)
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
      ,.icache_req_addr_i(icache_req_addr_li)
@@ -156,7 +156,7 @@ module bp_core_lite
      ,.dcache_req_o(dcache_req_lo)
      ,.dcache_req_v_o(dcache_req_v_lo)
      ,.dcache_req_yumi_i(dcache_req_yumi_li)
-     ,.dcache_req_busy_i(dcache_req_busy_li)
+     ,.dcache_req_lock_i(dcache_req_lock_li)
      ,.dcache_req_metadata_o(dcache_req_metadata_lo)
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
      ,.dcache_req_addr_i(dcache_req_addr_li)
@@ -209,7 +209,7 @@ module bp_core_lite
      ,.cache_req_i(icache_req_lo)
      ,.cache_req_v_i(icache_req_v_lo)
      ,.cache_req_yumi_o(icache_req_yumi_li)
-     ,.cache_req_busy_o(icache_req_busy_li)
+     ,.cache_req_lock_o(icache_req_lock_li)
      ,.cache_req_metadata_i(icache_req_metadata_lo)
      ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
      ,.cache_req_addr_o(icache_req_addr_li)
@@ -304,7 +304,7 @@ module bp_core_lite
      ,.cache_req_i(dcache_req_lo)
      ,.cache_req_v_i(dcache_req_v_lo)
      ,.cache_req_yumi_o(dcache_req_yumi_li)
-     ,.cache_req_busy_o(dcache_req_busy_li)
+     ,.cache_req_lock_o(dcache_req_lock_li)
      ,.cache_req_metadata_i(dcache_req_metadata_lo)
      ,.cache_req_metadata_v_i(dcache_req_metadata_v_lo)
      ,.cache_req_addr_o(dcache_req_addr_li)

--- a/bp_top/src/v/bp_core_minimal.sv
+++ b/bp_top/src/v/bp_core_minimal.sv
@@ -28,6 +28,7 @@ module bp_core_minimal
    , output logic [icache_req_metadata_width_lp-1:0] icache_req_metadata_o
    , output logic                                    icache_req_metadata_v_o
    , input [paddr_width_p-1:0]                       icache_req_addr_i
+   , input [dword_width_gp-1:0]                      icache_req_data_i
    , input                                           icache_req_critical_i
    , input                                           icache_req_last_i
    , input                                           icache_req_credits_full_i
@@ -57,6 +58,7 @@ module bp_core_minimal
    , output logic [dcache_req_metadata_width_lp-1:0] dcache_req_metadata_o
    , output logic                                    dcache_req_metadata_v_o
    , input [paddr_width_p-1:0]                       dcache_req_addr_i
+   , input [dword_width_gp-1:0]                      dcache_req_data_i
    , input                                           dcache_req_critical_i
    , input                                           dcache_req_last_i
    , input                                           dcache_req_credits_full_i
@@ -117,6 +119,7 @@ module bp_core_minimal
      ,.cache_req_metadata_o(icache_req_metadata_o)
      ,.cache_req_metadata_v_o(icache_req_metadata_v_o)
      ,.cache_req_addr_i(icache_req_addr_i)
+     ,.cache_req_data_i(icache_req_data_i)
      ,.cache_req_critical_i(icache_req_critical_i)
      ,.cache_req_last_i(icache_req_last_i)
      ,.cache_req_credits_full_i(icache_req_credits_full_i)
@@ -161,6 +164,7 @@ module bp_core_minimal
      ,.cache_req_metadata_o(dcache_req_metadata_o)
      ,.cache_req_metadata_v_o(dcache_req_metadata_v_o)
      ,.cache_req_addr_i(dcache_req_addr_i)
+     ,.cache_req_data_i(dcache_req_data_i)
      ,.cache_req_critical_i(dcache_req_critical_i)
      ,.cache_req_last_i(dcache_req_last_i)
      ,.cache_req_credits_full_i(dcache_req_credits_full_i)

--- a/bp_top/src/v/bp_core_minimal.sv
+++ b/bp_top/src/v/bp_core_minimal.sv
@@ -24,7 +24,7 @@ module bp_core_minimal
    , output logic [icache_req_width_lp-1:0]          icache_req_o
    , output logic                                    icache_req_v_o
    , input                                           icache_req_yumi_i
-   , input                                           icache_req_busy_i
+   , input                                           icache_req_lock_i
    , output logic [icache_req_metadata_width_lp-1:0] icache_req_metadata_o
    , output logic                                    icache_req_metadata_v_o
    , input [paddr_width_p-1:0]                       icache_req_addr_i
@@ -54,7 +54,7 @@ module bp_core_minimal
    , output logic [dcache_req_width_lp-1:0]          dcache_req_o
    , output logic                                    dcache_req_v_o
    , input                                           dcache_req_yumi_i
-   , input                                           dcache_req_busy_i
+   , input                                           dcache_req_lock_i
    , output logic [dcache_req_metadata_width_lp-1:0] dcache_req_metadata_o
    , output logic                                    dcache_req_metadata_v_o
    , input [paddr_width_p-1:0]                       dcache_req_addr_i
@@ -115,7 +115,7 @@ module bp_core_minimal
      ,.cache_req_o(icache_req_o)
      ,.cache_req_v_o(icache_req_v_o)
      ,.cache_req_yumi_i(icache_req_yumi_i)
-     ,.cache_req_busy_i(icache_req_busy_i)
+     ,.cache_req_lock_i(icache_req_lock_i)
      ,.cache_req_metadata_o(icache_req_metadata_o)
      ,.cache_req_metadata_v_o(icache_req_metadata_v_o)
      ,.cache_req_addr_i(icache_req_addr_i)
@@ -160,7 +160,7 @@ module bp_core_minimal
      ,.cache_req_o(dcache_req_o)
      ,.cache_req_v_o(dcache_req_v_o)
      ,.cache_req_yumi_i(dcache_req_yumi_i)
-     ,.cache_req_busy_i(dcache_req_busy_i)
+     ,.cache_req_lock_i(dcache_req_lock_i)
      ,.cache_req_metadata_o(dcache_req_metadata_o)
      ,.cache_req_metadata_v_o(dcache_req_metadata_v_o)
      ,.cache_req_addr_i(dcache_req_addr_i)

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -45,7 +45,7 @@ module bp_unicore_lite
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
   bp_icache_req_s icache_req_lo;
-  logic icache_req_v_lo, icache_req_yumi_li, icache_req_busy_li, icache_req_metadata_v_lo;
+  logic icache_req_v_lo, icache_req_yumi_li, icache_req_lock_li, icache_req_metadata_v_lo;
   bp_icache_req_metadata_s icache_req_metadata_lo;
   logic [paddr_width_p-1:0] icache_req_addr_li;
   logic [dword_width_gp-1:0] icache_req_data_li;
@@ -63,7 +63,7 @@ module bp_unicore_lite
   bp_icache_stat_info_s icache_stat_mem_lo;
 
   bp_dcache_req_s dcache_req_lo;
-  logic dcache_req_v_lo, dcache_req_yumi_li, dcache_req_busy_li, dcache_req_metadata_v_lo;
+  logic dcache_req_v_lo, dcache_req_yumi_li, dcache_req_lock_li, dcache_req_metadata_v_lo;
   bp_dcache_req_metadata_s dcache_req_metadata_lo;
   logic [paddr_width_p-1:0] dcache_req_addr_li;
   logic [dword_width_gp-1:0] dcache_req_data_li;
@@ -94,7 +94,7 @@ module bp_unicore_lite
      ,.icache_req_o(icache_req_lo)
      ,.icache_req_v_o(icache_req_v_lo)
      ,.icache_req_yumi_i(icache_req_yumi_li)
-     ,.icache_req_busy_i(icache_req_busy_li)
+     ,.icache_req_lock_i(icache_req_lock_li)
      ,.icache_req_metadata_o(icache_req_metadata_lo)
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
      ,.icache_req_addr_i(icache_req_addr_li)
@@ -122,7 +122,7 @@ module bp_unicore_lite
      ,.dcache_req_o(dcache_req_lo)
      ,.dcache_req_v_o(dcache_req_v_lo)
      ,.dcache_req_yumi_i(dcache_req_yumi_li)
-     ,.dcache_req_busy_i(dcache_req_busy_li)
+     ,.dcache_req_lock_i(dcache_req_lock_li)
      ,.dcache_req_metadata_o(dcache_req_metadata_lo)
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
      ,.dcache_req_addr_i(dcache_req_addr_li)
@@ -172,7 +172,7 @@ module bp_unicore_lite
      ,.cache_req_i(icache_req_lo)
      ,.cache_req_v_i(icache_req_v_lo)
      ,.cache_req_yumi_o(icache_req_yumi_li)
-     ,.cache_req_busy_o(icache_req_busy_li)
+     ,.cache_req_lock_o(icache_req_lock_li)
      ,.cache_req_metadata_i(icache_req_metadata_lo)
      ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
      ,.cache_req_addr_o(icache_req_addr_li)
@@ -232,7 +232,7 @@ module bp_unicore_lite
      ,.cache_req_i(dcache_req_lo)
      ,.cache_req_v_i(dcache_req_v_lo)
      ,.cache_req_yumi_o(dcache_req_yumi_li)
-     ,.cache_req_busy_o(dcache_req_busy_li)
+     ,.cache_req_lock_o(dcache_req_lock_li)
      ,.cache_req_metadata_i(dcache_req_metadata_lo)
      ,.cache_req_metadata_v_i(dcache_req_metadata_v_lo)
      ,.cache_req_addr_o(dcache_req_addr_li)

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -48,6 +48,7 @@ module bp_unicore_lite
   logic icache_req_v_lo, icache_req_yumi_li, icache_req_busy_li, icache_req_metadata_v_lo;
   bp_icache_req_metadata_s icache_req_metadata_lo;
   logic [paddr_width_p-1:0] icache_req_addr_li;
+  logic [dword_width_gp-1:0] icache_req_data_li;
   logic icache_req_critical_li, icache_req_last_li;
   logic icache_req_credits_full_li, icache_req_credits_empty_li;
 
@@ -65,6 +66,7 @@ module bp_unicore_lite
   logic dcache_req_v_lo, dcache_req_yumi_li, dcache_req_busy_li, dcache_req_metadata_v_lo;
   bp_dcache_req_metadata_s dcache_req_metadata_lo;
   logic [paddr_width_p-1:0] dcache_req_addr_li;
+  logic [dword_width_gp-1:0] dcache_req_data_li;
   logic dcache_req_critical_li, dcache_req_last_li;
   logic dcache_req_credits_full_li, dcache_req_credits_empty_li;
 
@@ -96,6 +98,7 @@ module bp_unicore_lite
      ,.icache_req_metadata_o(icache_req_metadata_lo)
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
      ,.icache_req_addr_i(icache_req_addr_li)
+     ,.icache_req_data_i(icache_req_data_li)
      ,.icache_req_critical_i(icache_req_critical_li)
      ,.icache_req_last_i(icache_req_last_li)
      ,.icache_req_credits_full_i(icache_req_credits_full_li)
@@ -123,6 +126,7 @@ module bp_unicore_lite
      ,.dcache_req_metadata_o(dcache_req_metadata_lo)
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
      ,.dcache_req_addr_i(dcache_req_addr_li)
+     ,.dcache_req_data_i(dcache_req_data_li)
      ,.dcache_req_critical_i(dcache_req_critical_li)
      ,.dcache_req_last_i(dcache_req_last_li)
      ,.dcache_req_credits_full_i(dcache_req_credits_full_li)
@@ -172,6 +176,7 @@ module bp_unicore_lite
      ,.cache_req_metadata_i(icache_req_metadata_lo)
      ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
      ,.cache_req_addr_o(icache_req_addr_li)
+     ,.cache_req_data_o(icache_req_data_li)
      ,.cache_req_critical_o(icache_req_critical_li)
      ,.cache_req_last_o(icache_req_last_li)
      ,.cache_req_credits_full_o(icache_req_credits_full_li)
@@ -231,6 +236,7 @@ module bp_unicore_lite
      ,.cache_req_metadata_i(dcache_req_metadata_lo)
      ,.cache_req_metadata_v_i(dcache_req_metadata_v_lo)
      ,.cache_req_addr_o(dcache_req_addr_li)
+     ,.cache_req_data_o(dcache_req_data_li)
      ,.cache_req_critical_o(dcache_req_critical_li)
      ,.cache_req_last_o(dcache_req_last_li)
      ,.cache_req_credits_full_o(dcache_req_credits_full_li)

--- a/bp_top/test/common/bp_nonsynth_cosim.sv
+++ b/bp_top/test/common/bp_nonsynth_cosim.sv
@@ -203,7 +203,6 @@ module bp_nonsynth_cosim
 
   // We don't need to cross domains explicitly here, because using the slower clock is conservative
   logic [`BSG_WIDTH(128)-1:0] req_cnt_lo;
-  wire req_v_lo = (req_cnt_lo == '0);
   bsg_counter_up_down
    #(.max_val_p(128), .init_val_p(0), .max_step_p(1))
    req_counter
@@ -215,6 +214,7 @@ module bp_nonsynth_cosim
 
      ,.count_o(req_cnt_lo)
      );
+  wire req_v_lo = ~cache_req_v_r & (req_cnt_lo == '0);
 
   assign commit_fifo_yumi_li = commit_fifo_v_lo & ((~commit_ird_w_v_r | ird_fifo_v_lo[commit_instr_r.rd_addr])
                                                    & (~commit_frd_w_v_r | frd_fifo_v_lo[commit_instr_r.rd_addr])

--- a/docs/interface_specification.md
+++ b/docs/interface_specification.md
@@ -237,7 +237,7 @@ The stat memory contains LRU and dirty data for a block, and the packet format i
 - Replacement index
 
 When the critical data of a transaction is being sent, cache_req_critical_o will go high.
-When the last data of a transaction is sent, cache_req_complete_o will go high.
+When the last data of a transaction is sent, cache_req_last_o will go high.
 
 There are additional signals for available credits in the engine, used for fencing. Empty credits
 signify all downstream transactions have completed, whereas full credits signify no more


### PR DESCRIPTION
### Summary
This PR adds the capability to hit under a single miss in the D$. This gives a mild performance increase on workloads which are stalling on head of line for miss. The true benefit is that this sets us up for a future fully nonblocking implementation without any changes to the surrounding pipeline structure.

### Issue Fixed
None

### Area
D$/UCE/Memory System

### Reasoning (new feature, inefficient, verbose, etc.)
For an in-order core, a blocking D$ can present a significant bottleneck on performance as a bypassing cache will then only allow average 3 instructions (assuming 1/4 memory operations) after a miss. A hit-under-miss cache will allow up to the next dependency.

### Additional Changes Required (if any)
The cache engine interface terminology has changed slightly, so minor updates to downstream blocks are required.

### Analysis
Verified with synthesis to have <1% area impact

### Verification
Linux boot and manual waveform inspection

### Additional Context
None

