### PR TITLE
Adds src_did to the bedrock interfaces

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - add_did
   before_script:
       - git submodule update --init --checkout --recursive external/
       - cp -r $CI_RTL_INSTALL_DIR install/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - add_did
   before_script:
       - git submodule update --init --checkout --recursive external/
       - cp -r $CI_RTL_INSTALL_DIR install/

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -24,7 +24,7 @@ module bp_be_calculator_top
     `declare_bp_cache_engine_if_widths(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
 
    // Generated parameters
-   , localparam cfg_bus_width_lp        = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp        = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    , localparam dispatch_pkt_width_lp   = `bp_be_dispatch_pkt_width(vaddr_width_p)
    , localparam branch_pkt_width_lp     = `bp_be_branch_pkt_width(vaddr_width_p)
    , localparam commit_pkt_width_lp     = `bp_be_commit_pkt_width(vaddr_width_p, paddr_width_p)
@@ -98,7 +98,7 @@ module bp_be_calculator_top
    );
 
   // Declare parameterizable structs
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 
   `bp_cast_i(bp_be_dispatch_pkt_s, dispatch_pkt);

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -10,7 +10,7 @@ module bp_be_csr
 
    , localparam csr_cmd_width_lp = $bits(bp_be_csr_cmd_s)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
 
    , localparam commit_pkt_width_lp = `bp_be_commit_pkt_width(vaddr_width_p, paddr_width_p)
    , localparam decode_info_width_lp = `bp_be_decode_info_width
@@ -53,7 +53,7 @@ module bp_be_csr
    );
 
   // Declare parameterizable structs
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 
   `declare_csr_structs(vaddr_width_p, paddr_width_p);

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -20,7 +20,7 @@ module bp_be_pipe_mem
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
    // Generated parameters
-   , localparam cfg_bus_width_lp       = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp       = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    , localparam dispatch_pkt_width_lp  = `bp_be_dispatch_pkt_width(vaddr_width_p)
    , localparam ptw_fill_pkt_width_lp  = `bp_be_ptw_fill_pkt_width(vaddr_width_p, paddr_width_p)
    , localparam trans_info_width_lp    = `bp_be_trans_info_width(ptag_width_p)
@@ -102,7 +102,7 @@ module bp_be_pipe_mem
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
   `declare_bp_cache_engine_if(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache);
   `declare_bp_be_dcache_pkt_s(vaddr_width_p);
   `bp_cast_o(bp_dcache_req_s, cache_req);

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_sys.sv
@@ -17,7 +17,7 @@ module bp_be_pipe_sys
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
 
-   , localparam cfg_bus_width_lp       = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp       = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    , localparam csr_cmd_width_lp       = $bits(bp_be_csr_cmd_s)
    // Generated parameters
    , localparam dispatch_pkt_width_lp = `bp_be_dispatch_pkt_width(vaddr_width_p)

--- a/bp_be/src/v/bp_be_checker/bp_be_director.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_director.sv
@@ -22,7 +22,7 @@ module bp_be_director
    `declare_bp_core_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
 
    // Generated parameters
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    , localparam issue_pkt_width_lp = `bp_be_issue_pkt_width(vaddr_width_p, branch_metadata_fwd_width_p)
    , localparam branch_pkt_width_lp = `bp_be_branch_pkt_width(vaddr_width_p)
    , localparam commit_pkt_width_lp = `bp_be_commit_pkt_width(vaddr_width_p, paddr_width_p)
@@ -57,7 +57,7 @@ module bp_be_director
    );
 
   // Declare parameterized structures
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -104,7 +104,7 @@ module bp_be_dcache
 
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, dcache)
 
-   , localparam cfg_bus_width_lp    = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp    = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    , localparam dcache_pkt_width_lp = `bp_be_dcache_pkt_width(vaddr_width_p)
    )
   (input                                             clk_i
@@ -1267,7 +1267,7 @@ module bp_be_dcache
     end
 
   // synopsys translate_off
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
   always_ff @(negedge clk_i)

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -17,7 +17,7 @@ module bp_be_top
    `declare_bp_cache_engine_if_widths(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
 
    // Default parameters
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    , localparam wb_pkt_width_lp = `bp_be_wb_pkt_width(vaddr_width_p)
   )
   (input                                             clk_i

--- a/bp_be/test/tb/bp_be_dcache/testbench.sv
+++ b/bp_be/test/tb/bp_be_dcache/testbench.sv
@@ -14,7 +14,7 @@ module testbench
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = BP_CFG_FLOWVAR // Replaced by the flow with a specific bp_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
    // Tracing parameters
    , parameter cce_trace_p                 = 0
@@ -32,7 +32,7 @@ module testbench
    , parameter dram_type_p                 = BP_DRAM_FLOWVAR // Replaced by the flow with a specific dram_type
 
    // Derived parameters
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    , localparam dcache_pkt_width_lp = `bp_be_dcache_pkt_width(vaddr_width_p)
    , localparam trace_replay_data_width_lp = ptag_width_p + dcache_pkt_width_lp + 1 + dword_width_gp // The 1 extra bit is for uncached accesses
    , localparam trace_rom_addr_width_lp = 8
@@ -55,8 +55,8 @@ module testbench
   if (num_caches_p == 0)
     $error("Please provide a valid number of caches");
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
 
   // Bit to deal with initial X->0 transition detection
   bit clk_i;

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -17,14 +17,13 @@ module wrapper
    , parameter assoc_p = dcache_assoc_p
    , parameter block_width_p = dcache_block_width_p
    , parameter fill_width_p = dcache_fill_width_p
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, dcache_ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, dcache)
 
    , parameter debug_p=0
    , parameter lock_max_limit_p=8
 
-   , localparam cfg_bus_width_lp= `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp= `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
 
    , localparam dcache_pkt_width_lp = `bp_be_dcache_pkt_width(vaddr_width_p)
 
@@ -57,8 +56,7 @@ module wrapper
    , output logic                                      mem_rev_ready_and_o
    );
 
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `declare_bp_be_dcache_pkt_s(vaddr_width_p);
 
   // Cache to Rolly FIFO signals
@@ -121,7 +119,7 @@ module wrapper
   logic [num_caches_p-1:0] lce_fill_v_lo, lce_fill_ready_and_li;
   logic [num_caches_p-1:0][lg_num_lce_lp-1:0] lce_fill_dst;
 
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
   for (genvar i = 0; i < num_caches_p; i++)

--- a/bp_common/src/include/bp_common_aviary_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_pkgdef.svh
@@ -102,19 +102,19 @@
       ,bht_row_els              : 2
       ,ghist_width              : 2
 
-      ,icache_sets        : 512
-      ,icache_assoc       : 1
-      ,icache_block_width : 64
-      ,icache_fill_width  : 64
+      ,icache_sets        : 256
+      ,icache_assoc       : 2
+      ,icache_block_width : 128
+      ,icache_fill_width  : 128
 
       ,dcache_features    : (1 << e_cfg_enabled) | (1 << e_cfg_lr_sc)
-      ,dcache_sets        : 512
-      ,dcache_assoc       : 1
-      ,dcache_block_width : 64
-      ,dcache_fill_width  : 64
+      ,dcache_sets        : 256
+      ,dcache_assoc       : 2
+      ,dcache_block_width : 128
+      ,dcache_fill_width  : 128
 
-      ,bedrock_block_width: 64
-      ,bedrock_fill_width : 64
+      ,bedrock_block_width: 128
+      ,bedrock_fill_width : 128
 
       // We use L2 for the write buffer support
       ,l2_features   : (1 << e_cfg_enabled)
@@ -123,8 +123,8 @@
                        | (1 << e_cfg_amo_swap)
                        | (1 << e_cfg_amo_fetch_logic)
                        | (1 << e_cfg_amo_fetch_arithmetic)
-      ,l2_data_width : 64
-      ,l2_fill_width : 64
+      ,l2_data_width : 128
+      ,l2_fill_width : 128
 
       ,default : "inv"
       };
@@ -210,30 +210,30 @@
       ,bht_row_els              : 2
       ,ghist_width              : 2
 
-      ,icache_sets        : 512
-      ,icache_assoc       : 1
-      ,icache_block_width : 64
-      ,icache_fill_width  : 64
+      ,icache_sets        : 256
+      ,icache_assoc       : 2
+      ,icache_block_width : 128
+      ,icache_fill_width  : 128
 
-      ,dcache_sets        : 512
-      ,dcache_assoc       : 1
-      ,dcache_block_width : 64
-      ,dcache_fill_width  : 64
+      ,dcache_sets        : 256
+      ,dcache_assoc       : 2
+      ,dcache_block_width : 128
+      ,dcache_fill_width  : 128
 
-      ,acache_sets        : 512
-      ,acache_assoc       : 1
-      ,acache_block_width : 64
-      ,acache_fill_width  : 64
+      ,acache_sets        : 256
+      ,acache_assoc       : 2
+      ,acache_block_width : 128
+      ,acache_fill_width  : 128
 
-      ,bedrock_block_width : 64
-      ,bedrock_fill_width  : 64
+      ,bedrock_block_width : 128
+      ,bedrock_fill_width  : 128
 
-      ,l2_data_width : 64
-      ,l2_fill_width : 64
+      ,l2_data_width : 128
+      ,l2_fill_width : 128
 
-      ,coh_noc_flit_width : 64
-      ,dma_noc_flit_width : 64
-      ,mem_noc_flit_width  : 64
+      ,coh_noc_flit_width : 128
+      ,dma_noc_flit_width : 128
+      ,mem_noc_flit_width : 128
 
       ,default : "inv"
       };

--- a/bp_common/src/include/bp_common_cfg_bus_defines.svh
+++ b/bp_common/src/include/bp_common_cfg_bus_defines.svh
@@ -1,7 +1,7 @@
 `ifndef BP_COMMON_CFG_BUS_DEFINES_SVH
 `define BP_COMMON_CFG_BUS_DEFINES_SVH
 
-  `define declare_bp_cfg_bus_s(vaddr_width_mp, hio_width_mp, core_id_width_mp, cce_id_width_mp, lce_id_width_mp) \
+  `define declare_bp_cfg_bus_s(vaddr_width_mp, hio_width_mp, core_id_width_mp, cce_id_width_mp, lce_id_width_mp, did_width_mp) \
     typedef struct packed                             \
     {                                                 \
       logic                        freeze;            \
@@ -14,9 +14,10 @@
       logic [cce_id_width_mp-1:0]  cce_id;            \
       bp_cce_mode_e                cce_mode;          \
       logic [hio_width_mp-1:0]     hio_mask;          \
+      logic [did_width_mp-1:0]     did;               \
     }  bp_cfg_bus_s
 
-  `define bp_cfg_bus_width(vaddr_width_mp, hio_width_mp, core_id_width_mp, cce_id_width_mp, lce_id_width_mp) \
+  `define bp_cfg_bus_width(vaddr_width_mp, hio_width_mp, core_id_width_mp, cce_id_width_mp, lce_id_width_mp, did_width_mp) \
     (1                                \
      + vaddr_width_mp                 \
      + core_id_width_mp               \
@@ -27,6 +28,7 @@
      + cce_id_width_mp                \
      + $bits(bp_cce_mode_e)           \
      + hio_width_mp                   \
+     + did_width_mp                   \
      )
 
 `endif

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -47,7 +47,7 @@ module bp_fe_icache
    , parameter ctag_width_p  = icache_ctag_width_p
 
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, icache)
-   , localparam cfg_bus_width_lp    = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp    = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    , localparam icache_pkt_width_lp = `bp_fe_icache_pkt_width(vaddr_width_p)
    )
   (input                                              clk_i
@@ -133,7 +133,7 @@ module bp_fe_icache
    );
 
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, icache);
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
   // Various localparameters

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -14,7 +14,7 @@ module bp_fe_top
    `declare_bp_core_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    )
   (input                                              clk_i
    , input                                            reset_i
@@ -59,7 +59,7 @@ module bp_fe_top
    );
 
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
   `declare_bp_fe_branch_metadata_fwd_s(ras_idx_width_p, btb_tag_width_p, btb_idx_width_p, bht_idx_width_p, ghist_width_p, bht_row_els_p);
   `bp_cast_o(bp_fe_queue_s, fe_queue);
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);

--- a/bp_fe/test/tb/bp_fe_icache/testbench.sv
+++ b/bp_fe/test/tb/bp_fe_icache/testbench.sv
@@ -8,7 +8,7 @@ module testbench
   import bp_me_pkg::*;
   #(parameter bp_params_e bp_params_p = BP_CFG_FLOWVAR
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
    // Tracing parameters
    , parameter cce_trace_p                 = 0
@@ -22,7 +22,7 @@ module testbench
    // DRAM parameters
    , parameter dram_type_p                 = BP_DRAM_FLOWVAR // Replaced by the flow with a specific dram_type
 
-  , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+  , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
   , localparam trace_replay_data_width_lp = ptag_width_p + vaddr_width_p + 1
   , localparam trace_rom_addr_width_lp = 7
 
@@ -40,8 +40,8 @@ module testbench
   if (bedrock_block_width_p != icache_block_width_p)
     $error("Memory fetch block width does not match icache block width");
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
 
   // Bit to deal with initial X->0 transition detection
   bit clk_i;

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -10,11 +10,10 @@ module wrapper
    , parameter assoc_p = icache_assoc_p
    , parameter block_width_p = icache_block_width_p
    , parameter fill_width_p = icache_fill_width_p
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    )
   (input                                         clk_i
    , input                                       reset_i
@@ -44,11 +43,10 @@ module wrapper
    , output logic                                mem_rev_ready_and_o
    );
 
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
 
   // I$-LCE Interface signals
   // Miss, Management Interfaces

--- a/bp_me/src/include/bp_me_cce_defines.svh
+++ b/bp_me/src/include/bp_me_cce_defines.svh
@@ -3,7 +3,7 @@
 
   // Miss Status Handling Register Struct
   // This struct tracks the information required to process an LCE request
-  `define declare_bp_cce_mshr_s(lce_id_width_mp, lce_assoc_mp, paddr_width_mp) \
+  `define declare_bp_cce_mshr_s(paddr_width_mp, lce_id_width_mp, cce_id_width_mp, did_width_mp, lce_assoc_mp) \
     typedef struct packed                                                   \
     {                                                                       \
       logic [lce_id_width_mp-1:0]                   owner_lce_id;           \
@@ -17,6 +17,7 @@
       logic [paddr_width_mp-1:0]                    paddr;                  \
       bp_coh_states_e                               next_coh_state;         \
       logic [lce_id_width_mp-1:0]                   lce_id;                 \
+      logic [did_width_mp-1:0]                      src_did;                \
       bp_bedrock_msg_size_e                         msg_size;               \
       bp_bedrock_wr_subop_e                         msg_subop;              \
       bp_bedrock_msg_u                              msg_type;               \
@@ -29,10 +30,10 @@
       bp_coh_states_e          state;                \
     } dir_entry_s
 
-  `define bp_cce_mshr_width(lce_id_width_mp, lce_assoc_mp, paddr_width_mp)          \
+  `define bp_cce_mshr_width(paddr_width_mp, lce_id_width_mp, cce_id_width_mp, did_width_mp, lce_assoc_mp) \
     ((2*lce_id_width_mp)+(3*`BSG_SAFE_CLOG2(lce_assoc_mp))+(2*paddr_width_mp)       \
      +(3*$bits(bp_coh_states_e))+$bits(bp_cce_flags_s)+$bits(bp_bedrock_msg_size_e) \
-     +$bits(bp_bedrock_msg_u)+$bits(bp_bedrock_wr_subop_e))
+     +$bits(bp_bedrock_msg_u)+$bits(bp_bedrock_wr_subop_e)+did_width_mp)
 
   `define bp_cce_dir_entry_width(tag_width_mp) \
     ($bits(bp_coh_states_e)+tag_width_mp)

--- a/bp_me/src/v/cce/bp_cce.sv
+++ b/bp_me/src/v/cce/bp_cce.sv
@@ -27,9 +27,8 @@ module bp_cce
     , localparam lg_cce_way_groups_lp      = `BSG_SAFE_CLOG2(cce_way_groups_p)
 
     // Interface Widths
-    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
+    `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
   )
   (input                                            clk_i
    , input                                          reset_i
@@ -80,14 +79,13 @@ module bp_cce
 
 
   // LCE-CCE and Mem-CCE Interface
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
 
   // MSHR
-  `declare_bp_cce_mshr_s(lce_id_width_p, lce_assoc_p, paddr_width_p);
+  `declare_bp_cce_mshr_s(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
 
   // Config Interface
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
 
   // LCE-CCE Interface structs
   `bp_cast_i(bp_bedrock_lce_req_header_s, lce_req_header);

--- a/bp_me/src/v/cce/bp_cce_dir_segment.sv
+++ b/bp_me/src/v/cce/bp_cce_dir_segment.sv
@@ -54,7 +54,7 @@ module bp_cce_dir_segment
 
     , localparam hash_index_width_lp      = $clog2((2**lg_sets_lp+num_cce_p-1)/num_cce_p)
 
-    // Directory information widths
+    // Directory information width
     , localparam entry_width_lp           = (tag_width_p+$bits(bp_coh_states_e))
     , localparam tag_set_width_lp         = (entry_width_lp*assoc_p)
     , localparam row_width_lp             = (tag_set_width_lp*tag_sets_per_row_lp)

--- a/bp_me/src/v/cce/bp_cce_inst_ram.sv
+++ b/bp_me/src/v/cce/bp_cce_inst_ram.sv
@@ -24,7 +24,7 @@ module bp_cce_inst_ram
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
     // Derived parameters
-    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
   )
   (input                                         clk_i
    , input                                       reset_i
@@ -54,7 +54,7 @@ module bp_cce_inst_ram
   if ($bits(bp_cce_inst_s) != cce_instr_width_gp)
     $error("Param cce_instr_width_gp does not match width of bp_cce_inst_s");
 
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
   bp_cfg_bus_s cfg_bus_cast_i;
   assign cfg_bus_cast_i = cfg_bus_i;
 

--- a/bp_me/src/v/cce/bp_cce_src_sel.sv
+++ b/bp_me/src/v/cce/bp_cce_src_sel.sv
@@ -23,15 +23,14 @@ module bp_cce_src_sel
     `declare_bp_proc_params(bp_params_p)
 
     // Derived parameters
-    , localparam mshr_width_lp             = `bp_cce_mshr_width(lce_id_width_p, lce_assoc_p, paddr_width_p)
+    , localparam mshr_width_lp             = `bp_cce_mshr_width(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
     // number of way groups managed by this CCE
     , localparam num_way_groups_lp         = `BSG_CDIV(cce_way_groups_p, num_cce_p)
     , localparam lg_num_way_groups_lp      = `BSG_SAFE_CLOG2(num_way_groups_lp)
 
-    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
 
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+    `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
   )
   (// Select signals for src_a and src_b - from decoded instruction
@@ -84,17 +83,16 @@ module bp_cce_src_sel
    , output bp_coh_states_e                      state_o
   );
 
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
   bp_cfg_bus_s cfg_bus_cast;
   assign cfg_bus_cast = cfg_bus_i;
 
-  `declare_bp_cce_mshr_s(lce_id_width_p, lce_assoc_p, paddr_width_p);
+  `declare_bp_cce_mshr_s(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   bp_cce_mshr_s mshr;
   assign mshr = mshr_i;
 
   // LCE-CCE and Mem-CCE Interface
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
 
   // Message casting
   bp_bedrock_lce_req_header_s  lce_req_header_li;
@@ -144,7 +142,7 @@ module bp_cce_src_sel
       end
       e_src_sel_special: begin
         unique case (src_a_i.special)
-          e_opd_req_lce:         src_a_o[0+:lce_id_width_p] = mshr.lce_id;
+          e_opd_req_lce:         src_a_o[0+:did_width_p+lce_id_width_p] = {mshr.src_did, mshr.lce_id};
           e_opd_req_addr:        src_a_o[0+:paddr_width_p] = mshr.paddr;
           e_opd_req_way:         src_a_o[0+:lce_assoc_width_p] = mshr.way_id;
           e_opd_lru_addr:        src_a_o[0+:paddr_width_p] = mshr.lru_paddr;

--- a/bp_me/src/v/cce/bp_cce_wrapper.sv
+++ b/bp_me/src/v/cce/bp_cce_wrapper.sv
@@ -23,9 +23,8 @@ module bp_cce_wrapper
     `declare_bp_proc_params(bp_params_p)
 
     // Interface Widths
-    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+    , localparam cfg_bus_width_lp          = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
+    `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
   )
   (input                                            clk_i
    , input                                          reset_i
@@ -71,7 +70,7 @@ module bp_cce_wrapper
   );
 
   // Config Interface
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
 
   // Config bus casting
   bp_cfg_bus_s cfg_bus_cast_i;

--- a/bp_me/src/v/cce/bp_io_cce.sv
+++ b/bp_me/src/v/cce/bp_io_cce.sv
@@ -6,7 +6,7 @@
  * Description:
  *   This module acts as a CCE for uncacheable IO memory accesses.
  *
- *   It converts uncached load and store LCE requests to IO requests, and
+ *   It converts uncached load and store LCE fwduests to IO fwduests, and
  *   converts uncached IO responses to uncached LCE command messages.
  *
  */
@@ -19,13 +19,11 @@ module bp_io_cce
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
    )
   (input                                          clk_i
    , input                                        reset_i
 
-   , input [did_width_p-1:0]                      did_i
    , input [cce_id_width_p-1:0]                   cce_id_i
 
    // LCE-CCE Interface
@@ -51,45 +49,168 @@ module bp_io_cce
    , input                                        mem_fwd_ready_and_i
    );
 
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `bp_cast_i(bp_bedrock_lce_req_header_s, lce_req_header);
-  `bp_cast_o(bp_bedrock_lce_cmd_header_s, lce_cmd_header);
   `bp_cast_o(bp_bedrock_mem_fwd_header_s, mem_fwd_header);
   `bp_cast_i(bp_bedrock_mem_rev_header_s, mem_rev_header);
+  `bp_cast_o(bp_bedrock_lce_cmd_header_s, lce_cmd_header);
 
-  // LCE Request to IO Command
-  wire lce_req_wr_not_rd = (lce_req_header_cast_i.msg_type.req == e_bedrock_req_uc_wr);
-  always_comb begin
-    // header
-    mem_fwd_header_cast_o                  = '0;
-    mem_fwd_header_cast_o.msg_type.fwd     = lce_req_wr_not_rd ? e_bedrock_mem_uc_wr : e_bedrock_mem_uc_rd;
-    mem_fwd_header_cast_o.addr             = lce_req_header_cast_i.addr;
-    mem_fwd_header_cast_o.size             = lce_req_header_cast_i.size;
-    mem_fwd_header_cast_o.payload.lce_id   = lce_req_header_cast_i.payload.src_id;
-    mem_fwd_header_cast_o.payload.did      = did_i;
-    mem_fwd_header_cast_o.payload.uncached = 1'b1;
-    // data
-    mem_fwd_data_o                         = lce_req_data_i;
-    mem_fwd_v_o                            = lce_req_v_i;
-    lce_req_ready_and_o                   = mem_fwd_ready_and_i;
-  end
+  bp_bedrock_lce_req_header_s fsm_req_header_lo;
+  logic [bedrock_fill_width_p-1:0] fsm_req_data_lo;
+  logic fsm_req_v_lo, fsm_req_yumi_li;
+  logic [paddr_width_p-1:0] fsm_req_addr_lo;
+  logic fsm_req_new_lo, fsm_req_critical_lo, fsm_req_last_lo;
+  bp_me_stream_pump_in
+   #(.bp_params_p(bp_params_p)
+     ,.fsm_data_width_p(bedrock_fill_width_p)
+     ,.block_width_p(bedrock_block_width_p)
+     ,.payload_width_p(lce_req_payload_width_lp)
+     ,.msg_stream_mask_p(lce_req_stream_mask_gp)
+     ,.fsm_stream_mask_p(lce_req_stream_mask_gp)
+     )
+   req_pump_in
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
 
-  // IO Response to LCE Cmd
-  wire mem_rev_wr_not_rd = (mem_rev_header_cast_i.msg_type.rev == e_bedrock_mem_uc_wr);
-  always_comb begin
-    // header
-    lce_cmd_header_cast_o                = '0;
-    lce_cmd_header_cast_o.msg_type.cmd   = mem_rev_wr_not_rd ? e_bedrock_cmd_uc_st_done : e_bedrock_cmd_uc_data;
-    lce_cmd_header_cast_o.addr           = mem_rev_header_cast_i.addr;
-    lce_cmd_header_cast_o.size           = mem_rev_header_cast_i.size;
-    lce_cmd_header_cast_o.payload.dst_id = mem_rev_header_cast_i.payload.lce_id;
-    lce_cmd_header_cast_o.payload.src_id = cce_id_i;
-    // data
-    lce_cmd_data_o                       = mem_rev_data_i;
-    lce_cmd_v_o                          = mem_rev_v_i;
-    mem_rev_ready_and_o                   = lce_cmd_ready_and_i;
-  end
+     ,.msg_header_i(lce_req_header_cast_i)
+     ,.msg_data_i(lce_req_data_i)
+     ,.msg_v_i(lce_req_v_i)
+     ,.msg_ready_and_o(lce_req_ready_and_o)
+
+     ,.fsm_header_o(fsm_req_header_lo)
+     ,.fsm_data_o(fsm_req_data_lo)
+     ,.fsm_v_o(fsm_req_v_lo)
+     ,.fsm_yumi_i(fsm_req_yumi_li)
+     ,.fsm_addr_o(fsm_req_addr_lo)
+     ,.fsm_new_o(fsm_req_new_lo)
+     ,.fsm_critical_o(fsm_req_critical_lo)
+     ,.fsm_last_o(fsm_req_last_lo)
+     );
+
+  bp_bedrock_mem_fwd_header_s fsm_fwd_header_li;
+  logic [bedrock_fill_width_p-1:0] fsm_fwd_data_li;
+  logic fsm_fwd_v_li, fsm_fwd_ready_and_lo;
+  logic [paddr_width_p-1:0] fsm_fwd_addr_lo;
+  logic fsm_fwd_new_lo, fsm_fwd_critical_lo, fsm_fwd_last_lo;
+  bp_me_stream_pump_out
+   #(.bp_params_p(bp_params_p)
+     ,.fsm_data_width_p(bedrock_fill_width_p)
+     ,.block_width_p(bedrock_block_width_p)
+     ,.payload_width_p(mem_fwd_payload_width_lp)
+     ,.msg_stream_mask_p(mem_fwd_stream_mask_gp)
+     ,.fsm_stream_mask_p(mem_fwd_stream_mask_gp)
+     )
+   fwd_pump_out
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.msg_header_o(mem_fwd_header_cast_o)
+     ,.msg_data_o(mem_fwd_data_o)
+     ,.msg_v_o(mem_fwd_v_o)
+     ,.msg_ready_and_i(mem_fwd_ready_and_i)
+
+     ,.fsm_header_i(fsm_fwd_header_li)
+     ,.fsm_data_i(fsm_fwd_data_li)
+     ,.fsm_v_i(fsm_fwd_v_li)
+     ,.fsm_ready_and_o(fsm_fwd_ready_and_lo)
+     ,.fsm_addr_o(fsm_fwd_addr_lo)
+     ,.fsm_new_o(fsm_fwd_new_lo)
+     ,.fsm_critical_o(fsm_fwd_critical_lo)
+     ,.fsm_last_o(fsm_fwd_last_lo)
+     );
+
+  bp_bedrock_mem_rev_header_s fsm_rev_header_lo;
+  logic [bedrock_fill_width_p-1:0] fsm_rev_data_lo;
+  logic fsm_rev_v_lo, fsm_rev_yumi_li;
+  logic [paddr_width_p-1:0] fsm_rev_addr_lo;
+  logic fsm_rev_new_lo, fsm_rev_critical_lo, fsm_rev_last_lo;
+  bp_me_stream_pump_in
+   #(.bp_params_p(bp_params_p)
+     ,.fsm_data_width_p(bedrock_fill_width_p)
+     ,.block_width_p(bedrock_block_width_p)
+     ,.payload_width_p(mem_rev_payload_width_lp)
+     ,.msg_stream_mask_p(mem_rev_stream_mask_gp)
+     ,.fsm_stream_mask_p(mem_rev_stream_mask_gp)
+     )
+   rev_pump_in
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.msg_header_i(mem_rev_header_cast_i)
+     ,.msg_data_i(mem_rev_data_i)
+     ,.msg_v_i(mem_rev_v_i)
+     ,.msg_ready_and_o(mem_rev_ready_and_o)
+
+     ,.fsm_header_o(fsm_rev_header_lo)
+     ,.fsm_data_o(fsm_rev_data_lo)
+     ,.fsm_v_o(fsm_rev_v_lo)
+     ,.fsm_yumi_i(fsm_rev_yumi_li)
+     ,.fsm_addr_o(fsm_rev_addr_lo)
+     ,.fsm_new_o(fsm_rev_new_lo)
+     ,.fsm_critical_o(fsm_rev_critical_lo)
+     ,.fsm_last_o(fsm_rev_last_lo)
+     );
+
+  bp_bedrock_lce_cmd_header_s fsm_cmd_header_li;
+  logic [bedrock_fill_width_p-1:0] fsm_cmd_data_li;
+  logic fsm_cmd_v_li, fsm_cmd_ready_and_lo;
+  logic [paddr_width_p-1:0] fsm_cmd_addr_lo;
+  logic fsm_cmd_new_lo, fsm_cmd_critical_lo, fsm_cmd_last_lo;
+  bp_me_stream_pump_out
+   #(.bp_params_p(bp_params_p)
+     ,.fsm_data_width_p(bedrock_fill_width_p)
+     ,.block_width_p(bedrock_block_width_p)
+     ,.payload_width_p(lce_cmd_payload_width_lp)
+     ,.msg_stream_mask_p(lce_cmd_stream_mask_gp)
+     ,.fsm_stream_mask_p(lce_cmd_stream_mask_gp)
+     )
+   cmd_pump_out
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.msg_header_o(lce_cmd_header_cast_o)
+     ,.msg_data_o(lce_cmd_data_o)
+     ,.msg_v_o(lce_cmd_v_o)
+     ,.msg_ready_and_i(lce_cmd_ready_and_i)
+
+     ,.fsm_header_i(fsm_cmd_header_li)
+     ,.fsm_data_i(fsm_cmd_data_li)
+     ,.fsm_v_i(fsm_cmd_v_li)
+     ,.fsm_ready_and_o(fsm_cmd_ready_and_lo)
+     ,.fsm_addr_o(fsm_cmd_addr_lo)
+     ,.fsm_new_o(fsm_cmd_new_lo)
+     ,.fsm_critical_o(fsm_cmd_critical_lo)
+     ,.fsm_last_o(fsm_cmd_last_lo)
+     );
+
+  wire lce_req_wr_not_rd = (fsm_req_header_lo.msg_type.req == e_bedrock_req_uc_wr);
+  wire mem_rev_wr_not_rd = (fsm_rev_header_lo.msg_type.rev == e_bedrock_mem_uc_wr);
+  always_comb
+    begin
+      fsm_fwd_header_li.msg_type         = lce_req_wr_not_rd ? e_bedrock_mem_uc_wr : e_bedrock_mem_uc_rd;
+      fsm_fwd_header_li.subop            = e_bedrock_store; // TODO: support I/O AMOs
+      fsm_fwd_header_li.addr             = fsm_req_header_lo.addr;
+      fsm_fwd_header_li.size             = fsm_req_header_lo.size;
+      fsm_fwd_header_li.payload          = '0;
+      fsm_fwd_header_li.payload.lce_id   = fsm_req_header_lo.payload.src_id;
+      fsm_fwd_header_li.payload.src_did  = fsm_req_header_lo.payload.src_did;
+      fsm_fwd_header_li.payload.uncached = 1'b1;
+      fsm_fwd_data_li                    = fsm_req_data_lo;
+      fsm_fwd_v_li                       = fsm_req_v_lo;
+      fsm_req_yumi_li                    = fsm_fwd_ready_and_lo & fsm_fwd_v_li;
+
+      fsm_cmd_header_li.msg_type         = mem_rev_wr_not_rd ? e_bedrock_cmd_uc_st_done : e_bedrock_cmd_uc_data;
+      fsm_cmd_header_li.subop            = e_bedrock_store; // TODO: support I/O AMOs
+      fsm_cmd_header_li.addr             = fsm_rev_header_lo.addr;
+      fsm_cmd_header_li.size             = fsm_rev_header_lo.size;
+      fsm_cmd_header_li.payload          = '0;
+      fsm_cmd_header_li.payload.src_id   = cce_id_i;
+      fsm_cmd_header_li.payload.dst_id   = fsm_rev_header_lo.payload.lce_id;
+      fsm_cmd_header_li.payload.src_did  = fsm_rev_header_lo.payload.src_did;
+      fsm_cmd_data_li                    = fsm_rev_data_lo;
+      fsm_cmd_v_li                       = fsm_rev_v_lo;
+      fsm_rev_yumi_li                    = fsm_cmd_ready_and_lo & fsm_cmd_v_li;
+    end
 
 endmodule
 

--- a/bp_me/src/v/dev/bp_me_bedrock_register.sv
+++ b/bp_me/src/v/dev/bp_me_bedrock_register.sv
@@ -21,7 +21,7 @@ module bp_me_bedrock_register
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
    // The width of the registers. Currently, must all be the same.
    , parameter reg_data_width_p = dword_width_gp
@@ -70,7 +70,7 @@ module bp_me_bedrock_register
    );
 
   if (dword_width_gp != 64) $error("BedRock interface data width must be 64-bits");
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `bp_cast_i(bp_bedrock_mem_fwd_header_s, mem_fwd_header);
   `bp_cast_o(bp_bedrock_mem_rev_header_s, mem_rev_header);
 

--- a/bp_me/src/v/dev/bp_me_cache_controller.sv
+++ b/bp_me/src/v/dev/bp_me_cache_controller.sv
@@ -23,7 +23,7 @@ module bp_me_cache_controller
  import bsg_cache_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
    // L2 organization and interface
    , localparam cache_pkt_width_lp = `bsg_cache_pkt_width(daddr_width_p, l2_data_width_p)
@@ -63,7 +63,7 @@ module bp_me_cache_controller
   localparam data_byte_offset_width_lp = `BSG_SAFE_CLOG2(data_bytes_lp);
 
   `declare_bsg_cache_pkt_s(daddr_width_p, l2_data_width_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, daddr_width_p);
 
   bsg_cache_pkt_s cache_pkt;

--- a/bp_me/src/v/dev/bp_me_cache_slice.sv
+++ b/bp_me/src/v/dev/bp_me_cache_slice.sv
@@ -20,7 +20,7 @@ module bp_me_cache_slice
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
 
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
    , localparam dma_pkt_width_lp = `bsg_cache_dma_pkt_width(daddr_width_p, l2_block_size_in_words_p)
    )
@@ -51,8 +51,8 @@ module bp_me_cache_slice
    , input [l2_banks_p-1:0]                              dma_data_ready_and_i
    );
 
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
 
   `declare_bsg_cache_pkt_s(daddr_width_p, l2_data_width_p);
   bsg_cache_pkt_s [l2_banks_p-1:0] cache_pkt_li;

--- a/bp_me/src/v/dev/bp_me_cfg_slice.sv
+++ b/bp_me/src/v/dev/bp_me_cfg_slice.sv
@@ -15,9 +15,9 @@ module bp_me_cfg_slice
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    )
   (input                                            clk_i
    , input                                          reset_i
@@ -47,8 +47,8 @@ module bp_me_cfg_slice
 
   if (dword_width_gp != 64) $error("BedRock interface data width must be 64-bits");
 
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `bp_cast_o(bp_cfg_bus_s, cfg_bus);
 
   localparam reg_els_lp = 10;
@@ -119,7 +119,7 @@ module bp_me_cfg_slice
 
   // Access to CCE ucode memory must be aligned
   localparam cce_pc_offset_width_lp = `BSG_SAFE_CLOG2(`BSG_CDIV(cce_instr_width_gp,8));
-  // Prevent writing CCE ucode if we're already out of cached mode.
+  // Prevent writing CCE ucode if we're already out of uncached mode.
   //   We could also handle this by software, but seems dangerous to allow in hardware
   assign cce_ucode_v_o    = (cce_mode_r == e_cce_mode_uncached) & (cce_ucode_r_v_li | cce_ucode_w_v_li);
   assign cce_ucode_w_o    = (cce_mode_r == e_cce_mode_uncached) & cce_ucode_w_v_li;
@@ -149,6 +149,7 @@ module bp_me_cfg_slice
                             ,cce_id: cce_id_li
                             ,cce_mode: cce_mode_r
                             ,hio_mask: hio_mask_r
+                            ,did: did_i
                             };
 
   assign data_li[0] = freeze_r;

--- a/bp_me/src/v/dev/bp_me_clint_slice.sv
+++ b/bp_me/src/v/dev/bp_me_clint_slice.sv
@@ -17,9 +17,9 @@ module bp_me_clint_slice
  import bsg_wormhole_router_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    )
   (input                                                clk_i
    , input                                              rt_clk_i
@@ -47,8 +47,8 @@ module bp_me_clint_slice
 
   if (dword_width_gp != 64) $error("BedRock interface data width must be 64-bits");
 
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, caddr_width_p);
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 

--- a/bp_me/src/v/dev/bp_me_loopback.sv
+++ b/bp_me/src/v/dev/bp_me_loopback.sv
@@ -17,7 +17,7 @@ module bp_me_loopback
   import bp_me_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+    `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
     )
    (input                                            clk_i
     , input                                          reset_i
@@ -33,7 +33,7 @@ module bp_me_loopback
     , input                                          mem_rev_ready_and_i
     );
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `bp_cast_i(bp_bedrock_mem_fwd_header_s, mem_fwd_header);
   `bp_cast_o(bp_bedrock_mem_rev_header_s, mem_rev_header);
 

--- a/bp_me/src/v/lce/bp_lce.sv
+++ b/bp_me/src/v/lce/bp_lce.sv
@@ -30,7 +30,7 @@ module bp_lce
    , parameter non_excl_reads_p = 0
    , parameter `BSG_INV_PARAM(ctag_width_p)
 
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache)
   )
   (
@@ -38,6 +38,7 @@ module bp_lce
     , input                                          reset_i
 
     // LCE Configuration
+    , input [did_width_p-1:0]                        did_i
     , input [lce_id_width_p-1:0]                     lce_id_i
     , input bp_lce_mode_e                            lce_mode_i
 
@@ -120,7 +121,7 @@ module bp_lce
     $error("fill width must be greater or equal than cache request data width");
 
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache);
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
 
   // LCE Request Module
   logic req_busy_lo;
@@ -143,6 +144,7 @@ module bp_lce
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
 
+     ,.did_i(did_i)
      ,.lce_id_i(lce_id_i)
      ,.lce_mode_i(lce_mode_i)
      ,.sync_done_i(sync_done_lo)

--- a/bp_me/src/v/lce/bp_lce_cmd.sv
+++ b/bp_me/src/v/lce/bp_lce_cmd.sv
@@ -24,7 +24,7 @@ module bp_lce_cmd
    , parameter `BSG_INV_PARAM(fill_width_p)
    , parameter `BSG_INV_PARAM(ctag_width_p)
 
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache)
   )
   (
@@ -88,7 +88,7 @@ module bp_lce_cmd
     , input                                          lce_resp_ready_and_i
     );
 
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache);
   `bp_cast_i(bp_bedrock_lce_cmd_header_s, lce_cmd_header);
   `bp_cast_o(bp_bedrock_lce_fill_header_s, lce_fill_header);

--- a/bp_me/src/v/lce/bp_lce_req.sv
+++ b/bp_me/src/v/lce/bp_lce_req.sv
@@ -36,7 +36,7 @@ module bp_lce_req
    , localparam bedrock_byte_offset_lp = `BSG_SAFE_CLOG2(fill_width_p/8)
    , localparam bit [paddr_width_p-1:0] req_addr_mask = {paddr_width_p{1'b1}} << bedrock_byte_offset_lp
 
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache)
   )
   (
@@ -44,6 +44,7 @@ module bp_lce_req
     , input                                          reset_i
 
     // LCE Configuration
+    , input [did_width_p-1:0]                        did_i
     , input [lce_id_width_p-1:0]                     lce_id_i
     , input bp_lce_mode_e                            lce_mode_i
     , input                                          cache_init_done_i
@@ -84,7 +85,7 @@ module bp_lce_req
     , input                                          lce_req_ready_and_i
   );
 
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache);
   `bp_cast_o(bp_bedrock_lce_req_header_s, lce_req_header);
   `bp_cast_i(bp_cache_req_s, cache_req);
@@ -258,6 +259,7 @@ module bp_lce_req
     fsm_req_header_lo.size = bp_bedrock_msg_size_e'(cache_req_r.size);
     fsm_req_header_lo.payload.dst_id = req_cce_id_lo;
     fsm_req_header_lo.payload.src_id = lce_id_i;
+    fsm_req_header_lo.payload.src_did = did_i;
     fsm_req_header_lo.payload.lru_way_id = lce_assoc_width_p'(cache_req_metadata.hit_or_repl_way);
     fsm_req_header_lo.payload.non_exclusive =
       (miss_load_v_r && (non_excl_reads_p == 1)) ? e_bedrock_req_non_excl : e_bedrock_req_excl;

--- a/bp_me/src/v/network/bp_me_stream_gearbox.sv
+++ b/bp_me/src/v/network/bp_me_stream_gearbox.sv
@@ -13,7 +13,7 @@ module bp_me_stream_gearbox
    , parameter `BSG_INV_PARAM(out_data_width_p)
    , parameter `BSG_INV_PARAM(payload_width_p)
    , parameter `BSG_INV_PARAM(stream_mask_p)
-   `declare_bp_bedrock_if_widths(paddr_width_p, payload_width_p, xce)
+   `declare_bp_bedrock_generic_if_width(paddr_width_p, payload_width_p, xce)
    )
   (input                                            clk_i
    , input                                          reset_i
@@ -30,7 +30,7 @@ module bp_me_stream_gearbox
    , input                                          msg_ready_param_i
    );
 
-  `declare_bp_bedrock_if(paddr_width_p, payload_width_p, lce_id_width_p, lce_assoc_p, xce);
+  `declare_bp_bedrock_generic_if(paddr_width_p, payload_width_p, xce);
   `bp_cast_i(bp_bedrock_xce_header_s, msg_header);
   `bp_cast_o(bp_bedrock_xce_header_s, msg_header);
 

--- a/bp_me/src/v/network/bp_me_stream_pump_control.sv
+++ b/bp_me/src/v/network/bp_me_stream_pump_control.sv
@@ -29,7 +29,7 @@ module bp_me_stream_pump_control
    , parameter `BSG_INV_PARAM(data_width_p)
    , parameter `BSG_INV_PARAM(stream_mask_p)
    , parameter `BSG_INV_PARAM(widest_beat_size_p)
-   `declare_bp_bedrock_if_widths(paddr_width_p, payload_width_p, xce)
+   `declare_bp_bedrock_generic_if_width(paddr_width_p, payload_width_p, xce)
    )
   (input                                          clk_i
    , input                                        reset_i
@@ -46,7 +46,7 @@ module bp_me_stream_pump_control
    , output logic                                 last_o
    );
 
-  `declare_bp_bedrock_if(paddr_width_p, payload_width_p, lce_id_width_p, lce_assoc_p, xce);
+  `declare_bp_bedrock_generic_if(paddr_width_p, payload_width_p, xce);
   `bp_cast_i(bp_bedrock_xce_header_s, header);
 
   localparam bytes_lp = data_width_p >> 3;

--- a/bp_me/src/v/network/bp_me_stream_pump_in.sv
+++ b/bp_me/src/v/network/bp_me_stream_pump_in.sv
@@ -42,7 +42,7 @@ module bp_me_stream_pump_in
    , parameter `BSG_INV_PARAM(msg_stream_mask_p)
    , parameter `BSG_INV_PARAM(fsm_stream_mask_p)
 
-   `declare_bp_bedrock_if_widths(paddr_width_p, payload_width_p, xce)
+   `declare_bp_bedrock_generic_if_width(paddr_width_p, payload_width_p, xce)
 
    , localparam fsm_bytes_lp = fsm_data_width_p >> 3
    , localparam fsm_cnt_offset_width_lp = `BSG_SAFE_CLOG2(fsm_bytes_lp)
@@ -74,7 +74,7 @@ module bp_me_stream_pump_in
    , output logic                                   fsm_last_o
    );
 
-  `declare_bp_bedrock_if(paddr_width_p, payload_width_p, lce_id_width_p, lce_assoc_p, xce);
+  `declare_bp_bedrock_generic_if(paddr_width_p, payload_width_p, xce);
   `bp_cast_i(bp_bedrock_xce_header_s, msg_header);
   `bp_cast_o(bp_bedrock_xce_header_s, fsm_header);
 

--- a/bp_me/src/v/network/bp_me_stream_pump_out.sv
+++ b/bp_me/src/v/network/bp_me_stream_pump_out.sv
@@ -39,7 +39,7 @@ module bp_me_stream_pump_out
    , parameter `BSG_INV_PARAM(msg_stream_mask_p)
    , parameter `BSG_INV_PARAM(fsm_stream_mask_p)
 
-   `declare_bp_bedrock_if_widths(paddr_width_p, payload_width_p, xce)
+   `declare_bp_bedrock_generic_if_width(paddr_width_p, payload_width_p, xce)
 
    , localparam fsm_bytes_lp = fsm_data_width_p >> 3
    , localparam fsm_cnt_offset_width_lp = `BSG_SAFE_CLOG2(fsm_bytes_lp)
@@ -74,7 +74,7 @@ module bp_me_stream_pump_out
    , output logic                                   fsm_critical_o
    );
 
-  `declare_bp_bedrock_if(paddr_width_p, payload_width_p, lce_id_width_p, lce_assoc_p, xce);
+  `declare_bp_bedrock_generic_if(paddr_width_p, payload_width_p, xce);
   `bp_cast_i(bp_bedrock_xce_header_s, fsm_header);
   `bp_cast_o(bp_bedrock_xce_header_s, msg_header);
 

--- a/bp_me/src/v/network/bp_me_stream_to_wormhole.sv
+++ b/bp_me/src/v/network/bp_me_stream_to_wormhole.sv
@@ -12,7 +12,7 @@
  *  Usage of this module requires correctly formed wormhole headers. The length
  *    field of the wormhole message determines how many protocol data beats are
  *    expected (some multiple or divisor of the flit_width). We expect most
- *    link and protocol data widths to be powers of 2 (32, 64, 512), so this
+ *    link and protocol data width to be powers of 2 (32, 64, 512), so this
  *    length restriction is lenient.
  *
  *   - data width is a multiple of flit width (would be easy to add support)
@@ -93,9 +93,9 @@ module bp_me_stream_to_wormhole
 
   // parameter checks
   if (!(`BSG_IS_POW2(pr_data_width_p)) || !(`BSG_IS_POW2(flit_width_p)))
-    $error("Protocol and Network data widths must be powers of 2");
+    $error("Protocol and Network data width must be powers of 2");
 
-  `declare_bp_bedrock_if(paddr_width_p, pr_payload_width_p, lce_id_width_p, lce_assoc_p, msg);
+  `declare_bp_bedrock_generic_if(paddr_width_p, pr_payload_width_p, msg);
   `bp_cast_i(bp_bedrock_msg_header_s, pr_hdr);
 
   // WH control signals

--- a/bp_me/src/v/network/bp_me_wormhole_header_encode.sv
+++ b/bp_me/src/v/network/bp_me_wormhole_header_encode.sv
@@ -22,7 +22,7 @@ module bp_me_wormhole_header_encode
    , parameter `BSG_INV_PARAM(len_width_p)
    , parameter `BSG_INV_PARAM(payload_width_p)
 
-   `declare_bp_bedrock_if_widths(paddr_width_p, payload_width_p, msg)
+   `declare_bp_bedrock_generic_if_width(paddr_width_p, payload_width_p, msg)
 
    // Constructed as (1 << e_rd/wr_msg | 1 << e_uc_rd/wr_msg)
    , parameter stream_mask_p = 0
@@ -38,7 +38,7 @@ module bp_me_wormhole_header_encode
    , output logic [wh_header_width_lp-1:0]  wh_header_o
    );
 
-  `declare_bp_bedrock_if(paddr_width_p, payload_width_p, lce_id_width_p, lce_assoc_p, msg);
+  `declare_bp_bedrock_generic_if(paddr_width_p, payload_width_p, msg);
   `bp_cast_i(bp_bedrock_msg_header_s, header);
 
   `declare_bp_bedrock_wormhole_header_s(flit_width_p, cord_width_p, len_width_p, cid_width_p, bp_bedrock_msg_header_s, bedrock);

--- a/bp_me/src/v/network/bp_me_wormhole_to_stream.sv
+++ b/bp_me/src/v/network/bp_me_wormhole_to_stream.sv
@@ -14,7 +14,7 @@
  *  Usage of this module requires correctly formed wormhole headers. The length
  *    field of the wormhole message determines how many protocol data beats are
  *    expected (some multiple or divisor of the flit_width). We expect most
- *    link and protocol data widths to be powers of 2 (32, 64, 512), so this
+ *    link and protocol data width to be powers of 2 (32, 64, 512), so this
  *    length restriction is lenient.
  *
  *   - data width is a multiple of flit width
@@ -84,12 +84,12 @@ module bp_me_wormhole_to_stream
    , input                              pr_ready_and_i
    );
 
-  `declare_bp_bedrock_if(paddr_width_p, pr_payload_width_p, lce_id_width_p, lce_assoc_p, msg);
+  `declare_bp_bedrock_generic_if(paddr_width_p, pr_payload_width_p, msg);
   `bp_cast_o(bp_bedrock_msg_header_s, pr_hdr);
 
   // parameter checks
   if (!(`BSG_IS_POW2(pr_data_width_p)) || !(`BSG_IS_POW2(flit_width_p)))
-    $error("Protocol and Network data widths must be powers of 2");
+    $error("Protocol and Network data width must be powers of 2");
 
   // WH control signals
   logic is_hdr, is_data, wh_has_data, wh_last_data;

--- a/bp_me/src/v/network/bp_me_xbar_stream.sv
+++ b/bp_me/src/v/network/bp_me_xbar_stream.sv
@@ -23,7 +23,7 @@ module bp_me_xbar_stream
    , parameter `BSG_INV_PARAM(num_source_p)
    , parameter `BSG_INV_PARAM(num_sink_p)
    , parameter `BSG_INV_PARAM(stream_mask_p)
-   `declare_bp_bedrock_if_widths(paddr_width_p, payload_width_p, xbar)
+   `declare_bp_bedrock_generic_if_width(paddr_width_p, payload_width_p, xbar)
 
    , localparam lg_num_source_lp = `BSG_SAFE_CLOG2(num_source_p)
    , localparam lg_num_sink_lp   = `BSG_SAFE_CLOG2(num_sink_p)
@@ -43,7 +43,7 @@ module bp_me_xbar_stream
    , input [num_sink_p-1:0]                                           msg_ready_and_i
    );
 
-  `declare_bp_bedrock_if(paddr_width_p, payload_width_p, lce_id_width_p, lce_assoc_p, xbar);
+  `declare_bp_bedrock_generic_if(paddr_width_p, payload_width_p, xbar);
    bp_bedrock_xbar_header_s [num_source_p-1:0] msg_header_li;
    logic [num_source_p-1:0][data_width_p-1:0] msg_data_li;
    logic [num_source_p-1:0] msg_v_li, msg_yumi_lo;

--- a/bp_me/test/common/bp_me_nonsynth_cce_inst_tracer.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cce_inst_tracer.sv
@@ -18,8 +18,7 @@ module bp_me_nonsynth_cce_inst_tracer
 
     , localparam cce_inst_trace_file_p = "cce_inst"
 
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+    `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
   )
   (input                        clk_i
    , input                      reset_i

--- a/bp_me/test/common/bp_me_nonsynth_cce_perf.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cce_perf.sv
@@ -16,8 +16,7 @@ module bp_me_nonsynth_cce_perf
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
 
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+    `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
     , localparam cnt_max_lp = 64'h0FFF_FFFF_FFFF_FFFF
     , localparam cce_trace_file_p = "cce_perf"
@@ -40,8 +39,7 @@ module bp_me_nonsynth_cce_perf
    , input [mem_fwd_header_width_lp-1:0]            mem_fwd_header_i
   );
 
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   bp_bedrock_lce_req_header_s  lce_req;
 
   integer file;

--- a/bp_me/test/common/bp_me_nonsynth_cce_tracer.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cce_tracer.sv
@@ -27,8 +27,7 @@ module bp_me_nonsynth_cce_tracer
     , localparam lg_num_way_groups_lp      = `BSG_SAFE_CLOG2(num_way_groups_lp)
     , localparam lg_cce_way_groups_lp      = `BSG_SAFE_CLOG2(cce_way_groups_p)
 
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+    `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
   )
   (input                                            clk_i
    , input                                          reset_i
@@ -66,8 +65,7 @@ module bp_me_nonsynth_cce_tracer
   );
 
   // LCE-CCE and Mem-CCE Interface
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
 
   // LCE-CCE Interface structs
   `bp_cast_i(bp_bedrock_lce_req_header_s, lce_req_header);

--- a/bp_me/test/common/bp_me_nonsynth_cfg_loader.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cfg_loader.sv
@@ -20,7 +20,7 @@ module bp_me_nonsynth_cfg_loader
   import bp_me_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+    `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
     , parameter `BSG_INV_PARAM(inst_width_p)
     , parameter `BSG_INV_PARAM(inst_ram_addr_width_p)
@@ -58,7 +58,7 @@ module bp_me_nonsynth_cfg_loader
   wire unused0 = &{mem_rev_header_i, mem_rev_data_i};
   assign mem_rev_ready_and_o = 1'b1;
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, daddr_width_p);
 
   bp_bedrock_mem_fwd_header_s mem_fwd_cast_o;

--- a/bp_me/test/common/bp_me_nonsynth_dev_tracer.sv
+++ b/bp_me/test/common/bp_me_nonsynth_dev_tracer.sv
@@ -18,7 +18,7 @@ module bp_me_nonsynth_dev_tracer
 
     , parameter trace_file_p = "dev"
 
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+    `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
   )
   (input                                            clk_i
    , input                                          reset_i
@@ -39,7 +39,7 @@ module bp_me_nonsynth_dev_tracer
    , input                                          mem_rev_ready_and_i
   );
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
 
   `bp_cast_i(bp_bedrock_mem_fwd_header_s, mem_fwd_header);
   `bp_cast_i(bp_bedrock_mem_rev_header_s, mem_rev_header);

--- a/bp_me/test/common/bp_me_nonsynth_lce_tracer.sv
+++ b/bp_me/test/common/bp_me_nonsynth_lce_tracer.sv
@@ -32,7 +32,7 @@ module bp_me_nonsynth_lce_tracer
 
     , localparam lce_req_data_width_lp = dword_width_gp
 
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+    `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
     , localparam integer cnt_max_lp = 1<<31
     , localparam cnt_ptr_width_lp = `BSG_SAFE_CLOG2(cnt_max_lp+1)
@@ -73,7 +73,7 @@ module bp_me_nonsynth_lce_tracer
   );
 
   // LCE-CCE interface structs
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `bp_cast_i(bp_bedrock_lce_req_header_s, lce_req_header);
   `bp_cast_i(bp_bedrock_lce_cmd_header_s, lce_cmd_header);
   `bp_cast_i(bp_bedrock_lce_resp_header_s, lce_resp_header);

--- a/bp_me/test/common/bp_nonsynth_dram.sv
+++ b/bp_me/test/common/bp_nonsynth_dram.sv
@@ -14,7 +14,7 @@ module bp_nonsynth_dram
  import bsg_axi_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
    , parameter num_dma_p = 0
    , parameter preload_mem_p = 0

--- a/bp_me/test/common/bp_nonsynth_mem.sv
+++ b/bp_me/test/common/bp_nonsynth_mem.sv
@@ -13,7 +13,7 @@ module bp_nonsynth_mem
  import bsg_cache_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
    , parameter preload_mem_p = 0
    , parameter mem_bytes_p = 0

--- a/bp_me/test/common/bp_nonsynth_mem_tracer.sv
+++ b/bp_me/test/common/bp_nonsynth_mem_tracer.sv
@@ -12,7 +12,7 @@ module bp_nonsynth_mem_tracer
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
    , parameter trace_file_p = "dram.trace"
    )
@@ -31,7 +31,7 @@ module bp_nonsynth_mem_tracer
    , input                                      mem_rev_ready_and_i
    );
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `bp_cast_i(bp_bedrock_mem_fwd_header_s, mem_fwd_header);
   `bp_cast_i(bp_bedrock_mem_rev_header_s, mem_rev_header);
 

--- a/bp_me/test/tb/bp_cce/testbench.sv
+++ b/bp_me/test/tb/bp_cce/testbench.sv
@@ -41,8 +41,7 @@ module testbench
    , localparam trace_replay_data_width_lp=`bp_me_nonsynth_tr_pkt_width(paddr_width_p, dword_width_gp)
    , localparam trace_rom_addr_width_lp = 20
 
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, cache)
    )
   (output bit reset_i);
@@ -69,9 +68,8 @@ module testbench
     return (`BP_SIM_CLK_PERIOD);
   endfunction
 
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `declare_bp_me_nonsynth_tr_pkt_s(paddr_width_p, dword_width_gp);
 
   // Bit to deal with initial X->0 transition detection

--- a/bp_me/test/tb/bp_cce/wrapper.sv
+++ b/bp_me/test/tb/bp_cce/wrapper.sv
@@ -13,10 +13,9 @@ module wrapper
  #(parameter bp_params_e bp_params_p = BP_CFG_FLOWVAR
    `declare_bp_proc_params(bp_params_p)
 
-   // interface widths
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   // interface width
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    )
   (input                                            clk_i
    , input                                          reset_i

--- a/bp_top/src/v/bp_cacc_tile.sv
+++ b/bp_top/src/v/bp_cacc_tile.sv
@@ -16,8 +16,7 @@ module bp_cacc_tile
  import bsg_wormhole_router_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
@@ -42,8 +41,7 @@ module bp_cacc_tile
 
    );
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
 
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, bp_coh_ready_and_link_s);
 
@@ -126,7 +124,6 @@ module bp_cacc_tile
      ,.reset_i(reset_r)
 
      ,.cce_id_i(cce_id_li)
-     ,.did_i('0)
 
      ,.lce_req_header_i(lce_req_header_li)
      ,.lce_req_data_i(lce_req_data_li)

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -9,11 +9,10 @@ module bp_cacc_vdp
  import bp_me_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
-    `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
-    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+    `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
     `declare_bp_cache_engine_if_widths(paddr_width_p, acache_ctag_width_p, acache_sets_p, acache_assoc_p, dword_width_gp, acache_block_width_p, acache_fill_width_p, acache)
 
-    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
     )
    (input                                         clk_i
     , input                                       reset_i
@@ -61,7 +60,7 @@ module bp_cacc_vdp
     );
 
   // CCE-IO interface is used for uncached requests-read/write memory mapped CSR
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, daddr_width_p);
 
   localparam reg_els_lp = 1;
@@ -101,7 +100,7 @@ module bp_cacc_vdp
   logic [dword_width_gp-1:0] acache_data_lo;
   logic acache_v_lo;
 
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
   bp_cfg_bus_s cfg_bus_cast_i;
   assign cfg_bus_cast_i.dcache_id = lce_id_i;
   assign cfg_bus_cast_i.dcache_mode = e_lce_mode_normal;
@@ -209,6 +208,7 @@ module bp_cacc_vdp
      ,.reset_i(reset_i)
 
      ,.lce_id_i(cfg_bus_cast_i.dcache_id)
+     ,.did_i(cfg_bus_cast_i.did)
      ,.lce_mode_i(cfg_bus_cast_i.dcache_mode)
 
      ,.cache_req_i(acache_req_lo)

--- a/bp_top/src/v/bp_core.sv
+++ b/bp_top/src/v/bp_core.sv
@@ -22,10 +22,9 @@ module bp_core
  import bsg_wormhole_router_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    , localparam dma_pkt_width_lp = `bsg_cache_dma_pkt_width(daddr_width_p, l2_block_size_in_words_p)
    )
   (input                                                 clk_i
@@ -92,8 +91,8 @@ module bp_core
    , input [l2_slices_p-1:0][l2_banks_p-1:0]                              dma_data_ready_and_i
    );
 
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, daddr_width_p);
 
   // Only CCE acts as a proc for multicore

--- a/bp_top/src/v/bp_core_complex.sv
+++ b/bp_top/src/v/bp_core_complex.sv
@@ -62,7 +62,7 @@ module bp_core_complex
    , output logic [S:N][cc_x_dim_p-1:0][dma_noc_ral_link_width_lp-1:0] dma_link_o
    );
 
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, coh_noc_ral_link_s);
   `declare_bsg_ready_and_link_sif_s(dma_noc_flit_width_p, dma_noc_ral_link_s);
 

--- a/bp_top/src/v/bp_core_lite.sv
+++ b/bp_top/src/v/bp_core_lite.sv
@@ -15,11 +15,11 @@ module bp_core_lite
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_core_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache)
    `declare_bp_cache_engine_if_widths(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    )
   (input                                              clk_i
    , input                                            reset_i
@@ -60,8 +60,8 @@ module bp_core_lite
    , input                                            s_external_irq_i
    );
 
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `declare_bp_cache_engine_if(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache);
   `declare_bp_cache_engine_if(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache);
 
@@ -203,6 +203,7 @@ module bp_core_lite
     (.clk_i(posedge_clk)
      ,.reset_i(reset_i)
 
+     ,.did_i(cfg_bus_cast_i.did)
      ,.lce_id_i(cfg_bus_cast_i.icache_id)
      ,.lce_mode_i(cfg_bus_cast_i.icache_mode)
 
@@ -298,6 +299,7 @@ module bp_core_lite
     (.clk_i(negedge_clk)
      ,.reset_i(reset_i)
 
+     ,.did_i(cfg_bus_cast_i.did)
      ,.lce_id_i(cfg_bus_cast_i.dcache_id)
      ,.lce_mode_i(cfg_bus_cast_i.dcache_mode)
 

--- a/bp_top/src/v/bp_core_minimal.sv
+++ b/bp_top/src/v/bp_core_minimal.sv
@@ -14,7 +14,7 @@ module bp_core_minimal
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_cache_engine_if_widths(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache)
    `declare_bp_cache_engine_if_widths(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    )
   (input                                             clk_i
    , input                                           reset_i
@@ -87,7 +87,7 @@ module bp_core_minimal
    );
 
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
 
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 

--- a/bp_top/src/v/bp_core_tile.sv
+++ b/bp_top/src/v/bp_core_tile.sv
@@ -21,10 +21,9 @@ module bp_core_tile
  import bsg_wormhole_router_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
 
    // Wormhole parameters
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
@@ -55,9 +54,8 @@ module bp_core_tile
    , input [dma_noc_ral_link_width_lp-1:0]                    dma_link_i
    );
 
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, bp_coh_ready_and_link_s);
   `declare_bsg_ready_and_link_sif_s(dma_noc_flit_width_p, bp_dma_ready_and_link_s);
 

--- a/bp_top/src/v/bp_io_link_to_lce.sv
+++ b/bp_top/src/v/bp_io_link_to_lce.sv
@@ -20,8 +20,7 @@ module bp_io_link_to_lce
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam dma_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(dma_noc_flit_width_p)
@@ -53,65 +52,177 @@ module bp_io_link_to_lce
    , output logic                                   lce_cmd_ready_and_o
    );
 
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `bp_cast_i(bp_bedrock_mem_fwd_header_s, mem_fwd_header);
   `bp_cast_o(bp_bedrock_mem_rev_header_s, mem_rev_header);
   `bp_cast_o(bp_bedrock_lce_req_header_s, lce_req_header);
   `bp_cast_i(bp_bedrock_lce_cmd_header_s, lce_cmd_header);
 
-  bp_bedrock_mem_fwd_header_s [num_pseudo_cce_p-1:0] fifo_li;
-  logic [num_pseudo_cce_p-1:0] fifo_v_li, fifo_ready_and_lo;
-  bp_bedrock_mem_fwd_header_s [num_pseudo_cce_p-1:0] fifo_lo;
-  logic [num_pseudo_cce_p-1:0] fifo_yumi_li;
-  for (genvar i = 0; i < num_pseudo_cce_p; i++)
-    begin : return_fifos
-      bsg_fifo_1r1w_small
-       #(.width_p($bits(bp_bedrock_mem_fwd_header_s)), .els_p(mem_noc_max_credits_p/num_pseudo_cce_p))
-       fifo
-        (.clk_i(clk_i)
-         ,.reset_i(reset_i)
+  bp_bedrock_mem_fwd_header_s fsm_fwd_header_lo;
+  logic [bedrock_fill_width_p-1:0] fsm_fwd_data_lo;
+  logic fsm_fwd_v_lo, fsm_fwd_yumi_li;
+  logic [paddr_width_p-1:0] fsm_fwd_addr_lo;
+  logic fsm_fwd_new_lo, fsm_fwd_critical_lo, fsm_fwd_last_lo;
+  bp_me_stream_pump_in
+   #(.bp_params_p(bp_params_p)
+     ,.fsm_data_width_p(bedrock_fill_width_p)
+     ,.block_width_p(bedrock_block_width_p)
+     ,.payload_width_p(mem_fwd_payload_width_lp)
+     ,.msg_stream_mask_p(mem_fwd_stream_mask_gp)
+     ,.fsm_stream_mask_p(mem_fwd_stream_mask_gp)
+     )
+   fwd_pump_in
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
 
-         ,.data_i(fifo_li[i])
-         ,.v_i(fifo_v_li[i])
-         ,.ready_o(fifo_ready_and_lo[i])
+     ,.msg_header_i(mem_fwd_header_cast_i)
+     ,.msg_data_i(mem_fwd_data_i)
+     ,.msg_v_i(mem_fwd_v_i)
+     ,.msg_ready_and_o(mem_fwd_ready_and_o)
 
-         ,.data_o(fifo_lo[i])
-         ,.v_o(/* Correct by construction */)
-         ,.yumi_i(fifo_yumi_li[i])
-         );
-      assign fifo_li[i] = mem_fwd_header_cast_i;
-      assign fifo_v_li[i] = lce_req_ready_and_i & lce_req_v_o & (lce_req_header_cast_o.payload.dst_id == i);
+     ,.fsm_header_o(fsm_fwd_header_lo)
+     ,.fsm_data_o(fsm_fwd_data_lo)
+     ,.fsm_v_o(fsm_fwd_v_lo)
+     ,.fsm_yumi_i(fsm_fwd_yumi_li)
+     ,.fsm_addr_o(fsm_fwd_addr_lo)
+     ,.fsm_new_o(fsm_fwd_new_lo)
+     ,.fsm_critical_o(fsm_fwd_critical_lo)
+     ,.fsm_last_o(fsm_fwd_last_lo)
+     );
 
-      assign fifo_yumi_li[i] = mem_rev_ready_and_i & mem_rev_v_o & (lce_cmd_header_cast_i.payload.src_id == i);
-    end
-  assign mem_rev_data_o = lce_cmd_data_i;
-  assign mem_rev_header_cast_o = fifo_lo[lce_cmd_header_cast_i.payload.src_id];
-  assign mem_rev_v_o = lce_cmd_v_i;
-  assign lce_cmd_ready_and_o = mem_rev_ready_and_i;
+  bp_bedrock_lce_req_header_s fsm_req_header_li;
+  logic [bedrock_fill_width_p-1:0] fsm_req_data_li;
+  logic fsm_req_v_li, fsm_req_ready_and_lo;
+  logic [paddr_width_p-1:0] fsm_req_addr_lo;
+  logic fsm_req_new_lo, fsm_req_critical_lo, fsm_req_last_lo;
+  bp_me_stream_pump_out
+   #(.bp_params_p(bp_params_p)
+     ,.fsm_data_width_p(bedrock_fill_width_p)
+     ,.block_width_p(bedrock_block_width_p)
+     ,.payload_width_p(lce_req_payload_width_lp)
+     ,.msg_stream_mask_p(lce_req_stream_mask_gp)
+     ,.fsm_stream_mask_p(lce_req_stream_mask_gp)
+     )
+   req_pump_out
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.msg_header_o(lce_req_header_cast_o)
+     ,.msg_data_o(lce_req_data_o)
+     ,.msg_v_o(lce_req_v_o)
+     ,.msg_ready_and_i(lce_req_ready_and_i)
+
+     ,.fsm_header_i(fsm_req_header_li)
+     ,.fsm_data_i(fsm_req_data_li)
+     ,.fsm_v_i(fsm_req_v_li)
+     ,.fsm_ready_and_o(fsm_req_ready_and_lo)
+     ,.fsm_addr_o(fsm_req_addr_lo)
+     ,.fsm_new_o(fsm_req_new_lo)
+     ,.fsm_critical_o(fsm_req_critical_lo)
+     ,.fsm_last_o(fsm_req_last_lo)
+     );
+
+  bp_bedrock_lce_cmd_header_s fsm_cmd_header_lo;
+  logic [bedrock_fill_width_p-1:0] fsm_cmd_data_lo;
+  logic fsm_cmd_v_lo, fsm_cmd_yumi_li;
+  logic [paddr_width_p-1:0] fsm_cmd_addr_lo;
+  logic fsm_cmd_new_lo, fsm_cmd_critical_lo, fsm_cmd_last_lo;
+  bp_me_stream_pump_in
+   #(.bp_params_p(bp_params_p)
+     ,.fsm_data_width_p(bedrock_fill_width_p)
+     ,.block_width_p(bedrock_block_width_p)
+     ,.payload_width_p(lce_cmd_payload_width_lp)
+     ,.msg_stream_mask_p(lce_cmd_stream_mask_gp)
+     ,.fsm_stream_mask_p(lce_cmd_stream_mask_gp)
+     )
+   cmd_pump_in
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.msg_header_i(lce_cmd_header_cast_i)
+     ,.msg_data_i(lce_cmd_data_i)
+     ,.msg_v_i(lce_cmd_v_i)
+     ,.msg_ready_and_o(lce_cmd_ready_and_o)
+
+     ,.fsm_header_o(fsm_cmd_header_lo)
+     ,.fsm_data_o(fsm_cmd_data_lo)
+     ,.fsm_v_o(fsm_cmd_v_lo)
+     ,.fsm_yumi_i(fsm_cmd_yumi_li)
+     ,.fsm_addr_o(fsm_cmd_addr_lo)
+     ,.fsm_new_o(fsm_cmd_new_lo)
+     ,.fsm_critical_o(fsm_cmd_critical_lo)
+     ,.fsm_last_o(fsm_cmd_last_lo)
+     );
+
+  bp_bedrock_mem_rev_header_s fsm_rev_header_li;
+  logic [bedrock_fill_width_p-1:0] fsm_rev_data_li;
+  logic fsm_rev_v_li, fsm_rev_ready_and_lo;
+  logic [paddr_width_p-1:0] fsm_rev_addr_lo;
+  logic fsm_rev_new_lo, fsm_rev_critical_lo, fsm_rev_last_lo;
+  bp_me_stream_pump_out
+   #(.bp_params_p(bp_params_p)
+     ,.fsm_data_width_p(bedrock_fill_width_p)
+     ,.block_width_p(bedrock_block_width_p)
+     ,.payload_width_p(mem_rev_payload_width_lp)
+     ,.msg_stream_mask_p(mem_rev_stream_mask_gp)
+     ,.fsm_stream_mask_p(mem_rev_stream_mask_gp)
+     )
+   rev_pump_out
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.msg_header_o(mem_rev_header_cast_o)
+     ,.msg_data_o(mem_rev_data_o)
+     ,.msg_v_o(mem_rev_v_o)
+     ,.msg_ready_and_i(mem_rev_ready_and_i)
+
+     ,.fsm_header_i(fsm_rev_header_li)
+     ,.fsm_data_i(fsm_rev_data_li)
+     ,.fsm_v_i(fsm_rev_v_li)
+     ,.fsm_ready_and_o(fsm_rev_ready_and_lo)
+     ,.fsm_addr_o(fsm_rev_addr_lo)
+     ,.fsm_new_o(fsm_rev_new_lo)
+     ,.fsm_critical_o(fsm_rev_critical_lo)
+     ,.fsm_last_o(fsm_rev_last_lo)
+     );
 
   logic [cce_id_width_p-1:0] cce_id_lo;
   bp_me_addr_to_cce_id
    #(.bp_params_p(bp_params_p))
    addr_map
-    (.paddr_i(mem_fwd_header_cast_i.addr)
+    (.paddr_i(fsm_fwd_header_lo.addr)
      ,.cce_id_o(cce_id_lo)
      );
 
-  wire mem_fwd_wr_not_rd = (mem_fwd_header_cast_i.msg_type == e_bedrock_mem_uc_wr);
-  wire lce_cmd_wr_not_rd = (lce_cmd_header_cast_i.msg_type == e_bedrock_cmd_uc_st_done);
+  wire mem_fwd_wr_not_rd = (fsm_fwd_header_lo.msg_type == e_bedrock_mem_uc_wr);
+  wire lce_cmd_wr_not_rd = (fsm_cmd_header_lo.msg_type == e_bedrock_cmd_uc_st_done);
   always_comb
     begin
-      // Require all payloads to be ready to maintain helpfulness
-      mem_fwd_ready_and_o                   = &fifo_ready_and_lo & lce_req_ready_and_i;
-      lce_req_v_o                          = &fifo_ready_and_lo & mem_fwd_v_i;
-      lce_req_header_cast_o                = '0;
-      lce_req_header_cast_o.size           = mem_fwd_header_cast_i.size;
-      lce_req_header_cast_o.addr           = mem_fwd_header_cast_i.addr;
-      lce_req_header_cast_o.msg_type       = mem_fwd_wr_not_rd ? e_bedrock_req_uc_wr : e_bedrock_req_uc_rd;
-      lce_req_header_cast_o.payload.src_id = lce_id_i;
-      lce_req_header_cast_o.payload.dst_id = cce_id_lo;
-      lce_req_data_o                       = mem_fwd_data_i;
+      fsm_req_header_li.msg_type        = mem_fwd_wr_not_rd ? e_bedrock_req_uc_wr : e_bedrock_req_uc_rd;
+      fsm_req_header_li.subop           = e_bedrock_store; // TODO: support I/O AMOs
+      fsm_req_header_li.addr            = fsm_fwd_header_lo.addr;
+      fsm_req_header_li.size            = fsm_fwd_header_lo.size;
+      fsm_req_header_li.payload         = '0;
+      fsm_req_header_li.payload.src_id  = lce_id_i;
+      fsm_req_header_li.payload.dst_id  = cce_id_lo;
+      fsm_req_header_li.payload.src_did = fsm_fwd_header_lo.payload.src_did;
+      fsm_req_data_li                   = fsm_fwd_data_lo;
+      fsm_req_v_li                      = fsm_fwd_v_lo;
+
+      fsm_fwd_yumi_li = fsm_req_v_li & fsm_req_ready_and_lo;
+
+      fsm_rev_header_li.msg_type        = lce_cmd_wr_not_rd ? e_bedrock_mem_uc_wr : e_bedrock_mem_uc_rd;
+      fsm_rev_header_li.subop           = e_bedrock_store; // TODO: support I/O AMOs
+      fsm_rev_header_li.addr            = fsm_cmd_header_lo.addr;
+      fsm_rev_header_li.size            = fsm_cmd_header_lo.size;
+      fsm_rev_header_li.payload         = '0;
+      // TODO: Include
+      //fsm_rev_header_li.payload.lce_id  = fsm_cmd_header_lo.payload.lce_id;
+      fsm_rev_header_li.payload.src_did = fsm_cmd_header_lo.payload.src_did;
+      fsm_rev_data_li                   = fsm_cmd_data_lo;
+      fsm_rev_v_li                      = fsm_cmd_v_lo;
+
+      fsm_cmd_yumi_li = fsm_rev_v_li & fsm_rev_ready_and_lo;
     end
 
 endmodule

--- a/bp_top/src/v/bp_io_tile.sv
+++ b/bp_top/src/v/bp_io_tile.sv
@@ -8,8 +8,7 @@ module bp_io_tile
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
@@ -17,8 +16,8 @@ module bp_io_tile
   (input                                          clk_i
    , input                                        reset_i
 
-   , input [mem_noc_did_width_p-1:0]               my_did_i
-   , input [mem_noc_did_width_p-1:0]               host_did_i
+   , input [mem_noc_did_width_p-1:0]              my_did_i
+   , input [mem_noc_did_width_p-1:0]              host_did_i
    , input [coh_noc_cord_width_p-1:0]             my_cord_i
 
    , input [coh_noc_ral_link_width_lp-1:0]        lce_req_link_i
@@ -34,8 +33,7 @@ module bp_io_tile
    , output logic [mem_noc_ral_link_width_lp-1:0]  mem_rev_link_o
    );
 
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, daddr_width_p);
 
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, bp_coh_noc_ready_and_link_sif_s);
@@ -134,7 +132,6 @@ module bp_io_tile
      ,.reset_i(reset_r)
 
      ,.cce_id_i(cce_id_li)
-     ,.did_i(my_did_i)
 
      ,.lce_req_header_i(lce_req_header_li)
      ,.lce_req_data_i(lce_req_data_li)
@@ -326,7 +323,7 @@ module bp_io_tile
      ,.link_ready_and_i(mem_fwd_link_cast_i.ready_and_rev)
      );
 
-  wire [mem_noc_cord_width_p-1:0] mem_rev_dst_cord_lo = mem_rev_header_lo.payload.did;
+  wire [mem_noc_cord_width_p-1:0] mem_rev_dst_cord_lo = mem_rev_header_lo.payload.src_did;
   wire [mem_noc_cid_width_p-1:0] mem_rev_dst_cid_lo = '0;
   bp_me_stream_to_wormhole
    #(.bp_params_p(bp_params_p)

--- a/bp_top/src/v/bp_l2e_tile.sv
+++ b/bp_top/src/v/bp_l2e_tile.sv
@@ -21,10 +21,9 @@ module bp_l2e_tile
  import bsg_wormhole_router_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
-    , localparam cfg_bus_width_lp        = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+    , localparam cfg_bus_width_lp        = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    // Wormhole parameters
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam dma_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(dma_noc_flit_width_p)
@@ -49,9 +48,8 @@ module bp_l2e_tile
    , input [dma_noc_ral_link_width_lp-1:0]                    dma_link_i
    );
 
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, daddr_width_p);
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, bp_coh_ready_and_link_s);
   `declare_bsg_ready_and_link_sif_s(dma_noc_flit_width_p, bp_dma_ready_and_link_s);

--- a/bp_top/src/v/bp_multicore.sv
+++ b/bp_top/src/v/bp_multicore.sv
@@ -48,7 +48,7 @@ module bp_multicore
    , input [S:N][mc_x_dim_p-1:0][dma_noc_ral_link_width_lp-1:0]        dma_link_i
    );
 
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, bp_coh_ready_and_link_s);
   `declare_bsg_ready_and_link_sif_s(mem_noc_flit_width_p, bp_mem_ready_and_link_s);
   `declare_bsg_ready_and_link_sif_s(dma_noc_flit_width_p, bp_dma_ready_and_link_s);

--- a/bp_top/src/v/bp_processor.sv
+++ b/bp_top/src/v/bp_processor.sv
@@ -17,7 +17,7 @@ module bp_processor
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
 
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
    , localparam dma_pkt_width_lp = `bsg_cache_dma_pkt_width(daddr_width_p, l2_block_size_in_words_p)
    )
@@ -107,7 +107,7 @@ module bp_processor
          ,.dma_link_o(dma_link_lo)
          );
 
-      `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+      `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
       `declare_bsg_ready_and_link_sif_s(mem_noc_flit_width_p, bsg_ready_and_link_sif_s);
       `bp_cast_i(bp_bedrock_mem_fwd_header_s, mem_fwd_header);
       `bp_cast_o(bp_bedrock_mem_rev_header_s, mem_rev_header);
@@ -144,7 +144,7 @@ module bp_processor
          ,.link_ready_and_i(proc_fwd_link_lo[E].ready_and_rev)
          );
 
-      wire [mem_noc_cord_width_p-1:0] mem_rev_dst_cord_li = mem_rev_header_cast_i.payload.did;
+      wire [mem_noc_cord_width_p-1:0] mem_rev_dst_cord_li = mem_rev_header_cast_i.payload.src_did;
       wire [mem_noc_cid_width_p-1:0] mem_rev_dst_cid_li = '0;
 
       bp_me_stream_to_wormhole

--- a/bp_top/src/v/bp_sacc_scratchpad.sv
+++ b/bp_top/src/v/bp_sacc_scratchpad.sv
@@ -7,8 +7,8 @@ module bp_sacc_scratchpad
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
-   , localparam cfg_bus_width_lp= `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
+   , localparam cfg_bus_width_lp= `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    )
   (input                                        clk_i
    , input                                      reset_i
@@ -27,7 +27,7 @@ module bp_sacc_scratchpad
    );
 
   // CCE-IO interface is used for uncached requests-read/write memory mapped CSR
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, daddr_width_p);
 
   logic r_v_li, w_v_li;

--- a/bp_top/src/v/bp_sacc_tile.sv
+++ b/bp_top/src/v/bp_sacc_tile.sv
@@ -17,8 +17,7 @@ module bp_sacc_tile
 
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
    , localparam coh_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(coh_noc_flit_width_p)
    , localparam mem_noc_ral_link_width_lp = `bsg_ready_and_link_sif_width(mem_noc_flit_width_p)
@@ -37,8 +36,7 @@ module bp_sacc_tile
 
    );
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `declare_bsg_ready_and_link_sif_s(coh_noc_flit_width_p, bp_coh_ready_and_link_s);
 
   // LCE-CCE link casts
@@ -129,7 +127,6 @@ module bp_sacc_tile
      ,.reset_i(reset_r)
 
      ,.cce_id_i(cce_id_li)
-     ,.did_i('0)
 
      ,.lce_req_header_i(lce_req_header_li)
      ,.lce_req_data_i(lce_req_data_li)

--- a/bp_top/src/v/bp_sacc_vdp.sv
+++ b/bp_top/src/v/bp_sacc_vdp.sv
@@ -7,8 +7,8 @@ module bp_sacc_vdp
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    )
   (input                                        clk_i
    , input                                      reset_i
@@ -27,7 +27,7 @@ module bp_sacc_vdp
    );
 
   // CCE-IO interface is used for uncached requests-read/write memory mapped CSR
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `declare_bp_memory_map(paddr_width_p, daddr_width_p);
 
   logic r_v_li, w_v_li;

--- a/bp_top/src/v/bp_unicore_lite.sv
+++ b/bp_top/src/v/bp_unicore_lite.sv
@@ -11,9 +11,9 @@ module bp_unicore_lite
  import bsg_noc_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    )
   (input                                               clk_i
    , input                                             reset_i
@@ -38,10 +38,10 @@ module bp_unicore_lite
    , input                                             s_external_irq_i
    );
 
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
   `declare_bp_cache_engine_if(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache);
   `declare_bp_cache_engine_if(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
   bp_icache_req_s icache_req_lo;
@@ -83,6 +83,7 @@ module bp_unicore_lite
   wire posedge_clk = clk_i;
   wire negedge_clk = ~clk_i;
 
+  wire [did_width_p-1:0] did_li = cfg_bus_cast_i.did;
   wire [1:0][lce_id_width_p-1:0] lce_id_li = {cfg_bus_cast_i.dcache_id, cfg_bus_cast_i.icache_id};
   bp_core_minimal
    #(.bp_params_p(bp_params_p))
@@ -167,6 +168,7 @@ module bp_unicore_lite
     (.clk_i(posedge_clk)
      ,.reset_i(reset_i)
 
+     ,.did_i(did_li)
      ,.lce_id_i(lce_id_li[0])
 
      ,.cache_req_i(icache_req_lo)
@@ -227,6 +229,7 @@ module bp_unicore_lite
     (.clk_i(negedge_clk)
      ,.reset_i(reset_i)
 
+     ,.did_i(did_li)
      ,.lce_id_i(lce_id_li[1])
 
      ,.cache_req_i(dcache_req_lo)

--- a/bp_top/test/common/bp_nonsynth_host.sv
+++ b/bp_top/test/common/bp_nonsynth_host.sv
@@ -9,7 +9,7 @@ module bp_nonsynth_host
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
    , parameter icache_trace_p         = 0
    , parameter dcache_trace_p         = 0
@@ -114,7 +114,7 @@ module bp_nonsynth_host
   localparam lg_num_core_lp = `BSG_SAFE_CLOG2(num_core_p);
   wire [lg_num_core_lp-1:0] addr_core_enc = addr_lo[byte_offset_width_lp+:lg_num_core_lp];
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   bp_bedrock_mem_fwd_header_s mem_fwd_header_li;
   assign mem_fwd_header_li = mem_fwd_header_i;
   wire [hio_width_p-1:0] hio_id = mem_fwd_header_li.addr[paddr_width_p-1-:hio_width_p];

--- a/bp_top/test/common/bp_nonsynth_if_verif.sv
+++ b/bp_top/test/common/bp_nonsynth_if_verif.sv
@@ -12,20 +12,18 @@ module bp_nonsynth_if_verif
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_core_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
-   `declare_bp_bedrock_lce_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
-   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    )
   ();
 
   bp_proc_param_s proc_param;
   assign proc_param = all_cfgs_gp[bp_params_p];
 
-  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);
+  `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
-  `declare_bp_bedrock_lce_if(paddr_width_p, lce_id_width_p, cce_id_width_p, lce_assoc_p);
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `declare_bp_fe_branch_metadata_fwd_s(ras_idx_width_p, btb_tag_width_p, btb_idx_width_p, bht_idx_width_p, ghist_width_p, bht_row_els_p);
 
   initial
@@ -130,7 +128,7 @@ module bp_nonsynth_if_verif
 
   // Unicore
   if ((cce_type_p == e_cce_uce) && (icache_fill_width_p != dcache_fill_width_p))
-    $error("Error: unicore requires L1-Cache fill widths to match");
+    $error("Error: unicore requires L1-Cache fill width to match");
   if ((cce_type_p == e_cce_uce) && (num_core_p != 1))
     $error("Error: Unicore only supports a single core configuration in the tethered testbench");
   if ((cce_type_p == e_cce_uce) && (bedrock_fill_width_p < dword_width_gp))
@@ -142,13 +140,13 @@ module bp_nonsynth_if_verif
   if ((cce_type_p != e_cce_uce) && (l2_data_width_p != bedrock_fill_width_p))
     $error("Error: Multicore requires L2 data width same as BedRock data width");
   if ((cce_type_p != e_cce_uce) && (icache_fill_width_p != dcache_fill_width_p))
-    $error("Error: Multicore requires L1-Cache fill widths to be the same");
+    $error("Error: Multicore requires L1-Cache fill width to be the same");
   if ((cce_type_p != e_cce_uce) && (num_cacc_p > 0) && (icache_fill_width_p != acache_fill_width_p))
-    $error("Error: Multicore requires L1-Cache fill widths to be the same");
+    $error("Error: Multicore requires L1-Cache fill width to be the same");
   if ((cce_type_p != e_cce_uce) && (dcache_block_width_p != icache_block_width_p))
-    $error("Error: Multicore requires L1-Cache block widths to be the same");
+    $error("Error: Multicore requires L1-Cache block width to be the same");
   if ((cce_type_p != e_cce_uce) && (num_cacc_p > 0) && (icache_block_width_p != acache_block_width_p))
-    $error("Error: Multicore requires L1-Cache block widths to be the same");
+    $error("Error: Multicore requires L1-Cache block width to be the same");
   if ((cce_type_p != e_cce_uce) && (l2_block_width_p < icache_block_width_p))
     $error("Error: Multicore requires L2-Cache block width to be at least L1-Cache block width");
   if ((cce_type_p != e_cce_uce) && (bedrock_fill_width_p < dword_width_gp))

--- a/bp_top/test/common/bp_nonsynth_nbf_loader.sv
+++ b/bp_top/test/common/bp_nonsynth_nbf_loader.sv
@@ -12,7 +12,7 @@ module bp_nonsynth_nbf_loader
  import bp_me_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
    , parameter nbf_filename_p = "prog.nbf"
    , parameter verbose_p = 1
@@ -105,7 +105,7 @@ module bp_nonsynth_nbf_loader
      ,.data_o(read_data_r)
      );
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
   `bp_cast_o(bp_bedrock_mem_fwd_header_s, mem_fwd_header);
   `bp_cast_i(bp_bedrock_mem_rev_header_s, mem_rev_header);
 
@@ -141,7 +141,7 @@ module bp_nonsynth_nbf_loader
     begin
       mem_fwd_header_cast_o = '0;
       mem_fwd_header_cast_o.payload.lce_id = lce_id_i;
-      mem_fwd_header_cast_o.payload.did = did_i;
+      mem_fwd_header_cast_o.payload.src_did = did_i;
       mem_fwd_header_cast_o.addr = curr_nbf.addr;
       mem_fwd_header_cast_o.msg_type.fwd = curr_nbf.opcode[5] ? e_bedrock_mem_uc_rd : e_bedrock_mem_uc_wr;
       mem_fwd_header_cast_o.subop = e_bedrock_store;

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -53,7 +53,7 @@ module testbench
    // Synthesis parameters
    , parameter no_bind_p                   = 0
 
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
    )
   (output bit reset_i);
 
@@ -69,7 +69,7 @@ module testbench
     return (`BP_SIM_CLK_PERIOD);
   endfunction
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
 
 // Bit to deal with initial X->0 transition detection
   bit clk_i;

--- a/bp_top/test/tb/bp_tethered/wrapper.sv
+++ b/bp_top/test/tb/bp_tethered/wrapper.sv
@@ -18,7 +18,7 @@ module wrapper
  #(parameter bp_params_e bp_params_p = BP_CFG_FLOWVAR
    `declare_bp_proc_params(bp_params_p)
 
-   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+   `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 
    , localparam dma_pkt_width_lp = `bsg_cache_dma_pkt_width(daddr_width_p, l2_block_size_in_words_p)
    )


### PR DESCRIPTION
### Summary
This PR adds src_did to the Bedrock interfaces. This is useful to return statelessly over LCE->IO bridges without maintaining return fifo or MSHRs.

### Issue Fixed
None

### Area
I/O interfaces especially in multicore

### Reasoning (new feature, inefficient, verbose, etc.)
Currently, we have many places in the code where we need single beat I/O messages as a result of a lack of MSHRs. This PR allows us to encapsulate these messages in a way that allows us to tunnel LCE and IO messages seamlessly.

### Additional Changes Required (if any)
Other repos (such as zynq-parrot) which instantiate these macros need to adapt.

### Analysis
This PR intrinsically pins our internal network width to 128b, which has previously been analyzed as a 'sweet spot'.

### Verification
Standard regression

### Additional Context
None

