### PR TITLE
Refactor fencei for robustness

### DIFF
--- a/bp_be/src/include/bp_be_ctl_pkgdef.svh
+++ b/bp_be/src/include/bp_be_ctl_pkgdef.svh
@@ -93,7 +93,7 @@
     ,e_dcache_op_amominud = 6'b100000
     ,e_dcache_op_amomaxud = 6'b100001
 
-    ,e_dcache_op_fencei   = 6'b111111
+    ,e_dcache_op_clean    = 6'b111110
   } bp_be_dcache_fu_op_e;
 
   typedef enum logic [5:0]
@@ -224,13 +224,12 @@
     logic instr_misaligned;
 
     // BP "exceptions"
-    logic unfreeze;
+    logic resume;
     logic itlb_miss;
     logic icache_miss;
     logic dcache_replay;
     logic dtlb_load_miss;
     logic dtlb_store_miss;
-    logic fencei_dirty;
     logic itlb_fill;
     logic dtlb_fill;
     logic _interrupt;
@@ -242,7 +241,7 @@
   {
     logic dcache_store_miss;
     logic dcache_load_miss;
-    logic fencei_clean;
+    logic fencei;
     logic sfence_vma;
     logic dbreak;
     logic dret;

--- a/bp_be/src/include/bp_be_dcache_pkgdef.svh
+++ b/bp_be/src/include/bp_be_dcache_pkgdef.svh
@@ -29,7 +29,7 @@
     logic                         word_op;
     logic                         half_op;
     logic                         byte_op;
-    logic                         fencei_op;
+    logic                         clean_op;
     logic                         uncached_op;
     logic                         lr_op;
     logic                         sc_op;

--- a/bp_be/src/include/bp_be_defines.svh
+++ b/bp_be/src/include/bp_be_defines.svh
@@ -48,6 +48,7 @@
       logic                                    sret;                                               \
       logic                                    wfi;                                                \
       logic                                    sfence_vma;                                         \
+      logic                                    fencei;                                             \
                                                                                                    \
       logic [vaddr_width_mp-1:0]               pc;                                                 \
       rv64_instr_s                             instr;                                              \
@@ -149,7 +150,7 @@
       logic                           translation_en_n;                                            \
       logic                           exception;                                                   \
       logic                           _interrupt;                                                  \
-      logic                           unfreeze;                                                    \
+      logic                           resume;                                                      \
       logic                           eret;                                                        \
       logic                           fencei;                                                      \
       logic                           sfence;                                                      \
@@ -236,7 +237,7 @@
     (6+rv64_instr_width_gp)
 
   `define bp_be_issue_pkt_width(vaddr_width_mp, branch_metadata_fwd_width_mp) \
-    (7+vaddr_width_mp+instr_width_gp+$bits(bp_be_decode_s)+dpath_width_gp+branch_metadata_fwd_width_mp+11)
+    (7+vaddr_width_mp+instr_width_gp+$bits(bp_be_decode_s)+dpath_width_gp+branch_metadata_fwd_width_mp+12)
 
   `define bp_be_dispatch_pkt_width(vaddr_width_mp) \
     (4                                                                                             \

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -118,7 +118,6 @@ module bp_be_calculator_top
 
   logic pipe_mem_dtlb_load_miss_lo, pipe_mem_dtlb_store_miss_lo;
   logic pipe_mem_dcache_load_miss_lo, pipe_mem_dcache_store_miss_lo, pipe_mem_dcache_replay_lo;
-  logic pipe_mem_fencei_clean_lo, pipe_mem_fencei_dirty_lo;
   logic pipe_mem_load_misaligned_lo, pipe_mem_load_access_fault_lo, pipe_mem_load_page_fault_lo;
   logic pipe_mem_store_misaligned_lo, pipe_mem_store_access_fault_lo, pipe_mem_store_page_fault_lo;
 
@@ -379,8 +378,6 @@ module bp_be_calculator_top
      ,.cache_replay_v_o(pipe_mem_dcache_replay_lo)
      ,.cache_load_miss_v_o(pipe_mem_dcache_load_miss_lo)
      ,.cache_store_miss_v_o(pipe_mem_dcache_store_miss_lo)
-     ,.fencei_clean_v_o(pipe_mem_fencei_clean_lo)
-     ,.fencei_dirty_v_o(pipe_mem_fencei_dirty_lo)
      ,.load_misaligned_v_o(pipe_mem_load_misaligned_lo)
      ,.load_access_fault_v_o(pipe_mem_load_access_fault_lo)
      ,.load_page_fault_v_o(pipe_mem_load_page_fault_lo)
@@ -511,45 +508,43 @@ module bp_be_calculator_top
           // Normally, shift down in the pipe
           exc_stage_n[i] = (i == 0) ? '0 : exc_stage_r[i-1];
         end
-          exc_stage_n[0].v                      |= reservation_n.v;
-          exc_stage_n[0].queue_v                |= reservation_n.queue_v;
-          exc_stage_n[0].ispec_v                |= reservation_n.ispec_v;
-          exc_stage_n[0].spec                   |= reservation_n.special;
-          exc_stage_n[0].exc                    |= reservation_n.exception;
+          exc_stage_n[0].v                        |= reservation_n.v;
+          exc_stage_n[0].queue_v                  |= reservation_n.queue_v;
+          exc_stage_n[0].ispec_v                  |= reservation_n.ispec_v;
+          exc_stage_n[0].spec                     |= reservation_n.special;
+          exc_stage_n[0].exc                      |= reservation_n.exception;
 
-          exc_stage_n[0].v                      &= ~commit_pkt_cast_o.npc_w_v;
-          exc_stage_n[1].v                      &= ~commit_pkt_cast_o.npc_w_v;
-          exc_stage_n[2].v                      &= ~commit_pkt_cast_o.npc_w_v;
-          exc_stage_n[3].v                      &= commit_pkt_cast_o.instret;
+          exc_stage_n[0].v                        &= ~commit_pkt_cast_o.npc_w_v;
+          exc_stage_n[1].v                        &= ~commit_pkt_cast_o.npc_w_v;
+          exc_stage_n[2].v                        &= ~commit_pkt_cast_o.npc_w_v;
+          exc_stage_n[3].v                        &= commit_pkt_cast_o.instret;
 
-          exc_stage_n[0].queue_v                &= ~commit_pkt_cast_o.npc_w_v;
-          exc_stage_n[1].queue_v                &= ~commit_pkt_cast_o.npc_w_v;
-          exc_stage_n[2].queue_v                &= ~commit_pkt_cast_o.npc_w_v;
-          exc_stage_n[3].queue_v                &= ~commit_pkt_cast_o.npc_w_v;
+          exc_stage_n[0].queue_v                  &= ~commit_pkt_cast_o.npc_w_v;
+          exc_stage_n[1].queue_v                  &= ~commit_pkt_cast_o.npc_w_v;
+          exc_stage_n[2].queue_v                  &= ~commit_pkt_cast_o.npc_w_v;
+          exc_stage_n[3].queue_v                  &= ~commit_pkt_cast_o.npc_w_v;
 
-          exc_stage_n[1].exc.illegal_instr      |= pipe_sys_illegal_instr_lo;
-          exc_stage_n[1].spec.csrw              |= pipe_sys_csrw_lo;
+          exc_stage_n[1].exc.illegal_instr        |= pipe_sys_illegal_instr_lo;
+          exc_stage_n[1].spec.csrw                |= pipe_sys_csrw_lo;
 
-          exc_stage_n[1].exc.instr_misaligned   |= pipe_int_early_instr_misaligned_lo & ~exc_stage_r[0].ispec_v;
+          exc_stage_n[1].exc.instr_misaligned     |= pipe_int_early_instr_misaligned_lo & ~exc_stage_r[0].ispec_v;
 
-          exc_stage_n[1].exc.dtlb_store_miss    |= pipe_mem_dtlb_store_miss_lo;
-          exc_stage_n[1].exc.dtlb_load_miss     |= pipe_mem_dtlb_load_miss_lo;
-          exc_stage_n[1].exc.load_misaligned    |= pipe_mem_load_misaligned_lo;
-          exc_stage_n[1].exc.load_access_fault  |= pipe_mem_load_access_fault_lo;
-          exc_stage_n[1].exc.load_page_fault    |= pipe_mem_load_page_fault_lo;
-          exc_stage_n[1].exc.store_misaligned   |= pipe_mem_store_misaligned_lo;
-          exc_stage_n[1].exc.store_access_fault |= pipe_mem_store_access_fault_lo;
-          exc_stage_n[1].exc.store_page_fault   |= pipe_mem_store_page_fault_lo;
+          exc_stage_n[1].exc.dtlb_store_miss      |= pipe_mem_dtlb_store_miss_lo;
+          exc_stage_n[1].exc.dtlb_load_miss       |= pipe_mem_dtlb_load_miss_lo;
+          exc_stage_n[1].exc.load_misaligned      |= pipe_mem_load_misaligned_lo;
+          exc_stage_n[1].exc.load_access_fault    |= pipe_mem_load_access_fault_lo;
+          exc_stage_n[1].exc.load_page_fault      |= pipe_mem_load_page_fault_lo;
+          exc_stage_n[1].exc.store_misaligned     |= pipe_mem_store_misaligned_lo;
+          exc_stage_n[1].exc.store_access_fault   |= pipe_mem_store_access_fault_lo;
+          exc_stage_n[1].exc.store_page_fault     |= pipe_mem_store_page_fault_lo;
 
-          exc_stage_n[2].exc.instr_misaligned   |= pipe_int_catchup_instr_misaligned_lo;
-          exc_stage_n[2].exc.mispredict         |= pipe_int_catchup_mispredict_lo;
+          exc_stage_n[2].exc.instr_misaligned     |= pipe_int_catchup_instr_misaligned_lo;
+          exc_stage_n[2].exc.mispredict           |= pipe_int_catchup_mispredict_lo;
 
-          exc_stage_n[2].exc.fencei_dirty       |= pipe_mem_fencei_dirty_lo;
-          exc_stage_n[2].exc.dcache_replay      |= pipe_mem_dcache_replay_lo;
-          exc_stage_n[2].spec.dcache_load_miss  |= pipe_mem_dcache_load_miss_lo;
-          exc_stage_n[2].spec.dcache_store_miss |= pipe_mem_dcache_store_miss_lo;
-          exc_stage_n[2].spec.fencei_clean      |= pipe_mem_fencei_clean_lo;
-          exc_stage_n[2].exc.cmd_full           |= |{exc_stage_r[2].exc, exc_stage_r[2].spec} & cmd_full_n_i;
+          exc_stage_n[2].exc.dcache_replay        |= pipe_mem_dcache_replay_lo;
+          exc_stage_n[2].spec.dcache_load_miss    |= pipe_mem_dcache_load_miss_lo;
+          exc_stage_n[2].spec.dcache_store_miss   |= pipe_mem_dcache_store_miss_lo;
+          exc_stage_n[2].exc.cmd_full             |= |{exc_stage_r[2].exc, exc_stage_r[2].spec} & cmd_full_n_i;
     end
 
   // Exception pipeline

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -298,7 +298,7 @@ module bp_be_csr
         ? retire_pkt_cast_i.npc
         : apc_r;
 
-  assign apc_n = (enter_debug | commit_pkt_cast_o.unfreeze) ? debug_halt_pc : core_npc;
+  assign apc_n = (enter_debug | cfg_bus_cast_i.freeze) ? debug_halt_pc : core_npc;
 
   assign translation_en_n = ((priv_mode_n < `PRIV_MODE_M) & (satp_li.mode == 4'd8));
   bsg_dff_reset
@@ -691,12 +691,12 @@ module bp_be_csr
   assign commit_pkt_cast_o.exception         = exception_v_lo;
   // Debug mode acts as a pseudo-interrupt
   assign commit_pkt_cast_o._interrupt        = interrupt_v_lo | enter_debug;
-  assign commit_pkt_cast_o.fencei            = retire_pkt_cast_i.special.fencei_clean;
+  assign commit_pkt_cast_o.fencei            = retire_pkt_cast_i.special.fencei;
   assign commit_pkt_cast_o.sfence            = retire_pkt_cast_i.special.sfence_vma;
   assign commit_pkt_cast_o.wfi               = retire_pkt_cast_i.special.wfi;
   assign commit_pkt_cast_o.eret              = |{retire_pkt_cast_i.special.dret, retire_pkt_cast_i.special.mret, retire_pkt_cast_i.special.sret};
   assign commit_pkt_cast_o.csrw              = retire_pkt_cast_i.special.csrw;
-  assign commit_pkt_cast_o.unfreeze          = retire_pkt_cast_i.exception.unfreeze;
+  assign commit_pkt_cast_o.resume            = retire_pkt_cast_i.exception.resume;
   assign commit_pkt_cast_o.itlb_miss         = retire_pkt_cast_i.exception.itlb_miss;
   assign commit_pkt_cast_o.icache_miss       = retire_pkt_cast_i.exception.icache_miss;
   assign commit_pkt_cast_o.dtlb_store_miss   = retire_pkt_cast_i.exception.dtlb_store_miss;

--- a/bp_be/src/v/bp_be_checker/bp_be_instr_decoder.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_instr_decoder.sv
@@ -41,6 +41,7 @@ module bp_be_instr_decoder
    , output logic                       sret_o
    , output logic                       wfi_o
    , output logic                       sfence_vma_o
+   , output logic                       fencei_o
 
    , output logic [dword_width_gp-1:0]  imm_o
    );
@@ -76,6 +77,7 @@ module bp_be_instr_decoder
       sret_o          = '0;
       wfi_o           = '0;
       sfence_vma_o    = '0;
+      fencei_o        = '0;
 
       imm_o           = '0;
 
@@ -265,7 +267,8 @@ module bp_be_instr_decoder
               `RV64_FENCE_I :
                 begin
                   decode_cast_o.pipe_mem_early_v = 1'b1;
-                  decode_cast_o.fu_op            = e_dcache_op_fencei;
+                  decode_cast_o.fu_op            = e_dcache_op_clean;
+                  fencei_o                       = ~illegal_instr_o;
                 end
               default : illegal_instr_o = 1'b1;
             endcase

--- a/bp_be/src/v/bp_be_checker/bp_be_issue_queue.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_issue_queue.sv
@@ -257,7 +257,7 @@ module bp_be_issue_queue
   logic ecall_m_lo, ecall_s_lo, ecall_u_lo;
   logic ebreak_lo, dbreak_lo;
   logic dret_lo, mret_lo, sret_lo;
-  logic wfi_lo, sfence_vma_lo;
+  logic wfi_lo, sfence_vma_lo, fencei_lo;
   bp_be_instr_decoder
    #(.bp_params_p(bp_params_p))
    instr_decoder
@@ -278,6 +278,7 @@ module bp_be_issue_queue
      ,.sret_o(sret_lo)
      ,.wfi_o(wfi_lo)
      ,.sfence_vma_o(sfence_vma_lo)
+     ,.fencei_o(fencei_lo)
      );
 
   wire issue_pkt_v = ~empty & ~inject & ~suppress;
@@ -303,6 +304,7 @@ module bp_be_issue_queue
       issue_pkt_cast_o.sret                 = sret_lo;
       issue_pkt_cast_o.wfi                  = wfi_lo;
       issue_pkt_cast_o.sfence_vma           = sfence_vma_lo;
+      issue_pkt_cast_o.fencei               = fencei_lo;
 
       issue_pkt_cast_o.pc                   = issue_pc;
       issue_pkt_cast_o.instr                = issue_instr;

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -133,8 +133,9 @@ module bp_be_dcache
    // Data (or miss result) comes out of the cache
    , output logic                                    v_o
    , output logic [dword_width_gp-1:0]               data_o
+   , output logic [paddr_width_p-1:0]                addr_o
    , output logic [reg_addr_width_gp-1:0]            rd_addr_o
-   , output logic                                    fencei_o
+   , output logic                                    clean_o
    , output logic                                    float_o
    , output logic                                    ret_o
    , output logic                                    late_o
@@ -195,7 +196,6 @@ module bp_be_dcache
   logic tl_we, tv_we;
   logic safe_tl_we, safe_tv_we;
   logic v_tl_r, v_tv_r;
-  logic gdirty_r;
   logic tag_mem_write_hazard, data_mem_write_hazard, blocking_hazard, engine_hazard, fill_hazard;
   logic blocking_req, blocking_sent;
   logic nonblocking_req, nonblocking_sent;
@@ -356,7 +356,7 @@ module bp_be_dcache
      ,.o(bank_sel_one_hot_tl)
      );
 
-  wire uncached_op_tl =  decode_tl_r.uncached_op | (~decode_tl_r.fencei_op & ptag_uncached_i);
+  wire uncached_op_tl =  decode_tl_r.uncached_op | (~decode_tl_r.clean_op & ptag_uncached_i);
   wire dram_op_tl =  ptag_dram_i;
   wire [dword_width_gp-1:0] st_data_tl = st_data_i;
 
@@ -375,8 +375,8 @@ module bp_be_dcache
   wire [sindex_width_lp-1:0] paddr_index_tv = paddr_tv_r[block_offset_width_lp+:sindex_width_lp];
   wire [ctag_width_p-1:0]    paddr_tag_tv   = paddr_tv_r[block_offset_width_lp+sindex_width_lp+:ctag_width_p];
 
-  // fencei does not require a ptag
-  assign safe_tv_we = v_tl_r & (ptag_v_i | decode_tl_r.fencei_op);
+  // clean does not require a ptag
+  assign safe_tv_we = v_tl_r & (ptag_v_i | decode_tl_r.clean_op);
   assign tv_we = safe_tv_we & ~flush_tv;
   bsg_dff_reset
    #(.width_p(1))
@@ -506,16 +506,17 @@ module bp_be_dcache
   wire load_miss_tv     = decode_tv_r.load_op & ~load_hit_tv & ~sc_fail_tv & ~nonblocking_req;
   wire ldst_miss_tv     = load_miss_tv | store_miss_tv;
 
-  wire fencei_miss_tv   = decode_tv_r.fencei_op & gdirty_r;
+  wire clean_miss_tv    = decode_tv_r.clean_op & !coherent_p;
   wire engine_miss_tv   = cache_req_v_o & ~cache_req_yumi_i;
-  wire any_miss_tv      = ldst_miss_tv | fencei_miss_tv | engine_miss_tv;
+  wire any_miss_tv      = ldst_miss_tv | clean_miss_tv | engine_miss_tv;
 
+  assign addr_o = paddr_tv_r;
   assign data_o = sc_success_tv ? 1'b0 : sc_fail_tv ? 1'b1 : final_data;
 
   assign v_o       = v_tv_r & ~any_miss_tv;
   assign rd_addr_o = decode_tv_r.rd_addr;
   assign float_o   = decode_tv_r.float_op;
-  assign fencei_o  = decode_tv_r.fencei_op;
+  assign clean_o   = decode_tv_r.clean_op;
   assign late_o    = snoop_tv_r;
   assign ret_o     = decode_tv_r.ret_op;
   assign store_o   = decode_tv_r.store_op;
@@ -707,18 +708,18 @@ module bp_be_dcache
   `bp_cast_o(bp_dcache_req_s, cache_req);
   `bp_cast_o(bp_dcache_req_metadata_s, cache_req_metadata);
 
-  wire load_req            = ~uncached_op_tv_r & load_miss_tv;
-  wire store_req           = ~uncached_op_tv_r & store_miss_tv;
+  wire load_req            = ~uncached_op_tv_r & load_miss_tv & ~snoop_tv_r;
+  wire store_req           = ~uncached_op_tv_r & store_miss_tv & ~snoop_tv_r;
   wire uncached_amo_req    =  uncached_op_tv_r & decode_tv_r.amo_op & decode_tv_r.ret_op & ~snoop_tv_r;
   wire uncached_load_req   =  uncached_op_tv_r & ~decode_tv_r.amo_op & decode_tv_r.load_op & ~snoop_tv_r;
   wire uncached_store_req  =  uncached_op_tv_r & decode_tv_r.store_op & ~decode_tv_r.ret_op & ~snoop_tv_r;
-  wire fencei_req          = fencei_miss_tv & (coherent_p == 0);
-  wire backoff_req         = ~uncached_op_tv_r & sc_fail_tv & (coherent_p == 1);
-  wire wt_req              = ~uncached_op_tv_r & decode_tv_r.store_op & ~sc_fail_tv & !writeback_p;
+  wire clean_req           = ~uncached_op_tv_r & decode_tv_r.clean_op & !coherent_p & ~snoop_tv_r;
+  wire backoff_req         = ~uncached_op_tv_r & sc_fail_tv & coherent_p & ~snoop_tv_r;
+  wire wt_req              = ~uncached_op_tv_r & decode_tv_r.store_op & ~sc_fail_tv & !writeback_p & ~snoop_tv_r;
 
   // Uncached stores and writethrough requests are non-blocking
   assign nonblocking_req   = (uncached_store_req | wt_req | backoff_req);
-  assign blocking_req      = (fencei_req | load_req | store_req | uncached_amo_req | uncached_load_req);
+  assign blocking_req      = (clean_req | load_req | store_req | uncached_amo_req | uncached_load_req);
   assign nonblocking_sent  = nonblocking_req & cache_req_yumi_i;
   assign blocking_sent     = blocking_req & cache_req_yumi_i;
 
@@ -768,8 +769,8 @@ module bp_be_dcache
 
       if (backoff_req)
         cache_req_cast_o.msg_type = e_cache_backoff;
-      else if (fencei_req)
-        cache_req_cast_o.msg_type = e_cache_flush;
+      else if (clean_req)
+        cache_req_cast_o.msg_type = e_cache_clean;
       else if (store_req)
         cache_req_cast_o.msg_type = e_miss_store;
       else if (load_req)
@@ -832,7 +833,7 @@ module bp_be_dcache
   ///////////////////////////
   // Tag Mem Control
   ///////////////////////////
-  wire tag_mem_fast_read = (safe_tl_we & ~decode_lo.fencei_op) & ~tag_mem_write_hazard;
+  wire tag_mem_fast_read = (safe_tl_we & ~decode_lo.clean_op) & ~tag_mem_write_hazard;
   wire tag_mem_slow_read = tag_mem_pkt_yumi_o & (tag_mem_pkt_cast_i.opcode == e_cache_tag_mem_read);
   wire tag_mem_slow_write = tag_mem_pkt_yumi_o & (tag_mem_pkt_cast_i.opcode != e_cache_tag_mem_read);
   wire tag_mem_fast_write = v_tv_r & (uncached_op_tv_r & load_hit_tv & ~snoop_tv_r);
@@ -1013,7 +1014,7 @@ module bp_be_dcache
   // Stat Mem Control
   ///////////////////////////
   wire stat_mem_fast_read  = (v_tv_r & cache_req_metadata_v_n);
-  wire stat_mem_fast_write = (v_tv_r & load_hit_tv & ~decode_tv_r.fencei_op & ~uncached_op_tv_r);
+  wire stat_mem_fast_write = (v_tv_r & load_hit_tv & ~decode_tv_r.clean_op & ~uncached_op_tv_r);
   wire stat_mem_slow_write = stat_mem_pkt_yumi_o & (stat_mem_pkt_cast_i.opcode != e_cache_stat_mem_read);
   wire stat_mem_slow_read  = stat_mem_pkt_yumi_o & (stat_mem_pkt_cast_i.opcode == e_cache_stat_mem_read);
   assign stat_mem_v_li = stat_mem_fast_read | stat_mem_fast_write
@@ -1058,35 +1059,6 @@ module bp_be_dcache
       // We don't track dirty
       // Note: This will synthesize out of stat_mem...unless hardened
       assign dirty_mask_lo = '0;
-    end
-
-  if (coherent_p == 0)
-    begin : tgd
-      // Maintain a global dirty bit for the cache. When data is written to the write buffer, we set
-      //   it. When we send a flush request to the CE, we clear it.
-      // The way this works with fence.i is:
-      //   1) If dirty bit is set, we force a miss and send off a flush request to the CE
-      //   2) If dirty bit is not set, we do not send a request and simply return valid flush.
-      //        A clear request is now sent to I$ through the FE exception mechanism
-      // For a non-coherent writeback cache, we set the dirty when we have a store hit
-      // For a non-coherent writethrough write-no-allocate cache, we set the dirty regardless of hit
-      // For a coherent cache, we never set the dirty bit as the coherence system should handle it
-      wire set_dirty = wbuf_v_li;
-      wire clear_dirty = complete_recv & fill_decode_r.fencei_op;
-      bsg_dff_reset_set_clear
-       #(.width_p(1))
-       gdirty_reg
-       (.clk_i(clk_i)
-        ,.reset_i(reset_i)
-        ,.set_i(set_dirty)
-        ,.clear_i(clear_dirty)
-
-        ,.data_o(gdirty_r)
-        );
-    end
-  else
-    begin : ntgd
-      assign gdirty_r = '0;
     end
 
   always_comb

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache_decoder.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache_decoder.sv
@@ -37,7 +37,7 @@ module bp_be_dcache_decoder
     // Atomic op decoding
     decode_cast_o.lr_op = dcache_pkt.opcode inside {e_dcache_op_lrw, e_dcache_op_lrd};
     decode_cast_o.sc_op = dcache_pkt.opcode inside {e_dcache_op_scw, e_dcache_op_scd};
-    decode_cast_o.fencei_op = dcache_pkt.opcode inside {e_dcache_op_fencei};
+    decode_cast_o.clean_op = dcache_pkt.opcode inside {e_dcache_op_clean};
 
     // Atomic subop decoding
     unique casez (dcache_pkt.opcode)

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -28,11 +28,11 @@ module bp_be_top
    // FE queue interface
    , input [fe_queue_width_lp-1:0]                   fe_queue_i
    , input                                           fe_queue_v_i
-   , output                                          fe_queue_ready_and_o
+   , output logic                                    fe_queue_ready_and_o
 
    // FE cmd interface
-   , output [fe_cmd_width_lp-1:0]                    fe_cmd_o
-   , output                                          fe_cmd_v_o
+   , output logic [fe_cmd_width_lp-1:0]              fe_cmd_o
+   , output logic                                    fe_cmd_v_o
    , input                                           fe_cmd_yumi_i
 
    // D$-LCE Interface
@@ -93,7 +93,7 @@ module bp_be_top
 
   bp_be_issue_pkt_s issue_pkt;
   logic [vaddr_width_p-1:0] expected_npc_lo;
-  logic npc_mismatch_lo, poison_isd_lo, clear_iss_lo, suppress_iss_lo, unfreeze_lo;
+  logic npc_mismatch_lo, poison_isd_lo, clear_iss_lo, suppress_iss_lo, resume_lo;
 
   logic cmd_full_n_lo, cmd_full_r_lo, cmd_empty_n_lo, cmd_empty_r_lo;
   logic mem_ordered_lo, mem_busy_lo, idiv_busy_lo, fdiv_busy_lo, ptw_busy_lo;
@@ -112,11 +112,12 @@ module bp_be_top
      ,.fe_cmd_v_o(fe_cmd_v_o)
      ,.fe_cmd_yumi_i(fe_cmd_yumi_i)
 
-     ,.unfreeze_o(unfreeze_lo)
+     ,.resume_o(resume_lo)
      ,.poison_isd_o(poison_isd_lo)
      ,.clear_iss_o(clear_iss_lo)
      ,.suppress_iss_o(suppress_iss_lo)
      ,.irq_waiting_i(irq_waiting_lo)
+     ,.mem_busy_i(mem_busy_lo)
      ,.cmd_empty_n_o()
      ,.cmd_empty_r_o()
      ,.cmd_full_n_o(cmd_full_n_lo)
@@ -159,7 +160,7 @@ module bp_be_top
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
-     ,.unfreeze_i(unfreeze_lo)
+     ,.resume_i(resume_lo)
      ,.decode_info_i(decode_info_lo)
      ,.issue_pkt_o(issue_pkt)
      ,.poison_isd_i(poison_isd_lo)

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -192,10 +192,11 @@ module wrapper
 
       ,.data_o(data_o[i])
       ,.v_o(v_o[i])
-      ,.fencei_o()
+      ,.clean_o()
       ,.ret_o()
       ,.late_o()
       ,.rd_addr_o()
+      ,.addr_o()
       ,.ordered_o()
       ,.float_o()
       ,.store_o()

--- a/bp_common/src/include/bp_common_cache_engine_pkgdef.svh
+++ b/bp_common/src/include/bp_common_cache_engine_pkgdef.svh
@@ -10,8 +10,8 @@
     ,e_uc_load          = 4'b0011
     ,e_uc_store         = 4'b0100
     ,e_uc_amo           = 4'b0101
-    ,e_cache_flush      = 4'b0110
-    ,e_cache_clear      = 4'b0111
+    ,e_cache_inval      = 4'b0110
+    ,e_cache_clean      = 4'b0111
     ,e_cache_backoff    = 4'b1000
   } bp_cache_req_msg_type_e;
 

--- a/bp_common/src/include/bp_common_core_pkgdef.svh
+++ b/bp_common/src/include/bp_common_core_pkgdef.svh
@@ -66,6 +66,7 @@
    * e_subop_trap is at-fault PC redirection. It will changes the permission bits.
    * e_subop_context_switch is no-fault PC redirection. It redirect pc to a new address space.
    * e_subop_translation_switch is no-fault PC redirection resulting from translation mode changes
+   * e_subop_resume is resuming from a no-fault PC redirect wait state.
    */
   typedef enum logic [2:0]
   {
@@ -75,6 +76,7 @@
     ,e_subop_trap
     ,e_subop_context_switch
     ,e_subop_translation_switch
+    ,e_subop_resume
   } bp_fe_command_queue_subopcodes_e;
 
 `endif

--- a/bp_fe/src/include/bp_fe_icache_pkgdef.svh
+++ b/bp_fe/src/include/bp_fe_icache_pkgdef.svh
@@ -4,7 +4,7 @@
   typedef enum
   {
     e_icache_fetch
-    ,e_icache_fencei
+    ,e_icache_inval
   } bp_fe_icache_op_e;
 
 `endif

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -154,7 +154,8 @@ module bp_cacc_vdp
 
      ,.data_o(acache_data_lo)
      ,.v_o(acache_v_lo)
-     ,.fencei_o()
+     ,.addr_o()
+     ,.clean_o()
      ,.ret_o()
      ,.store_o()
      ,.float_o()

--- a/bp_top/test/common/bp_nonsynth_cache_tracer.sv
+++ b/bp_top/test/common/bp_nonsynth_cache_tracer.sv
@@ -145,10 +145,10 @@ module bp_nonsynth_cache_tracer
       op = "[uncached load]";
     else if (cache_req_v_o & cache_req_cast_o.msg_type == e_uc_store)
       op = "[uncached store]";
-    else if (cache_req_v_o & cache_req_cast_o.msg_type == e_cache_flush)
-      op = "[fencei req]";
-    else if (cache_req_v_o & cache_req_cast_o.msg_type == e_cache_clear)
-      op = "[fencei req]";
+    else if (cache_req_v_o & cache_req_cast_o.msg_type == e_cache_clean)
+      op = "[clean req]";
+    else if (cache_req_v_o & cache_req_cast_o.msg_type == e_cache_inval)
+      op = "[inval req]";
     else
       op = "[null]";
   end

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -464,7 +464,7 @@ module testbench
           ,.icache_yumi_i(fe.icache.yumi_o)
 
           ,.fe_cmd_nonattaboy_i(fe.fe_cmd_yumi_o & ~fe.controller.attaboy_v)
-          ,.fe_cmd_fence_i(be.director.is_fence)
+          ,.fe_cmd_fence_i(be.director.is_cmd_fence)
           ,.fe_queue_empty_i(be.scheduler.issue_queue.empty)
 
           ,.mispredict_i(be.director.npc_mismatch_v)


### PR DESCRIPTION
### Summary
This PR edits the fence.i implementation to eschew replays. This leads a more robust and less special-casey implementation.

### Issue Fixed
None

### Area
FE-BE interface, BE memory pipeline.

### Reasoning (new feature, inefficient, verbose, etc.)
Before the flow for a fence.i was
- check dirty bit in cache
- flush d$
- replay fencei
- send I$ invalidation
- continue fetching

With the new flow, I$ invalidation will happen in parallel with D$ clear. This has better performance and energy efficiency (since we won't continue fetching during this time).

### Additional Changes Required (if any)
None

### Analysis
No PPA change

### Verification
Standard regression

### Additional Context
None

