### PR TITLE
Adding megapage support

### DIFF
--- a/bp_be/src/include/bp_be_defines.svh
+++ b/bp_be/src/include/bp_be_defines.svh
@@ -130,6 +130,7 @@
     {                                                                                              \
       logic [paddr_width_mp-page_offset_width_gp-1:0] ptag;                                        \
       logic                                           gigapage;                                    \
+      logic                                           megapage;                                    \
       logic                                           a;                                           \
       logic                                           d;                                           \
       logic                                           u;                                           \
@@ -265,7 +266,7 @@
     (6 + dpath_width_gp + 2*vaddr_width_mp + instr_width_gp + 1 + $bits(bp_be_exception_s) + $bits(bp_be_special_s))
 
   `define bp_be_pte_leaf_width(paddr_width_mp) \
-    (paddr_width_mp - page_offset_width_gp + 7)
+    (paddr_width_mp - page_offset_width_gp + 8)
 
   `define bp_be_commit_pkt_width(vaddr_width_mp, paddr_width_mp) \
     (5 + `bp_be_pte_leaf_width(paddr_width_mp) +  3*vaddr_width_mp + instr_width_gp + rv64_priv_width_gp + 20)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -201,13 +201,15 @@ module bp_be_pipe_mem
   bp_mmu
    #(.bp_params_p(bp_params_p)
      ,.tlb_els_4k_p(dtlb_els_4k_p)
+     ,.tlb_els_2m_p(dtlb_els_2m_p)
      ,.tlb_els_1g_p(dtlb_els_1g_p)
      )
    dmmu
     (.clk_i(negedge_clk)
      ,.reset_i(reset_i)
 
-     ,.flush_i(sfence_i)
+     ,.flush_i(flush_i)
+     ,.fence_i(sfence_i)
      ,.priv_mode_i(trans_info.priv_mode)
      ,.sum_i(trans_info.mstatus_sum)
      ,.mxr_i(trans_info.mstatus_mxr)

--- a/bp_be/src/v/bp_be_calculator/bp_be_ptw.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_ptw.sv
@@ -134,6 +134,7 @@ module bp_be_ptw
   bp_be_pte_leaf_s tlb_w_entry;
   assign tlb_w_entry.ptag       = writeback_ppn;
   assign tlb_w_entry.gigapage   = pte_is_gigapage;
+  assign tlb_w_entry.megapage   = pte_is_megapage;
   assign tlb_w_entry.a          = dcache_pte_r.a;
   assign tlb_w_entry.d          = dcache_pte_r.d;
   assign tlb_w_entry.u          = dcache_pte_r.u;

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -132,8 +132,10 @@
 
     // Capacity of the Instruction/Data TLBs
     integer unsigned itlb_els_4k;
+    integer unsigned itlb_els_2m;
     integer unsigned itlb_els_1g;
     integer unsigned dtlb_els_4k;
+    integer unsigned dtlb_els_2m;
     integer unsigned dtlb_els_1g;
 
     // I$ cache features
@@ -275,9 +277,11 @@
       ,ghist_width              : 2
 
       ,itlb_els_4k : 8
+      ,itlb_els_2m : 2
+      ,itlb_els_1g : 1
       ,dtlb_els_4k : 8
-      ,itlb_els_1g : 0
-      ,dtlb_els_1g : 0
+      ,dtlb_els_2m : 2
+      ,dtlb_els_1g : 1
 
       ,dcache_features      : (1 << e_cfg_enabled)
                               | (1 << e_cfg_writeback)
@@ -397,8 +401,10 @@
       ,`bp_aviary_define_override(ghist_width, BP_GHIST_WIDTH, `BP_CUSTOM_BASE_CFG)
 
       ,`bp_aviary_define_override(itlb_els_4k, BP_ITLB_ELS_4K, `BP_CUSTOM_BASE_CFG)
+      ,`bp_aviary_define_override(itlb_els_2m, BP_ITLB_ELS_2M, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(itlb_els_1g, BP_ITLB_ELS_1G, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(dtlb_els_4k, BP_DTLB_ELS_4K, `BP_CUSTOM_BASE_CFG)
+      ,`bp_aviary_define_override(dtlb_els_2m, BP_DTLB_ELS_2M, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(dtlb_els_1g, BP_DTLB_ELS_1G, `BP_CUSTOM_BASE_CFG)
 
       ,`bp_aviary_define_override(icache_features, BP_ICACHE_FEATURES, `BP_CUSTOM_BASE_CFG)

--- a/bp_common/src/include/bp_common_aviary_defines.svh
+++ b/bp_common/src/include/bp_common_aviary_defines.svh
@@ -58,8 +58,10 @@
     , localparam bht_offset_width_p          = `BSG_SAFE_CLOG2(bht_row_els_p)                      \
                                                                                                    \
     , localparam itlb_els_4k_p              = proc_param_lp.itlb_els_4k                            \
+    , localparam itlb_els_2m_p              = proc_param_lp.itlb_els_2m                            \
     , localparam itlb_els_1g_p              = proc_param_lp.itlb_els_1g                            \
     , localparam dtlb_els_4k_p              = proc_param_lp.dtlb_els_4k                            \
+    , localparam dtlb_els_2m_p              = proc_param_lp.dtlb_els_2m                            \
     , localparam dtlb_els_1g_p              = proc_param_lp.dtlb_els_1g                            \
                                                                                                    \
     , localparam dcache_features_p          = proc_param_lp.dcache_features                        \
@@ -222,8 +224,10 @@
           ,`bp_aviary_parameter_override(ghist_width, override_cfg_mp, default_cfg_mp)             \
                                                                                                    \
           ,`bp_aviary_parameter_override(itlb_els_4k, override_cfg_mp, default_cfg_mp)             \
+          ,`bp_aviary_parameter_override(itlb_els_2m, override_cfg_mp, default_cfg_mp)             \
           ,`bp_aviary_parameter_override(itlb_els_1g, override_cfg_mp, default_cfg_mp)             \
           ,`bp_aviary_parameter_override(dtlb_els_4k, override_cfg_mp, default_cfg_mp)             \
+          ,`bp_aviary_parameter_override(dtlb_els_2m, override_cfg_mp, default_cfg_mp)             \
           ,`bp_aviary_parameter_override(dtlb_els_1g, override_cfg_mp, default_cfg_mp)             \
                                                                                                    \
           ,`bp_aviary_parameter_override(icache_features, override_cfg_mp, default_cfg_mp)         \

--- a/bp_common/src/include/bp_common_core_if.svh
+++ b/bp_common/src/include/bp_common_core_if.svh
@@ -89,6 +89,7 @@
     {                                                                                              \
       logic [paddr_width_mp-page_offset_width_gp-1:0] ptag;                                        \
       logic                                           gigapage;                                    \
+      logic                                           megapage;                                    \
       logic                                           a;                                           \
       logic                                           d;                                           \
       logic                                           u;                                           \
@@ -187,7 +188,7 @@
     (`bp_fe_cmd_operands_u_width(vaddr_width_mp, paddr_width_mp, asid_width_mp, branch_metadata_fwd_width_mp))
 
   `define bp_pte_leaf_width(paddr_width_mp) \
-    (paddr_width_mp - page_offset_width_gp + 7)
+    (paddr_width_mp - page_offset_width_gp + 8)
 
   `define bp_fe_cmd_itlb_fence_width(vaddr_width_mp, paddr_width_mp, asid_width_mp, branch_metadata_fwd_width_mp) \
     (`bp_fe_cmd_operands_u_width(vaddr_width_mp, paddr_width_mp, asid_width_mp, branch_metadata_fwd_width_mp))

--- a/bp_common/src/v/bp_mmu.sv
+++ b/bp_common/src/v/bp_mmu.sv
@@ -9,6 +9,7 @@ module bp_mmu
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
    , parameter `BSG_INV_PARAM(tlb_els_4k_p)
+   , parameter `BSG_INV_PARAM(tlb_els_2m_p)
    , parameter `BSG_INV_PARAM(tlb_els_1g_p)
 
    , localparam entry_width_lp = `bp_pte_leaf_width(paddr_width_p)
@@ -17,6 +18,7 @@ module bp_mmu
    , input                                            reset_i
 
    , input                                            flush_i
+   , input                                            fence_i
    , input [1:0]                                      priv_mode_i
    , input                                            trans_en_i
    , input                                            sum_i
@@ -57,17 +59,6 @@ module bp_mmu
 
   `declare_bp_core_if(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 
-  logic trans_en_r, sum_r, mxr_r;
-  logic [1:0] priv_mode_r;
-  bsg_dff_reset
-   #(.width_p(5))
-   base_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-     ,.data_i({mxr_i, sum_i, priv_mode_i, trans_en_i})
-     ,.data_o({mxr_r, sum_r, priv_mode_r, trans_en_r})
-     );
-
   // This logic only works for 8-byte words max.
   logic r_misaligned;
   always_comb
@@ -79,53 +70,59 @@ module bp_mmu
     endcase
 
   logic r_instr_r, r_load_r, r_store_r, r_misaligned_r;
+  logic [etag_width_p-1:0] r_etag_r;
+  wire [etag_width_p-1:0] r_etag_li = r_eaddr_i[dword_width_gp-1-:etag_width_p];
   bsg_dff_reset_en
-   #(.width_p(4))
+   #(.width_p(5+etag_width_p))
    read_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
      ,.en_i(r_v_i)
-     ,.data_i({r_misaligned, r_instr_i, r_load_i, r_store_i})
-     ,.data_o({r_misaligned_r, r_instr_r, r_load_r, r_store_r})
+
+     ,.data_i({trans_en_i, r_misaligned, r_instr_i, r_load_i, r_store_i, r_etag_li})
+     ,.data_o({trans_en_r, r_misaligned_r, r_instr_r, r_load_r, r_store_r, r_etag_r})
      );
 
-  logic [etag_width_p-1:0] r_etag_r;
-  wire [etag_width_p-1:0] r_etag_li = r_eaddr_i[dword_width_gp-1-:etag_width_p];
-  bsg_dff_reset_en
-   #(.width_p(etag_width_p))
-   etag_reg
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
-     ,.en_i(r_v_i)
-
-     ,.data_i(r_etag_li)
-     ,.data_o(r_etag_r)
-     );
-
-  logic tlb_bypass_r;
-  wire tlb_bypass = ~flush_i & ~w_v_i & (r_etag_li[0+:vtag_width_p] == r_etag_r[0+:vtag_width_p]) & trans_en_r & trans_en_i;
-  bsg_dff_reset
+  logic r_v_r;
+  bsg_dff_reset_set_clear
    #(.width_p(1))
-   tlb_bypass_reg
+   r_v_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
-     ,.data_i(tlb_bypass)
-     ,.data_o(tlb_bypass_r)
+     ,.set_i(r_v_i)
+     ,.clear_i(flush_i)
+     ,.data_o(r_v_r)
+     );
+
+  logic bypass_v_r;
+  wire r_etag_match = r_etag_li[0+:vtag_width_p] == r_etag_r[0+:vtag_width_p];
+  wire tlb_bypass = (~trans_en_i & ~flush_i) | (bypass_v_r & r_etag_match);
+  bsg_dff_reset_set_clear
+   #(.width_p(1), .clear_over_set_p(1))
+   bypass_v_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.set_i(r_v_i)
+     ,.clear_i(flush_i)
+     ,.data_o(bypass_v_r)
      );
 
   logic tlb_r_v_lo;
   bp_pte_leaf_s tlb_r_entry_lo;
-  wire [vtag_width_p-1:0] w_vtag_li = w_v_i ? w_vtag_i : r_eaddr_i[vaddr_width_p-1-:vtag_width_p];
+  wire tlb_r_v_li = (r_v_i & ~tlb_bypass);
+  wire tlb_w_v_li = w_v_i;
+  wire tlb_v_li = tlb_r_v_li | tlb_w_v_li;
+  wire [vtag_width_p-1:0] tlb_vtag_li = w_v_i ? w_vtag_i : r_etag_li;
   bp_tlb
-   #(.bp_params_p(bp_params_p), .els_4k_p(tlb_els_4k_p), .els_1g_p(tlb_els_1g_p))
+   #(.bp_params_p(bp_params_p), .els_4k_p(tlb_els_4k_p), .els_2m_p(tlb_els_2m_p), .els_1g_p(tlb_els_1g_p))
    tlb
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
-     ,.flush_i(flush_i)
+     ,.fence_i(fence_i)
 
-     ,.v_i((r_v_i | w_v_i) & trans_en_i & ~tlb_bypass)
-     ,.w_i(w_v_i)
-     ,.vtag_i(w_vtag_li)
+     ,.v_i(tlb_v_li)
+     ,.w_i(tlb_w_v_li)
+     ,.vtag_i(tlb_vtag_li)
      ,.entry_i(w_entry_i)
 
      ,.v_o(tlb_r_v_lo)
@@ -134,17 +131,18 @@ module bp_mmu
 
   bp_pte_leaf_s tlb_r_entry_r;
   logic tlb_r_v_r;
-  bsg_dff_en_bypass
-   #(.width_p(1+$bits(bp_pte_leaf_s)))
+  bsg_dff_sync_read
+   #(.width_p(1+$bits(bp_pte_leaf_s)), .bypass_p(1))
    entry_reg
     (.clk_i(clk_i)
-     ,.en_i(~tlb_bypass_r)
+     ,.reset_i(reset_i)
+     ,.v_n_i(tlb_r_v_li)
      ,.data_i({tlb_r_v_lo, tlb_r_entry_lo})
      ,.data_o({tlb_r_v_r, tlb_r_entry_r})
      );
 
   bp_pte_leaf_s passthrough_entry, tlb_entry_lo;
-  assign passthrough_entry = '{ptag: r_etag_r[0+:ptag_width_p], default: '0};
+  assign passthrough_entry = '{ptag: r_etag_r, default: '0};
   assign tlb_entry_lo      = trans_en_r ? tlb_r_entry_r : passthrough_entry;
   wire tlb_v_lo            = trans_en_r ? tlb_r_v_r : 1'b1;
 
@@ -181,36 +179,38 @@ module bp_mmu
 
   // Page faults
   wire instr_exe_page_fault_v  = tlb_v_lo & ~tlb_entry_lo.x;
-  wire instr_priv_page_fault_v = tlb_v_lo & (((priv_mode_r == `PRIV_MODE_S) & tlb_entry_lo.u)
-                                             | ((priv_mode_r == `PRIV_MODE_U) & ~tlb_entry_lo.u)
+  wire instr_priv_page_fault_v = tlb_v_lo & (((priv_mode_i == `PRIV_MODE_S) & tlb_entry_lo.u)
+                                             | ((priv_mode_i == `PRIV_MODE_U) & ~tlb_entry_lo.u)
                                             );
-  wire data_priv_page_fault = tlb_v_lo & (((priv_mode_r == `PRIV_MODE_S) & ~sum_r & tlb_entry_lo.u)
-                                           | ((priv_mode_r == `PRIV_MODE_U) & ~tlb_entry_lo.u)
+  wire data_priv_page_fault = tlb_v_lo & (((priv_mode_i == `PRIV_MODE_S) & ~sum_i & tlb_entry_lo.u)
+                                           | ((priv_mode_i == `PRIV_MODE_U) & ~tlb_entry_lo.u)
                                           );
-  wire data_read_page_fault  = tlb_v_lo & ~(tlb_entry_lo.r | (tlb_entry_lo.x & mxr_r));
+  wire data_read_page_fault  = tlb_v_lo & ~(tlb_entry_lo.r | (tlb_entry_lo.x & mxr_i));
   wire data_write_page_fault = tlb_v_lo & ~(tlb_entry_lo.w & tlb_entry_lo.d);
-  wire instr_page_fault_v = trans_en_r & r_instr_r & (instr_priv_page_fault_v | instr_exe_page_fault_v);
+  wire instr_page_fault_v = trans_en_r & r_instr_r & (instr_priv_page_fault_v | instr_exe_page_fault_v | eaddr_fault_v);
   wire load_page_fault_v  = trans_en_r & r_load_r & (data_priv_page_fault | data_read_page_fault  | eaddr_fault_v);
   wire store_page_fault_v = trans_en_r & r_store_r & (data_priv_page_fault | data_write_page_fault | eaddr_fault_v);
   wire any_page_fault_v   = |{instr_page_fault_v, load_page_fault_v, store_page_fault_v};
 
-  assign r_v_o                   = tlb_v_lo & ~any_access_fault_v & ~any_page_fault_v;
+  wire any_fault_v        = any_access_fault_v | any_page_fault_v;
+
+  assign r_v_o                   = r_v_r &  tlb_v_lo & ~any_fault_v;
+  assign r_instr_miss_o          = r_v_r & ~tlb_v_lo & ~any_fault_v & r_instr_r;
+  assign r_load_miss_o           = r_v_r & ~tlb_v_lo & ~any_fault_v & r_load_r;
+  assign r_store_miss_o          = r_v_r & ~tlb_v_lo & ~any_fault_v & r_store_r;
+  assign r_instr_misaligned_o    = r_v_r & r_misaligned_r & r_instr_r;
+  assign r_load_misaligned_o     = r_v_r & r_misaligned_r & r_load_r;
+  assign r_store_misaligned_o    = r_v_r & r_misaligned_r & r_store_r;
+  assign r_instr_access_fault_o  = r_v_r & instr_access_fault_v;
+  assign r_load_access_fault_o   = r_v_r & load_access_fault_v;
+  assign r_store_access_fault_o  = r_v_r & store_access_fault_v;
+  assign r_instr_page_fault_o    = r_v_r & instr_page_fault_v;
+  assign r_load_page_fault_o     = r_v_r & load_page_fault_v;
+  assign r_store_page_fault_o    = r_v_r & store_page_fault_v;
   assign r_ptag_o                = ptag_lo;
-  assign r_instr_miss_o          = ~tlb_v_lo & r_instr_r & ~any_access_fault_v & ~any_page_fault_v;
-  assign r_load_miss_o           = ~tlb_v_lo & r_load_r  & ~any_access_fault_v & ~any_page_fault_v;
-  assign r_store_miss_o          = ~tlb_v_lo & r_store_r & ~any_access_fault_v & ~any_page_fault_v;
-  assign r_uncached_o            =  tlb_v_lo & ptag_uncached_lo;
-  assign r_nonidem_o             =  tlb_v_lo & ptag_nonidem_lo;
-  assign r_dram_o                =  tlb_v_lo & ptag_dram_lo;
-  assign r_instr_misaligned_o    = r_misaligned_r & r_instr_r;
-  assign r_load_misaligned_o     = r_misaligned_r & r_load_r;
-  assign r_store_misaligned_o    = r_misaligned_r & r_store_r;
-  assign r_instr_access_fault_o  = instr_access_fault_v;
-  assign r_load_access_fault_o   = load_access_fault_v;
-  assign r_store_access_fault_o  = store_access_fault_v;
-  assign r_instr_page_fault_o    = instr_page_fault_v;
-  assign r_load_page_fault_o     = load_page_fault_v;
-  assign r_store_page_fault_o    = store_page_fault_v;
+  assign r_uncached_o            = ptag_uncached_lo;
+  assign r_nonidem_o             = ptag_nonidem_lo;
+  assign r_dram_o                = ptag_dram_lo;
 
 endmodule
 

--- a/bp_fe/src/v/bp_fe_controller.sv
+++ b/bp_fe/src/v/bp_fe_controller.sv
@@ -58,6 +58,7 @@ module bp_fe_controller
    , output logic                                     itlb_r_v_o
    , output logic                                     itlb_w_v_o
    , output logic                                     itlb_flush_v_o
+   , output logic                                     itlb_fence_v_o
    , output logic                                     icache_v_o
    , output logic                                     icache_force_o
    , output logic [icache_pkt_width_lp-1:0]           icache_pkt_o
@@ -164,6 +165,7 @@ module bp_fe_controller
       itlb_r_v_o = 1'b0;
       itlb_w_v_o = 1'b0;
       itlb_flush_v_o = 1'b0;
+      itlb_fence_v_o = 1'b0;
 
       case (state_r)
         e_reset:
@@ -176,7 +178,8 @@ module bp_fe_controller
             if1_we_o = icache_yumi_i & ~cmd_complex_v;
             itlb_r_v_o = icache_yumi_i;
             itlb_w_v_o = itlb_fill_response_v;
-            itlb_flush_v_o = itlb_fence_v;
+            itlb_fence_v_o = itlb_fence_v;
+            itlb_flush_v_o = cmd_nonattaboy_v;
             state_n = (wait_v | icache_fence_v)
                       ? e_wait
                       : cmd_complex_v

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -154,7 +154,7 @@ module bp_fe_top
 
   wire [dword_width_gp-1:0] r_eaddr_li = `BSG_SIGN_EXTEND(next_pc_lo, dword_width_gp);
   wire [1:0] r_size_li = 2'b10;
-  logic itlb_r_v_li, itlb_w_v_li, itlb_flush_v_li;
+  logic itlb_r_v_li, itlb_w_v_li, itlb_flush_v_li, itlb_fence_v_li;
 
   bp_pte_leaf_s w_tlb_entry_li;
   wire [vtag_width_p-1:0] w_vtag_li = fe_cmd_cast_i.npc[vaddr_width_p-1-:vtag_width_p];
@@ -169,6 +169,7 @@ module bp_fe_top
   bp_mmu
    #(.bp_params_p(bp_params_p)
      ,.tlb_els_4k_p(itlb_els_4k_p)
+     ,.tlb_els_2m_p(itlb_els_2m_p)
      ,.tlb_els_1g_p(itlb_els_1g_p)
      )
    immu
@@ -176,6 +177,7 @@ module bp_fe_top
      ,.reset_i(reset_i)
 
      ,.flush_i(itlb_flush_v_li)
+     ,.fence_i(itlb_fence_v_li)
      ,.priv_mode_i(shadow_priv_r)
      ,.trans_en_i(shadow_translation_en_r)
      // Supervisor use of user memory is always disabled for immu
@@ -419,6 +421,7 @@ module bp_fe_top
      ,.itlb_r_v_o(itlb_r_v_li)
      ,.itlb_w_v_o(itlb_w_v_li)
      ,.itlb_flush_v_o(itlb_flush_v_li)
+     ,.itlb_fence_v_o(itlb_fence_v_li)
      ,.icache_v_o(icache_v_li)
      ,.icache_force_o(icache_force_li)
      ,.icache_pkt_o(icache_pkt_li)

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -151,6 +151,7 @@ $BASEJUMP_STL_DIR/bsg_misc/bsg_muxi2_gatestack.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_nor2.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_nor3.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_nand.v
+$BASEJUMP_STL_DIR/bsg_misc/bsg_popcount.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_priority_encode.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_priority_encode_one_hot_out.v
 $BASEJUMP_STL_DIR/bsg_misc/bsg_reduce.v

--- a/bp_top/test/common/bp_nonsynth_vm_tracer.sv
+++ b/bp_top/test/common/bp_nonsynth_vm_tracer.sv
@@ -27,6 +27,7 @@ module bp_nonsynth_vm_tracer
    , input                           itlb_clear_i
    , input                           itlb_fill_v_i
    , input                           itlb_fill_g_i
+   , input                           itlb_fill_m_i
    , input [vtag_width_p-1:0]        itlb_vtag_i
    , input [itlb_entry_width_lp-1:0] itlb_entry_i
    , input                           itlb_r_v_i
@@ -34,6 +35,7 @@ module bp_nonsynth_vm_tracer
    , input                           dtlb_clear_i
    , input                           dtlb_fill_v_i
    , input                           dtlb_fill_g_i
+   , input                           dtlb_fill_m_i
    , input [vtag_width_p-1:0]        dtlb_vtag_i
    , input [dtlb_entry_width_lp-1:0] dtlb_entry_i
    , input                           dtlb_r_v_i
@@ -65,13 +67,14 @@ module bp_nonsynth_vm_tracer
       if (itlb_clear_i)
         $fwrite(file, "%12t | ITLB Clear\n", $time);
       if (itlb_fill_v_i)
-        $fwrite(file, "%12t | ITLB map %x -> %x [R:%x W:%x X:%x] GP: %x\n" //A:%x D:%x]"
+        $fwrite(file, "%12t | ITLB map %x -> %x [R:%x W:%x X:%x] MP: %x GP: %x\n" //A:%x D:%x]"
                 ,$time
                 ,itlb_vtag_i
                 ,itlb_w_entry.ptag
                 ,itlb_w_entry.r
                 ,itlb_w_entry.w
                 ,itlb_w_entry.x
+                ,itlb_fill_m_i
                 ,itlb_fill_g_i
                 //,itlb_w_entry.a
                 //,itlb_w_entry.d
@@ -79,13 +82,14 @@ module bp_nonsynth_vm_tracer
       if (dtlb_clear_i)
         $fwrite(file, "%12t | DTLB Clear\n", $time);
       if (dtlb_fill_v_i)
-        $fwrite(file, "%12t | DTLB map %x -> %x [R:%x W:%x X:%x] GP: %x\n" //A:%x D:%x]"
+        $fwrite(file, "%12t | DTLB map %x -> %x [R:%x W:%x X:%x] MP: %x GP: %x\n" //A:%x D:%x]"
                 ,$time
                 ,dtlb_vtag_i
                 ,dtlb_w_entry.ptag
                 ,dtlb_w_entry.r
                 ,dtlb_w_entry.w
                 ,dtlb_w_entry.x
+                ,dtlb_fill_m_i
                 ,dtlb_fill_g_i
                 //,dtlb_w_entry.a
                 //,dtlb_w_entry.d

--- a/bp_top/test/tb/bp_tethered/Makefile.testlist
+++ b/bp_top/test/tb/bp_tethered/Makefile.testlist
@@ -502,7 +502,6 @@ MC_TESTLIST := $(addprefix bp-tests@, $(MC_TESTS))
 RISCVDV_TESTS := \
   riscv_arithmetic_basic_test     \
   riscv_full_interrupt_test       \
-  riscv_illegal_instr_test        \
   riscv_loop_test                 \
   riscv_mmu_stress_test           \
   riscv_no_fence_test             \

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -430,16 +430,18 @@ module testbench
 
            ,.mhartid_i(be.calculator.pipe_sys.csr.cfg_bus_cast_i.core_id)
 
-           ,.itlb_clear_i(fe.immu.tlb.flush_i)
+           ,.itlb_clear_i(fe.immu.tlb.fence_i)
            ,.itlb_fill_v_i(fe.immu.tlb.w_v_li)
            ,.itlb_fill_g_i(fe.immu.tlb.entry_cast_i.gigapage)
+           ,.itlb_fill_m_i(fe.immu.tlb.entry_cast_i.megapage)
            ,.itlb_vtag_i(fe.immu.tlb.vtag_i)
            ,.itlb_entry_i(fe.immu.tlb.entry_i)
            ,.itlb_r_v_i(fe.immu.tlb.r_v_li)
 
-           ,.dtlb_clear_i(be.calculator.pipe_mem.dmmu.tlb.flush_i)
+           ,.dtlb_clear_i(be.calculator.pipe_mem.dmmu.tlb.fence_i)
            ,.dtlb_fill_v_i(be.calculator.pipe_mem.dmmu.tlb.w_v_li)
            ,.dtlb_fill_g_i(be.calculator.pipe_mem.dmmu.tlb.entry_cast_i.gigapage)
+           ,.dtlb_fill_m_i(be.calculator.pipe_mem.dmmu.tlb.entry_cast_i.megapage)
            ,.dtlb_vtag_i(be.calculator.pipe_mem.dmmu.tlb.vtag_i)
            ,.dtlb_entry_i(be.calculator.pipe_mem.dmmu.tlb.entry_i)
            ,.dtlb_r_v_i(be.calculator.pipe_mem.dmmu.tlb.r_v_li)


### PR DESCRIPTION
### Summary
This PR adds parametrizable megapage support to BlackParrot.

### Issue Fixed
None

### Area
MMU / TLB

### Reasoning (new feature, inefficient, verbose, etc.)
Megapages are predominately used in user space Linux applications such as SPEC benchmarks. Leveraging them grants a larger effective TLB capacity

### Additional Changes Required (if any)
None

### Analysis
No critical path increase when parameterized out

### Verification
Linux boot and synthesis

### Additional Context


