### PR TITLE
Fix late writeback for scalability

### DIFF
--- a/bp_be/src/include/bp_be_ctl_pkgdef.svh
+++ b/bp_be/src/include/bp_be_ctl_pkgdef.svh
@@ -197,6 +197,8 @@
     logic                             mem_v;
     logic                             opw_v;
     logic                             ops_v;
+    logic                             score_v;
+    logic                             spec_w_v;
 
     bp_be_fu_op_s                     fu_op;
 

--- a/bp_be/src/include/bp_be_defines.svh
+++ b/bp_be/src/include/bp_be_defines.svh
@@ -93,6 +93,8 @@
       logic                              mul_fwb_v;                                                \
       logic                              fma_iwb_v;                                                \
       logic                              fma_fwb_v;                                                \
+      logic                              long_iwb_v;                                               \
+      logic                              long_fwb_v;                                               \
       logic                              fflags_w_v;                                               \
                                                                                                    \
       logic [rv64_reg_addr_width_gp-1:0] rd_addr;                                                  \
@@ -120,6 +122,8 @@
       logic                      compressed;                                                       \
       bp_be_exception_s          exception;                                                        \
       bp_be_special_s            special;                                                          \
+      logic                      iscore;                                                           \
+      logic                      fscore;                                                           \
     }  bp_be_retire_pkt_s;                                                                         \
                                                                                                    \
     typedef struct packed                                                                          \
@@ -165,6 +169,8 @@
       logic                           dcache_replay;                                               \
       logic                           itlb_fill_v;                                                 \
       logic                           dtlb_fill_v;                                                 \
+      logic                           iscore_v;                                                    \
+      logic                           fscore_v;                                                    \
     }  bp_be_commit_pkt_s;                                                                         \
                                                                                                    \
     typedef struct packed                                                                          \
@@ -251,25 +257,24 @@
      )
 
   `define bp_be_dep_status_width \
-    (15 + rv64_reg_addr_width_gp)
+    (17 + rv64_reg_addr_width_gp)
 
   `define bp_be_branch_pkt_width(vaddr_width_mp) \
     (4 + vaddr_width_mp)
 
   `define bp_be_retire_pkt_width(vaddr_width_mp) \
-    (4 + dpath_width_gp + 2*vaddr_width_mp + instr_width_gp + 1 + $bits(bp_be_exception_s) + $bits(bp_be_special_s))
+    (6 + dpath_width_gp + 2*vaddr_width_mp + instr_width_gp + 1 + $bits(bp_be_exception_s) + $bits(bp_be_special_s))
 
   `define bp_be_pte_leaf_width(paddr_width_mp) \
     (paddr_width_mp - page_offset_width_gp + 7)
 
   `define bp_be_commit_pkt_width(vaddr_width_mp, paddr_width_mp) \
-    (5 + `bp_be_pte_leaf_width(paddr_width_mp) +  3*vaddr_width_mp + instr_width_gp + rv64_priv_width_gp + 18)
+    (5 + `bp_be_pte_leaf_width(paddr_width_mp) +  3*vaddr_width_mp + instr_width_gp + rv64_priv_width_gp + 20)
 
   `define bp_be_wb_pkt_width(vaddr_width_mp) \
-    (3                                                                                             \
+    (4                                                                                             \
      + reg_addr_width_gp                                                                           \
      + dpath_width_gp                                                                              \
-     + 1                                                                                           \
      + $bits(rv64_fflags_s)                                                                        \
      )
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -52,7 +52,12 @@ module bp_be_calculator_top
    , output logic [branch_pkt_width_lp-1:0]          br_pkt_o
    , output logic [wb_pkt_width_lp-1:0]              iwb_pkt_o
    , output logic [wb_pkt_width_lp-1:0]              fwb_pkt_o
+
    , output logic [ptw_fill_pkt_width_lp-1:0]        ptw_fill_pkt_o
+   , output logic [wb_pkt_width_lp-1:0]              late_wb_pkt_o
+   , output logic                                    late_wb_v_o
+   , output logic                                    late_wb_force_o
+   , input                                           late_wb_yumi_i
 
    , input                                           debug_irq_i
    , input                                           timer_irq_i
@@ -98,6 +103,9 @@ module bp_be_calculator_top
   `bp_cast_i(bp_be_dispatch_pkt_s, dispatch_pkt);
   `bp_cast_o(bp_be_commit_pkt_s, commit_pkt);
   `bp_cast_o(bp_be_branch_pkt_s, br_pkt);
+  `bp_cast_o(bp_be_wb_pkt_s, iwb_pkt);
+  `bp_cast_o(bp_be_wb_pkt_s, fwb_pkt);
+  `bp_cast_o(bp_be_wb_pkt_s, late_wb_pkt);
 
   // Pipeline stage registers
   localparam pipe_stage_els_lp = 5;
@@ -111,7 +119,7 @@ module bp_be_calculator_top
   bp_be_trans_info_s   trans_info_lo;
   rv64_frm_e           frm_dyn_lo;
 
-  bp_be_wb_pkt_s long_iwb_pkt, long_fwb_pkt;
+  bp_be_wb_pkt_s pipe_long_iwb_pkt, pipe_long_fwb_pkt;
 
   logic pipe_int_early_instr_misaligned_lo;
   logic pipe_int_catchup_instr_misaligned_lo, pipe_int_catchup_mispredict_lo;
@@ -123,8 +131,8 @@ module bp_be_calculator_top
 
   logic pipe_sys_illegal_instr_lo, pipe_sys_csrw_lo;
 
-  logic pipe_int_early_data_lo_v, pipe_int_catchup_data_lo_v, pipe_aux_data_lo_v, pipe_mem_early_data_lo_v, pipe_mem_final_data_lo_v, pipe_sys_data_lo_v, pipe_mul_data_lo_v, pipe_fma_data_lo_v;
-  logic pipe_long_idata_lo_v, pipe_long_idata_lo_yumi, pipe_long_fdata_lo_v, pipe_long_fdata_lo_yumi;
+  logic pipe_int_early_data_v_lo, pipe_int_catchup_data_v_lo, pipe_aux_data_v_lo, pipe_mem_early_data_v_lo, pipe_mem_final_data_v_lo, pipe_sys_data_v_lo, pipe_mul_data_v_lo, pipe_fma_data_v_lo;
+  logic pipe_long_idata_v_lo, pipe_long_idata_yumi_lo, pipe_long_fdata_v_lo, pipe_long_fdata_yumi_lo;
   logic [dpath_width_gp-1:0] pipe_int_early_data_lo, pipe_int_catchup_data_lo, pipe_aux_data_lo, pipe_mem_early_data_lo, pipe_mem_final_data_lo, pipe_sys_data_lo, pipe_mul_data_lo, pipe_fma_data_lo;
   rv64_fflags_s pipe_aux_fflags_lo, pipe_fma_fflags_lo;
 
@@ -134,10 +142,8 @@ module bp_be_calculator_top
   logic [vaddr_width_p-1:0] pipe_int_catchup_npc_lo;
   logic pipe_int_catchup_branch_lo, pipe_int_catchup_btaken_lo;
 
-  bp_be_wb_pkt_s pipe_mem_late_iwb_pkt;
-  logic pipe_mem_late_iwb_pkt_v, pipe_mem_late_iwb_pkt_yumi;
-  bp_be_wb_pkt_s pipe_mem_late_fwb_pkt;
-  logic pipe_mem_late_fwb_pkt_v, pipe_mem_late_fwb_pkt_yumi;
+  bp_be_wb_pkt_s pipe_mem_late_wb_pkt;
+  logic pipe_mem_late_wb_v, pipe_mem_late_wb_yumi;
 
   // Generating match vector for bypass
   logic [2:0][pipe_stage_els_lp-1:0] match_rs;
@@ -145,10 +151,10 @@ module bp_be_calculator_top
   for (genvar i = 0; i < pipe_stage_els_lp; i++)
     begin : forward_match
       assign match_rs[0][i] = ((i < 4) & dispatch_pkt_cast_i.decode.irs1_r_v & comp_stage_r[i].ird_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs1_addr == comp_stage_r[i].rd_addr))
-                              || ((i > 0) & dispatch_pkt_cast_i.decode.frs1_r_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs1_addr == comp_stage_r[i].rd_addr));
+                              || (dispatch_pkt_cast_i.decode.frs1_r_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs1_addr == comp_stage_r[i].rd_addr));
       assign match_rs[1][i] = ((i < 4) & dispatch_pkt_cast_i.decode.irs2_r_v & comp_stage_r[i].ird_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs2_addr == comp_stage_r[i].rd_addr))
-                              || ((i > 0) & dispatch_pkt_cast_i.decode.frs2_r_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs2_addr == comp_stage_r[i].rd_addr));
-      assign match_rs[2][i] = ((i > 0) & dispatch_pkt_cast_i.decode.frs3_r_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs3_addr == comp_stage_r[i].rd_addr));
+                              || (dispatch_pkt_cast_i.decode.frs2_r_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs2_addr == comp_stage_r[i].rd_addr));
+      assign match_rs[2][i] = (dispatch_pkt_cast_i.decode.frs3_r_v & comp_stage_r[i].frd_w_v & (dispatch_pkt_cast_i.instr.t.fmatype.rs3_addr == comp_stage_r[i].rd_addr));
 
       assign forward_data[i] = comp_stage_n[i+1].rd_data;
     end
@@ -226,7 +232,7 @@ module bp_be_calculator_top
      ,.illegal_instr_o(pipe_sys_illegal_instr_lo)
      ,.csrw_o(pipe_sys_csrw_lo)
      ,.data_o(pipe_sys_data_lo)
-     ,.v_o(pipe_sys_data_lo_v)
+     ,.v_o(pipe_sys_data_v_lo)
 
      ,.decode_info_o(decode_info_o)
      ,.trans_info_o(trans_info_lo)
@@ -245,7 +251,7 @@ module bp_be_calculator_top
      ,.flush_i(commit_pkt_cast_o.npc_w_v)
 
      ,.data_o(pipe_int_early_data_lo)
-     ,.v_o(pipe_int_early_data_lo_v)
+     ,.v_o(pipe_int_early_data_v_lo)
      ,.npc_o(pipe_int_early_npc_lo)
      ,.branch_o(pipe_int_early_branch_lo)
      ,.btaken_o(pipe_int_early_btaken_lo)
@@ -293,7 +299,7 @@ module bp_be_calculator_top
          ,.flush_i(commit_pkt_cast_o.npc_w_v)
 
          ,.data_o(pipe_int_catchup_data_lo)
-         ,.v_o(pipe_int_catchup_data_lo_v)
+         ,.v_o(pipe_int_catchup_data_v_lo)
          ,.npc_o(pipe_int_catchup_npc_lo)
          ,.branch_o(pipe_int_catchup_branch_lo)
          ,.btaken_o(pipe_int_catchup_btaken_lo)
@@ -304,7 +310,7 @@ module bp_be_calculator_top
   else
     begin : no_catchup
       assign pipe_int_catchup_data_lo = '0;
-      assign pipe_int_catchup_data_lo_v = '0;
+      assign pipe_int_catchup_data_v_lo = '0;
       assign pipe_int_catchup_mispredict_lo = '0;
       assign pipe_int_catchup_instr_misaligned_lo = '0;
     end
@@ -322,7 +328,7 @@ module bp_be_calculator_top
 
      ,.data_o(pipe_aux_data_lo)
      ,.fflags_o(pipe_aux_fflags_lo)
-     ,.v_o(pipe_aux_data_lo_v)
+     ,.v_o(pipe_aux_data_v_lo)
      );
 
   // Memory pipe: 2/3 cycle latency
@@ -386,17 +392,13 @@ module bp_be_calculator_top
      ,.store_page_fault_v_o(pipe_mem_store_page_fault_lo)
 
      ,.early_data_o(pipe_mem_early_data_lo)
-     ,.early_v_o(pipe_mem_early_data_lo_v)
+     ,.early_v_o(pipe_mem_early_data_v_lo)
 
      ,.final_data_o(pipe_mem_final_data_lo)
-     ,.final_v_o(pipe_mem_final_data_lo_v)
+     ,.final_v_o(pipe_mem_final_data_v_lo)
 
-     ,.late_iwb_pkt_o(pipe_mem_late_iwb_pkt)
-     ,.late_iwb_pkt_v_o(pipe_mem_late_iwb_pkt_v)
-     ,.late_iwb_pkt_yumi_i(pipe_mem_late_iwb_pkt_yumi)
-     ,.late_fwb_pkt_o(pipe_mem_late_fwb_pkt)
-     ,.late_fwb_pkt_v_o(pipe_mem_late_fwb_pkt_v)
-     ,.late_fwb_pkt_yumi_i(pipe_mem_late_fwb_pkt_yumi)
+     ,.late_wb_pkt_o(pipe_mem_late_wb_pkt)
+     ,.late_wb_v_o(pipe_mem_late_wb_v)
 
      ,.trans_info_i(trans_info_lo)
      );
@@ -413,10 +415,10 @@ module bp_be_calculator_top
      ,.frm_dyn_i(frm_dyn_lo)
 
      ,.imul_data_o(pipe_mul_data_lo)
-     ,.imul_v_o(pipe_mul_data_lo_v)
+     ,.imul_v_o(pipe_mul_data_v_lo)
      ,.fma_data_o(pipe_fma_data_lo)
      ,.fma_fflags_o(pipe_fma_fflags_lo)
-     ,.fma_v_o(pipe_fma_data_lo_v)
+     ,.fma_v_o(pipe_fma_data_v_lo)
      );
 
   // Variable length pipeline, used for long (potentially scoreboarded operations)
@@ -432,14 +434,43 @@ module bp_be_calculator_top
      ,.fbusy_o(fdiv_busy_o)
      ,.frm_dyn_i(frm_dyn_lo)
 
-     ,.iwb_pkt_o(long_iwb_pkt)
-     ,.iwb_v_o(pipe_long_idata_lo_v)
-     ,.iwb_yumi_i(pipe_long_idata_lo_yumi)
+     ,.iwb_pkt_o(pipe_long_iwb_pkt)
+     ,.iwb_v_o(pipe_long_idata_v_lo)
+     ,.iwb_yumi_i(pipe_long_idata_yumi_lo)
 
-     ,.fwb_pkt_o(long_fwb_pkt)
-     ,.fwb_v_o(pipe_long_fdata_lo_v)
-     ,.fwb_yumi_i(pipe_long_fdata_lo_yumi)
+     ,.fwb_pkt_o(pipe_long_fwb_pkt)
+     ,.fwb_v_o(pipe_long_fdata_v_lo)
+     ,.fwb_yumi_i(pipe_long_fdata_yumi_lo)
      );
+
+  localparam num_late_wb_lp = 3;
+  logic late_wb_v_lo, late_wb_yumi_li;
+  logic [num_late_wb_lp-1:0] late_wb_reqs_li, late_wb_grants_lo;
+  assign {pipe_long_fdata_yumi_lo, pipe_long_idata_yumi_lo, pipe_mem_late_wb_yumi} =
+    late_wb_grants_lo & {num_late_wb_lp{late_wb_yumi_i}};
+  assign late_wb_reqs_li = {pipe_long_fdata_v_lo, pipe_long_idata_v_lo, pipe_mem_late_wb_v};
+  bsg_arb_fixed
+   #(.inputs_p(num_late_wb_lp), .lo_to_hi_p(1))
+   late_wb_arb
+    (.ready_i(1'b1)
+     ,.reqs_i(late_wb_reqs_li)
+     ,.grants_o(late_wb_grants_lo)
+     );
+
+  bp_be_wb_pkt_s late_wb_pkt_sel;
+  wire [num_late_wb_lp-1:0][$bits(bp_be_wb_pkt_s)-1:0] late_wb_pkts_li =
+    {pipe_long_fwb_pkt, pipe_long_iwb_pkt, pipe_mem_late_wb_pkt};
+  bsg_mux_one_hot
+   #(.width_p($bits(bp_be_wb_pkt_s)), .els_p(num_late_wb_lp))
+   late_wb_mux_oh
+    (.data_i(late_wb_pkts_li)
+     ,.sel_one_hot_i(late_wb_grants_lo)
+     ,.data_o(late_wb_pkt_sel)
+     );
+
+  assign late_wb_pkt_cast_o = late_wb_pkt_sel;
+  assign late_wb_v_o = |late_wb_reqs_li;
+  assign late_wb_force_o = pipe_mem_late_wb_v;
 
   // If a pipeline has completed an instruction (pipe_xxx_v), then mux in the calculated result.
   // Else, mux in the previous stage of the completion pipe. Since we are single issue and have
@@ -450,27 +481,28 @@ module bp_be_calculator_top
         begin : comp_stage
           // Normally, shift down in the pipe
           comp_stage_n[i] = (i == 0)
-            ? '{ird_w_v    : reservation_n.decode.irf_w_v
-                ,frd_w_v   : reservation_n.decode.frf_w_v
-                ,fflags_w_v: reservation_n.decode.fflags_w_v
-                ,rd_addr   : reservation_n.instr.t.rtype.rd_addr
+            ? '{ird_w_v    : late_wb_yumi_i ? late_wb_pkt_cast_o.ird_w_v    : reservation_n.decode.irf_w_v
+                ,frd_w_v   : late_wb_yumi_i ? late_wb_pkt_cast_o.frd_w_v    : reservation_n.decode.frf_w_v
+                ,fflags_w_v: late_wb_yumi_i ? late_wb_pkt_cast_o.fflags_w_v : reservation_n.decode.fflags_w_v
+                ,rd_addr   : late_wb_yumi_i ? late_wb_pkt_cast_o.rd_addr    : reservation_n.instr.t.rtype.rd_addr
                 ,default: '0
                 }
             : comp_stage_r[i-1];
         end
       // Injected instructions can carry a payload in rs2
       comp_stage_n[0].rd_data    |= injection                  ? dispatch_pkt_cast_i.rs2  : '0;
-      comp_stage_n[1].rd_data    |= pipe_int_early_data_lo_v   ? pipe_int_early_data_lo   : '0;
-      comp_stage_n[1].rd_data    |= pipe_sys_data_lo_v         ? pipe_sys_data_lo         : '0;
-      comp_stage_n[2].rd_data    |= pipe_mem_early_data_lo_v   ? pipe_mem_early_data_lo   : '0;
-      comp_stage_n[2].rd_data    |= pipe_aux_data_lo_v         ? pipe_aux_data_lo         : '0;
-      comp_stage_n[2].rd_data    |= pipe_int_catchup_data_lo_v ? pipe_int_catchup_data_lo : '0;
-      comp_stage_n[3].rd_data    |= pipe_mem_final_data_lo_v   ? pipe_mem_final_data_lo   : '0;
-      comp_stage_n[3].rd_data    |= pipe_mul_data_lo_v         ? pipe_mul_data_lo         : '0;
-      comp_stage_n[4].rd_data    |= pipe_fma_data_lo_v         ? pipe_fma_data_lo         : '0;
+      comp_stage_n[1].rd_data    |= pipe_int_early_data_v_lo   ? pipe_int_early_data_lo   : '0;
+      comp_stage_n[1].rd_data    |= pipe_sys_data_v_lo         ? pipe_sys_data_lo         : '0;
+      comp_stage_n[2].rd_data    |= pipe_mem_early_data_v_lo   ? pipe_mem_early_data_lo   : '0;
+      comp_stage_n[2].rd_data    |= pipe_aux_data_v_lo         ? pipe_aux_data_lo         : '0;
+      comp_stage_n[2].rd_data    |= pipe_int_catchup_data_v_lo ? pipe_int_catchup_data_lo : '0;
+      comp_stage_n[3].rd_data    |= pipe_mem_final_data_v_lo   ? pipe_mem_final_data_lo   : '0;
+      comp_stage_n[3].rd_data    |= pipe_mul_data_v_lo         ? pipe_mul_data_lo         : '0;
+      comp_stage_n[4].rd_data    |= pipe_fma_data_v_lo         ? pipe_fma_data_lo         : '0;
 
-      comp_stage_n[2].fflags     |= pipe_aux_data_lo_v         ? pipe_aux_fflags_lo       : '0;
-      comp_stage_n[4].fflags     |= pipe_fma_data_lo_v         ? pipe_fma_fflags_lo       : '0;
+      comp_stage_n[0].fflags     |= injection                  ? dispatch_pkt_cast_i.rs1  : '0;
+      comp_stage_n[2].fflags     |= pipe_aux_data_v_lo         ? pipe_aux_fflags_lo       : '0;
+      comp_stage_n[4].fflags     |= pipe_fma_data_v_lo         ? pipe_fma_fflags_lo       : '0;
 
       comp_stage_n[0].ird_w_v    &= exc_stage_n[0].v;
       comp_stage_n[1].ird_w_v    &= exc_stage_n[1].v;
@@ -487,9 +519,8 @@ module bp_be_calculator_top
       comp_stage_n[2].fflags_w_v &= exc_stage_n[2].v;
       comp_stage_n[3].fflags_w_v &= exc_stage_n[3].v;
 
-      // Inject D$ miss so we don't accidentally write back the data
-      comp_stage_n[2].ird_w_v    &= ~pipe_mem_dcache_load_miss_lo;
-      comp_stage_n[2].frd_w_v    &= ~pipe_mem_dcache_load_miss_lo;
+      comp_stage_n[3].ird_w_v    &= ~commit_pkt_cast_o.iscore_v;
+      comp_stage_n[3].frd_w_v    &= ~commit_pkt_cast_o.fscore_v;
     end
 
   bsg_dff
@@ -499,6 +530,8 @@ module bp_be_calculator_top
      ,.data_i(comp_stage_n[0+:pipe_stage_els_lp])
      ,.data_o(comp_stage_r)
      );
+  assign iwb_pkt_cast_o = comp_stage_r[3];
+  assign fwb_pkt_cast_o = comp_stage_r[4];
 
   always_comb
     begin
@@ -514,15 +547,14 @@ module bp_be_calculator_top
           exc_stage_n[0].spec                     |= reservation_n.special;
           exc_stage_n[0].exc                      |= reservation_n.exception;
 
-          exc_stage_n[0].v                        &= ~commit_pkt_cast_o.npc_w_v;
-          exc_stage_n[1].v                        &= ~commit_pkt_cast_o.npc_w_v;
-          exc_stage_n[2].v                        &= ~commit_pkt_cast_o.npc_w_v;
-          exc_stage_n[3].v                        &= commit_pkt_cast_o.instret;
+          exc_stage_n[0].v                        &= ~commit_pkt_cast_o.npc_w_v | ~reservation_n.queue_v;
+          exc_stage_n[1].v                        &= ~commit_pkt_cast_o.npc_w_v | ~exc_stage_r[0].queue_v;
+          exc_stage_n[2].v                        &= ~commit_pkt_cast_o.npc_w_v | ~exc_stage_r[1].queue_v;
+          exc_stage_n[3].v                        &=  commit_pkt_cast_o.instret | ~exc_stage_r[2].queue_v;
 
           exc_stage_n[0].queue_v                  &= ~commit_pkt_cast_o.npc_w_v;
           exc_stage_n[1].queue_v                  &= ~commit_pkt_cast_o.npc_w_v;
           exc_stage_n[2].queue_v                  &= ~commit_pkt_cast_o.npc_w_v;
-          exc_stage_n[3].queue_v                  &= ~commit_pkt_cast_o.npc_w_v;
 
           exc_stage_n[1].exc.illegal_instr        |= pipe_sys_illegal_instr_lo;
           exc_stage_n[1].spec.csrw                |= pipe_sys_csrw_lo;
@@ -555,15 +587,6 @@ module bp_be_calculator_top
      ,.data_i(exc_stage_n[0+:pipe_stage_els_lp])
      ,.data_o(exc_stage_r)
      );
-
-  assign pipe_mem_late_iwb_pkt_yumi = pipe_mem_late_iwb_pkt_v & ~comp_stage_r[3].ird_w_v;
-  assign pipe_mem_late_fwb_pkt_yumi = pipe_mem_late_fwb_pkt_v & ~comp_stage_r[4].frd_w_v;
-
-  assign pipe_long_idata_lo_yumi = pipe_long_idata_lo_v & ~pipe_mem_late_iwb_pkt_v & ~comp_stage_r[3].ird_w_v;
-  assign pipe_long_fdata_lo_yumi = pipe_long_fdata_lo_v & ~pipe_mem_late_fwb_pkt_v & ~comp_stage_r[4].frd_w_v & ~comp_stage_r[4].fflags_w_v;
-
-  assign iwb_pkt_o = pipe_mem_late_iwb_pkt_yumi ? pipe_mem_late_iwb_pkt : pipe_long_idata_lo_yumi ? long_iwb_pkt : comp_stage_r[3];
-  assign fwb_pkt_o = pipe_mem_late_fwb_pkt_yumi ? pipe_mem_late_fwb_pkt : pipe_long_fdata_lo_yumi ? long_fwb_pkt : comp_stage_r[4];
 
 endmodule
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -706,6 +706,8 @@ module bp_be_csr
   assign commit_pkt_cast_o.dcache_load_miss  = retire_pkt_cast_i.special.dcache_load_miss;
   assign commit_pkt_cast_o.itlb_fill_v       = retire_pkt_cast_i.exception.itlb_fill;
   assign commit_pkt_cast_o.dtlb_fill_v       = retire_pkt_cast_i.exception.dtlb_fill;
+  assign commit_pkt_cast_o.iscore_v          = retire_pkt_cast_i.iscore;
+  assign commit_pkt_cast_o.fscore_v          = retire_pkt_cast_i.fscore;
 
   assign trans_info_cast_o.priv_mode      = priv_mode_r;
   assign trans_info_cast_o.base_ppn       = satp_lo.ppn;

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -46,8 +46,9 @@ module bp_be_detector
    , output logic                      interrupt_v_o
    , input [dispatch_pkt_width_lp-1:0] dispatch_pkt_i
    , input [commit_pkt_width_lp-1:0]   commit_pkt_i
-   , input [wb_pkt_width_lp-1:0]       iwb_pkt_i
-   , input [wb_pkt_width_lp-1:0]       fwb_pkt_i
+
+   , input [wb_pkt_width_lp-1:0]       late_wb_pkt_i
+   , input                             late_wb_yumi_i
 
    , output logic                      ispec_v_o
    );
@@ -57,8 +58,7 @@ module bp_be_detector
   `bp_cast_i(bp_be_issue_pkt_s, issue_pkt);
   `bp_cast_i(bp_be_dispatch_pkt_s, dispatch_pkt);
   `bp_cast_i(bp_be_commit_pkt_s, commit_pkt);
-  `bp_cast_i(bp_be_wb_pkt_s, iwb_pkt);
-  `bp_cast_i(bp_be_wb_pkt_s, fwb_pkt);
+  `bp_cast_i(bp_be_wb_pkt_s, late_wb_pkt);
 
   // Integer data hazards
   logic irs1_sb_raw_haz_v, irs2_sb_raw_haz_v;
@@ -69,29 +69,31 @@ module bp_be_detector
   logic frd_sb_waw_haz_v;
   logic [2:0] frs1_data_haz_v , frs2_data_haz_v, frs3_data_haz_v;
   logic [2:0] rs1_match_vector, rs2_match_vector, rs3_match_vector;
+  logic score_rs1_match, score_rs2_match, score_rs3_match, score_rd_match;
 
+  bp_be_decode_s decode;
+  rv64_instr_s instr;
+  assign decode = issue_pkt_cast_i.decode;
   bp_be_dep_status_s [3:0] dep_status_r;
 
-  logic fence_haz_v, cmd_haz_v, fflags_haz_v, csr_haz_v, exception_haz_v;
+  logic fence_haz_v, cmd_haz_v, fflags_haz_v, csr_haz_v, exception_haz_v, score_haz_v;
   logic data_haz_v, control_haz_v, struct_haz_v;
-  logic long_haz_v;
 
-  wire [reg_addr_width_gp-1:0] score_rd_li  = commit_pkt_cast_i.dcache_load_miss
-    ? commit_pkt_cast_i.instr.t.fmatype.rd_addr
-    : dispatch_pkt_cast_i.instr.t.fmatype.rd_addr;
-  wire [reg_addr_width_gp-1:0] score_rs1_li = dispatch_pkt_cast_i.instr.t.fmatype.rs1_addr;
-  wire [reg_addr_width_gp-1:0] score_rs2_li = dispatch_pkt_cast_i.instr.t.fmatype.rs2_addr;
-  wire [reg_addr_width_gp-1:0] score_rs3_li = dispatch_pkt_cast_i.instr.t.fmatype.rs3_addr;
-  wire [reg_addr_width_gp-1:0] clear_ird_li = iwb_pkt_cast_i.rd_addr;
-  wire [reg_addr_width_gp-1:0] clear_frd_li = fwb_pkt_cast_i.rd_addr;
+  wire [reg_addr_width_gp-1:0] score_rd_li  = commit_pkt_cast_i.instr.t.fmatype.rd_addr;
+  wire [reg_addr_width_gp-1:0] check_rs1_li = issue_pkt_cast_i.instr.t.fmatype.rs1_addr;
+  wire [reg_addr_width_gp-1:0] check_rs2_li = issue_pkt_cast_i.instr.t.fmatype.rs2_addr;
+  wire [reg_addr_width_gp-1:0] check_rs3_li = issue_pkt_cast_i.instr.t.fmatype.rs3_addr;
+  wire [reg_addr_width_gp-1:0] check_rd_li  = issue_pkt_cast_i.instr.t.fmatype.rd_addr;
 
-  wire irs1_ispec_v = issue_pkt_cast_i.decode.irs1_r_v & rs1_match_vector[0]
-    & issue_pkt_cast_i.decode.pipe_int_v
+  wire [reg_addr_width_gp-1:0] clear_rd_li = late_wb_pkt_cast_i.rd_addr;
+
+  wire irs1_ispec_v = decode.irs1_r_v & rs1_match_vector[0]
+    & decode.pipe_int_v
     & (dep_status_r[0].aux_iwb_v | dep_status_r[0].emem_iwb_v | dep_status_r[0].fint_iwb_v)
     & integer_support_p[e_catchup];
 
-  wire irs2_ispec_v = issue_pkt_cast_i.decode.irs2_r_v & rs2_match_vector[0]
-    & issue_pkt_cast_i.decode.pipe_int_v
+  wire irs2_ispec_v = decode.irs2_r_v & rs2_match_vector[0]
+    & decode.pipe_int_v
     & (dep_status_r[0].aux_iwb_v | dep_status_r[0].emem_iwb_v | dep_status_r[0].fint_iwb_v)
     & integer_support_p[e_catchup];
 
@@ -99,9 +101,8 @@ module bp_be_detector
 
   logic [1:0] irs_match_lo;
   logic       ird_match_lo;
-  wire score_int_v_li = (dispatch_pkt_cast_i.v & dispatch_pkt_cast_i.decode.late_iwb_v)
-    || (commit_pkt_cast_i.dcache_load_miss & commit_pkt_cast_i.instr.t.fmatype.opcode inside {`RV64_LOAD_OP, `RV64_AMO_OP});
-  wire clear_int_v_li = iwb_pkt_cast_i.ird_w_v & iwb_pkt_cast_i.late;
+  wire score_int_v_li = commit_pkt_cast_i.iscore_v;
+  wire clear_int_v_li = late_wb_pkt_cast_i.ird_w_v & late_wb_yumi_i;
   bp_be_scoreboard
    #(.bp_params_p(bp_params_p), .num_rs_p(2))
    int_scoreboard
@@ -112,19 +113,18 @@ module bp_be_detector
      ,.score_rd_i(score_rd_li)
 
      ,.clear_v_i(clear_int_v_li)
-     ,.clear_rd_i(clear_ird_li)
+     ,.clear_rd_i(clear_rd_li)
 
-     ,.rs_i({score_rs2_li, score_rs1_li})
-     ,.rd_i(score_rd_li)
+     ,.check_rs_i({check_rs2_li, check_rs1_li})
+     ,.check_rd_i(check_rd_li)
      ,.rs_match_o(irs_match_lo)
      ,.rd_match_o(ird_match_lo)
      );
 
   logic [2:0] frs_match_lo;
   logic       frd_match_lo;
-  wire score_fp_v_li = (dispatch_pkt_cast_i.v & dispatch_pkt_cast_i.decode.late_fwb_v)
-    || (commit_pkt_cast_i.dcache_load_miss & commit_pkt_cast_i.instr.t.fmatype.opcode == `RV64_FLOAD_OP);
-  wire clear_fp_v_li = fwb_pkt_cast_i.frd_w_v & fwb_pkt_cast_i.late;
+  wire score_fp_v_li = commit_pkt_cast_i.fscore_v;
+  wire clear_fp_v_li = late_wb_pkt_cast_i.frd_w_v & late_wb_yumi_i;
   bp_be_scoreboard
    #(.bp_params_p(bp_params_p), .num_rs_p(3))
    fp_scoreboard
@@ -135,17 +135,17 @@ module bp_be_detector
      ,.score_rd_i(score_rd_li)
 
      ,.clear_v_i(clear_fp_v_li)
-     ,.clear_rd_i(clear_frd_li)
+     ,.clear_rd_i(clear_rd_li)
 
-     ,.rs_i({score_rs3_li, score_rs2_li, score_rs1_li})
-     ,.rd_i(score_rd_li)
+     ,.check_rs_i({check_rs3_li, check_rs2_li, check_rs1_li})
+     ,.check_rd_i(check_rd_li)
      ,.rs_match_o(frs_match_lo)
      ,.rd_match_o(frd_match_lo)
      );
 
   always_comb
     begin
-      // Generate matches for rs1, rs2. rs3
+      // Generate matches for rs1, rs2, rs3
       // 3 stages because we only care about ex1, ex2, and iwb dependencies. fwb dependencies
       //   can be handled through forwarding
       for (integer i = 0; i < 3; i++)
@@ -154,69 +154,81 @@ module bp_be_detector
           rs2_match_vector[i] = (issue_pkt_cast_i.instr.t.fmatype.rs2_addr == dep_status_r[i].rd_addr);
           rs3_match_vector[i] = (issue_pkt_cast_i.instr.t.fmatype.rs3_addr == dep_status_r[i].rd_addr);
         end
+      score_rs1_match = (issue_pkt_cast_i.instr.t.fmatype.rs1_addr == score_rd_li);
+      score_rs2_match = (issue_pkt_cast_i.instr.t.fmatype.rs2_addr == score_rd_li);
+      score_rs3_match = (issue_pkt_cast_i.instr.t.fmatype.rs3_addr == score_rd_li);
+      score_rd_match  = (issue_pkt_cast_i.instr.t.fmatype.rd_addr  == score_rd_li);
 
       // Detect scoreboard hazards
-      irs1_sb_raw_haz_v = (issue_pkt_cast_i.decode.irs1_r_v & irs_match_lo[0]);
-      irs2_sb_raw_haz_v = (issue_pkt_cast_i.decode.irs2_r_v & irs_match_lo[1]);
-      ird_sb_waw_haz_v = ((issue_pkt_cast_i.decode.irf_w_v | issue_pkt_cast_i.decode.late_iwb_v) & ird_match_lo);
+      irs1_sb_raw_haz_v = (decode.irs1_r_v & irs_match_lo[0]);
+      irs2_sb_raw_haz_v = (decode.irs2_r_v & irs_match_lo[1]);
+      ird_sb_waw_haz_v = ((decode.irf_w_v | decode.late_iwb_v) & ird_match_lo);
 
-      frs1_sb_raw_haz_v = (issue_pkt_cast_i.decode.frs1_r_v & frs_match_lo[0]);
-      frs2_sb_raw_haz_v = (issue_pkt_cast_i.decode.frs2_r_v & frs_match_lo[1]);
-      frs3_sb_raw_haz_v = (issue_pkt_cast_i.decode.frs3_r_v & frs_match_lo[2]);
-      frd_sb_waw_haz_v = ((issue_pkt_cast_i.decode.frf_w_v | issue_pkt_cast_i.decode.late_fwb_v) & frd_match_lo);
+      frs1_sb_raw_haz_v = (decode.frs1_r_v & frs_match_lo[0]);
+      frs2_sb_raw_haz_v = (decode.frs2_r_v & frs_match_lo[1]);
+      frs3_sb_raw_haz_v = (decode.frs3_r_v & frs_match_lo[2]);
+      frd_sb_waw_haz_v = ((decode.frf_w_v | decode.late_fwb_v) & frd_match_lo);
 
       // Detect integer and float data hazards for EX1
-      irs1_data_haz_v[0] = (issue_pkt_cast_i.decode.irs1_r_v & rs1_match_vector[0])
-                           & (dep_status_r[0].fint_iwb_v | dep_status_r[0].aux_iwb_v | dep_status_r[0].mul_iwb_v | dep_status_r[0].emem_iwb_v | dep_status_r[0].fmem_iwb_v)
+      irs1_data_haz_v[0] = (decode.irs1_r_v & rs1_match_vector[0])
+                           & (dep_status_r[0].fint_iwb_v | dep_status_r[0].aux_iwb_v | dep_status_r[0].mul_iwb_v | dep_status_r[0].emem_iwb_v | dep_status_r[0].fmem_iwb_v | dep_status_r[0].long_iwb_v)
                            & ~irs1_ispec_v;
 
-      irs2_data_haz_v[0] = (issue_pkt_cast_i.decode.irs2_r_v & rs2_match_vector[0])
-                           & (dep_status_r[0].fint_iwb_v | dep_status_r[0].aux_iwb_v | dep_status_r[0].mul_iwb_v | dep_status_r[0].emem_iwb_v | dep_status_r[0].fmem_iwb_v)
+      irs2_data_haz_v[0] = (decode.irs2_r_v & rs2_match_vector[0])
+                           & (dep_status_r[0].fint_iwb_v | dep_status_r[0].aux_iwb_v | dep_status_r[0].mul_iwb_v | dep_status_r[0].emem_iwb_v | dep_status_r[0].fmem_iwb_v | dep_status_r[0].long_iwb_v)
                            & ~irs2_ispec_v;
 
-      frs1_data_haz_v[0] = (issue_pkt_cast_i.decode.frs1_r_v & rs1_match_vector[0])
-                           & (dep_status_r[0].fint_fwb_v | dep_status_r[0].aux_fwb_v | dep_status_r[0].emem_fwb_v | dep_status_r[0].fmem_fwb_v | dep_status_r[0].fma_fwb_v);
+      frs1_data_haz_v[0] = (decode.frs1_r_v & rs1_match_vector[0])
+                           & (dep_status_r[0].fint_fwb_v | dep_status_r[0].aux_fwb_v | dep_status_r[0].emem_fwb_v | dep_status_r[0].fmem_fwb_v | dep_status_r[0].fma_fwb_v | dep_status_r[0].long_fwb_v);
 
-      frs2_data_haz_v[0] = (issue_pkt_cast_i.decode.frs2_r_v & rs2_match_vector[0])
-                           & (dep_status_r[0].fint_fwb_v | dep_status_r[0].aux_fwb_v | dep_status_r[0].emem_fwb_v | dep_status_r[0].fmem_fwb_v | dep_status_r[0].fma_fwb_v);
+      frs2_data_haz_v[0] = (decode.frs2_r_v & rs2_match_vector[0])
+                           & (dep_status_r[0].fint_fwb_v | dep_status_r[0].aux_fwb_v | dep_status_r[0].emem_fwb_v | dep_status_r[0].fmem_fwb_v | dep_status_r[0].fma_fwb_v | dep_status_r[0].long_fwb_v);
 
-      frs3_data_haz_v[0] = (issue_pkt_cast_i.decode.frs3_r_v & rs3_match_vector[0])
-                           & (dep_status_r[0].fint_fwb_v | dep_status_r[0].aux_fwb_v | dep_status_r[0].emem_fwb_v | dep_status_r[0].fmem_fwb_v | dep_status_r[0].fma_fwb_v);
+      frs3_data_haz_v[0] = (decode.frs3_r_v & rs3_match_vector[0])
+                           & (dep_status_r[0].fint_fwb_v | dep_status_r[0].aux_fwb_v | dep_status_r[0].emem_fwb_v | dep_status_r[0].fmem_fwb_v | dep_status_r[0].fma_fwb_v | dep_status_r[0].long_fwb_v);
 
       // Detect integer and float data hazards for EX2
-      irs1_data_haz_v[1] = (issue_pkt_cast_i.decode.irs1_r_v & rs1_match_vector[1])
-                           & (dep_status_r[1].fmem_iwb_v | dep_status_r[1].mul_iwb_v);
+      irs1_data_haz_v[1] = (decode.irs1_r_v & rs1_match_vector[1])
+                           & (dep_status_r[1].fmem_iwb_v | dep_status_r[1].mul_iwb_v | dep_status_r[1].long_iwb_v);
 
-      irs2_data_haz_v[1] = (issue_pkt_cast_i.decode.irs2_r_v & rs2_match_vector[1])
-                           & (dep_status_r[1].fmem_iwb_v | dep_status_r[1].mul_iwb_v);
+      irs2_data_haz_v[1] = (decode.irs2_r_v & rs2_match_vector[1])
+                           & (dep_status_r[1].fmem_iwb_v | dep_status_r[1].mul_iwb_v | dep_status_r[1].long_iwb_v);
 
-      frs1_data_haz_v[1] = (issue_pkt_cast_i.decode.frs1_r_v & rs1_match_vector[1])
-                           & (dep_status_r[1].fmem_fwb_v | dep_status_r[1].fma_fwb_v);
+      frs1_data_haz_v[1] = (decode.frs1_r_v & rs1_match_vector[1])
+                           & (dep_status_r[1].fmem_fwb_v | dep_status_r[1].fma_fwb_v | dep_status_r[1].long_fwb_v);
 
-      frs2_data_haz_v[1] = (issue_pkt_cast_i.decode.frs2_r_v & rs2_match_vector[1])
-                           & (dep_status_r[1].fmem_fwb_v | dep_status_r[1].fma_fwb_v);
+      frs2_data_haz_v[1] = (decode.frs2_r_v & rs2_match_vector[1])
+                           & (dep_status_r[1].fmem_fwb_v | dep_status_r[1].fma_fwb_v | dep_status_r[1].long_fwb_v);
 
-      frs3_data_haz_v[1] = (issue_pkt_cast_i.decode.frs3_r_v & rs3_match_vector[1])
-                           & (dep_status_r[1].fmem_fwb_v | dep_status_r[1].fma_fwb_v);
+      frs3_data_haz_v[1] = (decode.frs3_r_v & rs3_match_vector[1])
+                           & (dep_status_r[1].fmem_fwb_v | dep_status_r[1].fma_fwb_v | dep_status_r[1].long_fwb_v);
 
       irs1_data_haz_v[2] = '0;
 
       irs2_data_haz_v[2] = '0;
 
-      frs1_data_haz_v[2] = (issue_pkt_cast_i.decode.frs1_r_v & rs1_match_vector[2])
-                           & (dep_status_r[2].fma_fwb_v);
+      frs1_data_haz_v[2] = (decode.frs1_r_v & rs1_match_vector[2])
+                           & (dep_status_r[2].fma_fwb_v | dep_status_r[1].long_fwb_v);
 
-      frs2_data_haz_v[2] = (issue_pkt_cast_i.decode.frs2_r_v & rs2_match_vector[2])
-                           & (dep_status_r[2].fma_fwb_v);
+      frs2_data_haz_v[2] = (decode.frs2_r_v & rs2_match_vector[2])
+                           & (dep_status_r[2].fma_fwb_v | dep_status_r[1].long_fwb_v);
 
-      frs3_data_haz_v[2] = (issue_pkt_cast_i.decode.frs3_r_v & rs3_match_vector[2])
-                           & (dep_status_r[2].fma_fwb_v);
+      frs3_data_haz_v[2] = (decode.frs3_r_v & rs3_match_vector[2])
+                           & (dep_status_r[2].fma_fwb_v | dep_status_r[1].long_fwb_v);
 
-      fence_haz_v        = issue_pkt_cast_i.decode.fence_v & ~mem_ordered_i;
+      score_haz_v        = (commit_pkt_cast_i.iscore_v & decode.irs1_r_v & score_rs1_match)
+                           | (commit_pkt_cast_i.iscore_v & decode.irs2_r_v & score_rs2_match)
+                           | (commit_pkt_cast_i.fscore_v & decode.frs1_r_v & score_rs1_match)
+                           | (commit_pkt_cast_i.fscore_v & decode.frs2_r_v & score_rs2_match)
+                           | (commit_pkt_cast_i.fscore_v & decode.frs3_r_v & score_rs3_match)
+                           | (commit_pkt_cast_i.iscore_v & decode.irf_w_v & score_rd_match)
+                           | (commit_pkt_cast_i.fscore_v & decode.frf_w_v & score_rd_match);
+
+      fence_haz_v        = decode.fence_v & ~mem_ordered_i;
       cmd_haz_v          = cmd_full_i;
 
       // TODO: Pessimistic, could have a separate fflags r/w_v
-      fflags_haz_v = (issue_pkt_cast_i.decode.csr_r_v | issue_pkt_cast_i.decode.csr_w_v)
+      fflags_haz_v = (decode.csr_r_v | decode.csr_w_v)
                      & ((dep_status_r[0].fflags_w_v)
                         | (dep_status_r[1].fflags_w_v)
                         | (dep_status_r[2].fflags_w_v)
@@ -224,17 +236,7 @@ module bp_be_detector
                         | fdiv_busy_i
                         );
 
-      // TODO: This is pessimistic. Could instead flush currently
-      //   executing instructions on trap, and only pause on dependency in
-      //   EX4, rather than any instruction. Most likely not a huge
-      //   performance problem at the moment.
-      long_haz_v = issue_pkt_cast_i.decode.pipe_long_v
-                   & ((dep_status_r[0].v)
-                      | (dep_status_r[1].v)
-                      | (dep_status_r[2].v)
-                      );
-
-      csr_haz_v     = (issue_pkt_cast_i.decode.csr_r_v | issue_pkt_cast_i.decode.csr_w_v)
+      csr_haz_v     = (decode.csr_r_v | decode.csr_w_v)
                       & ((dep_status_r[0].v)
                          | (dep_status_r[1].v)
                          | (dep_status_r[2].v)
@@ -242,7 +244,7 @@ module bp_be_detector
 
       exception_haz_v = commit_pkt_cast_i.npc_w_v;
 
-      control_haz_v = fence_haz_v | csr_haz_v | fflags_haz_v | long_haz_v | exception_haz_v;
+      control_haz_v = fence_haz_v | csr_haz_v | fflags_haz_v | exception_haz_v;
 
       // Combine all data hazard information
       // TODO: Parameterize away floating point data hazards without hardware support
@@ -257,10 +259,11 @@ module bp_be_detector
       // Combine all structural hazard information
       struct_haz_v = ptw_busy_i
                      | cmd_haz_v
-                     | (mem_busy_i & issue_pkt_cast_i.decode.pipe_mem_early_v)
-                     | (mem_busy_i & issue_pkt_cast_i.decode.pipe_mem_final_v)
-                     | (fdiv_busy_i & issue_pkt_cast_i.decode.pipe_long_v)
-                     | (idiv_busy_i & issue_pkt_cast_i.decode.pipe_long_v);
+                     | score_haz_v
+                     | (mem_busy_i & decode.pipe_mem_early_v)
+                     | (mem_busy_i & decode.pipe_mem_final_v)
+                     | (fdiv_busy_i & decode.pipe_long_v)
+                     | (idiv_busy_i & decode.pipe_long_v);
     end
 
   // Dispatch if we have a valid issue. Don't stall on data hazards for exceptions
@@ -287,6 +290,8 @@ module bp_be_detector
       dep_status_n.mul_fwb_v  = dispatch_pkt_cast_i.decode.pipe_mul_v       & dispatch_pkt_cast_i.decode.frf_w_v;
       dep_status_n.fma_iwb_v  = dispatch_pkt_cast_i.decode.pipe_fma_v       & dispatch_pkt_cast_i.decode.irf_w_v;
       dep_status_n.fma_fwb_v  = dispatch_pkt_cast_i.decode.pipe_fma_v       & dispatch_pkt_cast_i.decode.frf_w_v;
+      dep_status_n.long_iwb_v = dispatch_pkt_cast_i.decode.pipe_long_v      & dispatch_pkt_cast_i.decode.irf_w_v;
+      dep_status_n.long_fwb_v = dispatch_pkt_cast_i.decode.pipe_long_v      & dispatch_pkt_cast_i.decode.frf_w_v;
       dep_status_n.fflags_w_v = dispatch_pkt_cast_i.decode.fflags_w_v;
       dep_status_n.rd_addr    = dispatch_pkt_cast_i.instr.t.rtype.rd_addr;
     end

--- a/bp_be/src/v/bp_be_checker/bp_be_scoreboard.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scoreboard.sv
@@ -10,20 +10,20 @@ module bp_be_scoreboard
 
    , parameter `BSG_INV_PARAM(num_rs_p)
    )
-  (input                                        clk_i
-   , input                                      reset_i
+  (input                                         clk_i
+   , input                                       reset_i
 
-   , input                                      score_v_i
+   , input                                       score_v_i
    , input [reg_addr_width_gp-1:0]               score_rd_i
 
-   , input                                      clear_v_i
+   , input                                       clear_v_i
    , input [reg_addr_width_gp-1:0]               clear_rd_i
 
-   , input [num_rs_p-1:0][reg_addr_width_gp-1:0] rs_i
-   , input               [reg_addr_width_gp-1:0] rd_i
+   , input [num_rs_p-1:0][reg_addr_width_gp-1:0] check_rs_i
+   , input               [reg_addr_width_gp-1:0] check_rd_i
 
-   , output logic [num_rs_p-1:0]                rs_match_o
-   , output logic                               rd_match_o
+   , output logic [num_rs_p-1:0]                 rs_match_o
+   , output logic                                rd_match_o
    );
 
   localparam rf_els_lp = 2**reg_addr_width_gp;
@@ -48,7 +48,7 @@ module bp_be_scoreboard
      );
 
   bsg_dff_reset_set_clear
-   #(.width_p(rf_els_lp))
+   #(.width_p(rf_els_lp), .clear_over_set_p(1))
    scoreboard_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
@@ -60,9 +60,9 @@ module bp_be_scoreboard
 
   for (genvar i = 0; i < num_rs_p; i++)
     begin : rs
-      assign rs_match_o[i] = scoreboard_r[rs_i[i]];
+      assign rs_match_o[i] = scoreboard_r[check_rs_i[i]];
     end
-  assign rd_match_o = scoreboard_r[rd_i];
+  assign rd_match_o = scoreboard_r[check_rd_i];
 
 endmodule
 

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -18,6 +18,7 @@ module bp_be_top
 
    // Default parameters
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
+   , localparam wb_pkt_width_lp = `bp_be_wb_pkt_width(vaddr_width_p)
   )
   (input                                             clk_i
    , input                                           reset_i
@@ -91,6 +92,9 @@ module bp_be_top
   bp_be_wb_pkt_s iwb_pkt, fwb_pkt;
   bp_be_decode_info_s decode_info_lo;
 
+  logic [wb_pkt_width_lp-1:0] late_wb_pkt;
+  logic late_wb_v_lo, late_wb_force_lo, late_wb_yumi_li;
+
   bp_be_issue_pkt_s issue_pkt;
   logic [vaddr_width_p-1:0] expected_npc_lo;
   logic npc_mismatch_lo, poison_isd_lo, clear_iss_lo, suppress_iss_lo, resume_lo;
@@ -150,8 +154,9 @@ module bp_be_top
      ,.interrupt_v_o(interrupt_v)
      ,.dispatch_pkt_i(dispatch_pkt)
      ,.commit_pkt_i(commit_pkt)
-     ,.iwb_pkt_i(iwb_pkt)
-     ,.fwb_pkt_i(fwb_pkt)
+
+     ,.late_wb_pkt_i(late_wb_pkt)
+     ,.late_wb_yumi_i(late_wb_yumi_li)
      );
 
   bp_be_scheduler
@@ -176,11 +181,15 @@ module bp_be_top
      ,.fe_queue_ready_and_o(fe_queue_ready_and_o)
 
      ,.dispatch_pkt_o(dispatch_pkt)
-
      ,.commit_pkt_i(commit_pkt)
-     ,.ptw_fill_pkt_i(ptw_fill_pkt)
      ,.iwb_pkt_i(iwb_pkt)
      ,.fwb_pkt_i(fwb_pkt)
+
+     ,.ptw_fill_pkt_i(ptw_fill_pkt)
+     ,.late_wb_pkt_i(late_wb_pkt)
+     ,.late_wb_v_i(late_wb_v_lo)
+     ,.late_wb_force_i(late_wb_force_lo)
+     ,.late_wb_yumi_o(late_wb_yumi_li)
      );
 
   bp_be_calculator_top
@@ -190,8 +199,6 @@ module bp_be_top
      ,.reset_i(reset_i)
      ,.cfg_bus_i(cfg_bus_i)
 
-     ,.dispatch_pkt_i(dispatch_pkt)
-
      ,.decode_info_o(decode_info_lo)
      ,.mem_busy_o(mem_busy_lo)
      ,.mem_ordered_o(mem_ordered_lo)
@@ -199,11 +206,17 @@ module bp_be_top
      ,.fdiv_busy_o(fdiv_busy_lo)
      ,.ptw_busy_o(ptw_busy_lo)
 
+     ,.dispatch_pkt_i(dispatch_pkt)
      ,.br_pkt_o(br_pkt)
      ,.commit_pkt_o(commit_pkt)
-     ,.ptw_fill_pkt_o(ptw_fill_pkt)
      ,.iwb_pkt_o(iwb_pkt)
      ,.fwb_pkt_o(fwb_pkt)
+
+     ,.ptw_fill_pkt_o(ptw_fill_pkt)
+     ,.late_wb_pkt_o(late_wb_pkt)
+     ,.late_wb_v_o(late_wb_v_lo)
+     ,.late_wb_force_o(late_wb_force_lo)
+     ,.late_wb_yumi_i(late_wb_yumi_li)
 
      ,.cache_req_o(cache_req_o)
      ,.cache_req_metadata_o(cache_req_metadata_o)

--- a/bp_be/test/tb/bp_be_dcache/testbench.sv
+++ b/bp_be/test/tb/bp_be_dcache/testbench.sv
@@ -115,7 +115,7 @@ module testbench
   logic [num_caches_p-1:0][dcache_pkt_width_lp-1:0] dcache_pkt_li;
   logic [num_caches_p-1:0][ptag_width_p-1:0] ptag_li;
   logic [num_caches_p-1:0] uncached_li;
-  logic [num_caches_p-1:0][dword_width_gp-1:0] st_data_li, st_data_r;
+  logic [num_caches_p-1:0][dpath_width_gp-1:0] st_data_li, st_data_r;
   logic [num_caches_p-1:0] dcache_ready_li;
 
   logic [num_caches_p-1:0] fifo_yumi_li, fifo_v_lo, fifo_random_yumi_lo;
@@ -188,7 +188,7 @@ module testbench
       assign uncached_li[i] = trace_data_lo[i][(dword_width_gp+dcache_pkt_width_lp+ptag_width_p)+:1];
 
       bsg_dff
-       #(.width_p(dword_width_gp))
+       #(.width_p(dpath_width_gp))
        st_data_reg
         (.clk_i(clk_i)
          ,.data_i(st_data_li[i])

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -41,7 +41,7 @@ module wrapper
 
    , input [num_caches_p-1:0][ptag_width_p-1:0]        ptag_i
    , input [num_caches_p-1:0]                          uncached_i
-   , input [num_caches_p-1:0][dword_width_gp-1:0]      st_data_i
+   , input [num_caches_p-1:0][dpath_width_gp-1:0]      st_data_i
 
    , output logic [num_caches_p-1:0][dword_width_gp-1:0] data_o
    , output logic [num_caches_p-1:0]                     v_o
@@ -195,7 +195,6 @@ module wrapper
       ,.v_o(v_o[i])
       ,.clean_o()
       ,.ret_o()
-      ,.late_o()
       ,.rd_addr_o()
       ,.addr_o()
       ,.ordered_o()

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -160,7 +160,6 @@ module bp_cacc_vdp
      ,.store_o()
      ,.float_o()
      ,.ordered_o()
-     ,.late_o()
      ,.rd_addr_o()
      ,.req_o()
 

--- a/bp_top/test/common/bp_nonsynth_core_profiler.sv
+++ b/bp_top/test/common/bp_nonsynth_core_profiler.sv
@@ -8,7 +8,6 @@
     logic fe_cmd;
     logic mispredict;
     logic control_haz;
-    logic long_haz;
     logic data_haz;
     logic aux_dep;
     logic load_dep;
@@ -34,14 +33,13 @@
 
   typedef enum logic [4:0]
   {
-    icache_miss          = 5'd28
-    ,branch_override     = 5'd27
-    ,ret_override        = 5'd26
-    ,realigner           = 5'd25
-    ,fe_cmd              = 5'd24
-    ,mispredict          = 5'd23
-    ,control_haz         = 5'd22
-    ,long_haz            = 5'd21
+    icache_miss          = 5'd27
+    ,branch_override     = 5'd26
+    ,ret_override        = 5'd25
+    ,realigner           = 5'd24
+    ,fe_cmd              = 5'd23
+    ,mispredict          = 5'd22
+    ,control_haz         = 5'd21
     ,data_haz            = 5'd20
     ,aux_dep             = 5'd19
     ,load_dep            = 5'd18
@@ -107,7 +105,6 @@ module bp_nonsynth_core_profiler
     // ISD events
     , input dcache_miss_i
     , input mispredict_i
-    , input long_haz_i
     , input control_haz_i
     , input data_haz_i
     , input aux_dep_i
@@ -207,7 +204,6 @@ module bp_nonsynth_core_profiler
       stall_stage_n[3].fdiv_haz          |= fdiv_haz_i;
       stall_stage_n[3].ptw_busy          |= ptw_busy_i;
       stall_stage_n[3].control_haz       |= control_haz_i;
-      stall_stage_n[3].long_haz          |= long_haz_i;
 
       stall_stage_n[3].special           |= |retire_pkt.special;
       stall_stage_n[3].replay            |= |retire_pkt.exception;

--- a/bp_top/test/common/bp_nonsynth_cosim.sv
+++ b/bp_top/test/common/bp_nonsynth_cosim.sv
@@ -120,8 +120,8 @@ module bp_nonsynth_cosim
   wire instret_v_li = commit_pkt_r.instret;
   wire [vaddr_width_p-1:0] commit_pc_li = commit_pkt_r.pc;
   wire [instr_width_gp-1:0] commit_instr_li = commit_pkt_r.instr;
-  wire commit_ird_w_v_li = instret_v_li & (decode_r.irf_w_v | decode_r.late_iwb_v);
-  wire commit_frd_w_v_li = instret_v_li & (decode_r.frf_w_v | decode_r.late_fwb_v);
+  wire commit_ird_w_v_li = instret_v_li & decode_r.irf_w_v;
+  wire commit_frd_w_v_li = instret_v_li & decode_r.frf_w_v;
   wire commit_req_v_li   = instret_v_li & cache_req_v_r;
   wire trap_v_li = commit_pkt_r.exception | commit_pkt_r._interrupt;
   wire [dword_width_gp-1:0] cause_li = (priv_mode_i == `PRIV_MODE_M) ? mcause_i : scause_i;

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -470,7 +470,6 @@ module testbench
 
           ,.mispredict_i(be.director.npc_mismatch_v)
           ,.dcache_miss_i(~be.calculator.pipe_mem.dcache.ready_and_o)
-          ,.long_haz_i(be.detector.long_haz_v)
           ,.control_haz_i(be.detector.control_haz_v)
           ,.data_haz_i(be.detector.data_haz_v)
           ,.aux_dep_i((be.detector.dep_status_r[0].aux_iwb_v


### PR DESCRIPTION
### Summary
This PR fixes the late writeback capability of the pipeline to support multiple asynchronous functional units. In order to avoid adding ports to the register file or requiring backpressure on the memory system, we inject writebacks directly into the completion pipeline. From there, normal forwarding paths can handle the dependencies.

### Issue Fixed
None

### Area
calculator / pipe_long / pipe_mem

### Reasoning (new feature, inefficient, verbose, etc.)
For adding multiple late writers, a round robin is desired. However, our memory pipe relies on a nonblocking writeback pipeline. To avoid multiporting the register file or implementing a reorder buffer, we repurpose the normal completion pipeline. This is the TINY solution

### Additional Changes Required (if any)
None

### Analysis
PPA unaffected confirmed by synthesis

### Verification
Normal regression with manual inspection of write backs

### Additional Context
None
