### PR TITLE
[WIP] Added L2-bypass

### DIFF
--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -172,6 +172,8 @@
     // L2 slice parameters (per core)
     // L2 cache features
     integer unsigned l2_features;
+    // Enable L2 instantiation
+    integer unsigned l2_en;
     // Number of L2 banks present in the slice
     integer unsigned l2_banks;
     integer unsigned l2_data_width;
@@ -315,6 +317,7 @@
                               | (1 << e_cfg_amo_swap)
                               | (1 << e_cfg_amo_fetch_logic)
                               | (1 << e_cfg_amo_fetch_arithmetic)
+      ,l2_en               : 1
       ,l2_banks            : 2
       ,l2_data_width       : 128
       ,l2_sets             : 128
@@ -426,6 +429,7 @@
       ,`bp_aviary_define_override(bedrock_fill_width, BP_BEDROCK_FILL_WIDTH, `BP_CUSTOM_BASE_CFG)
 
       ,`bp_aviary_define_override(l2_features, BP_L2_FEATURES, `BP_CUSTOM_BASE_CFG)
+      ,`bp_aviary_define_override(l2_en, BP_L2_EN, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(l2_banks, BP_L2_BANKS, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(l2_data_width, BP_L2_DATA_WIDTH, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(l2_sets, BP_L2_SETS, `BP_CUSTOM_BASE_CFG)

--- a/bp_common/src/include/bp_common_aviary_defines.svh
+++ b/bp_common/src/include/bp_common_aviary_defines.svh
@@ -92,7 +92,7 @@
     , localparam cce_way_groups_p           =                                                      \
         `BSG_MIN(dcache_sets_p, `BSG_MIN(icache_sets_p, num_cacc_p ? acache_sets_p : icache_sets_p)) \
                                                                                                    \
-    /* L2 enable turns the L2 into a small write buffer, which is minimal size                  */ \
+    , localparam l2_en_p               = proc_param_lp.l2_en                                       \
     , localparam l2_features_p         = proc_param_lp.l2_features                                 \
     , localparam l2_banks_p            = l2_features_p[e_cfg_enabled] ? proc_param_lp.l2_banks : 1 \
     , localparam l2_sets_p             = l2_features_p[e_cfg_enabled] ? proc_param_lp.l2_sets  : 4 \
@@ -104,6 +104,8 @@
                                                                                                    \
     , localparam l2_block_size_in_words_p = l2_block_width_p / l2_data_width_p                     \
     , localparam l2_block_size_in_fill_p  = l2_block_width_p / l2_fill_width_p                     \
+    , localparam dma_els_p                = l2_en_p ? l2_banks_p : 1                               \
+    , localparam dma_mask_width_p         = l2_en_p ? l2_block_size_in_words_p : (bedrock_block_width_p >> 3) \
                                                                                                    \
     , localparam fe_queue_fifo_els_p  = proc_param_lp.fe_queue_fifo_els                            \
     , localparam fe_cmd_fifo_els_p    = proc_param_lp.fe_cmd_fifo_els                              \
@@ -249,6 +251,7 @@
           ,`bp_aviary_parameter_override(bedrock_fill_width, override_cfg_mp, default_cfg_mp)      \
                                                                                                    \
           ,`bp_aviary_parameter_override(l2_features, override_cfg_mp, default_cfg_mp)             \
+          ,`bp_aviary_parameter_override(l2_en, override_cfg_mp, default_cfg_mp)                   \
           ,`bp_aviary_parameter_override(l2_banks, override_cfg_mp, default_cfg_mp)                \
           ,`bp_aviary_parameter_override(l2_data_width, override_cfg_mp, default_cfg_mp)           \
           ,`bp_aviary_parameter_override(l2_sets, override_cfg_mp, default_cfg_mp)                 \

--- a/bp_common/src/include/bp_common_cache_pkgdef.svh
+++ b/bp_common/src/include/bp_common_cache_pkgdef.svh
@@ -2,8 +2,11 @@
 `ifndef BP_COMMON_CACHE_PKGDEF_SVH
 `define BP_COMMON_CACHE_PKGDEF_SVH
 
-  localparam cache_base_addr_gp   = (dev_id_width_gp+dev_addr_width_gp)'('h0400_0000);
-  localparam cache_tagfl_addr_gp  = (dev_addr_width_gp)'('h0_0000);
+  localparam cache_base_addr_gp          = (dev_id_width_gp+dev_addr_width_gp)'('h0400_0000);
+  localparam cache_tagfl_addr_gp         = (dev_addr_width_gp)'('h0_0000);
+  localparam cache_tagfl_all_addr_gp     = (dev_addr_width_gp)'('h0_1000);
+  localparam cache_taginv_all_addr_gp    = (dev_addr_width_gp)'('h0_2000);
+  localparam cache_tagflinv_all_addr_gp  = (dev_addr_width_gp)'('h0_3000);
 
 `endif
 

--- a/bp_common/src/include/bp_common_cache_pkgdef.svh
+++ b/bp_common/src/include/bp_common_cache_pkgdef.svh
@@ -4,9 +4,12 @@
 
   localparam cache_base_addr_gp          = (dev_id_width_gp+dev_addr_width_gp)'('h0400_0000);
   localparam cache_tagfl_addr_gp         = (dev_addr_width_gp)'('h0_0000);
-  localparam cache_tagfl_all_addr_gp     = (dev_addr_width_gp)'('h0_1000);
-  localparam cache_taginv_all_addr_gp    = (dev_addr_width_gp)'('h0_2000);
-  localparam cache_tagflinv_all_addr_gp  = (dev_addr_width_gp)'('h0_3000);
+  localparam cache_afl_addr_gp           = (dev_addr_width_gp)'('h0_1000);
+  localparam cache_ainv_addr_gp          = (dev_addr_width_gp)'('h0_2000);
+  localparam cache_aflinv_addr_gp        = (dev_addr_width_gp)'('h0_3000);
+  localparam cache_tagfl_all_addr_gp     = (dev_addr_width_gp)'('h0_4000);
+  localparam cache_taginv_all_addr_gp    = (dev_addr_width_gp)'('h0_5000);
+  localparam cache_tagflinv_all_addr_gp  = (dev_addr_width_gp)'('h0_6000);
 
 `endif
 

--- a/bp_me/src/v/dev/bp_me_cache_slice.sv
+++ b/bp_me/src/v/dev/bp_me_cache_slice.sv
@@ -106,7 +106,9 @@ module bp_me_cache_slice
        ,.cache_data_v_i(cache_data_v_lo)
        ,.cache_data_yumi_o(cache_data_yumi_li)
        );
-  
+
+    `declare_bsg_cache_dma_pkt_s(daddr_width_p, dma_mask_width_p);
+    bsg_cache_dma_pkt_s [l2_banks_p-1:0] dma_pkt_lo, dma_pkt_cast_o;
     for (genvar i = 0; i < l2_banks_p; i++)
       begin : bank
       bsg_cache
@@ -140,7 +142,7 @@ module bp_me_cache_slice
          ,.v_o(cache_data_v_lo[i])
          ,.yumi_i(cache_data_yumi_li[i])
 
-         ,.dma_pkt_o(dma_pkt_o[i])
+         ,.dma_pkt_o(dma_pkt_lo[i])
          ,.dma_pkt_v_o(dma_pkt_v_o[i])
          ,.dma_pkt_yumi_i(dma_pkt_ready_and_i[i] & dma_pkt_v_o[i])
 
@@ -154,6 +156,17 @@ module bp_me_cache_slice
 
          ,.v_we_o()
          );
+
+      bp_me_dram_hash_decode
+        #(.bp_params_p(bp_params_p))
+        dma_addr_hash_decode
+         (.daddr_i(dma_pkt_lo[i].addr)
+          ,.daddr_o(dma_pkt_cast_o[i].addr)
+          );
+
+      assign dma_pkt_cast_o[i].write_not_read = dma_pkt_lo[i].write_not_read;
+      assign dma_pkt_cast_o[i].mask = dma_pkt_lo[i].mask;
+      assign dma_pkt_o[i] = dma_pkt_cast_o[i];
     end
   end
   else begin: nol2

--- a/bp_me/src/v/dev/bp_me_cce_to_cache.sv
+++ b/bp_me/src/v/dev/bp_me_cce_to_cache.sv
@@ -351,10 +351,11 @@ module bp_me_cce_to_cache
                   e_bedrock_msg_size_2: cache_pkt.opcode = LH;
                   e_bedrock_msg_size_4: cache_pkt.opcode = LW;
                   e_bedrock_msg_size_8: cache_pkt.opcode = LD;
-                  e_bedrock_msg_size_16
-                  ,e_bedrock_msg_size_32
-                  ,e_bedrock_msg_size_64: cache_pkt.opcode = LD;
-                  default: cache_pkt.opcode = LB;
+                  //e_bedrock_msg_size_16
+                  //,e_bedrock_msg_size_32
+                  //,e_bedrock_msg_size_64
+                  //,e_bedrock_msg_size_128
+                  default: cache_pkt.opcode = LM;
                 endcase
               e_bedrock_mem_uc_wr
               ,e_bedrock_mem_wr
@@ -376,10 +377,11 @@ module bp_me_cce_to_cache
                       e_bedrock_amomaxu: cache_pkt.opcode = is_word_op ? AMOMAXU_W : AMOMAXU_D;
                       default : begin end
                     endcase
-                  e_bedrock_msg_size_16
-                  ,e_bedrock_msg_size_32
-                  ,e_bedrock_msg_size_64: cache_pkt.opcode = SD;
-                  default: cache_pkt.opcode = LB;
+                  //e_bedrock_msg_size_16
+                  //,e_bedrock_msg_size_32
+                  //,e_bedrock_msg_size_64
+                  //,e_bedrock_msg_size_128
+                  default: cache_pkt.opcode = SM;
                 endcase
               default: cache_pkt.opcode = LB;
             endcase

--- a/bp_me/src/v/dev/bp_me_cce_to_cache_dma.sv
+++ b/bp_me/src/v/dev/bp_me_cce_to_cache_dma.sv
@@ -1,0 +1,303 @@
+
+`include "bp_common_defines.svh"
+`include "bp_me_defines.svh"
+`include "bsg_cache.vh"
+
+module bp_me_cce_to_cache_dma
+ import bp_common_pkg::*;
+ import bp_me_pkg::*;
+ import bsg_cache_pkg::*;
+ #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+   `declare_bp_proc_params(bp_params_p)
+   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+
+   , localparam cache_dma_pkt_width_lp=`bsg_cache_dma_pkt_width(daddr_width_p, dma_mask_width_p)
+   )
+  (input                                                   clk_i
+   , input                                                 reset_i
+
+   // BedRock Stream interface
+   , input [mem_fwd_header_width_lp-1:0]                   mem_fwd_header_i
+   , input [bedrock_fill_width_p-1:0]                      mem_fwd_data_i
+   , input                                                 mem_fwd_v_i
+   , output logic                                          mem_fwd_ready_and_o
+
+   , output logic [mem_rev_header_width_lp-1:0]            mem_rev_header_o
+   , output logic [bedrock_fill_width_p-1:0]               mem_rev_data_o
+   , output logic                                          mem_rev_v_o
+   , input                                                 mem_rev_ready_and_i
+
+   // cache DMA
+   ,output logic [cache_dma_pkt_width_lp-1:0]              dma_pkt_o
+   ,output logic                                           dma_pkt_v_o
+   ,input                                                  dma_pkt_yumi_i
+
+   ,input [l2_fill_width_p-1:0]                            dma_data_i
+   ,input                                                  dma_data_v_i
+   ,output logic                                           dma_data_ready_o
+
+   ,output logic [l2_fill_width_p-1:0]                     dma_data_o
+   ,output logic                                           dma_data_v_o
+   ,input                                                  dma_data_yumi_i
+   );
+
+  localparam dma_burst_len_lp = (bedrock_block_width_p / l2_fill_width_p);
+  localparam lg_dma_burst_len_lp = `BSG_SAFE_CLOG2(dma_burst_len_lp);
+  localparam bytemask_width_lp = (bedrock_block_width_p >> 3);
+  localparam lg_bytemask_width_lp = `BSG_SAFE_CLOG2(bytemask_width_lp);
+  localparam l2_fill_in_bytes_lp = (l2_fill_width_p >> 3);
+  localparam l2_fill_offset_width_lp = `BSG_SAFE_CLOG2(l2_fill_in_bytes_lp);
+  localparam lg_l2_fill_in_bytes_lp = $clog2(l2_fill_in_bytes_lp);
+  localparam bedrock_fill_offset_width_lp = `BSG_SAFE_CLOG2(bedrock_fill_width_p >> 3);
+
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `declare_bsg_cache_dma_pkt_s(daddr_width_p, dma_mask_width_p);
+
+  `bp_cast_i(bp_bedrock_mem_fwd_header_s, mem_fwd_header);
+  `bp_cast_o(bsg_cache_dma_pkt_s, dma_pkt);
+
+  // Command
+  bp_bedrock_mem_fwd_header_s fsm_fwd_header_lo;
+  logic [l2_fill_width_p-1:0] fsm_fwd_data_lo;
+  logic fsm_fwd_v_lo, fsm_fwd_yumi_li;
+  logic [paddr_width_p-1:0] fsm_fwd_addr_lo;
+  logic fsm_fwd_new_lo, fsm_fwd_critical_lo, fsm_fwd_last_lo;
+  wire wr_cmd = fsm_fwd_v_lo & fsm_fwd_header_lo.msg_type inside {e_bedrock_mem_uc_wr, e_bedrock_mem_wr};
+  wire rd_cmd = fsm_fwd_v_lo & fsm_fwd_header_lo.msg_type inside {e_bedrock_mem_uc_rd, e_bedrock_mem_rd};
+  wire csr_cmd = fsm_fwd_v_lo & (fsm_fwd_header_lo.addr < dram_base_addr_gp);
+
+  wire [bedrock_fill_width_p-1:0] mem_fwd_data_shifted_li = mem_fwd_data_i << {mem_fwd_header_cast_i.addr[0+:bedrock_fill_offset_width_lp], 3'b0};
+
+  bp_me_stream_pump_in
+   #(.bp_params_p(bp_params_p)
+     ,.fsm_data_width_p(l2_fill_width_p)
+     ,.block_width_p(l2_block_width_p)
+     ,.payload_width_p(mem_fwd_payload_width_lp)
+     ,.msg_stream_mask_p(mem_fwd_stream_mask_gp)
+     ,.fsm_stream_mask_p(mem_fwd_stream_mask_gp)
+     )
+   fwd_pump_in
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.msg_header_i(mem_fwd_header_i)
+     ,.msg_data_i(mem_fwd_data_shifted_li)
+     ,.msg_v_i(mem_fwd_v_i)
+     ,.msg_ready_and_o(mem_fwd_ready_and_o)
+
+     ,.fsm_header_o(fsm_fwd_header_lo)
+     ,.fsm_data_o(fsm_fwd_data_lo)
+     ,.fsm_v_o(fsm_fwd_v_lo)
+     ,.fsm_yumi_i(fsm_fwd_yumi_li)
+     ,.fsm_addr_o(fsm_fwd_addr_lo)
+     ,.fsm_new_o(fsm_fwd_new_lo)
+     ,.fsm_critical_o(fsm_fwd_critical_lo)
+     ,.fsm_last_o(fsm_fwd_last_lo)
+     );
+
+  bp_bedrock_mem_rev_header_s fsm_rev_header_li;
+  logic fifo_v_li, fifo_ready_lo, fifo_v_lo, fifo_yumi_li;
+  assign fifo_v_li = fsm_fwd_yumi_li & fsm_fwd_new_lo;
+  bsg_fifo_1r1w_small
+   #(.width_p(mem_fwd_header_width_lp), .els_p(l2_outstanding_reqs_p))
+   stream_fifo
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.v_i(fifo_v_li)
+     ,.data_i(fsm_fwd_header_lo)
+     ,.ready_o(fifo_ready_lo)
+
+     ,.v_o(fifo_v_lo)
+     ,.data_o(fsm_rev_header_li)
+     ,.yumi_i(fifo_yumi_li)
+     );
+
+  localparam mux_els_lp = lg_bytemask_width_lp + 1;
+  localparam lg_mux_els_lp = `BSG_SAFE_CLOG2(mux_els_lp);
+
+  logic [mux_els_lp-1:0][bytemask_width_lp-1:0] dma_mask_mux_li;
+  logic [bytemask_width_lp-1:0] dma_mask_lo;
+
+  for (genvar i = 0; i < mux_els_lp; i++)
+    begin : dma_sel
+      localparam slice_width_lp = (2**i);
+      localparam num_slices_lp = (bytemask_width_lp/slice_width_lp);
+      localparam lg_num_slices_lp = `BSG_SAFE_CLOG2(num_slices_lp);
+
+      if (i == mux_els_lp-1)
+        begin: max_size
+          assign dma_mask_mux_li[i] = {bytemask_width_lp{1'b1}};
+        end
+      else
+        begin: non_max_size
+          wire [lg_num_slices_lp-1:0] slice_index = fsm_fwd_header_lo.addr[i+:lg_num_slices_lp];
+          wire [num_slices_lp-1:0] decoded_slice_index = (1'b1 << slice_index);
+
+          bsg_expand_bitmask
+           #(.in_width_p(num_slices_lp)
+             ,.expand_p(slice_width_lp))
+           mask_expand
+            (.i(decoded_slice_index)
+            ,.o(dma_mask_mux_li[i])
+          );
+        end
+    end
+
+  wire [lg_mux_els_lp-1:0] dma_mask_sel_li = (fsm_fwd_header_lo.size > lg_bytemask_width_lp)
+                                             ? lg_mux_els_lp'(mux_els_lp-1)
+                                             : fsm_fwd_header_lo.size[0+:lg_mux_els_lp];
+
+  bsg_mux
+   #(.width_p(bytemask_width_lp)
+   ,.els_p(mux_els_lp))
+   dma_mask_mux
+    (.data_i(dma_mask_mux_li)
+    ,.sel_i(dma_mask_sel_li)
+    ,.data_o(dma_mask_lo)
+    );
+
+  logic [lg_dma_burst_len_lp-1:0] cmd_burst_cnt_n, cmd_burst_cnt_r;
+  logic [l2_fill_in_bytes_lp-1:0] dma_mask_word_selected_lo;
+  bsg_mux
+   #(.width_p(l2_fill_in_bytes_lp)
+   ,.els_p(dma_burst_len_lp))
+   dma_mask_word_sel_mux
+    (.data_i(dma_mask_lo)
+    ,.sel_i(cmd_burst_cnt_r)
+    ,.data_o(dma_mask_word_selected_lo)
+    );
+
+  logic wr_pkt_sent_n, wr_pkt_sent_r;
+
+  always_comb begin
+    dma_pkt_v_o = 1'b0;
+    dma_data_v_o = 1'b0;
+    fsm_fwd_yumi_li = 1'b0;
+
+    dma_pkt_cast_o.write_not_read = wr_cmd;
+    dma_pkt_cast_o.mask = dma_mask_lo;
+    dma_pkt_cast_o.addr = fsm_fwd_header_lo.addr & ~((1 << lg_bytemask_width_lp) - 1);
+
+    dma_data_o = fsm_fwd_data_lo;
+
+    cmd_burst_cnt_n = cmd_burst_cnt_r;
+    wr_pkt_sent_n = wr_pkt_sent_r;
+
+    if(csr_cmd) begin
+      fsm_fwd_yumi_li = fsm_fwd_v_lo & fifo_ready_lo;
+    end
+    else if(wr_cmd) begin
+      dma_pkt_v_o = fsm_fwd_v_lo & fsm_fwd_new_lo & ~wr_pkt_sent_r & fifo_ready_lo;
+      dma_data_v_o = fsm_fwd_v_lo & wr_pkt_sent_r;
+      fsm_fwd_yumi_li = dma_data_yumi_i & (fsm_fwd_last_lo ? (cmd_burst_cnt_r == dma_burst_len_lp - 1) : (|dma_mask_word_selected_lo));
+
+      cmd_burst_cnt_n = dma_data_yumi_i ? (cmd_burst_cnt_r + 1'b1) : cmd_burst_cnt_r;
+      wr_pkt_sent_n = dma_pkt_yumi_i ? 1'b1 : ((fsm_fwd_yumi_li & fsm_fwd_last_lo) ? 1'b0 : wr_pkt_sent_r);
+    end
+    else if(rd_cmd) begin
+      dma_pkt_v_o = fsm_fwd_v_lo & fsm_fwd_new_lo & fifo_ready_lo;
+      fsm_fwd_yumi_li = dma_pkt_yumi_i;
+    end
+  end
+
+  // Response
+  logic [l2_fill_width_p-1:0] fsm_rev_data_li;
+  logic fsm_rev_v_li, fsm_rev_ready_and_lo;
+  logic [paddr_width_p-1:0] fsm_rev_addr_lo;
+  logic fsm_rev_new_lo, fsm_rev_critical_lo, fsm_rev_last_lo;
+  bp_me_stream_pump_out
+   #(.bp_params_p(bp_params_p)
+     ,.fsm_data_width_p(l2_fill_width_p)
+     ,.block_width_p(l2_block_width_p)
+     ,.payload_width_p(mem_rev_payload_width_lp)
+     ,.msg_stream_mask_p(mem_rev_stream_mask_gp)
+     ,.fsm_stream_mask_p(mem_fwd_stream_mask_gp)
+     )
+   rev_pump_out
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+
+     ,.msg_header_o(mem_rev_header_o)
+     ,.msg_data_o(mem_rev_data_o)
+     ,.msg_v_o(mem_rev_v_o)
+     ,.msg_ready_and_i(mem_rev_ready_and_i)
+
+     ,.fsm_header_i(fsm_rev_header_li)
+     ,.fsm_data_i(fsm_rev_data_li)
+     ,.fsm_v_i(fsm_rev_v_li)
+     ,.fsm_ready_and_o(fsm_rev_ready_and_lo)
+     ,.fsm_addr_o(fsm_rev_addr_lo)
+     ,.fsm_new_o(fsm_rev_new_lo)
+     ,.fsm_critical_o(fsm_rev_critical_lo)
+     ,.fsm_last_o(fsm_rev_last_lo)
+     );
+
+  logic [`BSG_WIDTH(l2_fill_offset_width_lp)-1:0] fsm_rev_data_size_li;
+  logic [l2_fill_offset_width_lp-1:0] fsm_rev_data_sel_li;
+  assign fsm_rev_data_size_li = `BSG_MIN(fsm_rev_header_li.size, `BSG_WIDTH(l2_fill_offset_width_lp)'(l2_fill_offset_width_lp));
+  assign fsm_rev_data_sel_li = fsm_rev_header_li.addr[0+:l2_fill_offset_width_lp] & ({l2_fill_offset_width_lp{1'b1}} << fsm_rev_header_li.size);
+
+
+  bsg_bus_pack
+   #(.in_width_p(l2_fill_width_p))
+   fsm_rev_data_bus_pack
+    (.data_i(dma_data_i)
+    ,.sel_i(fsm_rev_data_sel_li)
+    ,.size_i(fsm_rev_data_size_li)
+    ,.data_o(fsm_rev_data_li)
+    );
+
+  wire [`BSG_SAFE_CLOG2(lg_dma_burst_len_lp):0] stream_size = (fsm_rev_header_li.size > lg_l2_fill_in_bytes_lp)
+                                                                ? (fsm_rev_header_li.size - lg_l2_fill_in_bytes_lp)
+                                                                : '0;
+  wire [lg_dma_burst_len_lp-1:0] stream_cnt = (1 << stream_size) - 1'b1;
+  wire [lg_dma_burst_len_lp-1:0] first_cnt = fsm_rev_header_li.addr[l2_fill_offset_width_lp+:lg_dma_burst_len_lp]
+                                             & ({lg_dma_burst_len_lp{1'b1}} << stream_size);
+  wire [lg_dma_burst_len_lp-1:0] last_cnt = first_cnt + stream_cnt;
+
+
+  wire wr_resp = fifo_v_lo & fsm_rev_header_li.msg_type inside {e_bedrock_mem_uc_wr, e_bedrock_mem_wr};
+  wire rd_resp = fifo_v_lo & fsm_rev_header_li.msg_type inside {e_bedrock_mem_uc_rd, e_bedrock_mem_rd};
+  wire csr_resp = fifo_v_lo & (fsm_rev_header_li.addr < dram_base_addr_gp);
+
+  logic [lg_dma_burst_len_lp-1:0] resp_burst_cnt_n, resp_burst_cnt_r;
+  always_comb begin
+    dma_data_ready_o = 1'b0;
+
+    fsm_rev_v_li = 1'b0;
+    fifo_yumi_li = 1'b0;
+
+    resp_burst_cnt_n = resp_burst_cnt_r;
+
+    if(rd_resp) begin
+      dma_data_ready_o = fifo_v_lo & fsm_rev_ready_and_lo;
+
+      fsm_rev_v_li = dma_data_ready_o & dma_data_v_i & (resp_burst_cnt_r >= first_cnt) & (resp_burst_cnt_r <= last_cnt);
+      fifo_yumi_li = dma_data_ready_o & dma_data_v_i & (resp_burst_cnt_r == dma_burst_len_lp - 1);
+
+      resp_burst_cnt_n = (dma_data_ready_o & dma_data_v_i) ? (resp_burst_cnt_r + 1'b1) : resp_burst_cnt_r;
+    end
+    else if(wr_resp | csr_resp) begin
+      fsm_rev_v_li = fifo_v_lo;
+      fifo_yumi_li = fsm_rev_v_li & fsm_rev_ready_and_lo;
+    end
+  end
+
+  always_ff @(posedge clk_i) begin
+    if (reset_i) begin
+      cmd_burst_cnt_r <= '0;
+      resp_burst_cnt_r <= '0;
+      wr_pkt_sent_r <= 1'b0;
+    end
+    else begin
+      cmd_burst_cnt_r <= cmd_burst_cnt_n;
+      resp_burst_cnt_r <= resp_burst_cnt_n;
+      wr_pkt_sent_r <= wr_pkt_sent_n;
+    end
+  end
+
+  if (l2_block_width_p != bedrock_block_width_p)
+    $error("L2 and Bedrock block widths must be equal in L2-bypass mode");
+
+endmodule

--- a/bp_me/test/common/bp_ddr.sv
+++ b/bp_me/test/common/bp_ddr.sv
@@ -9,7 +9,7 @@ module bp_ddr
   import bsg_dmc_pkg::*;
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   , localparam dma_pkt_width_lp = `bsg_cache_dma_pkt_width(daddr_width_p, l2_block_size_in_words_p)
+   , localparam dma_pkt_width_lp = `bsg_cache_dma_pkt_width(daddr_width_p, dma_mask_width_p)
 
    , parameter num_dma_p = 1
    )
@@ -180,12 +180,12 @@ module bp_ddr
     $error("BSG DMC is currently unsupported as a backend; raise an issue if this impacts your workflow!");
 
   //bsg_cache_to_dram_ctrl
-  // #(.num_cache_p(num_dma_p)
-  //   ,.addr_width_p(daddr_width_p)
-  //   ,.data_width_p(l2_fill_width_p)
-  //   ,.block_size_in_words_p(l2_block_size_in_fill_p)
+  // #(.num_dma_p(num_dma_p)
+  //   ,.dma_addr_width_p(daddr_width_p)
+  //   ,.dma_mask_width_p(dma_mask_width_p)
+  //   ,.dma_data_width_p(l2_fill_width_p)
+  //   ,.dma_burst_len_p(l2_block_size_in_fill_p)
   //   ,.dram_ctrl_burst_len_p(l2_block_size_in_fill_p)
-  //   ,.dram_ctrl_addr_width_p(dmc_addr_width_lp)
   //   )
   // cache2dmc
   //  (.clk_i(clk_i)

--- a/bp_me/test/common/bp_nonsynth_mem.sv
+++ b/bp_me/test/common/bp_nonsynth_mem.sv
@@ -36,13 +36,13 @@ module bp_nonsynth_mem
    , input                                          dram_reset_i
    );
 
-  `declare_bsg_cache_dma_pkt_s(daddr_width_p, l2_block_size_in_words_p);
-  bsg_cache_dma_pkt_s [l2_banks_p-1:0] dma_pkt_lo;
-  logic [l2_banks_p-1:0] dma_pkt_v_lo, dma_pkt_yumi_li;
-  logic [l2_banks_p-1:0][l2_fill_width_p-1:0] dma_data_li;
-  logic [l2_banks_p-1:0] dma_data_v_li, dma_data_ready_and_lo;
-  logic [l2_banks_p-1:0][l2_fill_width_p-1:0] dma_data_lo;
-  logic [l2_banks_p-1:0] dma_data_v_lo, dma_data_yumi_li;
+  `declare_bsg_cache_dma_pkt_s(daddr_width_p, dma_mask_width_p);
+  bsg_cache_dma_pkt_s [dma_els_p-1:0] dma_pkt_lo;
+  logic [dma_els_p-1:0] dma_pkt_v_lo, dma_pkt_yumi_li;
+  logic [dma_els_p-1:0][l2_fill_width_p-1:0] dma_data_li;
+  logic [dma_els_p-1:0] dma_data_v_li, dma_data_ready_and_lo;
+  logic [dma_els_p-1:0][l2_fill_width_p-1:0] dma_data_lo;
+  logic [dma_els_p-1:0] dma_data_v_lo, dma_data_yumi_li;
   bp_me_cache_slice
    #(.bp_params_p(bp_params_p))
    cce_to_cache
@@ -77,7 +77,7 @@ module bp_nonsynth_mem
      ,.preload_mem_p(preload_mem_p)
      ,.dram_type_p(dram_type_p)
      ,.mem_bytes_p(mem_bytes_p)
-     ,.num_dma_p(l2_banks_p)
+     ,.num_dma_p(dma_els_p)
      )
    dram
     (.clk_i(clk_i)

--- a/bp_top/src/v/bp_core.sv
+++ b/bp_top/src/v/bp_core.sv
@@ -26,7 +26,7 @@ module bp_core
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p)
-   , localparam dma_pkt_width_lp = `bsg_cache_dma_pkt_width(daddr_width_p, l2_block_size_in_words_p)
+   , localparam dma_pkt_width_lp = `bsg_cache_dma_pkt_width(daddr_width_p, dma_mask_width_p)
    )
   (input                                                 clk_i
    , input                                               rt_clk_i
@@ -79,17 +79,17 @@ module bp_core
    , output logic                                        mem_rev_v_o
    , input                                               mem_rev_ready_and_i
 
-   , output logic [l2_banks_p-1:0][dma_pkt_width_lp-1:0] dma_pkt_o
-   , output logic [l2_banks_p-1:0]                       dma_pkt_v_o
-   , input [l2_banks_p-1:0]                              dma_pkt_ready_and_i
+   , output logic [dma_els_p-1:0][dma_pkt_width_lp-1:0] dma_pkt_o
+   , output logic [dma_els_p-1:0]                       dma_pkt_v_o
+   , input [dma_els_p-1:0]                              dma_pkt_ready_and_i
 
-   , input [l2_banks_p-1:0][l2_fill_width_p-1:0]         dma_data_i
-   , input [l2_banks_p-1:0]                              dma_data_v_i
-   , output logic [l2_banks_p-1:0]                       dma_data_ready_and_o
+   , input [dma_els_p-1:0][l2_fill_width_p-1:0]         dma_data_i
+   , input [dma_els_p-1:0]                              dma_data_v_i
+   , output logic [dma_els_p-1:0]                       dma_data_ready_and_o
 
-   , output logic [l2_banks_p-1:0][l2_fill_width_p-1:0]  dma_data_o
-   , output logic [l2_banks_p-1:0]                       dma_data_v_o
-   , input [l2_banks_p-1:0]                              dma_data_ready_and_i
+   , output logic [dma_els_p-1:0][l2_fill_width_p-1:0]  dma_data_o
+   , output logic [dma_els_p-1:0]                       dma_data_v_o
+   , input [dma_els_p-1:0]                              dma_data_ready_and_i
    );
 
   `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);

--- a/bp_top/src/v/bp_core_tile.sv
+++ b/bp_top/src/v/bp_core_tile.sv
@@ -505,13 +505,13 @@ module bp_core_tile
   logic [bedrock_fill_width_p-1:0] mem_rev_data_li;
   logic mem_rev_v_li, mem_rev_ready_and_lo;
 
-  `declare_bsg_cache_dma_pkt_s(daddr_width_p, l2_block_size_in_words_p);
-  bsg_cache_dma_pkt_s [l2_banks_p-1:0] dma_pkt_lo;
-  logic [l2_banks_p-1:0] dma_pkt_v_lo, dma_pkt_yumi_li;
-  logic [l2_banks_p-1:0][l2_fill_width_p-1:0] dma_data_li;
-  logic [l2_banks_p-1:0] dma_data_v_li, dma_data_ready_and_lo;
-  logic [l2_banks_p-1:0][l2_fill_width_p-1:0] dma_data_lo;
-  logic [l2_banks_p-1:0] dma_data_v_lo, dma_data_yumi_li;
+  `declare_bsg_cache_dma_pkt_s(daddr_width_p, dma_mask_width_p);
+  bsg_cache_dma_pkt_s [dma_els_p-1:0] dma_pkt_lo;
+  logic [dma_els_p-1:0] dma_pkt_v_lo, dma_pkt_yumi_li;
+  logic [dma_els_p-1:0][l2_fill_width_p-1:0] dma_data_li;
+  logic [dma_els_p-1:0] dma_data_v_li, dma_data_ready_and_lo;
+  logic [dma_els_p-1:0][l2_fill_width_p-1:0] dma_data_lo;
+  logic [dma_els_p-1:0] dma_data_v_lo, dma_data_yumi_li;
   bp_core
    #(.bp_params_p(bp_params_p))
    core
@@ -623,8 +623,8 @@ module bp_core_tile
      ,.mem_fwd_ready_and_i(mem_fwd_ready_and_li)
      );
 
-  bp_dma_ready_and_link_s [l2_banks_p-1:0] dma_link_lo, dma_link_li;
-  for (genvar i = 0; i < l2_banks_p; i++)
+  bp_dma_ready_and_link_s [dma_els_p-1:0] dma_link_lo, dma_link_li;
+  for (genvar i = 0; i < dma_els_p; i++)
     begin : dma
       wire [dma_noc_cord_width_p-1:0] cord_li = my_cord_i[coh_noc_x_cord_width_p+:dma_noc_y_cord_width_p];
       wire [dma_noc_cid_width_p-1:0]   cid_li = i;
@@ -671,7 +671,7 @@ module bp_core_tile
      ,.len_width_p(dma_noc_len_width_p)
      ,.cid_width_p(dma_noc_cid_width_p)
      ,.cord_width_p(dma_noc_cord_width_p)
-     ,.num_in_p(l2_banks_p)
+     ,.num_in_p(dma_els_p)
      ,.hold_on_valid_p(1)
      )
    dma_concentrate

--- a/bp_top/src/v/bp_l2e_tile.sv
+++ b/bp_top/src/v/bp_l2e_tile.sv
@@ -370,13 +370,13 @@ module bp_l2e_tile
      );
 
   // CCE-Mem network to L2 Cache adapter
-  `declare_bsg_cache_dma_pkt_s(daddr_width_p, l2_block_size_in_words_p);
-  bsg_cache_dma_pkt_s [l2_banks_p-1:0] dma_pkt_lo;
-  logic [l2_banks_p-1:0] dma_pkt_v_lo, dma_pkt_yumi_li;
-  logic [l2_banks_p-1:0][l2_fill_width_p-1:0] dma_data_li;
-  logic [l2_banks_p-1:0] dma_data_v_li, dma_data_ready_and_lo;
-  logic [l2_banks_p-1:0][l2_fill_width_p-1:0] dma_data_lo;
-  logic [l2_banks_p-1:0] dma_data_v_lo, dma_data_yumi_li;
+  `declare_bsg_cache_dma_pkt_s(daddr_width_p, dma_mask_width_p);
+  bsg_cache_dma_pkt_s [dma_els_p-1:0] dma_pkt_lo;
+  logic [dma_els_p-1:0] dma_pkt_v_lo, dma_pkt_yumi_li;
+  logic [dma_els_p-1:0][l2_fill_width_p-1:0] dma_data_li;
+  logic [dma_els_p-1:0] dma_data_v_li, dma_data_ready_and_lo;
+  logic [dma_els_p-1:0][l2_fill_width_p-1:0] dma_data_lo;
+  logic [dma_els_p-1:0] dma_data_v_lo, dma_data_yumi_li;
   bp_me_cache_slice
    #(.bp_params_p(bp_params_p))
    l2s
@@ -406,8 +406,8 @@ module bp_l2e_tile
      ,.dma_data_ready_and_i(dma_data_yumi_li)
      );
 
-  bp_dma_ready_and_link_s [l2_banks_p-1:0] dma_link_lo, dma_link_li;
-  for (genvar i = 0; i < l2_banks_p; i++)
+  bp_dma_ready_and_link_s [dma_els_p-1:0] dma_link_lo, dma_link_li;
+  for (genvar i = 0; i < dma_els_p; i++)
     begin : dma
       wire [dma_noc_cord_width_p-1:0] cord_li = my_cord_i[coh_noc_x_cord_width_p+:dma_noc_y_cord_width_p];
       wire [dma_noc_cid_width_p-1:0]   cid_li = i;
@@ -454,7 +454,7 @@ module bp_l2e_tile
      ,.len_width_p(dma_noc_len_width_p)
      ,.cid_width_p(dma_noc_cid_width_p)
      ,.cord_width_p(dma_noc_cord_width_p)
-     ,.num_in_p(l2_banks_p)
+     ,.num_in_p(dma_els_p)
      ,.hold_on_valid_p(1)
      )
    dma_concentrate

--- a/bp_top/src/v/bp_unicore.sv
+++ b/bp_top/src/v/bp_unicore.sv
@@ -168,8 +168,9 @@ module bp_unicore
       wire is_clint_fwd    = is_my_core & is_local & (device_fwd_li == clint_dev_gp);
       wire is_cache_fwd    = is_my_core & is_local & (device_fwd_li == cache_dev_gp);
       wire is_host_fwd     = is_my_core & is_local & (device_fwd_li == host_dev_gp);
+      wire is_htif_cmd     = is_my_core & is_local & (device_fwd_li == 0);
 
-      wire is_io_fwd       = is_host_fwd | is_other_hio | is_other_core;
+      wire is_io_fwd       = is_host_fwd | is_htif_cmd | is_other_hio | is_other_core;
       wire is_l2_fwd       = is_cache_fwd | (~is_local & ~is_io_fwd);
       wire is_loopback_fwd = ~is_cfg_fwd & ~is_clint_fwd & ~is_io_fwd & ~is_l2_fwd;
 

--- a/bp_top/src/v/bp_unicore.sv
+++ b/bp_top/src/v/bp_unicore.sv
@@ -35,7 +35,7 @@ module bp_unicore
 
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
-   , localparam dma_pkt_width_lp = `bsg_cache_dma_pkt_width(daddr_width_p, l2_block_size_in_words_p)
+   , localparam dma_pkt_width_lp = `bsg_cache_dma_pkt_width(daddr_width_p, dma_mask_width_p)
    )
   (input                                                 clk_i
    , input                                               rt_clk_i
@@ -68,17 +68,17 @@ module bp_unicore
    , input                                               mem_rev_ready_and_i
 
    // DRAM interface
-   , output logic [l2_banks_p-1:0][dma_pkt_width_lp-1:0] dma_pkt_o
-   , output logic [l2_banks_p-1:0]                       dma_pkt_v_o
-   , input [l2_banks_p-1:0]                              dma_pkt_ready_and_i
+   , output logic [dma_els_p-1:0][dma_pkt_width_lp-1:0] dma_pkt_o
+   , output logic [dma_els_p-1:0]                       dma_pkt_v_o
+   , input [dma_els_p-1:0]                              dma_pkt_ready_and_i
 
-   , input [l2_banks_p-1:0][l2_fill_width_p-1:0]         dma_data_i
-   , input [l2_banks_p-1:0]                              dma_data_v_i
-   , output logic [l2_banks_p-1:0]                       dma_data_ready_and_o
+   , input [dma_els_p-1:0][l2_fill_width_p-1:0]         dma_data_i
+   , input [dma_els_p-1:0]                              dma_data_v_i
+   , output logic [dma_els_p-1:0]                       dma_data_ready_and_o
 
-   , output logic [l2_banks_p-1:0][l2_fill_width_p-1:0]  dma_data_o
-   , output logic [l2_banks_p-1:0]                       dma_data_v_o
-   , input [l2_banks_p-1:0]                              dma_data_ready_and_i
+   , output logic [dma_els_p-1:0][l2_fill_width_p-1:0]  dma_data_o
+   , output logic [dma_els_p-1:0]                       dma_data_v_o
+   , input [dma_els_p-1:0]                              dma_data_ready_and_i
    );
 
   `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p);

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -46,8 +46,8 @@ $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_dma.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_dma_to_wormhole.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_miss.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_decode.v
-$BASEJUMP_STL_DIR/bsg_cache/bsg_cache_sbuf.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_tbuf.v
+$BASEJUMP_STL_DIR/bsg_cache/bsg_cache_sbuf.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_cache_buffer_queue.v
 $BASEJUMP_STL_DIR/bsg_cache/bsg_wormhole_to_cache_dma_fanout.v
 $BASEJUMP_STL_DIR/bsg_dataflow/bsg_channel_tunnel.v
@@ -247,6 +247,7 @@ $BP_ME_DIR/src/v/lce/bp_lce_cmd.sv
 # Cache
 $BP_ME_DIR/src/v/dev/bp_me_bedrock_register.sv
 $BP_ME_DIR/src/v/dev/bp_me_cce_to_cache.sv
+$BP_ME_DIR/src/v/dev/bp_me_cce_to_cache_dma.sv
 $BP_ME_DIR/src/v/dev/bp_me_dram_hash_decode.sv
 $BP_ME_DIR/src/v/dev/bp_me_dram_hash_encode.sv
 $BP_ME_DIR/src/v/dev/bp_me_cache_slice.sv

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -19,6 +19,7 @@ module testbench
  import bp_be_pkg::*;
  import bp_me_pkg::*;
  import bsg_noc_pkg::*;
+ import bsg_cache_pkg::*;
  #(parameter bp_params_e bp_params_p = BP_CFG_FLOWVAR // Replaced by the flow with a specific bp_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_core_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
@@ -139,13 +140,13 @@ module testbench
   logic [bedrock_fill_width_p-1:0] proc_rev_data_lo;
   logic proc_rev_v_lo, proc_rev_ready_and_li;
 
-  `declare_bsg_cache_dma_pkt_s(daddr_width_p, l2_block_size_in_words_p);
-  bsg_cache_dma_pkt_s [num_cce_p-1:0][l2_banks_p-1:0] dma_pkt_lo;
-  logic [num_cce_p-1:0][l2_banks_p-1:0] dma_pkt_v_lo, dma_pkt_yumi_li;
-  logic [num_cce_p-1:0][l2_banks_p-1:0][l2_fill_width_p-1:0] dma_data_lo;
-  logic [num_cce_p-1:0][l2_banks_p-1:0] dma_data_v_lo, dma_data_yumi_li;
-  logic [num_cce_p-1:0][l2_banks_p-1:0][l2_fill_width_p-1:0] dma_data_li;
-  logic [num_cce_p-1:0][l2_banks_p-1:0] dma_data_v_li, dma_data_ready_and_lo;
+  `declare_bsg_cache_dma_pkt_s(daddr_width_p, dma_mask_width_p);
+  bsg_cache_dma_pkt_s [num_cce_p-1:0][dma_els_p-1:0] dma_pkt_lo;
+  logic [num_cce_p-1:0][dma_els_p-1:0] dma_pkt_v_lo, dma_pkt_yumi_li;
+  logic [num_cce_p-1:0][dma_els_p-1:0][l2_fill_width_p-1:0] dma_data_lo;
+  logic [num_cce_p-1:0][dma_els_p-1:0] dma_data_v_lo, dma_data_yumi_li;
+  logic [num_cce_p-1:0][dma_els_p-1:0][l2_fill_width_p-1:0] dma_data_li;
+  logic [num_cce_p-1:0][dma_els_p-1:0] dma_data_v_li, dma_data_ready_and_lo;
 
   wire [mem_noc_did_width_p-1:0] proc_did_li = 1;
   wire [mem_noc_did_width_p-1:0] host_did_li = '1;
@@ -194,7 +195,7 @@ module testbench
 
   bp_nonsynth_dram
    #(.bp_params_p(bp_params_p)
-     ,.num_dma_p(num_cce_p*l2_banks_p)
+     ,.num_dma_p(num_cce_p*dma_els_p)
      ,.preload_mem_p(preload_mem_p)
      ,.dram_type_p(dram_type_p)
      ,.mem_bytes_p(2**29)
@@ -768,7 +769,7 @@ module testbench
    if_verif
     ();
 
-  if (dram_type_p == "axi" && (num_cce_p*l2_banks_p) > 16)
+  if (dram_type_p == "axi" && (num_cce_p*dma_els_p) > 16)
     $error("AXI memory does not support >16 caches without increasing bsg_round_robin_arb size");
 
   `ifndef VERILATOR

--- a/bp_top/test/tb/bp_tethered/wrapper.sv
+++ b/bp_top/test/tb/bp_tethered/wrapper.sv
@@ -15,12 +15,13 @@ module wrapper
  import bp_be_pkg::*;
  import bp_me_pkg::*;
  import bsg_noc_pkg::*;
+ import bsg_cache_pkg::*;
  #(parameter bp_params_e bp_params_p = BP_CFG_FLOWVAR
    `declare_bp_proc_params(bp_params_p)
 
    `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
 
-   , localparam dma_pkt_width_lp = `bsg_cache_dma_pkt_width(daddr_width_p, l2_block_size_in_words_p)
+   , localparam dma_pkt_width_lp = `bsg_cache_dma_pkt_width(daddr_width_p, dma_mask_width_p)
    )
   (input                                                                clk_i
    , input                                                              rt_clk_i
@@ -52,17 +53,17 @@ module wrapper
    , input                                                              mem_rev_ready_and_i
 
    // DRAM interface
-   , output logic [num_cce_p-1:0][l2_banks_p-1:0][dma_pkt_width_lp-1:0] dma_pkt_o
-   , output logic [num_cce_p-1:0][l2_banks_p-1:0]                       dma_pkt_v_o
-   , input [num_cce_p-1:0][l2_banks_p-1:0]                              dma_pkt_ready_and_i
+   , output logic [num_cce_p-1:0][dma_els_p-1:0][dma_pkt_width_lp-1:0] dma_pkt_o
+   , output logic [num_cce_p-1:0][dma_els_p-1:0]                       dma_pkt_v_o
+   , input [num_cce_p-1:0][dma_els_p-1:0]                              dma_pkt_ready_and_i
 
-   , input [num_cce_p-1:0][l2_banks_p-1:0][l2_fill_width_p-1:0]         dma_data_i
-   , input [num_cce_p-1:0][l2_banks_p-1:0]                              dma_data_v_i
-   , output logic [num_cce_p-1:0][l2_banks_p-1:0]                       dma_data_ready_and_o
+   , input [num_cce_p-1:0][dma_els_p-1:0][l2_fill_width_p-1:0]         dma_data_i
+   , input [num_cce_p-1:0][dma_els_p-1:0]                              dma_data_v_i
+   , output logic [num_cce_p-1:0][dma_els_p-1:0]                       dma_data_ready_and_o
 
-   , output logic [num_cce_p-1:0][l2_banks_p-1:0][l2_fill_width_p-1:0]  dma_data_o
-   , output logic [num_cce_p-1:0][l2_banks_p-1:0]                       dma_data_v_o
-   , input [num_cce_p-1:0][l2_banks_p-1:0]                              dma_data_ready_and_i
+   , output logic [num_cce_p-1:0][dma_els_p-1:0][l2_fill_width_p-1:0]  dma_data_o
+   , output logic [num_cce_p-1:0][dma_els_p-1:0]                       dma_data_v_o
+   , input [num_cce_p-1:0][dma_els_p-1:0]                              dma_data_ready_and_i
    );
 
   bp_processor


### PR DESCRIPTION
This PR adds an L2 bypass path for converting CE requests to cache DMA requests in order to be able to completely omit the L2 instead of instantiating a tiny victim cache.

Checklist:
- [ ] Multicore compatibility (currently only tested on unicore) 
- [ ] Handling L2 atomics or adding assertion to restrict access
- [ ] Add to CI regression