### PR TITLE
L2 banking rework

### DIFF
--- a/bp_be/syn/flist.vcs
+++ b/bp_be/syn/flist.vcs
@@ -225,7 +225,7 @@ $BP_ME_DIR/src/v/lce/bp_lce.sv
 $BP_ME_DIR/src/v/lce/bp_lce_req.sv
 $BP_ME_DIR/src/v/lce/bp_lce_cmd.sv
 # Cache
-$BP_ME_DIR/src/v/dev/bp_me_cce_to_cache.sv
+$BP_ME_DIR/src/v/dev/bp_me_cache_controller.sv
 $BP_ME_DIR/src/v/dev/bp_me_dram_hash_decode.sv
 $BP_ME_DIR/src/v/dev/bp_me_dram_hash_encode.sv
 # CCE

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -321,7 +321,8 @@
       ,l2_assoc            : 8
       ,l2_block_width      : 512
       ,l2_fill_width       : 128
-      ,l2_outstanding_reqs : 6
+      // Set to L2 pipeline depth
+      ,l2_outstanding_reqs : 3
 
       ,fe_queue_fifo_els : 8
       ,fe_cmd_fifo_els   : 4

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -172,6 +172,7 @@
     // L2 slice parameters (per core)
     // L2 cache features
     integer unsigned l2_features;
+    integer unsigned l2_slices;
     // Number of L2 banks present in the slice
     integer unsigned l2_banks;
     integer unsigned l2_data_width;
@@ -179,9 +180,6 @@
     integer unsigned l2_assoc;
     integer unsigned l2_block_width;
     integer unsigned l2_fill_width;
-    // Number of requests which can be pending in a cache slice
-    // Should be 4 < N < 4*l2_banks_p to prevent stalling
-    integer unsigned l2_outstanding_reqs;
 
     // Size of the issue queue
     integer unsigned fe_queue_fifo_els;
@@ -315,14 +313,13 @@
                               | (1 << e_cfg_amo_swap)
                               | (1 << e_cfg_amo_fetch_logic)
                               | (1 << e_cfg_amo_fetch_arithmetic)
+      ,l2_slices           : 2
       ,l2_banks            : 2
       ,l2_data_width       : 128
       ,l2_sets             : 128
       ,l2_assoc            : 8
       ,l2_block_width      : 512
       ,l2_fill_width       : 128
-      // Set to L2 pipeline depth
-      ,l2_outstanding_reqs : 3
 
       ,fe_queue_fifo_els : 8
       ,fe_cmd_fifo_els   : 4
@@ -427,13 +424,13 @@
       ,`bp_aviary_define_override(bedrock_fill_width, BP_BEDROCK_FILL_WIDTH, `BP_CUSTOM_BASE_CFG)
 
       ,`bp_aviary_define_override(l2_features, BP_L2_FEATURES, `BP_CUSTOM_BASE_CFG)
+      ,`bp_aviary_define_override(l2_slices, BP_L2_SLICES, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(l2_banks, BP_L2_BANKS, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(l2_data_width, BP_L2_DATA_WIDTH, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(l2_sets, BP_L2_SETS, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(l2_assoc, BP_L2_ASSOC, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(l2_block_width, BP_L2_BLOCK_WIDTH, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(l2_fill_width, BP_L2_FILL_WIDTH, `BP_CUSTOM_BASE_CFG)
-      ,`bp_aviary_define_override(l2_outstanding_reqs, BP_L2_OUTSTANDING_REQS, `BP_CUSTOM_BASE_CFG)
 
       ,`bp_aviary_define_override(async_coh_clk, BP_ASYNC_COH_CLK, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(coh_noc_max_credits, BP_COH_NOC_MAX_CREDITS, `BP_CUSTOM_BASE_CFG)

--- a/bp_common/src/include/bp_common_aviary_defines.svh
+++ b/bp_common/src/include/bp_common_aviary_defines.svh
@@ -94,13 +94,14 @@
                                                                                                    \
     /* L2 enable turns the L2 into a small write buffer, which is minimal size                  */ \
     , localparam l2_features_p         = proc_param_lp.l2_features                                 \
+    , localparam l2_slices_p           = l2_features_p[e_cfg_enabled] ? proc_param_lp.l2_slices : 1 \
     , localparam l2_banks_p            = l2_features_p[e_cfg_enabled] ? proc_param_lp.l2_banks : 1 \
     , localparam l2_sets_p             = l2_features_p[e_cfg_enabled] ? proc_param_lp.l2_sets  : 4 \
     , localparam l2_assoc_p            = l2_features_p[e_cfg_enabled] ? proc_param_lp.l2_assoc : 2 \
     , localparam l2_block_width_p      = proc_param_lp.l2_block_width                              \
     , localparam l2_fill_width_p       = proc_param_lp.l2_fill_width                               \
     , localparam l2_data_width_p       = proc_param_lp.l2_data_width                               \
-    , localparam l2_outstanding_reqs_p = proc_param_lp.l2_outstanding_reqs                         \
+    , localparam l2_dmas_p = l2_slices_p * l2_banks_p                                              \
                                                                                                    \
     , localparam l2_block_size_in_words_p = l2_block_width_p / l2_data_width_p                     \
     , localparam l2_block_size_in_fill_p  = l2_block_width_p / l2_fill_width_p                     \
@@ -249,13 +250,13 @@
           ,`bp_aviary_parameter_override(bedrock_fill_width, override_cfg_mp, default_cfg_mp)      \
                                                                                                    \
           ,`bp_aviary_parameter_override(l2_features, override_cfg_mp, default_cfg_mp)             \
+          ,`bp_aviary_parameter_override(l2_slices, override_cfg_mp, default_cfg_mp)               \
           ,`bp_aviary_parameter_override(l2_banks, override_cfg_mp, default_cfg_mp)                \
           ,`bp_aviary_parameter_override(l2_data_width, override_cfg_mp, default_cfg_mp)           \
           ,`bp_aviary_parameter_override(l2_sets, override_cfg_mp, default_cfg_mp)                 \
           ,`bp_aviary_parameter_override(l2_assoc, override_cfg_mp, default_cfg_mp)                \
           ,`bp_aviary_parameter_override(l2_block_width, override_cfg_mp, default_cfg_mp)          \
           ,`bp_aviary_parameter_override(l2_fill_width, override_cfg_mp, default_cfg_mp)           \
-          ,`bp_aviary_parameter_override(l2_outstanding_reqs, override_cfg_mp, default_cfg_mp)     \
                                                                                                    \
           ,`bp_aviary_parameter_override(async_coh_clk, override_cfg_mp, default_cfg_mp)           \
           ,`bp_aviary_parameter_override(coh_noc_max_credits, override_cfg_mp, default_cfg_mp)     \

--- a/bp_common/src/include/bp_common_aviary_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_pkgdef.svh
@@ -39,7 +39,6 @@
       ,l2_assoc            : 8
       ,l2_block_width      : 512
       ,l2_fill_width       : 512
-      ,l2_outstanding_reqs : 32
 
       ,default : "inv"
       };
@@ -176,8 +175,8 @@
       ,dcache_block_width : 512
       ,dcache_fill_width  : 512
 
-      ,bedrock_fill_width  : 512
       ,bedrock_block_width : 512
+      ,bedrock_fill_width  : 512
 
       ,l2_banks            : 8
       ,l2_data_width       : 512
@@ -185,7 +184,6 @@
       ,l2_assoc            : 8
       ,l2_block_width      : 512
       ,l2_fill_width       : 512
-      ,l2_outstanding_reqs : 32
 
       ,dma_noc_flit_width  : 512
       ,coh_noc_flit_width  : 512

--- a/bp_fe/syn/flist.vcs
+++ b/bp_fe/syn/flist.vcs
@@ -197,7 +197,7 @@ $BP_ME_DIR/src/v/lce/bp_lce.sv
 $BP_ME_DIR/src/v/lce/bp_lce_req.sv
 $BP_ME_DIR/src/v/lce/bp_lce_cmd.sv
 # Cache
-$BP_ME_DIR/src/v/dev/bp_me_cce_to_cache.sv
+$BP_ME_DIR/src/v/dev/bp_me_cache_controller.sv
 $BP_ME_DIR/src/v/dev/bp_me_dram_hash_decode.sv
 $BP_ME_DIR/src/v/dev/bp_me_dram_hash_encode.sv
 # CCE

--- a/bp_me/src/v/dev/bp_me_cache_slice.sv
+++ b/bp_me/src/v/dev/bp_me_cache_slice.sv
@@ -38,27 +38,27 @@ module bp_me_cache_slice
    , input                                               mem_rev_ready_and_i
 
    // DRAM interface
-   , output logic [l2_banks_p-1:0][dma_pkt_width_lp-1:0] dma_pkt_o
-   , output logic [l2_banks_p-1:0]                       dma_pkt_v_o
-   , input [l2_banks_p-1:0]                              dma_pkt_ready_and_i
+   , output logic [dma_pkt_width_lp-1:0]                 dma_pkt_o
+   , output logic                                        dma_pkt_v_o
+   , input                                               dma_pkt_ready_and_i
 
-   , input [l2_banks_p-1:0][l2_fill_width_p-1:0]         dma_data_i
-   , input [l2_banks_p-1:0]                              dma_data_v_i
-   , output logic [l2_banks_p-1:0]                       dma_data_ready_and_o
+   , input [l2_fill_width_p-1:0]                         dma_data_i
+   , input                                               dma_data_v_i
+   , output logic                                        dma_data_ready_and_o
 
-   , output logic [l2_banks_p-1:0][l2_fill_width_p-1:0]  dma_data_o
-   , output logic [l2_banks_p-1:0]                       dma_data_v_o
-   , input [l2_banks_p-1:0]                              dma_data_ready_and_i
+   , output logic [l2_fill_width_p-1:0]                  dma_data_o
+   , output logic                                        dma_data_v_o
+   , input                                               dma_data_ready_and_i
    );
 
   `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
 
   `declare_bsg_cache_pkt_s(daddr_width_p, l2_data_width_p);
-  bsg_cache_pkt_s [l2_banks_p-1:0] cache_pkt_li;
-  logic [l2_banks_p-1:0] cache_pkt_v_li, cache_pkt_yumi_lo;
-  logic [l2_banks_p-1:0][l2_data_width_p-1:0] cache_data_lo;
-  logic [l2_banks_p-1:0] cache_data_v_lo, cache_data_yumi_li;
+  bsg_cache_pkt_s  cache_pkt_li;
+  logic cache_pkt_v_li, cache_pkt_yumi_lo;
+  logic [l2_data_width_p-1:0] cache_data_lo;
+  logic cache_data_v_lo, cache_data_yumi_li;
 
   // TODO: Buffering can be reduced by only saving headers per stream
   bp_bedrock_mem_fwd_header_s mem_fwd_header_li;
@@ -82,9 +82,9 @@ module bp_me_cache_slice
      ,.yumi_i(mem_fwd_ready_and_lo & mem_fwd_v_li)
      );
 
-  bp_me_cce_to_cache
+  bp_me_cache_controller
    #(.bp_params_p(bp_params_p))
-   cce_to_cache
+   cache_controller
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
@@ -107,54 +107,51 @@ module bp_me_cache_slice
      ,.cache_data_yumi_o(cache_data_yumi_li)
      );
 
-  for (genvar i = 0; i < l2_banks_p; i++)
-    begin : bank
-      bsg_cache
-       #(.addr_width_p(daddr_width_p)
-         ,.data_width_p(l2_data_width_p)
-         ,.dma_data_width_p(l2_fill_width_p)
-         ,.block_size_in_words_p(l2_block_size_in_words_p)
-         ,.sets_p(l2_sets_p)
-         ,.ways_p(l2_assoc_p)
-         ,.amo_support_p(((l2_features_p[e_cfg_amo_swap]) << e_cache_amo_swap)
-                         | ((l2_features_p[e_cfg_amo_fetch_logic]) << e_cache_amo_xor)
-                         | ((l2_features_p[e_cfg_amo_fetch_logic]) << e_cache_amo_and)
-                         | ((l2_features_p[e_cfg_amo_fetch_logic]) << e_cache_amo_or)
-                         | ((l2_features_p[e_cfg_amo_fetch_arithmetic]) << e_cache_amo_add)
-                         | ((l2_features_p[e_cfg_amo_fetch_arithmetic]) << e_cache_amo_min)
-                         | ((l2_features_p[e_cfg_amo_fetch_arithmetic]) << e_cache_amo_max)
-                         | ((l2_features_p[e_cfg_amo_fetch_arithmetic]) << e_cache_amo_minu)
-                         | ((l2_features_p[e_cfg_amo_fetch_arithmetic]) << e_cache_amo_maxu)
-                         )
-        ,.word_tracking_p(l2_features_p[e_cfg_word_tracking])
-        )
-       cache
-        (.clk_i(clk_i)
-         ,.reset_i(reset_i)
+  bsg_cache
+   #(.addr_width_p(daddr_width_p)
+     ,.data_width_p(l2_data_width_p)
+     ,.dma_data_width_p(l2_fill_width_p)
+     ,.block_size_in_words_p(l2_block_size_in_words_p)
+     ,.sets_p(l2_sets_p)
+     ,.ways_p(l2_assoc_p)
+     ,.amo_support_p(((l2_features_p[e_cfg_amo_swap]) << e_cache_amo_swap)
+                     | ((l2_features_p[e_cfg_amo_fetch_logic]) << e_cache_amo_xor)
+                     | ((l2_features_p[e_cfg_amo_fetch_logic]) << e_cache_amo_and)
+                     | ((l2_features_p[e_cfg_amo_fetch_logic]) << e_cache_amo_or)
+                     | ((l2_features_p[e_cfg_amo_fetch_arithmetic]) << e_cache_amo_add)
+                     | ((l2_features_p[e_cfg_amo_fetch_arithmetic]) << e_cache_amo_min)
+                     | ((l2_features_p[e_cfg_amo_fetch_arithmetic]) << e_cache_amo_max)
+                     | ((l2_features_p[e_cfg_amo_fetch_arithmetic]) << e_cache_amo_minu)
+                     | ((l2_features_p[e_cfg_amo_fetch_arithmetic]) << e_cache_amo_maxu)
+                     )
+    ,.word_tracking_p(l2_features_p[e_cfg_word_tracking])
+    )
+   cache
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
 
-         ,.cache_pkt_i(cache_pkt_li[i])
-         ,.v_i(cache_pkt_v_li[i])
-         ,.yumi_o(cache_pkt_yumi_lo[i])
+     ,.cache_pkt_i(cache_pkt_li)
+     ,.v_i(cache_pkt_v_li)
+     ,.yumi_o(cache_pkt_yumi_lo)
 
-         ,.data_o(cache_data_lo[i])
-         ,.v_o(cache_data_v_lo[i])
-         ,.yumi_i(cache_data_yumi_li[i])
+     ,.data_o(cache_data_lo)
+     ,.v_o(cache_data_v_lo)
+     ,.yumi_i(cache_data_yumi_li)
 
-         ,.dma_pkt_o(dma_pkt_o[i])
-         ,.dma_pkt_v_o(dma_pkt_v_o[i])
-         ,.dma_pkt_yumi_i(dma_pkt_ready_and_i[i] & dma_pkt_v_o[i])
+     ,.dma_pkt_o(dma_pkt_o)
+     ,.dma_pkt_v_o(dma_pkt_v_o)
+     ,.dma_pkt_yumi_i(dma_pkt_ready_and_i & dma_pkt_v_o)
 
-         ,.dma_data_i(dma_data_i[i])
-         ,.dma_data_v_i(dma_data_v_i[i])
-         ,.dma_data_ready_o(dma_data_ready_and_o[i])
+     ,.dma_data_i(dma_data_i)
+     ,.dma_data_v_i(dma_data_v_i)
+     ,.dma_data_ready_o(dma_data_ready_and_o)
 
-         ,.dma_data_o(dma_data_o[i])
-         ,.dma_data_v_o(dma_data_v_o[i])
-         ,.dma_data_yumi_i(dma_data_ready_and_i[i] & dma_data_v_o[i])
+     ,.dma_data_o(dma_data_o)
+     ,.dma_data_v_o(dma_data_v_o)
+     ,.dma_data_yumi_i(dma_data_ready_and_i & dma_data_v_o)
 
-         ,.v_we_o()
-         );
-    end
+     ,.v_we_o()
+     );
 
 endmodule
 

--- a/bp_me/src/v/dev/bp_me_cache_slice.sv
+++ b/bp_me/src/v/dev/bp_me_cache_slice.sv
@@ -38,27 +38,27 @@ module bp_me_cache_slice
    , input                                               mem_rev_ready_and_i
 
    // DRAM interface
-   , output logic [dma_pkt_width_lp-1:0]                 dma_pkt_o
-   , output logic                                        dma_pkt_v_o
-   , input                                               dma_pkt_ready_and_i
+   , output logic [l2_banks_p-1:0][dma_pkt_width_lp-1:0] dma_pkt_o
+   , output logic [l2_banks_p-1:0]                       dma_pkt_v_o
+   , input [l2_banks_p-1:0]                              dma_pkt_ready_and_i
 
-   , input [l2_fill_width_p-1:0]                         dma_data_i
-   , input                                               dma_data_v_i
-   , output logic                                        dma_data_ready_and_o
+   , input [l2_banks_p-1:0][l2_fill_width_p-1:0]         dma_data_i
+   , input [l2_banks_p-1:0]                              dma_data_v_i
+   , output logic [l2_banks_p-1:0]                       dma_data_ready_and_o
 
-   , output logic [l2_fill_width_p-1:0]                  dma_data_o
-   , output logic                                        dma_data_v_o
-   , input                                               dma_data_ready_and_i
+   , output logic [l2_banks_p-1:0][l2_fill_width_p-1:0]  dma_data_o
+   , output logic [l2_banks_p-1:0]                       dma_data_v_o
+   , input [l2_banks_p-1:0]                              dma_data_ready_and_i
    );
 
   `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
 
   `declare_bsg_cache_pkt_s(daddr_width_p, l2_data_width_p);
-  bsg_cache_pkt_s  cache_pkt_li;
-  logic cache_pkt_v_li, cache_pkt_yumi_lo;
-  logic [l2_data_width_p-1:0] cache_data_lo;
-  logic cache_data_v_lo, cache_data_yumi_li;
+  bsg_cache_pkt_s [l2_banks_p-1:0] cache_pkt_li;
+  logic [l2_banks_p-1:0] cache_pkt_v_li, cache_pkt_yumi_lo;
+  logic [l2_banks_p-1:0][l2_data_width_p-1:0] cache_data_lo;
+  logic [l2_banks_p-1:0] cache_data_v_lo, cache_data_yumi_li;
 
   // TODO: Buffering can be reduced by only saving headers per stream
   bp_bedrock_mem_fwd_header_s mem_fwd_header_li;
@@ -107,51 +107,54 @@ module bp_me_cache_slice
      ,.cache_data_yumi_o(cache_data_yumi_li)
      );
 
-  bsg_cache
-   #(.addr_width_p(daddr_width_p)
-     ,.data_width_p(l2_data_width_p)
-     ,.dma_data_width_p(l2_fill_width_p)
-     ,.block_size_in_words_p(l2_block_size_in_words_p)
-     ,.sets_p(l2_sets_p)
-     ,.ways_p(l2_assoc_p)
-     ,.amo_support_p(((l2_features_p[e_cfg_amo_swap]) << e_cache_amo_swap)
-                     | ((l2_features_p[e_cfg_amo_fetch_logic]) << e_cache_amo_xor)
-                     | ((l2_features_p[e_cfg_amo_fetch_logic]) << e_cache_amo_and)
-                     | ((l2_features_p[e_cfg_amo_fetch_logic]) << e_cache_amo_or)
-                     | ((l2_features_p[e_cfg_amo_fetch_arithmetic]) << e_cache_amo_add)
-                     | ((l2_features_p[e_cfg_amo_fetch_arithmetic]) << e_cache_amo_min)
-                     | ((l2_features_p[e_cfg_amo_fetch_arithmetic]) << e_cache_amo_max)
-                     | ((l2_features_p[e_cfg_amo_fetch_arithmetic]) << e_cache_amo_minu)
-                     | ((l2_features_p[e_cfg_amo_fetch_arithmetic]) << e_cache_amo_maxu)
-                     )
-    ,.word_tracking_p(l2_features_p[e_cfg_word_tracking])
-    )
-   cache
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+  for (genvar i = 0; i < l2_banks_p; i++)
+    begin : bank
+      bsg_cache
+       #(.addr_width_p(daddr_width_p)
+         ,.data_width_p(l2_data_width_p)
+         ,.dma_data_width_p(l2_fill_width_p)
+         ,.block_size_in_words_p(l2_block_size_in_words_p)
+         ,.sets_p(l2_sets_p)
+         ,.ways_p(l2_assoc_p)
+         ,.amo_support_p(((l2_features_p[e_cfg_amo_swap]) << e_cache_amo_swap)
+                         | ((l2_features_p[e_cfg_amo_fetch_logic]) << e_cache_amo_xor)
+                         | ((l2_features_p[e_cfg_amo_fetch_logic]) << e_cache_amo_and)
+                         | ((l2_features_p[e_cfg_amo_fetch_logic]) << e_cache_amo_or)
+                         | ((l2_features_p[e_cfg_amo_fetch_arithmetic]) << e_cache_amo_add)
+                         | ((l2_features_p[e_cfg_amo_fetch_arithmetic]) << e_cache_amo_min)
+                         | ((l2_features_p[e_cfg_amo_fetch_arithmetic]) << e_cache_amo_max)
+                         | ((l2_features_p[e_cfg_amo_fetch_arithmetic]) << e_cache_amo_minu)
+                         | ((l2_features_p[e_cfg_amo_fetch_arithmetic]) << e_cache_amo_maxu)
+                         )
+        ,.word_tracking_p(l2_features_p[e_cfg_word_tracking])
+        )
+       cache
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
 
-     ,.cache_pkt_i(cache_pkt_li)
-     ,.v_i(cache_pkt_v_li)
-     ,.yumi_o(cache_pkt_yumi_lo)
+         ,.cache_pkt_i(cache_pkt_li[i])
+         ,.v_i(cache_pkt_v_li[i])
+         ,.yumi_o(cache_pkt_yumi_lo[i])
 
-     ,.data_o(cache_data_lo)
-     ,.v_o(cache_data_v_lo)
-     ,.yumi_i(cache_data_yumi_li)
+         ,.data_o(cache_data_lo[i])
+         ,.v_o(cache_data_v_lo[i])
+         ,.yumi_i(cache_data_yumi_li[i])
 
-     ,.dma_pkt_o(dma_pkt_o)
-     ,.dma_pkt_v_o(dma_pkt_v_o)
-     ,.dma_pkt_yumi_i(dma_pkt_ready_and_i & dma_pkt_v_o)
+         ,.dma_pkt_o(dma_pkt_o[i])
+         ,.dma_pkt_v_o(dma_pkt_v_o[i])
+         ,.dma_pkt_yumi_i(dma_pkt_ready_and_i[i] & dma_pkt_v_o[i])
 
-     ,.dma_data_i(dma_data_i)
-     ,.dma_data_v_i(dma_data_v_i)
-     ,.dma_data_ready_o(dma_data_ready_and_o)
+         ,.dma_data_i(dma_data_i[i])
+         ,.dma_data_v_i(dma_data_v_i[i])
+         ,.dma_data_ready_o(dma_data_ready_and_o[i])
 
-     ,.dma_data_o(dma_data_o)
-     ,.dma_data_v_o(dma_data_v_o)
-     ,.dma_data_yumi_i(dma_data_ready_and_i & dma_data_v_o)
+         ,.dma_data_o(dma_data_o[i])
+         ,.dma_data_v_o(dma_data_v_o[i])
+         ,.dma_data_yumi_i(dma_data_ready_and_i[i] & dma_data_v_o[i])
 
-     ,.v_we_o()
-     );
+         ,.v_we_o()
+         );
+    end
 
 endmodule
 

--- a/bp_me/src/v/dev/bp_me_cce_to_cache.sv
+++ b/bp_me/src/v/dev/bp_me_cce_to_cache.sv
@@ -1,6 +1,6 @@
 /*
  * Name:
- *   bp_me_cache_controller.sv
+ *   bp_me_cce_to_cache.sv
  *
  * Description:
  *   This module converts an arriving BedRock Stream message into a bsg_cache message, and
@@ -17,7 +17,7 @@
 `include "bp_me_defines.svh"
 `include "bsg_cache.vh"
 
-module bp_me_cache_controller
+module bp_me_cce_to_cache
  import bp_common_pkg::*;
  import bp_me_pkg::*;
  import bsg_cache_pkg::*;
@@ -188,11 +188,9 @@ module bp_me_cache_controller
   // Swizzle address bits for L2 cache command
   bp_me_dram_hash_encode
    #(.bp_params_p(bp_params_p))
-   bank_select
+   fsm_fwd_hash
     (.daddr_i(fsm_fwd_addr_li[0+:daddr_width_p])
      ,.daddr_o(cache_pkt_addr_lo)
-     ,.cce_o()
-     ,.slice_o()
      ,.bank_o(cache_fwd_bank_lo)
      );
 
@@ -205,7 +203,7 @@ module bp_me_cache_controller
   logic stream_fifo_ready_lo, stream_header_v_lo;
   bsg_fifo_1r1w_small
    #(.width_p(lg_l2_banks_lp+$bits(bp_bedrock_mem_fwd_header_s))
-     ,.els_p(l2_banks_p*3)
+     ,.els_p(num_l2_banks_p*3)
      ,.ready_THEN_valid_p(1)
      )
    stream_fifo

--- a/bp_me/src/v/dev/bp_me_dram_hash_decode.sv
+++ b/bp_me/src/v/dev/bp_me_dram_hash_decode.sv
@@ -5,11 +5,8 @@
  * Description:
  *   This module reverses the bit swizzling applied by bp_me_dram_hash_encode.
  *
- *   Encode takes an address of form {A, b...bb, c...cc, D} and outputs
- *   address of {A, c...cc, b...bb, D}. The bit widths of b and c bits may differ and are
- *   specified by the offset_widths_p parameter.
- *   Decode reverses this swizzle operation, transforming {A, c...cc, b...bb, D} to
- *   {A, b...bb, c...cc, D}.
+ *   IN :  [ taghi ][ bank ][ slice ][ cce ][         taglo         ][     indexhi    ][ block ]
+ *   OUT:  [ taghi ][         taglo        ][     indexhi     ][ bank ][ slice ][ cce ][ block ]
  *
  */
 
@@ -19,27 +16,29 @@ module bp_me_dram_hash_decode
  import bp_common_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
+   , localparam lg_num_cce_lp   = `BSG_SAFE_CLOG2(num_cce_p)
+   , localparam lg_l2_slices_lp = `BSG_SAFE_CLOG2(l2_slices_p)
+   , localparam lg_l2_banks_lp  = `BSG_SAFE_CLOG2(l2_banks_p)
    )
   (input [daddr_width_p-1:0]          daddr_i
    , output logic [daddr_width_p-1:0] daddr_o
    );
 
   localparam l2_block_offset_width_lp = `BSG_SAFE_CLOG2(l2_block_width_p/8);
-  localparam lg_l2_sets_lp            = `BSG_SAFE_CLOG2(l2_sets_p);
-  localparam lg_num_cce_lp            = `BSG_SAFE_CLOG2(num_cce_p);
-  localparam int hash_offset_widths_lp[2:0] = '{(lg_l2_sets_lp-lg_num_cce_lp), lg_num_cce_lp, l2_block_offset_width_lp};
-  localparam offset_width_lp = hash_offset_widths_lp[0] + hash_offset_widths_lp[1] + hash_offset_widths_lp[2];
+  localparam l2_tag_offset_width_lp   = `BSG_SAFE_CLOG2(l2_block_width_p*l2_sets_p/8);
+  localparam l2_hash_offset_width_lp  = lg_num_cce_lp + lg_l2_slices_lp + lg_l2_banks_lp;
+  localparam l2_indexhi_width_lp = `BSG_SAFE_CLOG2(l2_sets_p) - l2_hash_offset_width_lp;
+  localparam l2_taghi_width_lp = daddr_width_p - l2_tag_offset_width_lp - l2_hash_offset_width_lp;
 
-  wire [hash_offset_widths_lp[2]+hash_offset_widths_lp[1]-1:0] decoded_bits =
-    {daddr_i[hash_offset_widths_lp[0]+:hash_offset_widths_lp[2]]
-     ,daddr_i[(hash_offset_widths_lp[0]+hash_offset_widths_lp[2])+:hash_offset_widths_lp[1]]
-     };
+  wire [l2_block_offset_width_lp-1:0] block = daddr_i[0+:l2_block_offset_width_lp];
+  wire [l2_indexhi_width_lp-1:0]    indexhi = daddr_i[l2_block_offset_width_lp+:l2_indexhi_width_lp];
+  wire [l2_hash_offset_width_lp-1:0]  taglo = daddr_i[l2_block_offset_width_lp+l2_indexhi_width_lp+:l2_hash_offset_width_lp];
+  wire [lg_num_cce_lp-1:0]              cce = daddr_i[l2_tag_offset_width_lp+:lg_num_cce_lp];
+  wire [lg_l2_slices_lp-1:0]          slice = daddr_i[l2_tag_offset_width_lp+lg_num_cce_lp+:lg_l2_slices_lp];
+  wire [lg_l2_banks_lp-1:0]            bank = daddr_i[l2_tag_offset_width_lp+lg_num_cce_lp+lg_l2_slices_lp+:lg_l2_banks_lp];
+  wire [l2_taghi_width_lp-1:0]        taghi = daddr_i[daddr_width_p-1-:l2_taghi_width_lp];
 
-  assign daddr_o =
-    {daddr_i[daddr_width_p-1:offset_width_lp]
-     ,decoded_bits
-     ,daddr_i[0+:hash_offset_widths_lp[0]]
-     };
+  assign daddr_o = {taghi, taglo, indexhi, bank, slice, cce, block};
 
 endmodule
 

--- a/bp_me/src/v/dev/bp_me_dram_hash_decode.sv
+++ b/bp_me/src/v/dev/bp_me_dram_hash_decode.sv
@@ -26,7 +26,6 @@ module bp_me_dram_hash_decode
 
   localparam l2_block_offset_width_lp = `BSG_SAFE_CLOG2(l2_block_width_p/8);
   localparam lg_l2_sets_lp            = `BSG_SAFE_CLOG2(l2_sets_p);
-  localparam lg_l2_banks_lp           = `BSG_SAFE_CLOG2(l2_banks_p);
   localparam lg_num_cce_lp            = `BSG_SAFE_CLOG2(num_cce_p);
   localparam int hash_offset_widths_lp[2:0] = '{(lg_l2_sets_lp-lg_num_cce_lp), lg_num_cce_lp, l2_block_offset_width_lp};
   localparam offset_width_lp = hash_offset_widths_lp[0] + hash_offset_widths_lp[1] + hash_offset_widths_lp[2];

--- a/bp_me/src/v/dev/bp_me_dram_hash_encode.sv
+++ b/bp_me/src/v/dev/bp_me_dram_hash_encode.sv
@@ -18,18 +18,14 @@ module bp_me_dram_hash_encode
  import bp_common_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-
-   , localparam lg_l2_banks_lp = `BSG_SAFE_CLOG2(l2_banks_p)
    )
   (input [daddr_width_p-1:0]           daddr_i
    , output logic [daddr_width_p-1:0]  daddr_o
-   , output logic [lg_l2_banks_lp-1:0] bank_o
    );
 
   localparam l2_block_offset_width_lp = `BSG_SAFE_CLOG2(l2_block_width_p/8);
   localparam lg_l2_sets_lp            = `BSG_SAFE_CLOG2(l2_sets_p);
   localparam lg_num_cce_lp            = `BSG_SAFE_CLOG2(num_cce_p);
-  localparam l2_bank_offset_width_lp  = (num_cce_p > 1) ? l2_block_offset_width_lp+lg_num_cce_lp : l2_block_offset_width_lp;
   localparam int hash_offset_widths_lp[2:0] = '{(lg_l2_sets_lp-lg_num_cce_lp), lg_num_cce_lp, l2_block_offset_width_lp};
   localparam offset_width_lp = hash_offset_widths_lp[0] + hash_offset_widths_lp[1] + hash_offset_widths_lp[2];
 
@@ -43,7 +39,6 @@ module bp_me_dram_hash_encode
      ,encoded_bits
      ,daddr_i[0+:hash_offset_widths_lp[0]]
      };
-  assign bank_o = (l2_banks_p > 1) ? daddr_i[l2_bank_offset_width_lp+:lg_l2_banks_lp] : '0;
 
 endmodule
 

--- a/bp_me/src/v/dev/bp_me_dram_hash_encode.sv
+++ b/bp_me/src/v/dev/bp_me_dram_hash_encode.sv
@@ -6,9 +6,8 @@
  *   This module swizzles bits in an address, primarily to enable uniform access to L2/memory
  *   in a BlackParrot multicore.
  *
- *   Encode takes an address of form {A, b...bb, c...cc, D} and outputs
- *   address of {A, c...cc, b...bb, D}. The bit widths of b and c bits may differ and are
- *   specified by the offset_widths_p parameter.
+ *   IN:  [ taghi ][         taglo        ][     indexhi     ][ bank ][ slice ][ cce ][ block ]
+ *   OUT: [ taghi ][ bank ][ slice ][ cce ][         taglo         ][     indexhi    ][ block ]
  *
  */
 
@@ -18,27 +17,35 @@ module bp_me_dram_hash_encode
  import bp_common_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
+   , localparam lg_num_cce_lp   = `BSG_SAFE_CLOG2(num_cce_p)
+   , localparam lg_l2_slices_lp = `BSG_SAFE_CLOG2(l2_slices_p)
+   , localparam lg_l2_banks_lp  = `BSG_SAFE_CLOG2(l2_banks_p)
    )
-  (input [daddr_width_p-1:0]           daddr_i
-   , output logic [daddr_width_p-1:0]  daddr_o
+  (input [daddr_width_p-1:0]            daddr_i
+   , output logic [daddr_width_p-1:0]   daddr_o
+   , output logic [lg_num_cce_lp-1:0]   cce_o
+   , output logic [lg_l2_slices_lp-1:0] slice_o
+   , output logic [lg_l2_banks_lp-1:0]  bank_o
    );
 
   localparam l2_block_offset_width_lp = `BSG_SAFE_CLOG2(l2_block_width_p/8);
-  localparam lg_l2_sets_lp            = `BSG_SAFE_CLOG2(l2_sets_p);
-  localparam lg_num_cce_lp            = `BSG_SAFE_CLOG2(num_cce_p);
-  localparam int hash_offset_widths_lp[2:0] = '{(lg_l2_sets_lp-lg_num_cce_lp), lg_num_cce_lp, l2_block_offset_width_lp};
-  localparam offset_width_lp = hash_offset_widths_lp[0] + hash_offset_widths_lp[1] + hash_offset_widths_lp[2];
+  localparam l2_tag_offset_width_lp   = `BSG_SAFE_CLOG2(l2_block_width_p*l2_sets_p/8);
+  localparam l2_hash_offset_width_lp  = lg_num_cce_lp + lg_l2_slices_lp + lg_l2_banks_lp;
+  localparam l2_indexhi_width_lp = `BSG_SAFE_CLOG2(l2_sets_p) - l2_hash_offset_width_lp;
+  localparam l2_taghi_width_lp = daddr_width_p - l2_tag_offset_width_lp - l2_hash_offset_width_lp;
 
-  wire [hash_offset_widths_lp[2]+hash_offset_widths_lp[1]-1:0] encoded_bits =
-    {daddr_i[hash_offset_widths_lp[0]+:hash_offset_widths_lp[1]]
-     ,daddr_i[(hash_offset_widths_lp[0]+hash_offset_widths_lp[1])+:hash_offset_widths_lp[2]]
-     };
+  wire [l2_block_offset_width_lp-1:0] block = daddr_i[0+:l2_block_offset_width_lp];
+  wire [lg_num_cce_lp-1:0]              cce = daddr_i[l2_block_offset_width_lp+:lg_num_cce_lp];
+  wire [lg_l2_slices_lp-1:0]          slice = daddr_i[l2_block_offset_width_lp+lg_num_cce_lp+:lg_l2_slices_lp];
+  wire [lg_l2_banks_lp-1:0]            bank = daddr_i[l2_block_offset_width_lp+lg_num_cce_lp+lg_l2_slices_lp+:lg_l2_banks_lp];
+  wire [l2_indexhi_width_lp-1:0]    indexhi = daddr_i[l2_block_offset_width_lp+l2_hash_offset_width_lp+:l2_indexhi_width_lp];
+  wire [l2_hash_offset_width_lp-1:0]  taglo = daddr_i[l2_tag_offset_width_lp+:l2_hash_offset_width_lp];
+  wire [l2_taghi_width_lp-1:0]        taghi = daddr_i[daddr_width_p-1-:l2_taghi_width_lp];
 
-  assign daddr_o =
-    {daddr_i[daddr_width_p-1:offset_width_lp]
-     ,encoded_bits
-     ,daddr_i[0+:hash_offset_widths_lp[0]]
-     };
+  assign daddr_o = {taghi, bank, slice, cce, taglo, indexhi, block};
+  assign cce_o   = (num_cce_p   > 1) ? cce   : '0;
+  assign slice_o = (l2_slices_p > 1) ? slice : '0;
+  assign bank_o  = (l2_banks_p  > 1) ? bank  : '0;
 
 endmodule
 

--- a/bp_me/test/common/bp_nonsynth_dram.sv
+++ b/bp_me/test/common/bp_nonsynth_dram.sv
@@ -41,27 +41,6 @@ module bp_nonsynth_dram
    , input                                                  dram_reset_i
    );
 
-  `declare_bsg_cache_dma_pkt_s(daddr_width_p, l2_block_size_in_words_p);
-  bsg_cache_dma_pkt_s [num_dma_p-1:0] dma_pkt_li, dma_pkt;
-  assign dma_pkt_li = dma_pkt_i;
-  // Unswizzle the dram
-  for (genvar i = 0; i < num_dma_p; i++)
-    begin : address_hash
-      logic [daddr_width_p-1:0] daddr_lo;
-      bp_me_dram_hash_decode
-       #(.bp_params_p(bp_params_p))
-        dma_addr_hash
-        (.daddr_i(dma_pkt_li[i].addr)
-         ,.daddr_o(daddr_lo)
-         );
-
-      always_comb
-        begin
-          dma_pkt[i] = dma_pkt_li[i];
-          dma_pkt[i].addr = daddr_lo;
-        end
-    end
-
   if (dram_type_p == "dmc")
     begin : ddr
       bp_ddr
@@ -70,7 +49,7 @@ module bp_nonsynth_dram
         (.clk_i(clk_i)
          ,.reset_i(reset_i)
 
-         ,.dma_pkt_i(dma_pkt)
+         ,.dma_pkt_i(dma_pkt_i)
          ,.dma_pkt_v_i(dma_pkt_v_i)
          ,.dma_pkt_yumi_o(dma_pkt_yumi_o)
 
@@ -123,7 +102,7 @@ module bp_nonsynth_dram
         (.core_clk_i(clk_i)
          ,.core_reset_i(reset_i)
 
-         ,.dma_pkt_i(dma_pkt)
+         ,.dma_pkt_i(dma_pkt_i)
          ,.dma_pkt_v_i(dma_pkt_v_i)
          ,.dma_pkt_yumi_o(dma_pkt_yumi_o)
 
@@ -282,7 +261,7 @@ module bp_nonsynth_dram
         (.clk_i(clk_i)
          ,.reset_i(reset_i)
 
-         ,.dma_pkt_i(dma_pkt)
+         ,.dma_pkt_i(dma_pkt_i)
          ,.dma_pkt_v_i(dma_pkt_v_i)
          ,.dma_pkt_yumi_o(dma_pkt_yumi_o)
 

--- a/bp_me/test/common/bp_nonsynth_mem.sv
+++ b/bp_me/test/common/bp_nonsynth_mem.sv
@@ -45,7 +45,7 @@ module bp_nonsynth_mem
   logic [l2_banks_p-1:0] dma_data_v_lo, dma_data_yumi_li;
   bp_me_cache_slice
    #(.bp_params_p(bp_params_p))
-   cce_to_cache
+   l2s
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 

--- a/bp_me/test/tb/bp_cce/flist.vcs
+++ b/bp_me/test/tb/bp_cce/flist.vcs
@@ -15,7 +15,7 @@ $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_dpi_clock_gen.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_dpi_clock_gen.cpp
 $BASEJUMP_STL_DIR/bsg_test/bsg_nonsynth_test_rom.v
 $BASEJUMP_STL_DIR/bsg_test/bsg_trace_replay.v
-$BP_ME_DIR/src/v/dev/bp_me_cce_to_cache.sv
+$BP_ME_DIR/src/v/dev/bp_me_cache_controller.sv
 $BP_ME_DIR/src/v/dev/bp_me_dram_hash_decode.sv
 $BP_ME_DIR/src/v/dev/bp_me_dram_hash_encode.sv
 $BP_ME_DIR/test/common/bp_me_nonsynth_pkg.sv

--- a/bp_top/src/v/bp_l2e_tile.sv
+++ b/bp_top/src/v/bp_l2e_tile.sv
@@ -33,7 +33,7 @@ module bp_l2e_tile
    , input                                                    reset_i
 
    // Memory side connection
-   , input [mem_noc_did_width_p-1:0]                           my_did_i
+   , input [mem_noc_did_width_p-1:0]                          my_did_i
    , input [coh_noc_cord_width_p-1:0]                         my_cord_i
 
    , input [coh_noc_ral_link_width_lp-1:0]                    lce_req_link_i

--- a/bp_top/src/v/bp_l2e_tile_node.sv
+++ b/bp_top/src/v/bp_l2e_tile_node.sv
@@ -24,7 +24,7 @@ module bp_l2e_tile_node
    , input                                             dma_clk_i
    , input                                             dma_reset_i
 
-   , input [mem_noc_did_width_p-1:0]                    my_did_i
+   , input [mem_noc_did_width_p-1:0]                   my_did_i
    , input [coh_noc_cord_width_p-1:0]                  my_cord_i
 
    , input [S:W][coh_noc_ral_link_width_lp-1:0]        coh_lce_req_link_i

--- a/bp_top/src/v/bp_multicore.sv
+++ b/bp_top/src/v/bp_multicore.sv
@@ -35,14 +35,14 @@ module bp_multicore
    , input                                                             dma_clk_i
    , input                                                             dma_reset_i
 
-   , input [mem_noc_did_width_p-1:0]                                    my_did_i
-   , input [mem_noc_did_width_p-1:0]                                    host_did_i
+   , input [mem_noc_did_width_p-1:0]                                   my_did_i
+   , input [mem_noc_did_width_p-1:0]                                   host_did_i
 
-   , input [E:W][mem_noc_ral_link_width_lp-1:0]                         mem_fwd_link_i
-   , output logic [E:W][mem_noc_ral_link_width_lp-1:0]                  mem_fwd_link_o
+   , input [E:W][mem_noc_ral_link_width_lp-1:0]                        mem_fwd_link_i
+   , output logic [E:W][mem_noc_ral_link_width_lp-1:0]                 mem_fwd_link_o
 
-   , input [E:W][mem_noc_ral_link_width_lp-1:0]                         mem_rev_link_i
-   , output logic [E:W][mem_noc_ral_link_width_lp-1:0]                  mem_rev_link_o
+   , input [E:W][mem_noc_ral_link_width_lp-1:0]                        mem_rev_link_i
+   , output logic [E:W][mem_noc_ral_link_width_lp-1:0]                 mem_rev_link_o
 
    , output logic [S:N][mc_x_dim_p-1:0][dma_noc_ral_link_width_lp-1:0] dma_link_o
    , input [S:N][mc_x_dim_p-1:0][dma_noc_ral_link_width_lp-1:0]        dma_link_i

--- a/bp_top/src/v/bp_processor.sv
+++ b/bp_top/src/v/bp_processor.sv
@@ -51,17 +51,17 @@ module bp_processor
    , input                                                              mem_rev_ready_and_i
 
    // DRAM interface
-   , output logic [num_cce_p-1:0][l2_banks_p-1:0][dma_pkt_width_lp-1:0] dma_pkt_o
-   , output logic [num_cce_p-1:0][l2_banks_p-1:0]                       dma_pkt_v_o
-   , input [num_cce_p-1:0][l2_banks_p-1:0]                              dma_pkt_ready_and_i
+   , output logic [num_cce_p-1:0][l2_dmas_p-1:0][dma_pkt_width_lp-1:0]  dma_pkt_o
+   , output logic [num_cce_p-1:0][l2_dmas_p-1:0]                        dma_pkt_v_o
+   , input [num_cce_p-1:0][l2_dmas_p-1:0]                               dma_pkt_ready_and_i
 
-   , input [num_cce_p-1:0][l2_banks_p-1:0][l2_fill_width_p-1:0]         dma_data_i
-   , input [num_cce_p-1:0][l2_banks_p-1:0]                              dma_data_v_i
-   , output logic [num_cce_p-1:0][l2_banks_p-1:0]                       dma_data_ready_and_o
+   , input [num_cce_p-1:0][l2_dmas_p-1:0][l2_fill_width_p-1:0]          dma_data_i
+   , input [num_cce_p-1:0][l2_dmas_p-1:0]                               dma_data_v_i
+   , output logic [num_cce_p-1:0][l2_dmas_p-1:0]                        dma_data_ready_and_o
 
-   , output logic [num_cce_p-1:0][l2_banks_p-1:0][l2_fill_width_p-1:0]  dma_data_o
-   , output logic [num_cce_p-1:0][l2_banks_p-1:0]                       dma_data_v_o
-   , input [num_cce_p-1:0][l2_banks_p-1:0]                              dma_data_ready_and_i
+   , output logic [num_cce_p-1:0][l2_dmas_p-1:0][l2_fill_width_p-1:0]   dma_data_o
+   , output logic [num_cce_p-1:0][l2_dmas_p-1:0]                        dma_data_v_o
+   , input [num_cce_p-1:0][l2_dmas_p-1:0]                               dma_data_ready_and_i
    );
 
   if (cce_type_p != e_cce_uce)
@@ -226,7 +226,7 @@ module bp_processor
 
       import bsg_cache_pkg::*;
       `declare_bsg_cache_wh_header_flit_s(dma_noc_flit_width_p, dma_noc_cord_width_p, dma_noc_len_width_p, dma_noc_cid_width_p);
-      localparam dma_per_col_lp = num_cce_p/mc_x_dim_p*l2_banks_p;
+      localparam dma_per_col_lp = num_cce_p/mc_x_dim_p*l2_dmas_p;
       logic [mc_x_dim_p-1:0][dma_per_col_lp-1:0][dma_pkt_width_lp-1:0] dma_pkt_lo;
       logic [mc_x_dim_p-1:0][dma_per_col_lp-1:0] dma_pkt_v_lo, dma_pkt_yumi_li;
       logic [mc_x_dim_p-1:0][dma_per_col_lp-1:0][l2_fill_width_p-1:0] dma_data_lo;
@@ -238,7 +238,7 @@ module bp_processor
           bsg_cache_wh_header_flit_s header_flit;
           assign header_flit = dma_link_lo[S][i].data;
           wire [`BSG_SAFE_CLOG2(dma_per_col_lp)-1:0] dma_id_li =
-            l2_banks_p*(header_flit.src_cord-1)+header_flit.src_cid;
+            l2_dmas_p*(header_flit.src_cord-1)+header_flit.src_cid;
           bsg_wormhole_to_cache_dma_fanout
            #(.wh_flit_width_p(dma_noc_flit_width_p)
              ,.wh_cid_width_p(dma_noc_cid_width_p)
@@ -275,10 +275,10 @@ module bp_processor
       // Transpose the DMA IDs
       for (genvar i = 0; i < num_cce_p; i++)
         begin : rof1
-          for (genvar j = 0; j < l2_banks_p; j++)
+          for (genvar j = 0; j < l2_dmas_p; j++)
             begin : rof2
               localparam col_lp     = i%mc_x_dim_p;
-              localparam col_pos_lp = (i/mc_x_dim_p)*l2_banks_p+j;
+              localparam col_pos_lp = (i/mc_x_dim_p)*l2_dmas_p+j;
 
               assign dma_pkt_o[i][j] = dma_pkt_lo[col_lp][col_pos_lp];
               assign dma_pkt_v_o[i][j] = dma_pkt_v_lo[col_lp][col_pos_lp];

--- a/bp_top/src/v/bp_unicore.sv
+++ b/bp_top/src/v/bp_unicore.sv
@@ -32,48 +32,48 @@ module bp_unicore
 
    , localparam dma_pkt_width_lp = `bsg_cache_dma_pkt_width(daddr_width_p, l2_block_size_in_words_p)
    )
-  (input                                                 clk_i
-   , input                                               rt_clk_i
-   , input                                               reset_i
+  (input                                                                  clk_i
+   , input                                                                rt_clk_i
+   , input                                                                reset_i
 
-   , input [mem_noc_did_width_p-1:0]                     my_did_i
-   , input [mem_noc_did_width_p-1:0]                     host_did_i
-   , input [coh_noc_cord_width_p-1:0]                    my_cord_i
+   , input [mem_noc_did_width_p-1:0]                                      my_did_i
+   , input [mem_noc_did_width_p-1:0]                                      host_did_i
+   , input [coh_noc_cord_width_p-1:0]                                     my_cord_i
 
    // Outgoing I/O
-   , output logic [mem_fwd_header_width_lp-1:0]          mem_fwd_header_o
-   , output logic [bedrock_fill_width_p-1:0]             mem_fwd_data_o
-   , output logic                                        mem_fwd_v_o
-   , input                                               mem_fwd_ready_and_i
+   , output logic [mem_fwd_header_width_lp-1:0]                           mem_fwd_header_o
+   , output logic [bedrock_fill_width_p-1:0]                              mem_fwd_data_o
+   , output logic                                                         mem_fwd_v_o
+   , input                                                                mem_fwd_ready_and_i
 
-   , input [mem_rev_header_width_lp-1:0]                 mem_rev_header_i
-   , input [bedrock_fill_width_p-1:0]                    mem_rev_data_i
-   , input                                               mem_rev_v_i
-   , output logic                                        mem_rev_ready_and_o
+   , input [mem_rev_header_width_lp-1:0]                                  mem_rev_header_i
+   , input [bedrock_fill_width_p-1:0]                                     mem_rev_data_i
+   , input                                                                mem_rev_v_i
+   , output logic                                                         mem_rev_ready_and_o
 
    // Incoming I/O
-   , input [mem_fwd_header_width_lp-1:0]                 mem_fwd_header_i
-   , input [bedrock_fill_width_p-1:0]                    mem_fwd_data_i
-   , input                                               mem_fwd_v_i
-   , output logic                                        mem_fwd_ready_and_o
+   , input [mem_fwd_header_width_lp-1:0]                                  mem_fwd_header_i
+   , input [bedrock_fill_width_p-1:0]                                     mem_fwd_data_i
+   , input                                                                mem_fwd_v_i
+   , output logic                                                         mem_fwd_ready_and_o
 
-   , output logic [mem_rev_header_width_lp-1:0]          mem_rev_header_o
-   , output logic [bedrock_fill_width_p-1:0]             mem_rev_data_o
-   , output logic                                        mem_rev_v_o
-   , input                                               mem_rev_ready_and_i
+   , output logic [mem_rev_header_width_lp-1:0]                           mem_rev_header_o
+   , output logic [bedrock_fill_width_p-1:0]                              mem_rev_data_o
+   , output logic                                                         mem_rev_v_o
+   , input                                                                mem_rev_ready_and_i
 
    // DRAM interface
-   , output logic [l2_banks_p-1:0][dma_pkt_width_lp-1:0] dma_pkt_o
-   , output logic [l2_banks_p-1:0]                       dma_pkt_v_o
-   , input [l2_banks_p-1:0]                              dma_pkt_ready_and_i
+   , output logic [l2_slices_p-1:0][l2_banks_p-1:0][dma_pkt_width_lp-1:0] dma_pkt_o
+   , output logic [l2_slices_p-1:0][l2_banks_p-1:0]                       dma_pkt_v_o
+   , input [l2_slices_p-1:0][l2_banks_p-1:0]                              dma_pkt_ready_and_i
 
-   , input [l2_banks_p-1:0][l2_fill_width_p-1:0]         dma_data_i
-   , input [l2_banks_p-1:0]                              dma_data_v_i
-   , output logic [l2_banks_p-1:0]                       dma_data_ready_and_o
+   , input [l2_slices_p-1:0][l2_banks_p-1:0][l2_fill_width_p-1:0]         dma_data_i
+   , input [l2_slices_p-1:0][l2_banks_p-1:0]                              dma_data_v_i
+   , output logic [l2_slices_p-1:0][l2_banks_p-1:0]                       dma_data_ready_and_o
 
-   , output logic [l2_banks_p-1:0][l2_fill_width_p-1:0]  dma_data_o
-   , output logic [l2_banks_p-1:0]                       dma_data_v_o
-   , input [l2_banks_p-1:0]                              dma_data_ready_and_i
+   , output logic [l2_slices_p-1:0][l2_banks_p-1:0][l2_fill_width_p-1:0]  dma_data_o
+   , output logic [l2_slices_p-1:0][l2_banks_p-1:0]                       dma_data_v_o
+   , input [l2_slices_p-1:0][l2_banks_p-1:0]                              dma_data_ready_and_i
    );
 
   `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
@@ -94,7 +94,7 @@ module bp_unicore
   localparam cfg_dev_id_lp      =                      0;
   localparam clint_dev_id_lp    = cfg_dev_id_lp      + 1;
   localparam l2s_dev_base_id_lp = clint_dev_id_lp    + 1;
-  localparam io_dev_id_lp       = l2s_dev_base_id_lp + l2_banks_p;
+  localparam io_dev_id_lp       = l2s_dev_base_id_lp + l2_slices_p;
   localparam loopback_dev_id_lp = io_dev_id_lp       + 1;
   localparam num_dev_lp         = loopback_dev_id_lp + 1;
   localparam lg_num_dev_lp      = `BSG_SAFE_CLOG2(num_dev_lp);
@@ -172,25 +172,31 @@ module bp_unicore
       wire is_l2s_fwd       = ~is_local & ~is_io_fwd;
       wire is_loopback_fwd = ~is_cfg_fwd & ~is_clint_fwd & ~is_io_fwd & ~is_l2s_fwd;
 
-      localparam l2_block_offset_width_lp = `BSG_SAFE_CLOG2(l2_block_width_p/8);
-      localparam lg_l2_sets_lp            = `BSG_SAFE_CLOG2(l2_sets_p);
-      localparam lg_num_cce_lp            = `BSG_SAFE_CLOG2(num_cce_p);
-      localparam lg_l2_banks_lp           = `BSG_SAFE_CLOG2(l2_banks_p);
-      localparam l2_bank_offset_width_lp  = (num_cce_p > 1) ? l2_block_offset_width_lp+lg_num_cce_lp : l2_block_offset_width_lp;
-      logic [l2_banks_p-1:0] is_l2s_bank_fwd;
-      wire [lg_l2_banks_lp-1:0] bank_id = (l2_banks_p > 1) ? local_addr[l2_bank_offset_width_lp+:lg_l2_banks_lp] : '0;
+      localparam lg_l2_slices_lp = `BSG_SAFE_CLOG2(l2_slices_p);
+      logic [lg_l2_slices_lp-1:0] slice_id;
+      bp_me_dram_hash_encode
+       #(.bp_params_p(bp_params_p))
+       slice_select
+        (.daddr_i(local_addr[0+:daddr_width_p])
+         ,.daddr_o()
+         ,.cce_o()
+         ,.slice_o(slice_id)
+         ,.bank_o()
+         );
+
+      logic [l2_slices_p-1:0] is_l2s_slice_fwd;
       bsg_decode_with_v
-       #(.num_out_p(l2_banks_p))
-       bank_decode
-        (.i(bank_id)
+       #(.num_out_p(l2_slices_p))
+       slice_decode
+        (.i(slice_id)
          ,.v_i(is_l2s_fwd)
-         ,.o(is_l2s_bank_fwd)
+         ,.o(is_l2s_slice_fwd)
          );
 
       wire [num_dev_lp-1:0] proc_fwd_dst_sel =
         (is_cfg_fwd << cfg_dev_id_lp)
         | (is_clint_fwd << clint_dev_id_lp) 
-        | (is_l2s_bank_fwd << l2s_dev_base_id_lp) 
+        | (is_l2s_slice_fwd << l2s_dev_base_id_lp) 
         | (is_io_fwd << io_dev_id_lp) 
         | (is_loopback_fwd << loopback_dev_id_lp);
 
@@ -312,8 +318,8 @@ module bp_unicore
      ,.s_external_irq_o(s_external_irq_li)
      );
 
-  for (genvar i = 0; i < l2_banks_p; i++)
-    begin : bank
+  for (genvar i = 0; i < l2_slices_p; i++)
+    begin : slices
       bp_me_cache_slice
        #(.bp_params_p(bp_params_p))
        l2s

--- a/bp_top/src/v/bp_unicore.sv
+++ b/bp_top/src/v/bp_unicore.sv
@@ -6,11 +6,6 @@
  * Description:
  *   This is the top level module for a unicore BlackParrot processor.
  *
- *   The unicore contains:
- *   - a BlackParrot processor core and devices (config, clint, CCE loopback) in bp_unicore_lite
- *   - L2 cache slice in bsg_cache
- *   - core to cache adapter in bp_me_cce_to_cache
- *
  */
 
 `include "bp_common_defines.svh"
@@ -84,20 +79,25 @@ module bp_unicore
   `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
   `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, daddr_width_p);
-  `bp_cast_o(bp_bedrock_mem_fwd_header_s, mem_fwd_header);
-  `bp_cast_i(bp_bedrock_mem_rev_header_s, mem_rev_header);
-  `bp_cast_i(bp_bedrock_mem_fwd_header_s, mem_fwd_header);
-  `bp_cast_o(bp_bedrock_mem_rev_header_s, mem_rev_header);
 
   // Reset
   logic reset_r;
   always_ff @(posedge clk_i)
     reset_r <= reset_i;
 
-  localparam num_proc_lp = 3;
-  localparam num_dev_lp  = 5;
-  localparam lg_num_proc_lp = `BSG_SAFE_CLOG2(num_proc_lp);
-  localparam lg_num_dev_lp = `BSG_SAFE_CLOG2(num_dev_lp);
+  localparam icache_proc_id_lp =                     0;
+  localparam dcache_proc_id_lp = icache_proc_id_lp + 1;
+  localparam io_proc_id_lp     = dcache_proc_id_lp + 1;
+  localparam num_proc_lp       = io_proc_id_lp     + 1;
+  localparam lg_num_proc_lp    = `BSG_SAFE_CLOG2(num_proc_lp);
+
+  localparam cfg_dev_id_lp      =                      0;
+  localparam clint_dev_id_lp    = cfg_dev_id_lp      + 1;
+  localparam l2s_dev_base_id_lp = clint_dev_id_lp    + 1;
+  localparam io_dev_id_lp       = l2s_dev_base_id_lp + l2_banks_p;
+  localparam loopback_dev_id_lp = io_dev_id_lp       + 1;
+  localparam num_dev_lp         = loopback_dev_id_lp + 1;
+  localparam lg_num_dev_lp      = `BSG_SAFE_CLOG2(num_dev_lp);
 
   // {IO, BE UCE, FE UCE}
   bp_bedrock_mem_fwd_header_s [num_proc_lp-1:0] proc_fwd_header_lo;
@@ -124,15 +124,15 @@ module bp_unicore
      ,.reset_i(reset_r)
      ,.cfg_bus_i(cfg_bus_lo)
 
-     ,.mem_fwd_header_o(proc_fwd_header_lo[0+:2])
-     ,.mem_fwd_data_o(proc_fwd_data_lo[0+:2])
-     ,.mem_fwd_v_o(proc_fwd_v_lo[0+:2])
-     ,.mem_fwd_ready_and_i(proc_fwd_ready_and_li[0+:2])
+     ,.mem_fwd_header_o({proc_fwd_header_lo[dcache_proc_id_lp], proc_fwd_header_lo[icache_proc_id_lp]})
+     ,.mem_fwd_data_o({proc_fwd_data_lo[dcache_proc_id_lp], proc_fwd_data_lo[icache_proc_id_lp]})
+     ,.mem_fwd_v_o({proc_fwd_v_lo[dcache_proc_id_lp], proc_fwd_v_lo[icache_proc_id_lp]})
+     ,.mem_fwd_ready_and_i({proc_fwd_ready_and_li[dcache_proc_id_lp], proc_fwd_ready_and_li[icache_proc_id_lp]})
 
-     ,.mem_rev_header_i(proc_rev_header_li[0+:2])
-     ,.mem_rev_data_i(proc_rev_data_li[0+:2])
-     ,.mem_rev_v_i(proc_rev_v_li[0+:2])
-     ,.mem_rev_ready_and_o(proc_rev_ready_and_lo[0+:2])
+     ,.mem_rev_header_i({proc_rev_header_li[dcache_proc_id_lp], proc_rev_header_li[icache_proc_id_lp]})
+     ,.mem_rev_data_i({proc_rev_data_li[dcache_proc_id_lp], proc_rev_data_li[icache_proc_id_lp]})
+     ,.mem_rev_v_i({proc_rev_v_li[dcache_proc_id_lp], proc_rev_v_li[icache_proc_id_lp]})
+     ,.mem_rev_ready_and_o({proc_rev_ready_and_lo[dcache_proc_id_lp], proc_rev_ready_and_lo[icache_proc_id_lp]})
 
      ,.debug_irq_i(debug_irq_li)
      ,.timer_irq_i(timer_irq_li)
@@ -142,15 +142,15 @@ module bp_unicore
      );
 
   // Assign incoming I/O as basically another UCE interface
-  assign proc_fwd_header_lo[2] = mem_fwd_header_cast_i;
-  assign proc_fwd_data_lo[2] = mem_fwd_data_i;
-  assign proc_fwd_v_lo[2] = mem_fwd_v_i;
-  assign mem_fwd_ready_and_o = proc_fwd_ready_and_li[2];
+  assign proc_fwd_header_lo[io_proc_id_lp] = mem_fwd_header_i;
+  assign proc_fwd_data_lo[io_proc_id_lp] = mem_fwd_data_i;
+  assign proc_fwd_v_lo[io_proc_id_lp] = mem_fwd_v_i;
+  assign mem_fwd_ready_and_o = proc_fwd_ready_and_li[io_proc_id_lp];
 
-  assign mem_rev_header_cast_o = proc_rev_header_li[2];
-  assign mem_rev_data_o = proc_rev_data_li[2];
-  assign mem_rev_v_o = proc_rev_v_li[2];
-  assign proc_rev_ready_and_lo[2] = mem_rev_ready_and_i;
+  assign mem_rev_header_o = proc_rev_header_li[io_proc_id_lp];
+  assign mem_rev_data_o = proc_rev_data_li[io_proc_id_lp];
+  assign mem_rev_v_o = proc_rev_v_li[io_proc_id_lp];
+  assign proc_rev_ready_and_lo[io_proc_id_lp] = mem_rev_ready_and_i;
 
   // Select destination of commands
   logic [num_proc_lp-1:0][lg_num_dev_lp-1:0] proc_fwd_dst_lo;
@@ -162,33 +162,52 @@ module bp_unicore
       wire is_local        = (proc_fwd_header_lo[i].addr < dram_base_addr_gp);
       wire is_my_core      = is_local & (local_addr.tile == cfg_bus_lo.core_id);
       wire is_other_core   = is_local & (local_addr.tile != cfg_bus_lo.core_id);
-      wire is_other_hio    = (proc_fwd_header_lo[i].addr[paddr_width_p-1-:hio_width_p] != 0);
+      wire is_other_hio    = (local_addr[paddr_width_p-1-:hio_width_p] != 0);
 
       wire is_cfg_fwd      = is_my_core & is_local & (device_fwd_li == cfg_dev_gp);
       wire is_clint_fwd    = is_my_core & is_local & (device_fwd_li == clint_dev_gp);
-      wire is_cache_fwd    = is_my_core & is_local & (device_fwd_li == cache_dev_gp);
       wire is_host_fwd     = is_my_core & is_local & (device_fwd_li == host_dev_gp);
 
       wire is_io_fwd       = is_host_fwd | is_other_hio | is_other_core;
-      wire is_l2_fwd       = is_cache_fwd | (~is_local & ~is_io_fwd);
-      wire is_loopback_fwd = ~is_cfg_fwd & ~is_clint_fwd & ~is_io_fwd & ~is_l2_fwd;
+      wire is_l2s_fwd       = ~is_local & ~is_io_fwd;
+      wire is_loopback_fwd = ~is_cfg_fwd & ~is_clint_fwd & ~is_io_fwd & ~is_l2s_fwd;
+
+      localparam l2_block_offset_width_lp = `BSG_SAFE_CLOG2(l2_block_width_p/8);
+      localparam lg_l2_sets_lp            = `BSG_SAFE_CLOG2(l2_sets_p);
+      localparam lg_num_cce_lp            = `BSG_SAFE_CLOG2(num_cce_p);
+      localparam lg_l2_banks_lp           = `BSG_SAFE_CLOG2(l2_banks_p);
+      localparam l2_bank_offset_width_lp  = (num_cce_p > 1) ? l2_block_offset_width_lp+lg_num_cce_lp : l2_block_offset_width_lp;
+      logic [l2_banks_p-1:0] is_l2s_bank_fwd;
+      wire [lg_l2_banks_lp-1:0] bank_id = (l2_banks_p > 1) ? local_addr[l2_bank_offset_width_lp+:lg_l2_banks_lp] : '0;
+      bsg_decode_with_v
+       #(.num_out_p(l2_banks_p))
+       bank_decode
+        (.i(bank_id)
+         ,.v_i(is_l2s_fwd)
+         ,.o(is_l2s_bank_fwd)
+         );
+
+      wire [num_dev_lp-1:0] proc_fwd_dst_sel =
+        (is_cfg_fwd << cfg_dev_id_lp)
+        | (is_clint_fwd << clint_dev_id_lp) 
+        | (is_l2s_bank_fwd << l2s_dev_base_id_lp) 
+        | (is_io_fwd << io_dev_id_lp) 
+        | (is_loopback_fwd << loopback_dev_id_lp);
 
       bsg_encode_one_hot
        #(.width_p(num_dev_lp), .lo_to_hi_p(1))
        fwd_pe
-        (.i({is_loopback_fwd, is_io_fwd, is_l2_fwd, is_clint_fwd, is_cfg_fwd})
+        (.i(proc_fwd_dst_sel)
          ,.addr_o(proc_fwd_dst_lo[i])
          ,.v_o()
          );
     end
 
-  // Select destination of responses. Were there a way to transpose structs...
   logic [num_dev_lp-1:0][lg_num_proc_lp-1:0] dev_rev_dst_lo;
-  assign dev_rev_dst_lo[4] = dev_rev_header_lo[4].payload.lce_id[0+:lg_num_proc_lp];
-  assign dev_rev_dst_lo[3] = dev_rev_header_lo[3].payload.lce_id[0+:lg_num_proc_lp];
-  assign dev_rev_dst_lo[2] = dev_rev_header_lo[2].payload.lce_id[0+:lg_num_proc_lp];
-  assign dev_rev_dst_lo[1] = dev_rev_header_lo[1].payload.lce_id[0+:lg_num_proc_lp];
-  assign dev_rev_dst_lo[0] = dev_rev_header_lo[0].payload.lce_id[0+:lg_num_proc_lp];
+  for (genvar i = 0; i < num_dev_lp; i++)
+    begin : dev_lce_id
+      assign dev_rev_dst_lo[i] = dev_rev_header_lo[i].payload.lce_id[0+:lg_num_proc_lp];
+    end
 
   bp_me_xbar_stream
    #(.bp_params_p(bp_params_p)
@@ -246,15 +265,15 @@ module bp_unicore
     (.clk_i(clk_i)
      ,.reset_i(reset_r)
 
-     ,.mem_fwd_header_i(dev_fwd_header_li[0])
-     ,.mem_fwd_data_i(dev_fwd_data_li[0])
-     ,.mem_fwd_v_i(dev_fwd_v_li[0])
-     ,.mem_fwd_ready_and_o(dev_fwd_ready_and_lo[0])
+     ,.mem_fwd_header_i(dev_fwd_header_li[cfg_dev_id_lp])
+     ,.mem_fwd_data_i(dev_fwd_data_li[cfg_dev_id_lp])
+     ,.mem_fwd_v_i(dev_fwd_v_li[cfg_dev_id_lp])
+     ,.mem_fwd_ready_and_o(dev_fwd_ready_and_lo[cfg_dev_id_lp])
 
-     ,.mem_rev_header_o(dev_rev_header_lo[0])
-     ,.mem_rev_data_o(dev_rev_data_lo[0])
-     ,.mem_rev_v_o(dev_rev_v_lo[0])
-     ,.mem_rev_ready_and_i(dev_rev_ready_and_li[0])
+     ,.mem_rev_header_o(dev_rev_header_lo[cfg_dev_id_lp])
+     ,.mem_rev_data_o(dev_rev_data_lo[cfg_dev_id_lp])
+     ,.mem_rev_v_o(dev_rev_v_lo[cfg_dev_id_lp])
+     ,.mem_rev_ready_and_i(dev_rev_ready_and_li[cfg_dev_id_lp])
 
      ,.cfg_bus_o(cfg_bus_lo)
      ,.did_i(my_did_i)
@@ -276,15 +295,15 @@ module bp_unicore
      ,.reset_i(reset_r)
      ,.cfg_bus_i(cfg_bus_lo)
 
-     ,.mem_fwd_header_i(dev_fwd_header_li[1])
-     ,.mem_fwd_data_i(dev_fwd_data_li[1])
-     ,.mem_fwd_v_i(dev_fwd_v_li[1])
-     ,.mem_fwd_ready_and_o(dev_fwd_ready_and_lo[1])
+     ,.mem_fwd_header_i(dev_fwd_header_li[clint_dev_id_lp])
+     ,.mem_fwd_data_i(dev_fwd_data_li[clint_dev_id_lp])
+     ,.mem_fwd_v_i(dev_fwd_v_li[clint_dev_id_lp])
+     ,.mem_fwd_ready_and_o(dev_fwd_ready_and_lo[clint_dev_id_lp])
 
-     ,.mem_rev_header_o(dev_rev_header_lo[1])
-     ,.mem_rev_data_o(dev_rev_data_lo[1])
-     ,.mem_rev_v_o(dev_rev_v_lo[1])
-     ,.mem_rev_ready_and_i(dev_rev_ready_and_li[1])
+     ,.mem_rev_header_o(dev_rev_header_lo[clint_dev_id_lp])
+     ,.mem_rev_data_o(dev_rev_data_lo[clint_dev_id_lp])
+     ,.mem_rev_v_o(dev_rev_v_lo[clint_dev_id_lp])
+     ,.mem_rev_ready_and_i(dev_rev_ready_and_li[clint_dev_id_lp])
 
      ,.debug_irq_o(debug_irq_li)
      ,.timer_irq_o(timer_irq_li)
@@ -293,45 +312,48 @@ module bp_unicore
      ,.s_external_irq_o(s_external_irq_li)
      );
 
-  bp_me_cache_slice
-   #(.bp_params_p(bp_params_p))
-   l2s
-    (.clk_i(clk_i)
-     ,.reset_i(reset_r)
+  for (genvar i = 0; i < l2_banks_p; i++)
+    begin : bank
+      bp_me_cache_slice
+       #(.bp_params_p(bp_params_p))
+       l2s
+        (.clk_i(clk_i)
+         ,.reset_i(reset_r)
 
-     ,.mem_fwd_header_i(dev_fwd_header_li[2])
-     ,.mem_fwd_data_i(dev_fwd_data_li[2])
-     ,.mem_fwd_v_i(dev_fwd_v_li[2])
-     ,.mem_fwd_ready_and_o(dev_fwd_ready_and_lo[2])
+         ,.mem_fwd_header_i(dev_fwd_header_li[l2s_dev_base_id_lp+i])
+         ,.mem_fwd_data_i(dev_fwd_data_li[l2s_dev_base_id_lp+i])
+         ,.mem_fwd_v_i(dev_fwd_v_li[l2s_dev_base_id_lp+i])
+         ,.mem_fwd_ready_and_o(dev_fwd_ready_and_lo[l2s_dev_base_id_lp+i])
 
-     ,.mem_rev_header_o(dev_rev_header_lo[2])
-     ,.mem_rev_data_o(dev_rev_data_lo[2])
-     ,.mem_rev_v_o(dev_rev_v_lo[2])
-     ,.mem_rev_ready_and_i(dev_rev_ready_and_li[2])
+         ,.mem_rev_header_o(dev_rev_header_lo[l2s_dev_base_id_lp+i])
+         ,.mem_rev_data_o(dev_rev_data_lo[l2s_dev_base_id_lp+i])
+         ,.mem_rev_v_o(dev_rev_v_lo[l2s_dev_base_id_lp+i])
+         ,.mem_rev_ready_and_i(dev_rev_ready_and_li[l2s_dev_base_id_lp+i])
 
-     ,.dma_pkt_o(dma_pkt_o)
-     ,.dma_pkt_v_o(dma_pkt_v_o)
-     ,.dma_pkt_ready_and_i(dma_pkt_ready_and_i)
+         ,.dma_pkt_o(dma_pkt_o[i])
+         ,.dma_pkt_v_o(dma_pkt_v_o[i])
+         ,.dma_pkt_ready_and_i(dma_pkt_ready_and_i[i])
 
-     ,.dma_data_i(dma_data_i)
-     ,.dma_data_v_i(dma_data_v_i)
-     ,.dma_data_ready_and_o(dma_data_ready_and_o)
+         ,.dma_data_i(dma_data_i[i])
+         ,.dma_data_v_i(dma_data_v_i[i])
+         ,.dma_data_ready_and_o(dma_data_ready_and_o[i])
 
-     ,.dma_data_o(dma_data_o)
-     ,.dma_data_v_o(dma_data_v_o)
-     ,.dma_data_ready_and_i(dma_data_ready_and_i)
-     );
+         ,.dma_data_o(dma_data_o[i])
+         ,.dma_data_v_o(dma_data_v_o[i])
+         ,.dma_data_ready_and_i(dma_data_ready_and_i[i])
+         );
+    end
 
   // Assign I/O as another device
-  assign mem_fwd_header_cast_o = dev_fwd_header_li[3];
-  assign mem_fwd_data_o = dev_fwd_data_li[3];
-  assign mem_fwd_v_o = dev_fwd_v_li[3];
-  assign dev_fwd_ready_and_lo[3] = mem_fwd_ready_and_i;
+  assign mem_fwd_header_o = dev_fwd_header_li[io_dev_id_lp];
+  assign mem_fwd_data_o = dev_fwd_data_li[io_dev_id_lp];
+  assign mem_fwd_v_o = dev_fwd_v_li[io_dev_id_lp];
+  assign dev_fwd_ready_and_lo[io_dev_id_lp] = mem_fwd_ready_and_i;
 
-  assign dev_rev_header_lo[3] = mem_rev_header_cast_i;
-  assign dev_rev_data_lo[3] = mem_rev_data_i;
-  assign dev_rev_v_lo[3] = mem_rev_v_i;
-  assign mem_rev_ready_and_o = dev_rev_ready_and_li[3];
+  assign dev_rev_header_lo[io_dev_id_lp] = mem_rev_header_i;
+  assign dev_rev_data_lo[io_dev_id_lp] = mem_rev_data_i;
+  assign dev_rev_v_lo[io_dev_id_lp] = mem_rev_v_i;
+  assign mem_rev_ready_and_o = dev_rev_ready_and_li[io_dev_id_lp];
 
   bp_me_loopback
    #(.bp_params_p(bp_params_p))
@@ -339,14 +361,14 @@ module bp_unicore
     (.clk_i(clk_i)
      ,.reset_i(reset_r)
 
-     ,.mem_fwd_header_i(dev_fwd_header_li[4])
-     ,.mem_fwd_data_i(dev_fwd_data_li[4])
-     ,.mem_fwd_v_i(dev_fwd_v_li[4])
-     ,.mem_fwd_ready_and_o(dev_fwd_ready_and_lo[4])
-     ,.mem_rev_header_o(dev_rev_header_lo[4])
-     ,.mem_rev_data_o(dev_rev_data_lo[4])
-     ,.mem_rev_v_o(dev_rev_v_lo[4])
-     ,.mem_rev_ready_and_i(dev_rev_ready_and_li[4])
+     ,.mem_fwd_header_i(dev_fwd_header_li[loopback_dev_id_lp])
+     ,.mem_fwd_data_i(dev_fwd_data_li[loopback_dev_id_lp])
+     ,.mem_fwd_v_i(dev_fwd_v_li[loopback_dev_id_lp])
+     ,.mem_fwd_ready_and_o(dev_fwd_ready_and_lo[loopback_dev_id_lp])
+     ,.mem_rev_header_o(dev_rev_header_lo[loopback_dev_id_lp])
+     ,.mem_rev_data_o(dev_rev_data_lo[loopback_dev_id_lp])
+     ,.mem_rev_v_o(dev_rev_v_lo[loopback_dev_id_lp])
+     ,.mem_rev_ready_and_i(dev_rev_ready_and_li[loopback_dev_id_lp])
      );
 
 endmodule

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -246,7 +246,7 @@ $BP_ME_DIR/src/v/lce/bp_lce_req.sv
 $BP_ME_DIR/src/v/lce/bp_lce_cmd.sv
 # Cache
 $BP_ME_DIR/src/v/dev/bp_me_bedrock_register.sv
-$BP_ME_DIR/src/v/dev/bp_me_cce_to_cache.sv
+$BP_ME_DIR/src/v/dev/bp_me_cache_controller.sv
 $BP_ME_DIR/src/v/dev/bp_me_dram_hash_decode.sv
 $BP_ME_DIR/src/v/dev/bp_me_dram_hash_encode.sv
 $BP_ME_DIR/src/v/dev/bp_me_cache_slice.sv

--- a/bp_top/test/common/bp_nonsynth_if_verif.sv
+++ b/bp_top/test/common/bp_nonsynth_if_verif.sv
@@ -125,7 +125,7 @@ module bp_nonsynth_if_verif
     $error("Error: L2 block width must be less than 1024");
   if (!`BSG_IS_POW2((l2_fill_width_p/l2_data_width_p)))
     $error("Error: L2 fill width must be POW2 multiple of L2 data width");
-  if (!`BSG_IS_POW2(l2_banks_p))
+  if (!`BSG_IS_POW2(l2_dmas_p))
     $error("Error: L2 banks must be a power of two");
 
   // Unicore
@@ -160,7 +160,7 @@ module bp_nonsynth_if_verif
   if ((cce_type_p != e_cce_uce) && (`BSG_SAFE_CLOG2(icache_block_width_p*icache_sets_p/8) > page_offset_width_gp) && (`BSG_SAFE_CLOG2(dcache_block_width_p*dcache_sets_p/8) > page_offset_width_gp))
     $error("Error: Multicore requires total cache size to be equal to 4kB * associativity");
 
-  if (num_cce_p/mc_x_dim_p*l2_banks_p > 16)
+  if (num_cce_p/mc_x_dim_p*l2_dmas_p > 16)
     $error("Round robin arbiter currently only supports 16 entries");
 
 endmodule

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -140,12 +140,12 @@ module testbench
   logic proc_rev_v_lo, proc_rev_ready_and_li;
 
   `declare_bsg_cache_dma_pkt_s(daddr_width_p, l2_block_size_in_words_p);
-  bsg_cache_dma_pkt_s [num_cce_p-1:0][l2_banks_p-1:0] dma_pkt_lo;
-  logic [num_cce_p-1:0][l2_banks_p-1:0] dma_pkt_v_lo, dma_pkt_yumi_li;
-  logic [num_cce_p-1:0][l2_banks_p-1:0][l2_fill_width_p-1:0] dma_data_lo;
-  logic [num_cce_p-1:0][l2_banks_p-1:0] dma_data_v_lo, dma_data_yumi_li;
-  logic [num_cce_p-1:0][l2_banks_p-1:0][l2_fill_width_p-1:0] dma_data_li;
-  logic [num_cce_p-1:0][l2_banks_p-1:0] dma_data_v_li, dma_data_ready_and_lo;
+  bsg_cache_dma_pkt_s [num_cce_p-1:0][l2_dmas_p-1:0] dma_pkt_lo;
+  logic [num_cce_p-1:0][l2_dmas_p-1:0] dma_pkt_v_lo, dma_pkt_yumi_li;
+  logic [num_cce_p-1:0][l2_dmas_p-1:0][l2_fill_width_p-1:0] dma_data_lo;
+  logic [num_cce_p-1:0][l2_dmas_p-1:0] dma_data_v_lo, dma_data_yumi_li;
+  logic [num_cce_p-1:0][l2_dmas_p-1:0][l2_fill_width_p-1:0] dma_data_li;
+  logic [num_cce_p-1:0][l2_dmas_p-1:0] dma_data_v_li, dma_data_ready_and_lo;
 
   wire [mem_noc_did_width_p-1:0] proc_did_li = 1;
   wire [mem_noc_did_width_p-1:0] host_did_li = '1;
@@ -194,7 +194,7 @@ module testbench
 
   bp_nonsynth_dram
    #(.bp_params_p(bp_params_p)
-     ,.num_dma_p(num_cce_p*l2_banks_p)
+     ,.num_dma_p(num_cce_p*l2_dmas_p)
      ,.preload_mem_p(preload_mem_p)
      ,.dram_type_p(dram_type_p)
      ,.mem_bytes_p(2**29)
@@ -769,7 +769,7 @@ module testbench
    if_verif
     ();
 
-  if (dram_type_p == "axi" && (num_cce_p*l2_banks_p) > 16)
+  if (dram_type_p == "axi" && (num_cce_p*l2_dmas_p) > 16)
     $error("AXI memory does not support >16 caches without increasing bsg_round_robin_arb size");
 
   `ifndef VERILATOR

--- a/bp_top/test/tb/bp_tethered/wrapper.sv
+++ b/bp_top/test/tb/bp_tethered/wrapper.sv
@@ -52,17 +52,17 @@ module wrapper
    , input                                                              mem_rev_ready_and_i
 
    // DRAM interface
-   , output logic [num_cce_p-1:0][l2_banks_p-1:0][dma_pkt_width_lp-1:0] dma_pkt_o
-   , output logic [num_cce_p-1:0][l2_banks_p-1:0]                       dma_pkt_v_o
-   , input [num_cce_p-1:0][l2_banks_p-1:0]                              dma_pkt_ready_and_i
+   , output logic [num_cce_p-1:0][l2_dmas_p-1:0][dma_pkt_width_lp-1:0]  dma_pkt_o
+   , output logic [num_cce_p-1:0][l2_dmas_p-1:0]                        dma_pkt_v_o
+   , input [num_cce_p-1:0][l2_dmas_p-1:0]                               dma_pkt_ready_and_i
 
-   , input [num_cce_p-1:0][l2_banks_p-1:0][l2_fill_width_p-1:0]         dma_data_i
-   , input [num_cce_p-1:0][l2_banks_p-1:0]                              dma_data_v_i
-   , output logic [num_cce_p-1:0][l2_banks_p-1:0]                       dma_data_ready_and_o
+   , input [num_cce_p-1:0][l2_dmas_p-1:0][l2_fill_width_p-1:0]          dma_data_i
+   , input [num_cce_p-1:0][l2_dmas_p-1:0]                               dma_data_v_i
+   , output logic [num_cce_p-1:0][l2_dmas_p-1:0]                        dma_data_ready_and_o
 
-   , output logic [num_cce_p-1:0][l2_banks_p-1:0][l2_fill_width_p-1:0]  dma_data_o
-   , output logic [num_cce_p-1:0][l2_banks_p-1:0]                       dma_data_v_o
-   , input [num_cce_p-1:0][l2_banks_p-1:0]                              dma_data_ready_and_i
+   , output logic [num_cce_p-1:0][l2_dmas_p-1:0][l2_fill_width_p-1:0]   dma_data_o
+   , output logic [num_cce_p-1:0][l2_dmas_p-1:0]                        dma_data_v_o
+   , input [num_cce_p-1:0][l2_dmas_p-1:0]                               dma_data_ready_and_i
    );
 
   bp_processor


### PR DESCRIPTION
### Summary
This PR reworks the L2 banking strategy to increase bandwidth linearly with number of banks. It also parameterizes the internal networking IDs to make it easier to add peripherals within a BlackParrot tile.

### Issue Fixed
None

### Area
L2 cache controller and unicore/core toplevels

### Reasoning (new feature, inefficient, verbose, etc.)
The current banking scheme allows for MLP on cache misses to independent banks, but the serialization in the crossbar means that simultaneous requests need to wait even if a single bank is idle. We want to unlock scalable bandwidth for attached accelerators.

(Also, the current code is confusing as to what the requirements are to add a new internal master/client to the crossbar. With these changes, there are only a few lines needed to add new master/client attached accelerators).

### Additional Changes Required (if any)
None

### Analysis
Saturation bandwidth now scales linearly with the number of banks. While the core tends not to use this much bandwidth, accelerators certainly appreciate it.

### Verification
Manual waveform inspection of memory system

### Additional Context
None

