### PR TITLE
Modifying cache engine interface

### DIFF
--- a/bp_be/src/include/bp_be_dcache_defines.svh
+++ b/bp_be/src/include/bp_be_dcache_defines.svh
@@ -11,20 +11,26 @@
     }  bp_be_dcache_pkt_s;                          \
 
   `define declare_bp_be_dcache_wbuf_entry_s(caddr_width_mp, ways_mp) \
-    typedef struct packed                           \
-    {                                               \
-      logic                                snoop;   \
-      logic [caddr_width_mp-1:0]           caddr;   \
-      logic [dword_width_gp-1:0]           data;    \
-      logic [(dword_width_gp>>3)-1:0]      mask;    \
-      logic [`BSG_SAFE_CLOG2(ways_mp)-1:0] way_id;  \
+    typedef struct packed                            \
+    {                                                \
+      logic                                snoop;    \
+      logic [ways_mp-1:0]                  bank_sel; \
+      logic [(dword_width_gp>>3)-1:0]      mask;     \
+      logic [dword_width_gp-1:0]           data;     \
+      logic [caddr_width_mp-1:0]           caddr;    \
     } bp_be_dcache_wbuf_entry_s
 
   `define bp_be_dcache_pkt_width(vaddr_width_mp) \
     (vaddr_width_mp+$bits(bp_be_dcache_fu_op_e)+reg_addr_width_gp)
 
   `define bp_be_dcache_wbuf_entry_width(caddr_width_mp, ways_mp) \
-    (1+caddr_width_mp+dword_width_gp+(dword_width_gp>>3)+`BSG_SAFE_CLOG2(ways_mp))
+    (1+ways_mp+(dword_width_gp>>3)+dword_width_gp+caddr_width_mp)
+
+  `define declare_bp_be_dcache_engine_if(addr_width_mp, tag_width_mp, sets_mp, ways_mp, data_width_mp, block_width_mp, fill_width_mp, id_width_mp) \
+    `declare_bp_cache_engine_generic_if(addr_width_mp, tag_width_mp, sets_mp, ways_mp, data_width_mp, block_width_mp, fill_width_mp, id_width_mp, be_dcache)
+
+  `define declare_bp_be_dcache_engine_if_widths(addr_width_mp, tag_width_mp, sets_mp, ways_mp, data_width_mp, block_width_mp, fill_width_mp, id_width_mp) \
+    `declare_bp_cache_engine_generic_if_widths(addr_width_mp, tag_width_mp, sets_mp, ways_mp, data_width_mp, block_width_mp, fill_width_mp, id_width_mp, dcache)
 
 `endif
 

--- a/bp_be/src/include/bp_be_dcache_pkgdef.svh
+++ b/bp_be/src/include/bp_be_dcache_pkgdef.svh
@@ -25,19 +25,26 @@
     logic                         store_op;
     logic                         signed_op;
     logic                         float_op;
+    logic                         ptw_op;
+    logic                         cache_op;
     logic                         double_op;
     logic                         word_op;
     logic                         half_op;
     logic                         byte_op;
-    logic                         clean_op;
     logic                         uncached_op;
-    logic                         ptw_op;
     logic                         lr_op;
     logic                         sc_op;
     logic                         amo_op;
+    logic                         clean_op;
     bp_be_amo_subop_e             amo_subop;
     logic [reg_addr_width_gp-1:0] rd_addr;
   }  bp_be_dcache_decode_s;
+
+  typedef struct packed
+  {
+    bp_be_dcache_decode_s decode;
+    logic                 uncached;
+  }  bp_be_dcache_req_payload_s;
 
 `endif
 

--- a/bp_be/src/include/bp_be_defines.svh
+++ b/bp_be/src/include/bp_be_defines.svh
@@ -187,20 +187,6 @@
                                                                                                    \
     typedef struct packed                                                                          \
     {                                                                                              \
-      /* Trans info */                                                                             \
-      logic [ptag_width_p-1:0]       base_ppn;                                                     \
-      logic [rv64_priv_width_gp-1:0] priv_mode;                                                    \
-      logic                          mstatus_sum;                                                  \
-      logic                          mstatus_mxr;                                                  \
-      logic                          instr_miss_v;                                                 \
-      logic                          load_miss_v;                                                  \
-      logic                          store_miss_v;                                                 \
-      logic                          partial;                                                      \
-      logic [vaddr_width_mp-1:0]     vaddr;                                                        \
-    }  bp_be_ptw_miss_pkt_s;                                                                       \
-                                                                                                   \
-    typedef struct packed                                                                          \
-    {                                                                                              \
       logic v;                                                                                     \
       logic itlb_fill_v;                                                                           \
       logic dtlb_fill_v;                                                                           \
@@ -283,9 +269,6 @@
      + $bits(rv64_fflags_s)                                                                        \
      )
 
-  `define bp_be_ptw_miss_pkt_width(vaddr_width_mp, ptag_width_mp) \
-    (ptag_width_mp + rv64_priv_width_gp + 6 + vaddr_width_mp)
-
   `define bp_be_ptw_fill_pkt_width(vaddr_width_mp, paddr_width_mp) \
     (7                                                                                             \
      + vaddr_width_mp                                                                              \
@@ -296,7 +279,7 @@
     (rv64_priv_width_gp+ptag_width_mp+3)
 
   `define bp_be_decode_info_width \
-    (13)
+    (rv64_priv_width_gp+11)
 
 `endif
 

--- a/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_calculator_top.sv
@@ -21,7 +21,7 @@ module bp_be_calculator_top
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
     `declare_bp_core_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
-    `declare_bp_cache_engine_if_widths(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
+    `declare_bp_be_dcache_engine_if_widths(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache_req_id_width_p)
 
    // Generated parameters
    , localparam cfg_bus_width_lp        = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
@@ -73,8 +73,7 @@ module bp_be_calculator_top
    , input                                           cache_req_lock_i
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
-   , input [paddr_width_p-1:0]                       cache_req_addr_i
-   , input [dword_width_gp-1:0]                      cache_req_data_i
+   , input [dcache_req_id_width_p-1:0]               cache_req_id_i
    , input                                           cache_req_critical_i
    , input                                           cache_req_last_i
    , input                                           cache_req_credits_full_i
@@ -357,8 +356,7 @@ module bp_be_calculator_top
      ,.cache_req_lock_i(cache_req_lock_i)
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
-     ,.cache_req_addr_i(cache_req_addr_i)
-     ,.cache_req_data_i(cache_req_data_i)
+     ,.cache_req_id_i(cache_req_id_i)
      ,.cache_req_critical_i(cache_req_critical_i)
      ,.cache_req_last_i(cache_req_last_i)
      ,.cache_req_credits_full_i(cache_req_credits_full_i)

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.sv
@@ -18,7 +18,7 @@ module bp_be_pipe_mem
  import bp_be_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_cache_engine_if_widths(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
+   `declare_bp_be_dcache_engine_if_widths(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache_req_id_width_p)
    // Generated parameters
    , localparam cfg_bus_width_lp       = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    , localparam dispatch_pkt_width_lp  = `bp_be_dispatch_pkt_width(vaddr_width_p)
@@ -74,8 +74,7 @@ module bp_be_pipe_mem
    , input                                           cache_req_lock_i
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
-   , input [paddr_width_p-1:0]                       cache_req_addr_i
-   , input [dword_width_gp-1:0]                      cache_req_data_i
+   , input [dcache_req_id_width_p-1:0]               cache_req_id_i
    , input                                           cache_req_critical_i
    , input                                           cache_req_last_i
    , input                                           cache_req_credits_full_i
@@ -101,9 +100,9 @@ module bp_be_pipe_mem
   `declare_bp_be_internal_if_structs(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p);
 
   `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
-  `declare_bp_cache_engine_if(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache);
+  `declare_bp_be_dcache_engine_if(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache_req_id_width_p);
   `declare_bp_be_dcache_pkt_s(vaddr_width_p);
-  `bp_cast_o(bp_dcache_req_s, cache_req);
+  `bp_cast_o(bp_be_dcache_req_s, cache_req);
   `bp_cast_o(bp_be_wb_pkt_s, late_wb_pkt);
 
   wire negedge_clk = ~clk_i;
@@ -248,19 +247,6 @@ module bp_be_pipe_mem
      ,.r_store_page_fault_o(store_page_fault_v)
      );
 
-  bp_be_ptw_miss_pkt_s ptw_miss_pkt;
-  assign ptw_miss_pkt =
-    '{instr_miss_v  : commit_pkt.itlb_miss
-      ,store_miss_v : commit_pkt.dtlb_store_miss
-      ,load_miss_v  : commit_pkt.dtlb_load_miss
-      ,partial      : commit_pkt.partial
-      ,vaddr        : commit_pkt.vaddr
-      ,mstatus_mxr  : trans_info.mstatus_mxr
-      ,mstatus_sum  : trans_info.mstatus_sum
-      ,base_ppn     : trans_info.base_ppn
-      ,priv_mode    : trans_info.priv_mode
-      };
-
   bp_be_ptw
    #(.bp_params_p(bp_params_p)
      ,.pte_width_p(sv39_pte_width_gp)
@@ -378,8 +364,7 @@ module bp_be_pipe_mem
       ,.cache_req_lock_i(cache_req_lock_i)
       ,.cache_req_metadata_o(cache_req_metadata_o)
       ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
-      ,.cache_req_addr_i(cache_req_addr_i)
-      ,.cache_req_data_i(cache_req_data_i)
+      ,.cache_req_id_i(cache_req_id_i)
       ,.cache_req_critical_i(cache_req_critical_i)
       ,.cache_req_last_i(cache_req_last_i)
       ,.cache_req_credits_full_i(cache_req_credits_full_i)

--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -260,7 +260,8 @@ module bp_be_detector
                      | (mem_busy_i & decode.pipe_mem_early_v)
                      | (mem_busy_i & decode.pipe_mem_final_v)
                      | (fdiv_busy_i & decode.pipe_long_v)
-                     | (idiv_busy_i & decode.pipe_long_v);
+                     | (idiv_busy_i & decode.pipe_long_v)
+                     | late_wb_yumi_i;
     end
 
   // Dispatch if we have a valid issue. Don't stall on data hazards for exceptions

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache_wbuf.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache_wbuf.sv
@@ -19,8 +19,9 @@ module bp_be_dcache_wbuf
    , parameter block_width_p  = dcache_block_width_p
    , parameter fill_width_p   = dcache_fill_width_p
    , parameter ctag_width_p   = dcache_ctag_width_p
+   , parameter id_width_p     = dcache_req_id_width_p
 
-   `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, dcache)
+   `declare_bp_be_dcache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, id_width_p)
 
    , localparam wbuf_entry_width_lp=`bp_be_dcache_wbuf_entry_width(caddr_width_p, dcache_assoc_p)
    )
@@ -50,11 +51,11 @@ module bp_be_dcache_wbuf
    );
 
   `declare_bp_be_dcache_wbuf_entry_s(caddr_width_p, dcache_assoc_p);
-  `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, dcache);
+  `declare_bp_be_dcache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, id_width_p);
   `bp_cast_i(bp_be_dcache_wbuf_entry_s, wbuf_entry);
-  `bp_cast_i(bp_dcache_data_mem_pkt_s, data_mem_pkt);
-  `bp_cast_i(bp_dcache_tag_mem_pkt_s, tag_mem_pkt);
-  `bp_cast_i(bp_dcache_stat_mem_pkt_s, stat_mem_pkt);
+  `bp_cast_i(bp_be_dcache_data_mem_pkt_s, data_mem_pkt);
+  `bp_cast_i(bp_be_dcache_tag_mem_pkt_s, tag_mem_pkt);
+  `bp_cast_i(bp_be_dcache_stat_mem_pkt_s, stat_mem_pkt);
 
   localparam data_mask_width_lp    = dword_width_gp >> 3;
   localparam byte_offset_width_lp  = `BSG_SAFE_CLOG2(data_mask_width_lp);
@@ -208,14 +209,11 @@ module bp_be_dcache_wbuf
   wire snoop_stat_match = v_tl_i & stat_mem_pkt_v_i
     & (addr_tl_i[block_offset_width_lp+:sindex_width_lp] == stat_mem_pkt_cast_i.index);
   wire snoop_el0_match = el0_valid & ~wbuf_entry_cast_i.snoop & data_mem_pkt_v_i
-    & (wbuf_entry_el0_r.caddr[block_offset_width_lp+:sindex_width_lp] == data_mem_pkt_cast_i.index)
-    & (wbuf_entry_el0_r.way_id == data_mem_pkt_cast_i.way_id);
+    & (wbuf_entry_el0_r.caddr[block_offset_width_lp+:sindex_width_lp] == data_mem_pkt_cast_i.index);
   wire snoop_el1_match = el1_valid & ~wbuf_entry_el1_r.snoop & data_mem_pkt_v_i
-    & (wbuf_entry_el1_r.caddr[block_offset_width_lp+:sindex_width_lp] == data_mem_pkt_cast_i.index)
-    & (wbuf_entry_el1_r.way_id == data_mem_pkt_cast_i.way_id);
+    & (wbuf_entry_el1_r.caddr[block_offset_width_lp+:sindex_width_lp] == data_mem_pkt_cast_i.index);
   wire snoop_el2_match = v_i & ~wbuf_entry_cast_i.snoop & data_mem_pkt_v_i
-    & (wbuf_entry_cast_i.caddr[block_offset_width_lp+:sindex_width_lp] == data_mem_pkt_cast_i.index)
-    & (wbuf_entry_cast_i.way_id == data_mem_pkt_cast_i.way_id);
+    & (wbuf_entry_cast_i.caddr[block_offset_width_lp+:sindex_width_lp] == data_mem_pkt_cast_i.index);
 
   assign snoop_match_o = snoop_tag_match | snoop_stat_match | snoop_el0_match | snoop_el1_match | snoop_el2_match;
 

--- a/bp_be/src/v/bp_be_top.sv
+++ b/bp_be/src/v/bp_be_top.sv
@@ -14,7 +14,7 @@ module bp_be_top
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_core_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
-   `declare_bp_cache_engine_if_widths(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
+   `declare_bp_be_dcache_engine_if_widths(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache_req_id_width_p)
 
    // Default parameters
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
@@ -44,8 +44,7 @@ module bp_be_top
    , input                                           cache_req_lock_i
    , output logic [dcache_req_metadata_width_lp-1:0] cache_req_metadata_o
    , output logic                                    cache_req_metadata_v_o
-   , input [paddr_width_p-1:0]                       cache_req_addr_i
-   , input [dword_width_gp-1:0]                      cache_req_data_i
+   , input [dcache_req_id_width_p-1:0]               cache_req_id_i
    , input                                           cache_req_critical_i
    , input                                           cache_req_last_i
    , input                                           cache_req_credits_full_i
@@ -224,8 +223,7 @@ module bp_be_top
      ,.cache_req_yumi_i(cache_req_yumi_i)
      ,.cache_req_lock_i(cache_req_lock_i)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
-     ,.cache_req_addr_i(cache_req_addr_i)
-     ,.cache_req_data_i(cache_req_data_i)
+     ,.cache_req_id_i(cache_req_id_i)
      ,.cache_req_critical_i(cache_req_critical_i)
      ,.cache_req_last_i(cache_req_last_i)
      ,.cache_req_credits_full_i(cache_req_credits_full_i)

--- a/bp_be/test/common/bp_be_nonsynth_dcache_tracer.sv
+++ b/bp_be/test/common/bp_be_nonsynth_dcache_tracer.sv
@@ -12,9 +12,9 @@ module bp_be_nonsynth_dcache_tracer
   , parameter fill_width_p = 512
   , parameter trace_file_p = "dcache"
   , parameter ctag_width_p = 27
+  , parameter id_width_p = 1
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp,
-block_width_p, fill_width_p, cache)
+   `declare_bp_be_dcache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, id_width_p)
 
    // Calculated parameters
    , localparam mhartid_width_lp = `BSG_SAFE_CLOG2(num_core_p)
@@ -37,11 +37,11 @@ block_width_p, fill_width_p, cache)
    , input [dpath_width_gp-1:0]                           final_data_o
    , input                                                final_v_o
 
-   , input [cache_req_width_lp-1:0]                       cache_req_o
+   , input [dcache_req_width_lp-1:0]                      cache_req_o
    , input                                                cache_req_v_o
    , input                                                cache_req_yumi_i
    , input                                                cache_req_lock_i
-   , input [cache_req_metadata_width_lp-1:0]              cache_req_metadata_o
+   , input [dcache_req_metadata_width_lp-1:0]             cache_req_metadata_o
    , input                                                cache_req_metadata_v_o
    , input                                                cache_req_critical_i
    , input                                                cache_req_last_i
@@ -50,19 +50,19 @@ block_width_p, fill_width_p, cache)
    , input                                                cache_req_credits_empty_i
 
    , input                                                data_mem_pkt_v_i
-   , input [cache_data_mem_pkt_width_lp-1:0]              data_mem_pkt_i
+   , input [dcache_data_mem_pkt_width_lp-1:0]             data_mem_pkt_i
    , input                                                data_mem_pkt_yumi_o
    , input [block_width_p-1:0]                            data_mem_o
 
    , input                                                tag_mem_pkt_v_i
-   , input [cache_tag_mem_pkt_width_lp-1:0]               tag_mem_pkt_i
+   , input [dcache_tag_mem_pkt_width_lp-1:0]              tag_mem_pkt_i
    , input                                                tag_mem_pkt_yumi_o
-   , input [cache_tag_info_width_lp-1:0]                  tag_mem_o
+   , input [dcache_tag_info_width_lp-1:0]                 tag_mem_o
 
    , input                                                stat_mem_pkt_v_i
-   , input [cache_stat_mem_pkt_width_lp-1:0]              stat_mem_pkt_i
+   , input [dcache_stat_mem_pkt_width_lp-1:0]             stat_mem_pkt_i
    , input                                                stat_mem_pkt_yumi_o
-   , input [cache_stat_info_width_lp-1:0]                 stat_mem_o
+   , input [dcache_stat_info_width_lp-1:0]                stat_mem_o
 
    , input [wbuf_entry_width_lp-1:0]                      wbuf_entry_out
    , input                                                wbuf_yumi_li
@@ -90,26 +90,26 @@ block_width_p, fill_width_p, cache)
    , input                                                stat_mem_fast_write
    );
 
-  `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache);
+  `declare_bp_be_dcache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, id_width_p);
   `declare_bp_be_dcache_pkt_s(vaddr_width_p);
   bp_be_dcache_pkt_s dcache_pkt_cast_i;
   assign dcache_pkt_cast_i = dcache_pkt_i;
 
-  bp_cache_req_s cache_req_cast_o;
-  bp_cache_req_metadata_s cache_req_metadata_cast_o;
+  bp_be_dcache_req_s cache_req_cast_o;
+  bp_be_dcache_req_metadata_s cache_req_metadata_cast_o;
   assign cache_req_cast_o = cache_req_o;
   assign cache_req_metadata_cast_o = cache_req_metadata_o;
 
-  bp_cache_data_mem_pkt_s data_mem_pkt_cast_i;
-  bp_cache_tag_mem_pkt_s tag_mem_pkt_cast_i;
-  bp_cache_stat_mem_pkt_s stat_mem_pkt_cast_i;
+  bp_be_dcache_data_mem_pkt_s data_mem_pkt_cast_i;
+  bp_be_dcache_tag_mem_pkt_s tag_mem_pkt_cast_i;
+  bp_be_dcache_stat_mem_pkt_s stat_mem_pkt_cast_i;
   assign data_mem_pkt_cast_i = data_mem_pkt_i;
   assign tag_mem_pkt_cast_i = tag_mem_pkt_i;
   assign stat_mem_pkt_cast_i = stat_mem_pkt_i;
 
   logic [assoc_p-1:0][bank_width_lp-1:0] data_mem_cast_o;
-  bp_cache_tag_info_s tag_mem_info_cast_o;
-  bp_cache_stat_info_s stat_mem_info_cast_o;
+  bp_be_dcache_tag_info_s tag_mem_info_cast_o;
+  bp_be_dcache_stat_info_s stat_mem_info_cast_o;
   assign data_mem_cast_o = data_mem_o;
   assign tag_mem_info_cast_o = tag_mem_o;
   assign stat_mem_info_cast_o = stat_mem_o;

--- a/bp_be/test/tb/bp_be_dcache/wrapper.sv
+++ b/bp_be/test/tb/bp_be_dcache/wrapper.sv
@@ -17,8 +17,9 @@ module wrapper
    , parameter assoc_p = dcache_assoc_p
    , parameter block_width_p = dcache_block_width_p
    , parameter fill_width_p = dcache_fill_width_p
+   , parameter id_width_p = dcache_req_id_width_p
    `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
-   `declare_bp_cache_engine_if_widths(paddr_width_p, dcache_ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, dcache)
+   `declare_bp_cache_engine_generic_if_widths(paddr_width_p, dcache_ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, id_width_p, dcache)
 
    , parameter debug_p=0
    , parameter lock_max_limit_p=8
@@ -72,8 +73,6 @@ module wrapper
   logic [num_caches_p-1:0] cache_req_v_lo, cache_req_metadata_v_lo;
   logic [num_caches_p-1:0] cache_req_yumi_lo, cache_req_lock_lo;
   logic [num_caches_p-1:0] cache_req_last_lo, cache_req_critical_lo;
-  logic [num_caches_p-1:0][paddr_width_p-1:0] cache_req_addr_lo;
-  logic [num_caches_p-1:0][dword_width_gp-1:0] cache_req_data_lo;
   logic [num_caches_p-1:0][dcache_req_width_lp-1:0] cache_req_lo;
   logic [num_caches_p-1:0][dcache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
 
@@ -217,8 +216,6 @@ module wrapper
       ,.cache_req_metadata_v_o(cache_req_metadata_v_lo[i])
       ,.cache_req_yumi_i(cache_req_yumi_lo[i])
       ,.cache_req_lock_i(cache_req_lock_lo[i])
-      ,.cache_req_addr_i(cache_req_addr_lo[i])
-      ,.cache_req_data_i(cache_req_data_lo[i])
       ,.cache_req_critical_i(cache_req_critical_lo[i])
       ,.cache_req_last_i(cache_req_last_lo[i])
       ,.cache_req_credits_full_i(cache_req_credits_full_lo[i])
@@ -251,6 +248,7 @@ module wrapper
              ,.timeout_max_limit_p(4)
              ,.credits_p(coh_noc_max_credits_p)
              ,.ctag_width_p(dcache_ctag_width_p)
+             ,.id_width_p(id_width_p)
              )
            dcache_lce
             (.clk_i(clk_i)
@@ -266,8 +264,6 @@ module wrapper
              ,.cache_req_lock_o(cache_req_lock_lo[i])
              ,.cache_req_metadata_i(cache_req_metadata_lo[i])
              ,.cache_req_metadata_v_i(cache_req_metadata_v_lo[i])
-             ,.cache_req_addr_o(cache_req_addr_lo[i])
-             ,.cache_req_data_o(cache_req_data_lo[i])
              ,.cache_req_critical_o(cache_req_critical_lo[i])
              ,.cache_req_last_o(cache_req_last_lo[i])
              ,.cache_req_credits_full_o(cache_req_credits_full_lo[i])
@@ -326,6 +322,7 @@ module wrapper
             ,.block_width_p(block_width_p)
             ,.fill_width_p(fill_width_p)
             ,.ctag_width_p(dcache_ctag_width_p)
+            ,.id_width_p(id_width_p)
             ,.writeback_p(!wt_p)
             )
           dcache_uce
@@ -340,8 +337,6 @@ module wrapper
             ,.cache_req_lock_o(cache_req_lock_lo)
             ,.cache_req_metadata_i(cache_req_metadata_lo)
             ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
-            ,.cache_req_addr_o(cache_req_addr_lo)
-            ,.cache_req_data_o(cache_req_data_lo)
             ,.cache_req_critical_o(cache_req_critical_lo)
             ,.cache_req_last_o(cache_req_last_lo)
             ,.cache_req_credits_full_o(cache_req_credits_full_lo)
@@ -399,8 +394,8 @@ module wrapper
        #(.bp_params_p(bp_params_p)
          ,.block_width_p(block_width_p)
          ,.data_width_p(fill_width_p)
-         ,.payload_width_p(lce_req_payload_width_lp)
          ,.stream_mask_p(lce_req_stream_mask_gp)
+         ,.payload_width_p(lce_req_payload_width_lp)
          ,.num_source_p(num_lce_p)
          ,.num_sink_p(num_cce_p)
          )

--- a/bp_common/src/include/bp_common_addr_defines.svh
+++ b/bp_common/src/include/bp_common_addr_defines.svh
@@ -17,5 +17,12 @@
       logic [dev_addr_width_gp-1:0]  addr;             \
     }  bp_local_addr_s
 
+  `define bp_addr_is_aligned(addr_mp, num_bytes_mp) \
+    (!(|{ addr_mp[$clog2(num_bytes_mp)-1:0] }))
+
+  `define bp_addr_align(addr_mp, num_bytes_mp) \
+    ((addr_mp >> $clog2(num_bytes_mp)) << $clog2(num_bytes_mp))
+
+
 `endif
 

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -145,6 +145,7 @@
     integer unsigned icache_assoc;
     integer unsigned icache_block_width;
     integer unsigned icache_fill_width;
+    integer unsigned icache_mshr;
 
     // D$ cache features
     integer unsigned dcache_features;
@@ -153,6 +154,7 @@
     integer unsigned dcache_assoc;
     integer unsigned dcache_block_width;
     integer unsigned dcache_fill_width;
+    integer unsigned dcache_mshr;
 
     // A$ cache features
     integer unsigned acache_features;
@@ -161,6 +163,7 @@
     integer unsigned acache_assoc;
     integer unsigned acache_block_width;
     integer unsigned acache_fill_width;
+    integer unsigned acache_mshr;
 
     // CCE selection and parameters
     // cce_type defined by bp_cce_type_e
@@ -283,6 +286,13 @@
       ,dtlb_els_2m : 2
       ,dtlb_els_1g : 1
 
+      ,icache_features      : (1 << e_cfg_enabled) | (1 << e_cfg_misaligned)
+      ,icache_sets          : 64
+      ,icache_assoc         : 8
+      ,icache_block_width   : 512
+      ,icache_fill_width    : 128
+      ,icache_mshr          : 1
+
       ,dcache_features      : (1 << e_cfg_enabled)
                               | (1 << e_cfg_writeback)
                               | (1 << e_cfg_lr_sc)
@@ -294,18 +304,14 @@
       ,dcache_assoc         : 8
       ,dcache_block_width   : 512
       ,dcache_fill_width    : 128
-
-      ,icache_features      : (1 << e_cfg_enabled) | (1 << e_cfg_misaligned)
-      ,icache_sets          : 64
-      ,icache_assoc         : 8
-      ,icache_block_width   : 512
-      ,icache_fill_width    : 128
+      ,dcache_mshr          : 1
 
       ,acache_features      : (1 << e_cfg_enabled)
       ,acache_sets          : 64
       ,acache_assoc         : 8
       ,acache_block_width   : 512
       ,acache_fill_width    : 128
+      ,acache_mshr          : 1
 
       ,cce_type             : e_cce_uce
       ,cce_pc_width         : 8
@@ -412,18 +418,21 @@
       ,`bp_aviary_define_override(icache_assoc, BP_ICACHE_ASSOC, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(icache_block_width, BP_ICACHE_BLOCK_WIDTH, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(icache_fill_width, BP_ICACHE_FILL_WIDTH, `BP_CUSTOM_BASE_CFG)
+      ,`bp_aviary_define_override(icache_mshr, BP_ICACHE_MSHR, `BP_CUSTOM_BASE_CFG)
 
       ,`bp_aviary_define_override(dcache_features, BP_DCACHE_FEATURES, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(dcache_sets, BP_DCACHE_SETS, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(dcache_assoc, BP_DCACHE_ASSOC, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(dcache_block_width, BP_DCACHE_BLOCK_WIDTH, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(dcache_fill_width, BP_DCACHE_FILL_WIDTH, `BP_CUSTOM_BASE_CFG)
+      ,`bp_aviary_define_override(dcache_mshr, BP_DCACHE_MSHR, `BP_CUSTOM_BASE_CFG)
 
       ,`bp_aviary_define_override(acache_features, BP_ACACHE_FEATURES, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(acache_sets, BP_ACACHE_SETS, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(acache_assoc, BP_ACACHE_ASSOC, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(acache_block_width, BP_ACACHE_BLOCK_WIDTH, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(acache_fill_width, BP_ACACHE_FILL_WIDTH, `BP_CUSTOM_BASE_CFG)
+      ,`bp_aviary_define_override(acache_mshr, BP_ACACHE_MSHR, `BP_CUSTOM_BASE_CFG)
 
       ,`bp_aviary_define_override(cce_type, BP_CCE_TYPE, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(cce_pc_width, BP_CCE_PC_WIDTH, `BP_CUSTOM_BASE_CFG)

--- a/bp_common/src/include/bp_common_aviary_defines.svh
+++ b/bp_common/src/include/bp_common_aviary_defines.svh
@@ -64,21 +64,30 @@
     , localparam dtlb_els_2m_p              = proc_param_lp.dtlb_els_2m                            \
     , localparam dtlb_els_1g_p              = proc_param_lp.dtlb_els_1g                            \
                                                                                                    \
-    , localparam dcache_features_p          = proc_param_lp.dcache_features                        \
-    , localparam dcache_sets_p              = proc_param_lp.dcache_sets                            \
-    , localparam dcache_assoc_p             = proc_param_lp.dcache_assoc                           \
-    , localparam dcache_block_width_p       = proc_param_lp.dcache_block_width                     \
-    , localparam dcache_fill_width_p        = proc_param_lp.dcache_fill_width                      \
     , localparam icache_features_p          = proc_param_lp.icache_features                        \
     , localparam icache_sets_p              = proc_param_lp.icache_sets                            \
     , localparam icache_assoc_p             = proc_param_lp.icache_assoc                           \
     , localparam icache_block_width_p       = proc_param_lp.icache_block_width                     \
     , localparam icache_fill_width_p        = proc_param_lp.icache_fill_width                      \
+    , localparam icache_mshr_p              = proc_param_lp.icache_mshr                            \
+    , localparam icache_req_id_width_p      = `BSG_SAFE_CLOG2(icache_mshr_p)                       \
+                                                                                                   \
+    , localparam dcache_features_p          = proc_param_lp.dcache_features                        \
+    , localparam dcache_sets_p              = proc_param_lp.dcache_sets                            \
+    , localparam dcache_assoc_p             = proc_param_lp.dcache_assoc                           \
+    , localparam dcache_block_width_p       = proc_param_lp.dcache_block_width                     \
+    , localparam dcache_fill_width_p        = proc_param_lp.dcache_fill_width                      \
+    , localparam dcache_mshr_p              = proc_param_lp.dcache_mshr                            \
+    , localparam dcache_req_id_width_p      = `BSG_SAFE_CLOG2(dcache_mshr_p)                       \
+                                                                                                   \
     , localparam acache_features_p          = proc_param_lp.acache_features                        \
     , localparam acache_sets_p              = proc_param_lp.acache_sets                            \
     , localparam acache_assoc_p             = proc_param_lp.acache_assoc                           \
     , localparam acache_block_width_p       = proc_param_lp.acache_block_width                     \
     , localparam acache_fill_width_p        = proc_param_lp.acache_fill_width                      \
+    , localparam acache_mshr_p              = proc_param_lp.acache_mshr                            \
+    , localparam acache_req_id_width_p      = `BSG_SAFE_CLOG2(acache_mshr_p)                       \
+                                                                                                   \
     , localparam lce_assoc_p                =                                                      \
         `BSG_MAX(dcache_assoc_p, `BSG_MAX(icache_assoc_p, num_cacc_p ? acache_assoc_p : '0))       \
     , localparam lce_assoc_width_p          = `BSG_SAFE_CLOG2(lce_assoc_p)                         \
@@ -235,18 +244,21 @@
           ,`bp_aviary_parameter_override(icache_assoc, override_cfg_mp, default_cfg_mp)            \
           ,`bp_aviary_parameter_override(icache_block_width, override_cfg_mp, default_cfg_mp)      \
           ,`bp_aviary_parameter_override(icache_fill_width, override_cfg_mp, default_cfg_mp)       \
+          ,`bp_aviary_parameter_override(icache_mshr, override_cfg_mp, default_cfg_mp)             \
                                                                                                    \
           ,`bp_aviary_parameter_override(dcache_features, override_cfg_mp, default_cfg_mp)         \
           ,`bp_aviary_parameter_override(dcache_sets, override_cfg_mp, default_cfg_mp)             \
           ,`bp_aviary_parameter_override(dcache_assoc, override_cfg_mp, default_cfg_mp)            \
           ,`bp_aviary_parameter_override(dcache_block_width, override_cfg_mp, default_cfg_mp)      \
           ,`bp_aviary_parameter_override(dcache_fill_width, override_cfg_mp, default_cfg_mp)       \
+          ,`bp_aviary_parameter_override(dcache_mshr, override_cfg_mp, default_cfg_mp)             \
                                                                                                    \
           ,`bp_aviary_parameter_override(acache_features, override_cfg_mp, default_cfg_mp)         \
           ,`bp_aviary_parameter_override(acache_sets, override_cfg_mp, default_cfg_mp)             \
           ,`bp_aviary_parameter_override(acache_assoc, override_cfg_mp, default_cfg_mp)            \
           ,`bp_aviary_parameter_override(acache_block_width, override_cfg_mp, default_cfg_mp)      \
           ,`bp_aviary_parameter_override(acache_fill_width, override_cfg_mp, default_cfg_mp)       \
+          ,`bp_aviary_parameter_override(acache_mshr, override_cfg_mp, default_cfg_mp)             \
                                                                                                    \
           ,`bp_aviary_parameter_override(cce_type, override_cfg_mp, default_cfg_mp)                \
           ,`bp_aviary_parameter_override(cce_pc_width, override_cfg_mp, default_cfg_mp)            \

--- a/bp_common/src/include/bp_common_cache_engine_if.svh
+++ b/bp_common/src/include/bp_common_cache_engine_if.svh
@@ -5,9 +5,10 @@
 `ifndef BP_COMMON_CACHE_ENGINE_SVH
 `define BP_COMMON_CACHE_ENGINE_SVH
 
-  `define declare_bp_cache_req_s(data_width_mp, paddr_width_mp, cache_name_mp) \
+  `define declare_bp_cache_req_s(data_width_mp, paddr_width_mp, id_width_mp, cache_name_mp) \
     typedef struct packed                             \
     {                                                 \
+      logic [id_width_mp-1:0] id;                     \
       logic hit;                                      \
       logic [data_width_mp-1:0] data;                 \
       bp_cache_req_size_e size;                       \
@@ -16,8 +17,8 @@
       bp_cache_req_wr_subop_e subop;                  \
     }  bp_``cache_name_mp``_req_s
 
-  `define bp_cache_req_width(data_width_mp, paddr_width_mp) \
-    (1+data_width_mp+$bits(bp_cache_req_size_e)+paddr_width_mp+$bits(bp_cache_req_msg_type_e)+$bits(bp_cache_req_wr_subop_e))
+  `define bp_cache_req_width(data_width_mp, paddr_width_mp, id_width_mp, cache_name_mp) \
+    (id_width_mp+1+data_width_mp+$bits(bp_cache_req_size_e)+paddr_width_mp+$bits(bp_cache_req_msg_type_e)+$bits(bp_cache_req_wr_subop_e))
 
   `define declare_bp_cache_req_metadata_s(ways_mp, cache_name_mp) \
     typedef struct packed                                   \
@@ -29,52 +30,8 @@
   `define bp_cache_req_metadata_width(ways_mp) \
     (`BSG_SAFE_CLOG2(ways_mp)+1)
 
-    typedef enum logic [1:0]
-    {// write cache block
-     e_cache_data_mem_write
-     // read cache block
-     ,e_cache_data_mem_read
-     // write uncached load data
-     ,e_cache_data_mem_uncached
-    } bp_cache_data_mem_opcode_e;
-
-    // Tag mem pkt opcodes
-    typedef enum logic [2:0]
-    {// clear all blocks in a set for a given index
-     e_cache_tag_mem_set_clear
-     // set tag and coherence state for given index and way_id
-     ,e_cache_tag_mem_set_tag
-     // set coherence state for given index and way_id
-     ,e_cache_tag_mem_set_state
-     // invalidate all ways in the set
-     ,e_cache_tag_mem_set_inval
-     // read tag mem packets for writeback and transfer (Used for UCE)
-     ,e_cache_tag_mem_read
-    } bp_cache_tag_mem_opcode_e;
-
-    // Stat mem pkt opcodes
-    typedef enum logic [1:0]
-    {// clear all dirty bits and LRU bits to zero for given index.
-     e_cache_stat_mem_set_clear
-     // read stat_info for given index.
-     ,e_cache_stat_mem_read
-     // clear dirty bit for given index and way_id.
-     ,e_cache_stat_mem_clear_dirty
-    } bp_cache_stat_mem_opcode_e;
-
-  `define declare_bp_cache_data_mem_pkt_s(sets_mp, ways_mp, block_data_width_mp, fill_width_mp, cache_name_mp) \
-    typedef struct packed                                                                     \
-    {                                                                                         \
-      logic [`BSG_SAFE_CLOG2(sets_mp)-1:0]            index;                                  \
-      logic [`BSG_SAFE_CLOG2(ways_mp)-1:0]            way_id;                                 \
-      logic [fill_width_mp-1:0]                       data;                                   \
-      logic [(block_data_width_mp/fill_width_mp)-1:0] fill_index;                             \
-      bp_cache_data_mem_opcode_e                      opcode;                                 \
-    }  bp_``cache_name_mp``_data_mem_pkt_s
-
-  `define bp_cache_data_mem_pkt_width(sets_mp, ways_mp, block_data_width_mp, fill_width_mp)   \
-    (`BSG_SAFE_CLOG2(sets_mp)+`BSG_SAFE_CLOG2(ways_mp)+fill_width_mp                          \
-     +(block_data_width_mp/fill_width_mp)+$bits(bp_cache_data_mem_opcode_e))
+  `define bp_cache_data_mem_pkt_width(sets_mp, ways_mp, block_width_mp, fill_width_mp)   \
+    (`BSG_SAFE_CLOG2(sets_mp)+`BSG_SAFE_CLOG2(ways_mp)+fill_width_mp+(block_width_mp/fill_width_mp)+$bits(bp_cache_data_mem_opcode_e))
 
   `define declare_bp_cache_tag_mem_pkt_s(sets_mp, ways_mp, tag_width_mp, cache_name_mp) \
     typedef struct packed                                                          \
@@ -120,23 +77,33 @@
   `define bp_cache_stat_info_width(ways_mp) \
     (`BSG_MAX(2,2*ways_mp-1))
 
-  `define declare_bp_cache_engine_if(addr_width_mp, tag_width_mp, sets_mp, ways_mp, req_data_width_mp, block_data_width_mp, fill_width_mp, cache_name_mp) \
-    `declare_bp_cache_req_s(req_data_width_mp, addr_width_mp, cache_name_mp);                              \
-    `declare_bp_cache_req_metadata_s(ways_mp, cache_name_mp);                                              \
-    `declare_bp_cache_data_mem_pkt_s(sets_mp, ways_mp, block_data_width_mp, fill_width_mp, cache_name_mp); \
-    `declare_bp_cache_tag_mem_pkt_s(sets_mp, ways_mp, tag_width_mp, cache_name_mp);                        \
-    `declare_bp_cache_tag_info_s(tag_width_mp, cache_name_mp);                                             \
-    `declare_bp_cache_stat_mem_pkt_s(sets_mp, ways_mp, cache_name_mp);                                     \
+  `define declare_bp_cache_data_mem_pkt_s(sets_mp, ways_mp, block_width_mp, fill_width_mp, cache_name_mp) \
+  typedef struct packed                                                                     \
+  {                                                                                         \
+    logic [`BSG_SAFE_CLOG2(sets_mp)-1:0]            index;                                  \
+    logic [`BSG_SAFE_CLOG2(ways_mp)-1:0]            way_id;                                 \
+    logic [fill_width_mp-1:0]                       data;                                   \
+    logic [(block_width_mp/fill_width_mp)-1:0]      fill_index;                             \
+    bp_cache_data_mem_opcode_e                      opcode;                                 \
+  }  bp_``cache_name_mp``_data_mem_pkt_s
+
+  `define declare_bp_cache_engine_generic_if(addr_width_mp, tag_width_mp, sets_mp, ways_mp, data_width_mp, block_width_mp, fill_width_mp, id_width_mp, cache_name_mp) \
+    `declare_bp_cache_req_s(data_width_mp, addr_width_mp, id_width_mp, cache_name_mp);                               \
+    `declare_bp_cache_req_metadata_s(ways_mp, cache_name_mp);                                                        \
+    `declare_bp_cache_data_mem_pkt_s(sets_mp, ways_mp, block_width_mp, fill_width_mp, cache_name_mp);                \
+    `declare_bp_cache_tag_mem_pkt_s(sets_mp, ways_mp, tag_width_mp, cache_name_mp);                                  \
+    `declare_bp_cache_tag_info_s(tag_width_mp, cache_name_mp);                                                       \
+    `declare_bp_cache_stat_mem_pkt_s(sets_mp, ways_mp, cache_name_mp);                                               \
     `declare_bp_cache_stat_info_s(ways_mp, cache_name_mp);
 
-
-  `define declare_bp_cache_engine_if_widths(addr_width_mp, tag_width_mp, sets_mp, ways_mp, req_data_width_mp, block_data_width_mp, fill_width_mp, cache_name_mp) \
-    , localparam ``cache_name_mp``_req_width_lp = `bp_cache_req_width(req_data_width_mp, addr_width_mp)                                  \
+  `define declare_bp_cache_engine_generic_if_widths(addr_width_mp, tag_width_mp, sets_mp, ways_mp, data_width_mp, block_width_mp, fill_width_mp, id_width_mp, cache_name_mp) \
+    , localparam ``cache_name_mp``_req_width_lp = `bp_cache_req_width(data_width_mp, addr_width_mp, id_width_mp, cache_name_mp)                       \
     , localparam ``cache_name_mp``_req_metadata_width_lp = `bp_cache_req_metadata_width(ways_mp)                                         \
-    , localparam ``cache_name_mp``_data_mem_pkt_width_lp=`bp_cache_data_mem_pkt_width(sets_mp,ways_mp,block_data_width_mp,fill_width_mp) \
-    , localparam ``cache_name_mp``_tag_mem_pkt_width_lp=`bp_cache_tag_mem_pkt_width(sets_mp,ways_mp,tag_width_mp)                        \
-    , localparam ``cache_name_mp``_tag_info_width_lp=`bp_cache_tag_info_width(tag_width_mp)                                              \
-    , localparam ``cache_name_mp``_stat_mem_pkt_width_lp=`bp_cache_stat_mem_pkt_width(sets_mp,ways_mp)                                   \
-    , localparam ``cache_name_mp``_stat_info_width_lp=`bp_cache_stat_info_width(ways_mp)
+    , localparam ``cache_name_mp``_data_mem_pkt_width_lp = `bp_cache_data_mem_pkt_width(sets_mp, ways_mp, block_width_mp, fill_width_mp) \
+    , localparam ``cache_name_mp``_tag_mem_pkt_width_lp = `bp_cache_tag_mem_pkt_width(sets_mp, ways_mp, tag_width_mp)                    \
+    , localparam ``cache_name_mp``_tag_info_width_lp = `bp_cache_tag_info_width(tag_width_mp)                                            \
+    , localparam ``cache_name_mp``_stat_mem_pkt_width_lp = `bp_cache_stat_mem_pkt_width(sets_mp, ways_mp)                                \
+    , localparam ``cache_name_mp``_stat_info_width_lp = `bp_cache_stat_info_width(ways_mp)
 
 `endif
+

--- a/bp_common/src/include/bp_common_cache_engine_pkgdef.svh
+++ b/bp_common/src/include/bp_common_cache_engine_pkgdef.svh
@@ -44,5 +44,38 @@
     ,e_req_amomaxu = 4'b1011
   } bp_cache_req_wr_subop_e;
 
+  typedef enum logic [1:0]
+  { // write cache block
+    e_cache_data_mem_write
+    // read cache block
+    ,e_cache_data_mem_read
+    // write uncached load data
+    ,e_cache_data_mem_uncached
+  } bp_cache_data_mem_opcode_e;
+
+  // Tag mem pkt opcodes
+  typedef enum logic [2:0]
+  {// clear all blocks in a set for a given index
+    e_cache_tag_mem_set_clear
+    // set tag and coherence state for given index and way_id
+    ,e_cache_tag_mem_set_tag
+    // set coherence state for given index and way_id
+    ,e_cache_tag_mem_set_state
+    // invalidate all ways in the set
+    ,e_cache_tag_mem_set_inval
+    // read tag mem packets for writeback and transfer (Used for UCE)
+    ,e_cache_tag_mem_read
+  } bp_cache_tag_mem_opcode_e;
+
+  // Stat mem pkt opcodes
+  typedef enum logic [1:0]
+  { // clear all dirty bits and LRU bits to zero for given index.
+    e_cache_stat_mem_set_clear
+    // read stat_info for given index.
+    ,e_cache_stat_mem_read
+    // clear dirty bit for given index and way_id.
+    ,e_cache_stat_mem_clear_dirty
+  } bp_cache_stat_mem_opcode_e;
+
 `endif
 

--- a/bp_fe/src/include/bp_fe_defines.svh
+++ b/bp_fe/src/include/bp_fe_defines.svh
@@ -32,11 +32,5 @@
       logic [ghist_width_mp-1:0]                  ghist;                                          \
     }  bp_fe_branch_metadata_fwd_s;
 
-  `define bp_addr_is_aligned(addr_mp, num_bytes_mp) \
-    (!(|{ addr_mp[$clog2(num_bytes_mp)-1:0] }))
-
-  `define bp_addr_align(addr_mp, num_bytes_mp) \
-    ((addr_mp >> $clog2(num_bytes_mp)) << $clog2(num_bytes_mp))
-
 `endif
 

--- a/bp_fe/src/include/bp_fe_icache_defines.svh
+++ b/bp_fe/src/include/bp_fe_icache_defines.svh
@@ -12,5 +12,11 @@
   `define bp_fe_icache_pkt_width(vaddr_width_mp) \
     (1+vaddr_width_mp+$bits(bp_fe_icache_op_e))
 
+  `define declare_bp_fe_icache_engine_if(addr_width_mp, tag_width_mp, sets_mp, ways_mp, data_width_mp, block_width_mp, fill_width_mp, id_width_mp) \
+    `declare_bp_cache_engine_generic_if(addr_width_mp, tag_width_mp, sets_mp, ways_mp, data_width_mp, block_width_mp, fill_width_mp, id_width_mp, fe_icache)
+
+  `define declare_bp_fe_icache_engine_if_widths(addr_width_mp, tag_width_mp, sets_mp, ways_mp, data_width_mp, block_width_mp, fill_width_mp, id_width_mp) \
+    `declare_bp_cache_engine_generic_if_widths(addr_width_mp, tag_width_mp, sets_mp, ways_mp, data_width_mp, block_width_mp, fill_width_mp, id_width_mp, icache)
+
 `endif
 

--- a/bp_fe/src/include/bp_fe_icache_pkgdef.svh
+++ b/bp_fe/src/include/bp_fe_icache_pkgdef.svh
@@ -7,5 +7,18 @@
     ,e_icache_inval
   } bp_fe_icache_op_e;
 
+  typedef struct packed
+  {
+    logic fetch_op;
+    logic inval_op;
+  }  bp_fe_icache_decode_s;
+
+  typedef struct packed
+  {
+    bp_fe_icache_decode_s decode;
+    logic uncached;
+    logic spec;
+  }  bp_fe_icache_req_payload_s;
+
 `endif
 

--- a/bp_fe/src/v/bp_fe_icache.sv
+++ b/bp_fe/src/v/bp_fe_icache.sv
@@ -45,8 +45,9 @@ module bp_fe_icache
    , parameter block_width_p = icache_block_width_p
    , parameter fill_width_p  = icache_fill_width_p
    , parameter ctag_width_p  = icache_ctag_width_p
+   , parameter id_width_p    = icache_req_id_width_p
 
-   `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, icache)
+   `declare_bp_fe_icache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, id_width_p)
    , localparam cfg_bus_width_lp    = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    , localparam icache_pkt_width_lp = `bp_fe_icache_pkt_width(vaddr_width_p)
    )
@@ -109,8 +110,7 @@ module bp_fe_icache
    , input                                            cache_req_lock_i
    , output logic [icache_req_metadata_width_lp-1:0]  cache_req_metadata_o
    , output logic                                     cache_req_metadata_v_o
-   , input [paddr_width_p-1:0]                        cache_req_addr_i
-   , input [dword_width_gp-1:0]                       cache_req_data_i
+   , input [id_width_p-1:0]                           cache_req_id_i
    , input                                            cache_req_critical_i
    , input                                            cache_req_last_i
    , input                                            cache_req_credits_full_i
@@ -132,7 +132,7 @@ module bp_fe_icache
    , output logic [icache_stat_info_width_lp-1:0]     stat_mem_o
    );
 
-  `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, icache);
+  `declare_bp_fe_icache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, id_width_p);
   `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
@@ -174,15 +174,15 @@ module bp_fe_icache
   logic [block_width_p-1:0] snoop_data;
   logic [1:0][assoc_p-1:0] snoop_hit;
   logic [assoc_p-1:0] snoop_bank_sel_one_hot;
+  logic snoop_spec, snoop_uncached;
+  bp_fe_icache_decode_s snoop_decode;
 
   /////////////////////////////////////////////////////////////////////////////
   // Decode stage
   /////////////////////////////////////////////////////////////////////////////
   `declare_bp_fe_icache_pkt_s(vaddr_width_p);
   `bp_cast_i(bp_fe_icache_pkt_s, icache_pkt);
-
-  wire fetch_op  = (icache_pkt_cast_i.op inside {e_icache_fetch});
-  wire inval_op = (icache_pkt_cast_i.op inside {e_icache_inval});
+  bp_fe_icache_decode_s decode_lo;
 
   wire [vaddr_width_p-1:0]   vaddr       = icache_pkt_cast_i.vaddr;
   wire [vtag_width_p-1:0]    vaddr_vtag  = vaddr[(vaddr_width_p-1)-:vtag_width_p];
@@ -191,21 +191,25 @@ module bp_fe_icache
 
   wire spec = icache_pkt_cast_i.spec;
 
+  assign decode_lo = '{fetch_op : icache_pkt_cast_i.op inside {e_icache_fetch}
+                       ,inval_op: icache_pkt_cast_i.op inside {e_icache_inval}
+                       };
+
   assign yumi_o = safe_tl_we;
 
   ///////////////////////////
   // Tag Mem Storage
   ///////////////////////////
-  `bp_cast_i(bp_icache_tag_mem_pkt_s, tag_mem_pkt);
+  `bp_cast_i(bp_fe_icache_tag_mem_pkt_s, tag_mem_pkt);
   logic                              tag_mem_v_li;
   logic                              tag_mem_w_li;
   logic [sindex_width_lp-1:0]        tag_mem_addr_li;
-  bp_icache_tag_info_s [assoc_p-1:0] tag_mem_w_mask_li;
-  bp_icache_tag_info_s [assoc_p-1:0] tag_mem_data_li;
-  bp_icache_tag_info_s [assoc_p-1:0] tag_mem_data_lo;
+  bp_fe_icache_tag_info_s [assoc_p-1:0] tag_mem_w_mask_li;
+  bp_fe_icache_tag_info_s [assoc_p-1:0] tag_mem_data_li;
+  bp_fe_icache_tag_info_s [assoc_p-1:0] tag_mem_data_lo;
 
   bsg_mem_1rw_sync_mask_write_bit
-   #(.width_p(assoc_p*($bits(bp_icache_tag_info_s))), .els_p(sets_p), .latch_last_read_p(1))
+   #(.width_p(assoc_p*($bits(bp_fe_icache_tag_info_s))), .els_p(sets_p), .latch_last_read_p(1))
    tag_mem
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
@@ -220,7 +224,7 @@ module bp_fe_icache
   ///////////////////////////
   // Data Mem Storage
   ///////////////////////////
-  `bp_cast_i(bp_icache_data_mem_pkt_s, data_mem_pkt);
+  `bp_cast_i(bp_fe_icache_data_mem_pkt_s, data_mem_pkt);
   localparam data_mem_addr_width_lp = (assoc_p > 1) ? (sindex_width_lp+bindex_width_lp) : sindex_width_lp;
   logic [assoc_p-1:0]                             data_mem_v_li;
   logic [assoc_p-1:0]                             data_mem_w_li;
@@ -246,7 +250,8 @@ module bp_fe_icache
   // TL Stage
   /////////////////////////////////////////////////////////////////////////////
   logic [vaddr_width_p-1:0] vaddr_tl_r;
-  logic spec_tl_r, fetch_op_tl_r, inval_op_tl_r;
+  logic spec_tl_r;
+  bp_fe_icache_decode_s decode_tl_r;
 
   // Accept requests when we're in ready state and there's no blocked request in TL
   // Also accept request when 'forced'
@@ -268,13 +273,13 @@ module bp_fe_icache
 
   // Save stage information
   bsg_dff_reset_en
-   #(.width_p(vaddr_width_p+3))
+   #(.width_p(vaddr_width_p+1+$bits(bp_fe_icache_decode_s)))
    tl_stage_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
      ,.en_i(tl_we)
-     ,.data_i({vaddr, spec, fetch_op, inval_op})
-     ,.data_o({vaddr_tl_r, spec_tl_r, fetch_op_tl_r, inval_op_tl_r})
+     ,.data_i({vaddr, spec, decode_lo})
+     ,.data_o({vaddr_tl_r, spec_tl_r, decode_tl_r})
      );
 
   wire [paddr_width_p-1:0]         paddr_tl = {ptag_i, vaddr_tl_r[0+:page_offset_width_gp]};
@@ -294,8 +299,8 @@ module bp_fe_icache
     assign way_v_tl[i] = (tag_mem_data_lo[i].state != e_COH_I);
     assign hit_v_tl[i] = (tag_mem_data_lo[i].tag == ctag_li && way_v_tl[i]);
   end
-  wire fetch_uncached_tl = (fetch_op_tl_r &  ptag_uncached_i);
-  wire fetch_cached_tl   = (fetch_op_tl_r & ~ptag_uncached_i);
+  wire fetch_uncached_tl = (decode_tl_r.fetch_op &  ptag_uncached_i);
+  wire fetch_cached_tl   = (decode_tl_r.fetch_op & ~ptag_uncached_i);
   wire spec_tl           = (spec_tl_r & ptag_nonidem_i);
 
   logic [assoc_p-1:0] bank_sel_one_hot_tl;
@@ -312,14 +317,15 @@ module bp_fe_icache
   localparam snoop_offset_width_lp = `BSG_SAFE_CLOG2(fill_width_p/word_width_gp);
   logic [paddr_width_p-1:0]              paddr_tv_r;
   logic [assoc_p-1:0]                    bank_sel_one_hot_tv_r, way_v_tv_r, hit_v_tv_r;
-  logic                                  spec_tv_r, fetch_op_tv_r, inval_op_tv_r, uncached_op_tv_r;
+  logic                                  spec_tv_r, uncached_tv_r;
+  bp_fe_icache_decode_s                  decode_tv_r;
   logic                                  snoop_tv_r;
   logic [assoc_p-1:0][bank_width_lp-1:0] ld_data_tv_r;
 
   // fence.i does not check tags
   assign safe_tv_we = v_tl & (~v_tv_r || yumi_i);
   assign tv_we = safe_tv_we | poison_tv_i;
-  assign v_tv_n = v_tl & (ptag_v_i | inval_op_tl_r) & ~poison_tv_i;
+  assign v_tv_n = v_tl & (ptag_v_i | decode_tl_r.inval_op) & ~poison_tv_i;
   bsg_dff_reset_en
    #(.width_p(1))
    v_tv_reg
@@ -336,32 +342,33 @@ module bp_fe_icache
 
   logic [assoc_p-1:0] bank_sel_one_hot_tv_n, way_v_tv_n, hit_v_tv_n;
   logic [block_width_p-1:0] ld_data_tv_n;
+  logic spec_tv_n, uncached_tv_n;
+  bp_fe_icache_decode_s decode_tv_n;
   bsg_mux
-   #(.width_p(3*assoc_p+block_width_p), .els_p(2))
+   #(.width_p(3*assoc_p+block_width_p+2+$bits(bp_fe_icache_decode_s)), .els_p(2))
    hit_mux
-    (.data_i({{snoop_bank_sel_one_hot, snoop_hit, snoop_data}
-              ,{bank_sel_one_hot_tl, way_v_tl, hit_v_tl, data_mem_data_lo}
+    (.data_i({{snoop_bank_sel_one_hot, snoop_hit, snoop_data
+               ,snoop_spec, snoop_uncached, snoop_decode}
+              ,{bank_sel_one_hot_tl, way_v_tl, hit_v_tl, data_mem_data_lo
+                ,spec_tl, fetch_uncached_tl, decode_tl_r}
               })
      ,.sel_i(critical_recv)
-     ,.data_o({bank_sel_one_hot_tv_n, way_v_tv_n, hit_v_tv_n, ld_data_tv_n})
+     ,.data_o({bank_sel_one_hot_tv_n, way_v_tv_n, hit_v_tv_n, ld_data_tv_n
+               ,spec_tv_n, uncached_tv_n, decode_tv_n})
      );
 
   wire snoop_tv_n = critical_recv;
-  wire spec_tv_n = critical_recv ? spec_tv_r : spec_tl;
-  wire fetch_op_tv_n = critical_recv ? fetch_op_tv_r : fetch_op_tl_r;
-  wire inval_op_tv_n = critical_recv ? inval_op_tv_r : inval_op_tl_r;
-  wire uncached_op_tv_n = critical_recv ? uncached_op_tv_r : fetch_uncached_tl;
   bsg_dff_reset_en
-   #(.width_p(block_width_p+1+3*assoc_p+4))
+   #(.width_p(block_width_p+1+3*assoc_p+2+$bits(bp_fe_icache_decode_s)))
    tv_stage_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
      ,.en_i(tv_we | critical_recv)
      ,.data_i({ld_data_tv_n, snoop_tv_n, bank_sel_one_hot_tv_n, way_v_tv_n, hit_v_tv_n
-               ,spec_tv_n, fetch_op_tv_n, inval_op_tv_n, uncached_op_tv_n
+               ,spec_tv_n, uncached_tv_n, decode_tv_n
                })
      ,.data_o({ld_data_tv_r, snoop_tv_r, bank_sel_one_hot_tv_r, way_v_tv_r, hit_v_tv_r
-               ,spec_tv_r, fetch_op_tv_r, inval_op_tv_r, uncached_op_tv_r
+               ,spec_tv_r, uncached_tv_r, decode_tv_r
                })
      );
 
@@ -417,7 +424,7 @@ module bp_fe_icache
      ,.data_o(ld_data_way_picked)
      );
 
-  // TODO: Actual fix this
+  // TODO: Can retime manually for critical path?
   logic [instr_width_gp-1:0] final_data_tv;
   wire [`BSG_SAFE_CLOG2(num_instr_per_bank_lp)-1:0] ld_data_word_sel_tv =
     paddr_tv_r[2+:`BSG_SAFE_CLOG2(num_instr_per_bank_lp)];
@@ -434,20 +441,20 @@ module bp_fe_icache
 
   assign data_o[0+:cinstr_width_gp] = upper_not_lower ? final_data_upper : final_data_lower;
   assign data_o[cinstr_width_gp+:cinstr_width_gp] = final_data_upper;
-  assign fence_v_o = v_tv &  inval_op_tv_r & snoop_tv_r;
-  assign data_v_o  = v_tv & ~inval_op_tv_r &  hit_v_tv;
-  assign spec_v_o  = v_tv & ~inval_op_tv_r & ~hit_v_tv & spec_tv_r;
+  assign fence_v_o = v_tv &  decode_tv_r.inval_op & snoop_tv_r;
+  assign data_v_o  = v_tv & ~decode_tv_r.inval_op &  hit_v_tv;
+  assign spec_v_o  = v_tv & ~decode_tv_r.inval_op & ~hit_v_tv & spec_tv_r;
 
   ///////////////////////////
   // Stat Mem Storage
   ///////////////////////////
-  `bp_cast_i(bp_icache_stat_mem_pkt_s, stat_mem_pkt);
+  `bp_cast_i(bp_fe_icache_stat_mem_pkt_s, stat_mem_pkt);
   logic                       stat_mem_v_li;
   logic                       stat_mem_w_li;
   logic [sindex_width_lp-1:0] stat_mem_addr_li;
-  bp_icache_stat_info_s       stat_mem_data_li;
-  bp_icache_stat_info_s       stat_mem_mask_li;
-  bp_icache_stat_info_s       stat_mem_data_lo;
+  bp_fe_icache_stat_info_s       stat_mem_data_li;
+  bp_fe_icache_stat_info_s       stat_mem_mask_li;
+  bp_fe_icache_stat_info_s       stat_mem_data_lo;
 
   bsg_mem_1rw_sync_mask_write_bit
    #(.width_p(assoc_p-1), .els_p(sets_p), .latch_last_read_p(1))
@@ -473,15 +480,16 @@ module bp_fe_icache
   /////////////////////////////////////////////////////////////////////////////
   // Slow Path
   /////////////////////////////////////////////////////////////////////////////
-  `bp_cast_o(bp_icache_req_s, cache_req);
-  `bp_cast_o(bp_icache_req_metadata_s, cache_req_metadata);
+  `bp_cast_o(bp_fe_icache_req_s, cache_req);
+  `bp_cast_o(bp_fe_icache_req_metadata_s, cache_req_metadata);
 
   localparam block_req_size = bp_cache_req_size_e'(`BSG_SAFE_CLOG2(block_width_p/8));
   localparam uncached_req_size = e_size_4B;
 
-  wire cached_req   = fetch_op_tv_r & ~uncached_op_tv_r & ~snoop_tv_r & ~hit_v_tv;
-  wire uncached_req = fetch_op_tv_r &  uncached_op_tv_r & ~snoop_tv_r & ~hit_v_tv;
-  wire inval_req   = inval_op_tv_r & ~snoop_tv_r;
+  wire cached_req   = decode_tv_r.fetch_op & ~uncached_tv_r & ~snoop_tv_r & ~hit_v_tv;
+  wire uncached_req = decode_tv_r.fetch_op &  uncached_tv_r & ~snoop_tv_r & ~hit_v_tv;
+  wire inval_req    = decode_tv_r.inval_op & ~snoop_tv_r;
+
 
   assign cache_req_v_o = v_tv & ~spec_tv_r & |{uncached_req, cached_req, inval_req};
   assign cache_req_cast_o =
@@ -489,8 +497,9 @@ module bp_fe_icache
      ,size    : bp_cache_req_size_e'(cached_req ? block_req_size : uncached_req_size)
      ,msg_type: cached_req ? e_miss_load : uncached_req ? e_uc_load : e_cache_inval
      ,subop   : e_req_amoswap
-     ,data    : '0
      ,hit     : hit_v_tv
+     ,id      : '0
+     ,data    : '0
      };
 
   // The cache pipeline is designed to always send metadata a cycle after the request
@@ -594,7 +603,7 @@ module bp_fe_icache
             tag_mem_data_li[i]   = '{state: tag_mem_pkt_cast_i.state, tag: '0};
             tag_mem_w_mask_li[i] = '{state: {$bits(bp_coh_states_e){tag_mem_way_one_hot[i]}}, tag: '0};
           end
-        e_cache_tag_mem_set_inval:
+        {1'b0, e_cache_tag_mem_set_inval}:
           begin
             tag_mem_data_li[i] = '{state: bp_coh_states_e'('0), tag: '0};
             tag_mem_w_mask_li[i] = '{state: bp_coh_states_e'('1), tag: '0};
@@ -674,7 +683,7 @@ module bp_fe_icache
       assign data_mem_slow_read[i] = data_mem_pkt_yumi_o & (data_mem_pkt_cast_i.opcode == e_cache_data_mem_read);
       assign data_mem_slow_write[i] = data_mem_pkt_yumi_o & (data_mem_pkt_cast_i.opcode == e_cache_data_mem_write) & data_mem_write_bank_mask[i];
 
-      assign data_mem_fast_read[i] = is_recover || safe_tl_we & fetch_op & (~data_mem_bypass | data_mem_bypass_select[i]);
+      assign data_mem_fast_read[i] = is_recover || safe_tl_we & decode_lo.fetch_op & (~data_mem_bypass | data_mem_bypass_select[i]);
 
       assign data_mem_v_li[i] = data_mem_fast_read[i] | data_mem_slow_read[i] | data_mem_slow_write[i];
       assign data_mem_w_li[i] = data_mem_slow_write[i];
@@ -709,8 +718,8 @@ module bp_fe_icache
   ///////////////////////////
   // Stat Mem Control
   ///////////////////////////
-  wire stat_mem_fast_read = (v_tv & cache_req_v_o & ~uncached_op_tv_r);
-  wire stat_mem_fast_write = (v_tv & data_v_o & ~uncached_op_tv_r & ~inval_op_tv_r);
+  wire stat_mem_fast_read = (v_tv & cache_req_v_o & ~uncached_tv_r);
+  wire stat_mem_fast_write = (v_tv & data_v_o & ~uncached_tv_r & ~decode_tv_r.inval_op);
   wire stat_mem_slow_write = stat_mem_pkt_v_i & (stat_mem_pkt_cast_i.opcode != e_cache_stat_mem_read);
   assign stat_mem_pkt_yumi_o = stat_mem_pkt_v_i & ~stat_mem_fast_write & ~stat_mem_fast_read;
   assign stat_mem_v_li = stat_mem_fast_read | stat_mem_fast_write | stat_mem_pkt_yumi_o;
@@ -740,14 +749,10 @@ module bp_fe_icache
     (data_mem_pkt_v_i << data_mem_pkt_cast_i.way_id) | (tag_mem_pkt_v_i << tag_mem_pkt_cast_i.way_id);
   assign snoop_hit = {2{pseudo_hit}};
   assign snoop_data = data_mem_data_li;
-
-  wire [bindex_width_lp-1:0] snoop_bank = cache_req_addr_i[byte_offset_width_lp+:bindex_width_lp];
-  bsg_decode
-   #(.num_out_p(assoc_p))
-   snoop_offset_decode
-    (.i(snoop_bank)
-     ,.o(snoop_bank_sel_one_hot)
-     );
+  assign snoop_spec = spec_tv_r;
+  assign snoop_uncached = uncached_tv_r;
+  assign snoop_decode = decode_tv_r;
+  assign snoop_bank_sel_one_hot = bank_sel_one_hot_tv_r;
 
   // synopsys translate_off
   if (`BSG_SAFE_CLOG2(block_width_p*sets_p/8) > page_offset_width_gp) begin

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -12,7 +12,7 @@ module bp_fe_top
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_core_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
-   `declare_bp_cache_engine_if_widths(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache)
+   `declare_bp_fe_icache_engine_if_widths(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache_req_id_width_p)
 
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    )
@@ -35,8 +35,7 @@ module bp_fe_top
    , input                                            cache_req_lock_i
    , output logic [icache_req_metadata_width_lp-1:0]  cache_req_metadata_o
    , output logic                                     cache_req_metadata_v_o
-   , input [paddr_width_p-1:0]                        cache_req_addr_i
-   , input [dword_width_gp-1:0]                       cache_req_data_i
+   , input [icache_req_id_width_p-1:0]                cache_req_id_i
    , input                                            cache_req_critical_i
    , input                                            cache_req_last_i
    , input                                            cache_req_credits_full_i
@@ -260,8 +259,7 @@ module bp_fe_top
      ,.cache_req_lock_i(cache_req_lock_i)
      ,.cache_req_metadata_o(cache_req_metadata_o)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_o)
-     ,.cache_req_addr_i(cache_req_addr_i)
-     ,.cache_req_data_i(cache_req_data_i)
+     ,.cache_req_id_i(cache_req_id_i)
      ,.cache_req_critical_i(cache_req_critical_i)
      ,.cache_req_last_i(cache_req_last_i)
      ,.cache_req_credits_full_i(cache_req_credits_full_i)

--- a/bp_fe/test/common/bp_fe_nonsynth_icache_tracer.sv
+++ b/bp_fe/test/common/bp_fe_nonsynth_icache_tracer.sv
@@ -12,8 +12,9 @@ module bp_fe_nonsynth_icache_tracer
    , parameter fill_width_p = 512
    , parameter trace_file_p = "icache"
    , parameter ctag_width_p = 27
+   , parameter id_width_p = 1
     `declare_bp_proc_params(bp_params_p)
-    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache)
+    `declare_bp_fe_icache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, id_width_p)
 
    // Calculated parameters
    , localparam mhartid_width_lp = `BSG_SAFE_CLOG2(num_core_p)
@@ -34,11 +35,11 @@ module bp_fe_nonsynth_icache_tracer
    , input                                                data_v_o
    , input                                                spec_v_o
 
-   , input [cache_req_width_lp-1:0]                       cache_req_o
+   , input [icache_req_width_lp-1:0]                      cache_req_o
    , input                                                cache_req_v_o
    , input                                                cache_req_yumi_i
    , input                                                cache_req_lock_i
-   , input [cache_req_metadata_width_lp-1:0]              cache_req_metadata_o
+   , input [icache_req_metadata_width_lp-1:0]             cache_req_metadata_o
    , input                                                cache_req_metadata_v_o
    , input                                                cache_req_critical_i
    , input                                                cache_req_last_i
@@ -47,43 +48,43 @@ module bp_fe_nonsynth_icache_tracer
    , input                                                cache_req_credits_empty_i
 
    , input                                                data_mem_pkt_v_i
-   , input [cache_data_mem_pkt_width_lp-1:0]              data_mem_pkt_i
+   , input [icache_data_mem_pkt_width_lp-1:0]             data_mem_pkt_i
    , input                                                data_mem_pkt_yumi_o
    , input [block_width_p-1:0]                            data_mem_o
 
    , input                                                tag_mem_pkt_v_i
-   , input [cache_tag_mem_pkt_width_lp-1:0]               tag_mem_pkt_i
+   , input [icache_tag_mem_pkt_width_lp-1:0]              tag_mem_pkt_i
    , input                                                tag_mem_pkt_yumi_o
-   , input [cache_tag_info_width_lp-1:0]                  tag_mem_o
+   , input [icache_tag_info_width_lp-1:0]                 tag_mem_o
 
    , input                                                stat_mem_pkt_v_i
-   , input [cache_stat_mem_pkt_width_lp-1:0]              stat_mem_pkt_i
+   , input [icache_stat_mem_pkt_width_lp-1:0]             stat_mem_pkt_i
    , input                                                stat_mem_pkt_yumi_o
-   , input [cache_stat_info_width_lp-1:0]                 stat_mem_o
+   , input [icache_stat_info_width_lp-1:0]                stat_mem_o
 
    , input [paddr_width_p-1:0]                            paddr_tv_r
    );
 
-  `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache);
+  `declare_bp_fe_icache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, id_width_p);
   `declare_bp_fe_icache_pkt_s(vaddr_width_p);
   bp_fe_icache_pkt_s icache_pkt_cast_i;
   assign icache_pkt_cast_i = icache_pkt_i;
 
-  bp_cache_req_s cache_req_cast_o;
-  bp_cache_req_metadata_s cache_req_metadata_cast_o;
+  bp_fe_icache_req_s cache_req_cast_o;
+  bp_fe_icache_req_metadata_s cache_req_metadata_cast_o;
   assign cache_req_cast_o = cache_req_o;
   assign cache_req_metadata_cast_o = cache_req_metadata_o;
 
-  bp_cache_data_mem_pkt_s data_mem_pkt_cast_i;
-  bp_cache_tag_mem_pkt_s tag_mem_pkt_cast_i;
-  bp_cache_stat_mem_pkt_s stat_mem_pkt_cast_i;
+  bp_fe_icache_data_mem_pkt_s data_mem_pkt_cast_i;
+  bp_fe_icache_tag_mem_pkt_s tag_mem_pkt_cast_i;
+  bp_fe_icache_stat_mem_pkt_s stat_mem_pkt_cast_i;
   assign data_mem_pkt_cast_i = data_mem_pkt_i;
   assign tag_mem_pkt_cast_i = tag_mem_pkt_i;
   assign stat_mem_pkt_cast_i = stat_mem_pkt_i;
 
   logic [assoc_p-1:0][bank_width_lp-1:0] data_mem_cast_o;
-  bp_cache_tag_info_s tag_mem_info_cast_o;
-  bp_cache_tag_info_s stat_mem_info_cast_o;
+  bp_fe_icache_tag_info_s tag_mem_info_cast_o;
+  bp_fe_icache_tag_info_s stat_mem_info_cast_o;
   assign data_mem_cast_o = data_mem_o;
   assign tag_mem_info_cast_o = tag_mem_o;
   assign stat_mem_info_cast_o = stat_mem_o;

--- a/bp_fe/test/tb/bp_fe_icache/wrapper.sv
+++ b/bp_fe/test/tb/bp_fe_icache/wrapper.sv
@@ -10,8 +10,9 @@ module wrapper
    , parameter assoc_p = icache_assoc_p
    , parameter block_width_p = icache_block_width_p
    , parameter fill_width_p = icache_fill_width_p
+   , parameter id_width_p = icache_req_id_width_p
    `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
-   `declare_bp_cache_engine_if_widths(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache)
+   `declare_bp_cache_engine_generic_if_widths(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache_req_id_width_p, icache)
 
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    )
@@ -55,8 +56,7 @@ module wrapper
   logic cache_req_v_lo;
   logic [icache_req_metadata_width_lp-1:0] cache_req_metadata_lo;
   logic cache_req_metadata_v_lo;
-  logic [paddr_width_p-1:0] cache_req_addr_li;
-  logic [dword_width_gp-1:0] cache_req_data_li;
+  logic [icache_req_id_width_p-1:0] cache_req_id_li;
   logic cache_req_critical_li, cache_req_last_li;
   logic cache_req_credits_full_li, cache_req_credits_empty_li;
 
@@ -130,8 +130,7 @@ module wrapper
      ,.cache_req_lock_i(cache_req_lock_li)
      ,.cache_req_metadata_o(cache_req_metadata_lo)
      ,.cache_req_metadata_v_o(cache_req_metadata_v_lo)
-     ,.cache_req_addr_i(cache_req_addr_li)
-     ,.cache_req_data_i(cache_req_data_li)
+     ,.cache_req_id_i(cache_req_id_li)
      ,.cache_req_critical_i(cache_req_critical_li)
      ,.cache_req_last_i(cache_req_last_li)
      ,.cache_req_credits_full_i(cache_req_credits_full_li)
@@ -181,6 +180,7 @@ module wrapper
        ,.sets_p(icache_sets_p)
        ,.block_width_p(icache_block_width_p)
        ,.fill_width_p(icache_fill_width_p)
+       ,.id_width_p(icache_req_id_width_p)
        ,.timeout_max_limit_p(4)
        ,.credits_p(coh_noc_max_credits_p)
        ,.non_excl_reads_p(1)
@@ -190,6 +190,7 @@ module wrapper
       (.clk_i(clk_i)
        ,.reset_i(reset_i)
 
+       ,.did_i('0)
        ,.lce_id_i(cfg_bus_cast_i.icache_id)
        ,.lce_mode_i(cfg_bus_cast_i.icache_mode)
 
@@ -199,8 +200,7 @@ module wrapper
        ,.cache_req_lock_o(cache_req_lock_li)
        ,.cache_req_metadata_i(cache_req_metadata_lo)
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
-       ,.cache_req_addr_o(cache_req_addr_li)
-       ,.cache_req_data_o(cache_req_data_li)
+       ,.cache_req_id_o(cache_req_id_li)
        ,.cache_req_critical_o(cache_req_critical_li)
        ,.cache_req_last_o(cache_req_last_li)
        ,.cache_req_credits_full_o(cache_req_credits_full_li)
@@ -295,6 +295,7 @@ module wrapper
        ,.block_width_p(icache_block_width_p)
        ,.fill_width_p(icache_fill_width_p)
        ,.ctag_width_p(icache_ctag_width_p)
+       ,.id_width_p(icache_req_id_width_p)
        ,.writeback_p(icache_features_p[e_cfg_writeback])
        )
      icache_uce
@@ -309,8 +310,7 @@ module wrapper
        ,.cache_req_lock_o(cache_req_lock_li)
        ,.cache_req_metadata_i(cache_req_metadata_lo)
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo)
-       ,.cache_req_addr_o(cache_req_addr_li)
-       ,.cache_req_data_o(cache_req_data_li)
+       ,.cache_req_id_o(cache_req_id_li)
        ,.cache_req_critical_o(cache_req_critical_li)
        ,.cache_req_last_o(cache_req_last_li)
        ,.cache_req_credits_full_o(cache_req_credits_full_li)

--- a/bp_me/src/v/cce/bp_uce.sv
+++ b/bp_me/src/v/cce/bp_uce.sv
@@ -23,8 +23,9 @@ module bp_uce
     , parameter `BSG_INV_PARAM(block_width_p)
     , parameter `BSG_INV_PARAM(fill_width_p)
     , parameter `BSG_INV_PARAM(ctag_width_p)
+    , parameter `BSG_INV_PARAM(id_width_p)
 
-    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache)
+    `declare_bp_cache_engine_generic_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, id_width_p, cache)
     )
    (input                                            clk_i
     , input                                          reset_i
@@ -38,8 +39,7 @@ module bp_uce
     , output logic                                   cache_req_lock_o
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
-    , output logic [paddr_width_p-1:0]               cache_req_addr_o
-    , output logic [dword_width_gp-1:0]              cache_req_data_o
+    , output logic [id_width_p-1:0]                  cache_req_id_o
     , output logic                                   cache_req_critical_o
     , output logic                                   cache_req_last_o
     , output logic                                   cache_req_credits_full_o
@@ -96,7 +96,7 @@ module bp_uce
                                                              : e_bedrock_msg_size_64;
 
   `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
-  `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache);
+  `declare_bp_cache_engine_generic_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, id_width_p, cache);
 
   `bp_cast_i(bp_cache_req_s, cache_req);
   `bp_cast_i(bp_cache_req_metadata_s, cache_req_metadata);
@@ -284,8 +284,6 @@ module bp_uce
      ,.fsm_critical_o(fsm_rev_critical_li)
      ,.fsm_last_o(fsm_rev_last_li)
      );
-  assign cache_req_addr_o = cache_req_r.addr;
-  assign cache_req_data_o = cache_req_r.data;
 
   // We check for uncached stores ealier than other requests, because they get sent out in ready
   wire clean_v_li         = cache_req_v_i & cache_req_cast_i.msg_type inside {e_cache_clean};

--- a/bp_me/src/v/lce/bp_lce.sv
+++ b/bp_me/src/v/lce/bp_lce.sv
@@ -21,6 +21,7 @@ module bp_lce
    , parameter `BSG_INV_PARAM(sets_p)
    , parameter `BSG_INV_PARAM(block_width_p)
    , parameter `BSG_INV_PARAM(fill_width_p)
+   , parameter `BSG_INV_PARAM(id_width_p)
 
    // LCE-cache interface timeout in cycles
    , parameter timeout_max_limit_p=4
@@ -31,7 +32,7 @@ module bp_lce
    , parameter `BSG_INV_PARAM(ctag_width_p)
 
    `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
-   `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache)
+   `declare_bp_cache_engine_generic_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, id_width_p, cache)
   )
   (
     input                                            clk_i
@@ -52,9 +53,8 @@ module bp_lce
     , output logic                                   cache_req_lock_o
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
-    , output logic [paddr_width_p-1:0]               cache_req_addr_o
-    , output logic [dword_width_gp-1:0]              cache_req_data_o
     , output logic                                   cache_req_critical_o
+    , output logic [id_width_p-1:0]                  cache_req_id_o
     , output logic                                   cache_req_last_o
     , output logic                                   cache_req_credits_full_o
     , output logic                                   cache_req_credits_empty_o
@@ -120,7 +120,7 @@ module bp_lce
   if (fill_width_p < dword_width_gp)
     $error("fill width must be greater or equal than cache request data width");
 
-  `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache);
+  `declare_bp_cache_engine_generic_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, id_width_p, cache);
   `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
 
   // LCE Request Module
@@ -138,6 +138,7 @@ module bp_lce
      ,.ctag_width_p(ctag_width_p)
      ,.credits_p(credits_p)
      ,.non_excl_reads_p(non_excl_reads_p)
+     ,.id_width_p(id_width_p)
      )
    request
     (.clk_i(clk_i)
@@ -160,8 +161,6 @@ module bp_lce
      ,.credits_empty_o(cache_req_credits_empty_o)
      ,.credit_return_i(credit_return_lo)
      ,.cache_req_done_i(cache_req_done_lo)
-     ,.cache_req_addr_o(cache_req_addr_o)
-     ,.cache_req_data_o(cache_req_data_o)
 
      ,.lce_req_header_o(lce_req_header_o)
      ,.lce_req_data_o(lce_req_data_o)
@@ -230,6 +229,7 @@ module bp_lce
      ,.block_width_p(block_width_p)
      ,.fill_width_p(fill_width_p)
      ,.ctag_width_p(ctag_width_p)
+     ,.id_width_p(id_width_p)
      )
    command
     (.clk_i(clk_i)
@@ -240,6 +240,7 @@ module bp_lce
 
      ,.cache_init_done_o(cache_init_done_lo)
      ,.sync_done_o(sync_done_lo)
+     ,.cache_req_id_o(cache_req_id_o)
      ,.cache_req_critical_o(cache_req_critical_o)
      ,.cache_req_last_o(cache_req_last_o)
      ,.credit_return_o(credit_return_lo)

--- a/bp_me/src/v/lce/bp_lce_cmd.sv
+++ b/bp_me/src/v/lce/bp_lce_cmd.sv
@@ -23,9 +23,10 @@ module bp_lce_cmd
    , parameter `BSG_INV_PARAM(block_width_p)
    , parameter `BSG_INV_PARAM(fill_width_p)
    , parameter `BSG_INV_PARAM(ctag_width_p)
+   , parameter `BSG_INV_PARAM(id_width_p)
 
    `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
-   `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache)
+   `declare_bp_cache_engine_generic_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, id_width_p, cache)
   )
   (
     input                                            clk_i
@@ -60,6 +61,7 @@ module bp_lce_cmd
     // request complete signals
     // cached requests and uncached loads block in the caches, but uncached stores do not
     // cache_req_last_o is routed to the cache to indicate a blocking request is complete
+    , output logic [id_width_p-1:0]                  cache_req_id_o
     , output logic                                   cache_req_critical_o
     , output logic                                   cache_req_last_o
 
@@ -88,7 +90,7 @@ module bp_lce_cmd
     );
 
   `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
-  `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache);
+  `declare_bp_cache_engine_generic_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, id_width_p, cache);
   `bp_cast_i(bp_bedrock_lce_cmd_header_s, lce_cmd_header);
   `bp_cast_o(bp_bedrock_lce_fill_header_s, lce_fill_header);
   `bp_cast_o(bp_bedrock_lce_resp_header_s, lce_resp_header);
@@ -335,6 +337,7 @@ module bp_lce_cmd
     // raised request is fully resolved
     cache_req_last_o = 1'b0;
     cache_req_critical_o = 1'b0;
+    cache_req_id_o = '0; // Only 1 outstanding request supported
 
     // LCE-CCE Interface signals
     fsm_cmd_yumi_lo = 1'b0;

--- a/bp_me/src/v/lce/bp_lce_req.sv
+++ b/bp_me/src/v/lce/bp_lce_req.sv
@@ -24,6 +24,7 @@ module bp_lce_req
    , parameter `BSG_INV_PARAM(block_width_p)
    , parameter `BSG_INV_PARAM(fill_width_p)
    , parameter `BSG_INV_PARAM(ctag_width_p)
+   , parameter `BSG_INV_PARAM(id_width_p)
 
    // LCE-cache interface timeout in cycles
    , parameter timeout_max_limit_p=4
@@ -37,7 +38,7 @@ module bp_lce_req
    , localparam bit [paddr_width_p-1:0] req_addr_mask = {paddr_width_p{1'b1}} << bedrock_byte_offset_lp
 
    `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
-   `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache)
+   `declare_bp_cache_engine_generic_if_widths(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, id_width_p, cache)
   )
   (
     input                                            clk_i
@@ -62,8 +63,6 @@ module bp_lce_req
     , output logic                                   cache_req_yumi_o
     , input [cache_req_metadata_width_lp-1:0]        cache_req_metadata_i
     , input                                          cache_req_metadata_v_i
-    , output logic [paddr_width_p-1:0]               cache_req_addr_o
-    , output logic [dword_width_gp-1:0]              cache_req_data_o
 
     // LCE-Cache Interface
     , output logic                                   credits_full_o
@@ -85,7 +84,7 @@ module bp_lce_req
   );
 
   `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
-  `declare_bp_cache_engine_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache);
+  `declare_bp_cache_engine_generic_if(paddr_width_p, ctag_width_p, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, id_width_p, cache);
   `bp_cast_o(bp_bedrock_lce_req_header_s, lce_req_header);
   `bp_cast_i(bp_cache_req_s, cache_req);
   `bp_cast_i(bp_cache_req_metadata_s, cache_req_metadata);
@@ -114,8 +113,6 @@ module bp_lce_req
      ,.v_o(cache_req_v_r)
      ,.yumi_i(cache_req_done)
      );
-  assign cache_req_addr_o = cache_req_r.addr;
-  assign cache_req_data_o = cache_req_r.data;
 
   bp_cache_req_metadata_s cache_req_metadata, cache_req_metadata_r;
   logic cache_req_metadata_v_r;

--- a/bp_me/test/common/bp_me_nonsynth_cache.sv
+++ b/bp_me/test/common/bp_me_nonsynth_cache.sv
@@ -31,6 +31,7 @@ module bp_me_nonsynth_cache
     , parameter assoc_p = 8
     , parameter block_width_p = 512
     , parameter fill_width_p = 64
+    , parameter id_width_p = 1
 
     , localparam lg_sets_lp=`BSG_SAFE_CLOG2(sets_p)
     , localparam lg_assoc_lp=`BSG_SAFE_CLOG2(assoc_p)
@@ -46,7 +47,7 @@ module bp_me_nonsynth_cache
 
     , localparam ctag_width_lp = caddr_width_p - (block_offset_width_lp+lg_sets_lp)
 
-    `declare_bp_cache_engine_if_widths(paddr_width_p, ctag_width_lp, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache)
+    `declare_bp_cache_engine_generic_if_widths(paddr_width_p, ctag_width_lp, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, id_width_p, cache)
    )
    (
     input                                                   clk_i
@@ -71,8 +72,7 @@ module bp_me_nonsynth_cache
     , input                                                 cache_req_lock_i
     , output logic [cache_req_metadata_width_lp-1:0]        cache_req_metadata_o
     , output logic                                          cache_req_metadata_v_o
-    , input [paddr_width_p-1:0]                             cache_req_addr_i
-    , input [dword_width_gp-1:0]                            cache_req_data_i
+    , input [id_width_p-1:0]                                cache_req_id_i
     , input                                                 cache_req_critical_i
     , input                                                 cache_req_last_i
     , input                                                 cache_req_credits_full_i
@@ -95,7 +95,7 @@ module bp_me_nonsynth_cache
     , output logic [cache_stat_info_width_lp-1:0]           stat_mem_o
    );
 
-  `declare_bp_cache_engine_if(paddr_width_p, ctag_width_lp, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, cache);
+  `declare_bp_cache_engine_generic_if(paddr_width_p, ctag_width_lp, sets_p, assoc_p, dword_width_gp, block_width_p, fill_width_p, id_width_p, cache);
 
     localparam bp_cache_req_size_e block_req_size = bp_cache_req_size_e'(`BSG_SAFE_CLOG2(block_width_p/8));
 

--- a/bp_me/test/tb/bp_cce/testbench.sv
+++ b/bp_me/test/tb/bp_cce/testbench.sv
@@ -42,7 +42,7 @@ module testbench
    , localparam trace_rom_addr_width_lp = 20
 
    `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
-   `declare_bp_cache_engine_if_widths(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, cache)
+   `declare_bp_cache_engine_generic_if_widths(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache_req_id_width_p, cache)
    )
   (output bit reset_i);
 
@@ -286,14 +286,13 @@ module testbench
      ,.msg_ready_and_i(lce_cmd_ready_and_lo)
      );
 
-  `declare_bp_cache_engine_if(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, cache);
+  `declare_bp_cache_engine_generic_if(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache_req_id_width_p, cache);
 
   bp_cache_req_s [num_lce_p-1:0] cache_req_lo;
   logic [num_lce_p-1:0] cache_req_v_lo, cache_req_yumi_li, cache_req_lock_li;
   bp_cache_req_metadata_s [num_lce_p-1:0] cache_req_metadata_lo;
   logic [num_lce_p-1:0] cache_req_metadata_v_lo;
-  logic [num_lce_p-1:0][paddr_width_p-1:0] cache_req_addr_li;
-  logic [num_lce_p-1:0][dword_width_gp-1:0] cache_req_data_li;
+  logic [num_lce_p-1:0] cache_req_id_li;
   logic [num_lce_p-1:0] cache_req_critical_li, cache_req_last_li;
   logic [num_lce_p-1:0] cache_req_credits_full_li, cache_req_credits_empty_li;
 
@@ -383,8 +382,7 @@ module testbench
        ,.cache_req_lock_i(cache_req_lock_li[i])
        ,.cache_req_metadata_o(cache_req_metadata_lo[i])
        ,.cache_req_metadata_v_o(cache_req_metadata_v_lo[i])
-       ,.cache_req_addr_i(cache_req_addr_li[i])
-       ,.cache_req_data_i(cache_req_data_li[i])
+       ,.cache_req_id_i(cache_req_id_li[i])
        ,.cache_req_critical_i(cache_req_critical_li[i])
        ,.cache_req_last_i(cache_req_last_li[i])
        ,.cache_req_credits_full_i(cache_req_credits_full_li[i])
@@ -418,6 +416,7 @@ module testbench
        ,.sets_p(icache_sets_p)
        ,.block_width_p(bedrock_block_width_p)
        ,.fill_width_p(bedrock_fill_width_p)
+       ,.id_width_p(icache_req_id_width_p)
        ,.timeout_max_limit_p(4)
        ,.credits_p(coh_noc_max_credits_p)
        ,.ctag_width_p(icache_ctag_width_p)
@@ -426,6 +425,7 @@ module testbench
       (.clk_i(clk_i)
        ,.reset_i(reset_i)
 
+       ,.did_i('0)
        ,.lce_id_i(lce_id_width_p'(i))
        ,.lce_mode_i(cfg_bus_lo.icache_mode)
 
@@ -435,8 +435,7 @@ module testbench
        ,.cache_req_lock_o(cache_req_lock_li[i])
        ,.cache_req_metadata_i(cache_req_metadata_lo[i])
        ,.cache_req_metadata_v_i(cache_req_metadata_v_lo[i])
-       ,.cache_req_addr_o(cache_req_addr_li[i])
-       ,.cache_req_data_o(cache_req_data_li[i])
+       ,.cache_req_id_o(cache_req_id_li[i])
        ,.cache_req_critical_o(cache_req_critical_li[i])
        ,.cache_req_last_o(cache_req_last_li[i])
        ,.cache_req_credits_full_o(cache_req_credits_full_li[i])

--- a/bp_top/src/v/bp_cacc_tile.sv
+++ b/bp_top/src/v/bp_cacc_tile.sv
@@ -146,74 +146,76 @@ module bp_cacc_tile
      ,.mem_rev_ready_and_o(mem_rev_ready_and_lo)
      );
 
-  if (cacc_type_p == e_cacc_vdp) begin : cacc_vdp
-    bp_cacc_vdp
-     #(.bp_params_p(bp_params_p))
-     accelerator_link
-      (.clk_i(clk_i)
-       ,.reset_i(reset_r)
+  if (cacc_type_p == e_cacc_vdp)
+    begin : cacc_vdp
+      bp_cacc_vdp
+       #(.bp_params_p(bp_params_p))
+       accelerator_link
+        (.clk_i(clk_i)
+         ,.reset_i(reset_r)
 
-       ,.lce_id_i(lce_id_li)
+         ,.lce_id_i(lce_id_li)
 
-       ,.mem_fwd_header_i(mem_fwd_header_lo)
-       ,.mem_fwd_data_i(mem_fwd_data_lo)
-       ,.mem_fwd_v_i(mem_fwd_v_lo)
-       ,.mem_fwd_ready_and_o(mem_fwd_ready_and_li)
+         ,.mem_fwd_header_i(mem_fwd_header_lo)
+         ,.mem_fwd_data_i(mem_fwd_data_lo)
+         ,.mem_fwd_v_i(mem_fwd_v_lo)
+         ,.mem_fwd_ready_and_o(mem_fwd_ready_and_li)
 
-       ,.mem_rev_header_o(mem_rev_header_li)
-       ,.mem_rev_data_o(mem_rev_data_li)
-       ,.mem_rev_v_o(mem_rev_v_li)
-       ,.mem_rev_ready_and_i(mem_rev_ready_and_lo)
+         ,.mem_rev_header_o(mem_rev_header_li)
+         ,.mem_rev_data_o(mem_rev_data_li)
+         ,.mem_rev_v_o(mem_rev_v_li)
+         ,.mem_rev_ready_and_i(mem_rev_ready_and_lo)
 
-       ,.lce_req_header_o(lce_req_header_lo)
-       ,.lce_req_data_o(lce_req_data_lo)
-       ,.lce_req_v_o(lce_req_v_lo)
-       ,.lce_req_ready_and_i(lce_req_ready_and_li)
+         ,.lce_req_header_o(lce_req_header_lo)
+         ,.lce_req_data_o(lce_req_data_lo)
+         ,.lce_req_v_o(lce_req_v_lo)
+         ,.lce_req_ready_and_i(lce_req_ready_and_li)
 
-       ,.lce_cmd_header_i(lce_cmd_header_li)
-       ,.lce_cmd_data_i(lce_cmd_data_li)
-       ,.lce_cmd_v_i(lce_cmd_v_li)
-       ,.lce_cmd_ready_and_o(lce_cmd_ready_and_lo)
+         ,.lce_cmd_header_i(lce_cmd_header_li)
+         ,.lce_cmd_data_i(lce_cmd_data_li)
+         ,.lce_cmd_v_i(lce_cmd_v_li)
+         ,.lce_cmd_ready_and_o(lce_cmd_ready_and_lo)
 
-       ,.lce_fill_header_i(lce_fill_header_li)
-       ,.lce_fill_data_i(lce_fill_data_li)
-       ,.lce_fill_v_i(lce_fill_v_li)
-       ,.lce_fill_ready_and_o(lce_fill_ready_and_lo)
+         ,.lce_fill_header_i(lce_fill_header_li)
+         ,.lce_fill_data_i(lce_fill_data_li)
+         ,.lce_fill_v_i(lce_fill_v_li)
+         ,.lce_fill_ready_and_o(lce_fill_ready_and_lo)
 
-       ,.lce_fill_header_o(lce_fill_header_lo)
-       ,.lce_fill_data_o(lce_fill_data_lo)
-       ,.lce_fill_v_o(lce_fill_v_lo)
-       ,.lce_fill_ready_and_i(lce_fill_ready_and_li)
+         ,.lce_fill_header_o(lce_fill_header_lo)
+         ,.lce_fill_data_o(lce_fill_data_lo)
+         ,.lce_fill_v_o(lce_fill_v_lo)
+         ,.lce_fill_ready_and_i(lce_fill_ready_and_li)
 
-       ,.lce_resp_header_o(lce_resp_header_lo)
-       ,.lce_resp_data_o(lce_resp_data_lo)
-       ,.lce_resp_v_o(lce_resp_v_lo)
-       ,.lce_resp_ready_and_i(lce_resp_ready_and_li)
-       );
-  end
-  else begin : none
-    assign mem_fwd_ready_and_li = '0;
+         ,.lce_resp_header_o(lce_resp_header_lo)
+         ,.lce_resp_data_o(lce_resp_data_lo)
+         ,.lce_resp_v_o(lce_resp_v_lo)
+         ,.lce_resp_ready_and_i(lce_resp_ready_and_li)
+         );
+    end
+  else
+    begin : none
+      assign mem_fwd_ready_and_li = '0;
 
-    assign mem_rev_header_li = '0;
-    assign mem_rev_data_li = '0;
-    assign mem_rev_v_li = '0;
+      assign mem_rev_header_li = '0;
+      assign mem_rev_data_li = '0;
+      assign mem_rev_v_li = '0;
 
-    assign lce_req_header_lo = '0;
-    assign lce_req_data_lo = '0;
-    assign lce_req_v_lo = '0;
+      assign lce_req_header_lo = '0;
+      assign lce_req_data_lo = '0;
+      assign lce_req_v_lo = '0;
 
-    assign lce_cmd_ready_and_lo = '0;
+      assign lce_cmd_ready_and_lo = '0;
 
-    assign lce_fill_header_lo = '0;
-    assign lce_fill_data_lo = '0;
-    assign lce_fill_v_lo = '0;
+      assign lce_fill_header_lo = '0;
+      assign lce_fill_data_lo = '0;
+      assign lce_fill_v_lo = '0;
 
-    assign lce_fill_ready_and_lo = '0;
+      assign lce_fill_ready_and_lo = '0;
 
-    assign lce_resp_header_lo = '0;
-    assign lce_resp_data_lo = '0;
-    assign lce_resp_v_lo = '0;
-  end
+      assign lce_resp_header_lo = '0;
+      assign lce_resp_data_lo = '0;
+      assign lce_resp_v_lo = '0;
+    end
 
   // Burst to WH (lce_req_header_lo)
   bp_me_cce_id_to_cord

--- a/bp_top/src/v/bp_cacc_vdp.sv
+++ b/bp_top/src/v/bp_cacc_vdp.sv
@@ -10,7 +10,7 @@ module bp_cacc_vdp
   #(parameter bp_params_e bp_params_p = e_bp_default_cfg
     `declare_bp_proc_params(bp_params_p)
     `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
-    `declare_bp_cache_engine_if_widths(paddr_width_p, acache_ctag_width_p, acache_sets_p, acache_assoc_p, dword_width_gp, acache_block_width_p, acache_fill_width_p, acache)
+    `declare_bp_be_dcache_engine_if_widths(paddr_width_p, acache_ctag_width_p, acache_sets_p, acache_assoc_p, dword_width_gp, acache_block_width_p, acache_fill_width_p, acache_req_id_width_p)
 
     , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
     )
@@ -105,24 +105,23 @@ module bp_cacc_vdp
   assign cfg_bus_cast_i.dcache_id = lce_id_i;
   assign cfg_bus_cast_i.dcache_mode = e_lce_mode_normal;
 
-  `declare_bp_cache_engine_if(paddr_width_p, acache_ctag_width_p, acache_sets_p, acache_assoc_p, dword_width_gp, acache_block_width_p, acache_fill_width_p, acache);
-  bp_acache_req_s acache_req_lo;
+  `declare_bp_be_dcache_engine_if(paddr_width_p, acache_ctag_width_p, acache_sets_p, acache_assoc_p, dword_width_gp, acache_block_width_p, acache_fill_width_p, acache_req_id_width_p);
+  bp_be_dcache_req_s acache_req_lo;
   logic acache_req_v_lo, acache_req_yumi_li, acache_req_lock_li;
-  bp_acache_req_metadata_s acache_req_metadata_lo;
+  bp_be_dcache_req_metadata_s acache_req_metadata_lo;
   logic acache_req_metadata_v_lo;
-  logic [paddr_width_p-1:0] acache_req_addr_lo;
-  logic [dword_width_gp-1:0] acache_req_data_lo;
+  logic [acache_req_id_width_p-1:0] acache_req_id_lo;
   logic acache_req_last_lo, acache_req_critical_lo;
   logic acache_req_credits_full_lo, acache_req_credits_empty_lo;
-  bp_acache_data_mem_pkt_s acache_data_mem_pkt_li;
+  bp_be_dcache_data_mem_pkt_s acache_data_mem_pkt_li;
   logic acache_data_mem_pkt_v_li, acache_data_mem_pkt_yumi_lo;
   logic [acache_block_width_p-1:0] acache_data_mem_lo;
-  bp_acache_tag_mem_pkt_s acache_tag_mem_pkt_li;
+  bp_be_dcache_tag_mem_pkt_s acache_tag_mem_pkt_li;
   logic acache_tag_mem_pkt_v_li, acache_tag_mem_pkt_yumi_lo;
-  bp_acache_tag_info_s acache_tag_mem_lo;
-  bp_acache_stat_mem_pkt_s acache_stat_mem_pkt_li;
+  bp_be_dcache_tag_info_s acache_tag_mem_lo;
+  bp_be_dcache_stat_mem_pkt_s acache_stat_mem_pkt_li;
   logic acache_stat_mem_pkt_v_li, acache_stat_mem_pkt_yumi_lo;
-  bp_acache_stat_info_s acache_stat_mem_lo;
+  bp_be_dcache_stat_info_s acache_stat_mem_lo;
 
   logic [ptag_width_p-1:0] acache_ptag_li;
   logic [dword_width_gp-1:0] acache_st_data_r;
@@ -144,6 +143,7 @@ module bp_cacc_vdp
      ,.v_i(acache_v_li)
      ,.ready_and_o(acache_ready_and_lo)
      ,.flush_i(1'b0)
+     ,.ordered_o()
 
      ,.ptag_v_i(1'b1)
      ,.ptag_i(acache_ptag_li)
@@ -156,11 +156,11 @@ module bp_cacc_vdp
      ,.early_req_o()
 
      ,.final_v_o()
-     ,.final_data_o()
      ,.final_addr_o()
+     ,.final_data_o()
      ,.final_rd_addr_o()
-     ,.final_int_o()
      ,.final_float_o()
+     ,.final_int_o()
      ,.final_ptw_o()
      ,.final_late_o()
 
@@ -173,8 +173,7 @@ module bp_cacc_vdp
      ,.cache_req_metadata_v_o(acache_req_metadata_v_lo)
      ,.cache_req_credits_full_i(acache_req_credits_full_lo)
      ,.cache_req_credits_empty_i(acache_req_credits_empty_lo)
-     ,.cache_req_addr_i(acache_req_addr_lo)
-     ,.cache_req_data_i(acache_req_data_lo)
+     ,.cache_req_id_i(acache_req_id_lo)
      ,.cache_req_critical_i(acache_req_critical_lo)
      ,.cache_req_last_i(acache_req_last_lo)
 
@@ -202,6 +201,7 @@ module bp_cacc_vdp
      ,.block_width_p(acache_block_width_p)
      ,.fill_width_p(acache_fill_width_p)
      ,.ctag_width_p(acache_ctag_width_p)
+     ,.id_width_p(acache_req_id_width_p)
      ,.timeout_max_limit_p(4)
      ,.credits_p(coh_noc_max_credits_p)
      )
@@ -219,8 +219,7 @@ module bp_cacc_vdp
      ,.cache_req_lock_o(acache_req_lock_li)
      ,.cache_req_metadata_i(acache_req_metadata_lo)
      ,.cache_req_metadata_v_i(acache_req_metadata_v_lo)
-     ,.cache_req_addr_o(acache_req_addr_lo)
-     ,.cache_req_data_o(acache_req_data_lo)
+     ,.cache_req_id_o(acache_req_id_lo)
      ,.cache_req_critical_o(acache_req_critical_lo)
      ,.cache_req_last_o(acache_req_last_lo)
      ,.cache_req_credits_full_o(acache_req_credits_full_lo)

--- a/bp_top/src/v/bp_core_lite.sv
+++ b/bp_top/src/v/bp_core_lite.sv
@@ -6,6 +6,8 @@
  */
 
 `include "bp_common_defines.svh"
+`include "bp_fe_defines.svh"
+`include "bp_be_defines.svh"
 `include "bp_top_defines.svh"
 
 module bp_core_lite
@@ -16,8 +18,8 @@ module bp_core_lite
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_core_if_widths(vaddr_width_p, paddr_width_p, asid_width_p, branch_metadata_fwd_width_p)
    `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
-   `declare_bp_cache_engine_if_widths(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache)
-   `declare_bp_cache_engine_if_widths(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
+   `declare_bp_fe_icache_engine_if_widths(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache_req_id_width_p)
+   `declare_bp_be_dcache_engine_if_widths(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache_req_id_width_p)
 
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    )
@@ -62,58 +64,56 @@ module bp_core_lite
 
   `declare_bp_cfg_bus_s(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p);
   `declare_bp_bedrock_if(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p);
-  `declare_bp_cache_engine_if(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache);
-  `declare_bp_cache_engine_if(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache);
+  `declare_bp_fe_icache_engine_if(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache_req_id_width_p);
+  `declare_bp_be_dcache_engine_if(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache_req_id_width_p);
 
   `bp_cast_i(bp_cfg_bus_s, cfg_bus);
 
-  bp_icache_req_s icache_req_lo;
+  bp_fe_icache_req_s icache_req_lo;
   logic icache_req_v_lo, icache_req_yumi_li, icache_req_lock_li;
-  bp_icache_req_metadata_s icache_req_metadata_lo;
+  bp_fe_icache_req_metadata_s icache_req_metadata_lo;
   logic icache_req_metadata_v_lo;
-  logic [paddr_width_p-1:0] icache_req_addr_li;
-  logic [dword_width_gp-1:0] icache_req_data_li;
+  logic [icache_req_id_width_p-1:0] icache_req_id_li;
   logic icache_req_critical_li, icache_req_last_li;
   logic icache_req_credits_full_li, icache_req_credits_empty_li;
 
-  bp_dcache_req_s dcache_req_lo;
+  bp_be_dcache_req_s dcache_req_lo;
   logic dcache_req_v_lo, dcache_req_yumi_li, dcache_req_lock_li;
-  bp_dcache_req_metadata_s dcache_req_metadata_lo;
+  bp_be_dcache_req_metadata_s dcache_req_metadata_lo;
   logic dcache_req_metadata_v_lo;
-  logic [paddr_width_p-1:0] dcache_req_addr_li;
-  logic [dword_width_gp-1:0] dcache_req_data_li;
+  logic [dcache_req_id_width_p-1:0] dcache_req_id_li;
   logic dcache_req_critical_li, dcache_req_last_li;
   logic dcache_req_credits_full_li, dcache_req_credits_empty_li;
 
-  bp_icache_tag_mem_pkt_s icache_tag_mem_pkt_li;
+  bp_fe_icache_tag_mem_pkt_s icache_tag_mem_pkt_li;
   logic icache_tag_mem_pkt_v_li;
   logic icache_tag_mem_pkt_yumi_lo;
-  bp_icache_tag_info_s icache_tag_mem_lo;
+  bp_fe_icache_tag_info_s icache_tag_mem_lo;
 
-  bp_icache_data_mem_pkt_s icache_data_mem_pkt_li;
+  bp_fe_icache_data_mem_pkt_s icache_data_mem_pkt_li;
   logic icache_data_mem_pkt_v_li;
   logic icache_data_mem_pkt_yumi_lo;
   logic [icache_block_width_p-1:0] icache_data_mem_lo;
 
-  bp_icache_stat_mem_pkt_s icache_stat_mem_pkt_li;
+  bp_fe_icache_stat_mem_pkt_s icache_stat_mem_pkt_li;
   logic icache_stat_mem_pkt_v_li;
   logic icache_stat_mem_pkt_yumi_lo;
-  bp_icache_stat_info_s icache_stat_mem_lo;
+  bp_fe_icache_stat_info_s icache_stat_mem_lo;
 
-  bp_dcache_tag_mem_pkt_s dcache_tag_mem_pkt_li;
+  bp_be_dcache_tag_mem_pkt_s dcache_tag_mem_pkt_li;
   logic dcache_tag_mem_pkt_v_li;
   logic dcache_tag_mem_pkt_yumi_lo;
-  bp_dcache_tag_info_s dcache_tag_mem_lo;
+  bp_be_dcache_tag_info_s dcache_tag_mem_lo;
 
-  bp_dcache_data_mem_pkt_s dcache_data_mem_pkt_li;
+  bp_be_dcache_data_mem_pkt_s dcache_data_mem_pkt_li;
   logic dcache_data_mem_pkt_v_li;
   logic dcache_data_mem_pkt_yumi_lo;
   logic [dcache_block_width_p-1:0] dcache_data_mem_lo;
 
-  bp_dcache_stat_mem_pkt_s dcache_stat_mem_pkt_li;
+  bp_be_dcache_stat_mem_pkt_s dcache_stat_mem_pkt_li;
   logic dcache_stat_mem_pkt_v_li;
   logic dcache_stat_mem_pkt_yumi_lo;
-  bp_dcache_stat_info_s dcache_stat_mem_lo;
+  bp_be_dcache_stat_info_s dcache_stat_mem_lo;
 
   wire posedge_clk =  clk_i;
   wire negedge_clk = ~clk_i;
@@ -131,8 +131,7 @@ module bp_core_lite
      ,.icache_req_lock_i(icache_req_lock_li)
      ,.icache_req_metadata_o(icache_req_metadata_lo)
      ,.icache_req_metadata_v_o(icache_req_metadata_v_lo)
-     ,.icache_req_addr_i(icache_req_addr_li)
-     ,.icache_req_data_i(icache_req_data_li)
+     ,.icache_req_id_i(icache_req_id_li)
      ,.icache_req_critical_i(icache_req_critical_li)
      ,.icache_req_last_i(icache_req_last_li)
      ,.icache_req_credits_full_i(icache_req_credits_full_li)
@@ -159,8 +158,7 @@ module bp_core_lite
      ,.dcache_req_lock_i(dcache_req_lock_li)
      ,.dcache_req_metadata_o(dcache_req_metadata_lo)
      ,.dcache_req_metadata_v_o(dcache_req_metadata_v_lo)
-     ,.dcache_req_addr_i(dcache_req_addr_li)
-     ,.dcache_req_data_i(dcache_req_data_li)
+     ,.dcache_req_id_i(dcache_req_id_li)
      ,.dcache_req_critical_i(dcache_req_critical_li)
      ,.dcache_req_last_i(dcache_req_last_li)
      ,.dcache_req_credits_full_i(dcache_req_credits_full_li)
@@ -195,6 +193,7 @@ module bp_core_lite
      ,.block_width_p(icache_block_width_p)
      ,.fill_width_p(icache_fill_width_p)
      ,.ctag_width_p(icache_ctag_width_p)
+     ,.id_width_p(icache_req_id_width_p)
      ,.timeout_max_limit_p(4)
      ,.credits_p(coh_noc_max_credits_p)
      ,.non_excl_reads_p(1)
@@ -213,8 +212,7 @@ module bp_core_lite
      ,.cache_req_lock_o(icache_req_lock_li)
      ,.cache_req_metadata_i(icache_req_metadata_lo)
      ,.cache_req_metadata_v_i(icache_req_metadata_v_lo)
-     ,.cache_req_addr_o(icache_req_addr_li)
-     ,.cache_req_data_o(icache_req_data_li)
+     ,.cache_req_id_o(icache_req_id_li)
      ,.cache_req_critical_o(icache_req_critical_li)
      ,.cache_req_last_o(icache_req_last_li)
      ,.cache_req_credits_full_o(icache_req_credits_full_li)
@@ -292,6 +290,7 @@ module bp_core_lite
      ,.block_width_p(dcache_block_width_p)
      ,.fill_width_p(dcache_fill_width_p)
      ,.ctag_width_p(dcache_ctag_width_p)
+     ,.id_width_p(dcache_req_id_width_p)
      ,.timeout_max_limit_p(4)
      ,.credits_p(coh_noc_max_credits_p)
      )
@@ -309,8 +308,7 @@ module bp_core_lite
      ,.cache_req_lock_o(dcache_req_lock_li)
      ,.cache_req_metadata_i(dcache_req_metadata_lo)
      ,.cache_req_metadata_v_i(dcache_req_metadata_v_lo)
-     ,.cache_req_addr_o(dcache_req_addr_li)
-     ,.cache_req_data_o(dcache_req_data_li)
+     ,.cache_req_id_o(dcache_req_id_li)
      ,.cache_req_critical_o(dcache_req_critical_li)
      ,.cache_req_last_o(dcache_req_last_li)
      ,.cache_req_credits_full_o(dcache_req_credits_full_li)

--- a/bp_top/src/v/bp_core_minimal.sv
+++ b/bp_top/src/v/bp_core_minimal.sv
@@ -4,6 +4,8 @@
  */
 
 `include "bp_common_defines.svh"
+`include "bp_fe_defines.svh"
+`include "bp_be_defines.svh"
 `include "bp_top_defines.svh"
 
 module bp_core_minimal
@@ -12,8 +14,8 @@ module bp_core_minimal
  import bp_be_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
-   `declare_bp_cache_engine_if_widths(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache)
-   `declare_bp_cache_engine_if_widths(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache)
+   `declare_bp_fe_icache_engine_if_widths(paddr_width_p, icache_ctag_width_p, icache_sets_p, icache_assoc_p, dword_width_gp, icache_block_width_p, icache_fill_width_p, icache_req_id_width_p)
+   `declare_bp_be_dcache_engine_if_widths(paddr_width_p, dcache_ctag_width_p, dcache_sets_p, dcache_assoc_p, dword_width_gp, dcache_block_width_p, dcache_fill_width_p, dcache_req_id_width_p)
    , localparam cfg_bus_width_lp = `bp_cfg_bus_width(vaddr_width_p, hio_width_p, core_id_width_p, cce_id_width_p, lce_id_width_p, did_width_p)
    )
   (input                                             clk_i
@@ -27,8 +29,7 @@ module bp_core_minimal
    , input                                           icache_req_lock_i
    , output logic [icache_req_metadata_width_lp-1:0] icache_req_metadata_o
    , output logic                                    icache_req_metadata_v_o
-   , input [paddr_width_p-1:0]                       icache_req_addr_i
-   , input [dword_width_gp-1:0]                      icache_req_data_i
+   , input [icache_req_id_width_p-1:0]               icache_req_id_i
    , input                                           icache_req_critical_i
    , input                                           icache_req_last_i
    , input                                           icache_req_credits_full_i
@@ -57,8 +58,7 @@ module bp_core_minimal
    , input                                           dcache_req_lock_i
    , output logic [dcache_req_metadata_width_lp-1:0] dcache_req_metadata_o
    , output logic                                    dcache_req_metadata_v_o
-   , input [paddr_width_p-1:0]                       dcache_req_addr_i
-   , input [dword_width_gp-1:0]                      dcache_req_data_i
+   , input [dcache_req_id_width_p-1:0]               dcache_req_id_i
    , input                                           dcache_req_critical_i
    , input                                           dcache_req_last_i
    , input                                           dcache_req_credits_full_i
@@ -118,8 +118,7 @@ module bp_core_minimal
      ,.cache_req_lock_i(icache_req_lock_i)
      ,.cache_req_metadata_o(icache_req_metadata_o)
      ,.cache_req_metadata_v_o(icache_req_metadata_v_o)
-     ,.cache_req_addr_i(icache_req_addr_i)
-     ,.cache_req_data_i(icache_req_data_i)
+     ,.cache_req_id_i(icache_req_id_i)
      ,.cache_req_critical_i(icache_req_critical_i)
      ,.cache_req_last_i(icache_req_last_i)
      ,.cache_req_credits_full_i(icache_req_credits_full_i)
@@ -163,8 +162,7 @@ module bp_core_minimal
      ,.cache_req_lock_i(dcache_req_lock_i)
      ,.cache_req_metadata_o(dcache_req_metadata_o)
      ,.cache_req_metadata_v_o(dcache_req_metadata_v_o)
-     ,.cache_req_addr_i(dcache_req_addr_i)
-     ,.cache_req_data_i(dcache_req_data_i)
+     ,.cache_req_id_i(dcache_req_id_i)
      ,.cache_req_critical_i(dcache_req_critical_i)
      ,.cache_req_last_i(dcache_req_last_i)
      ,.cache_req_credits_full_i(dcache_req_credits_full_i)

--- a/bp_top/src/v/bp_sacc_tile.sv
+++ b/bp_top/src/v/bp_sacc_tile.sv
@@ -149,52 +149,55 @@ module bp_sacc_tile
      ,.mem_rev_ready_and_o(mem_rev_ready_and_lo)
      );
 
-  if (sacc_type_p == e_sacc_vdp) begin : sacc_vdp
-    bp_sacc_vdp
-     #(.bp_params_p(bp_params_p))
-     accelerator
-      (.clk_i(clk_i)
-       ,.reset_i(reset_r)
+  if (sacc_type_p == e_sacc_vdp)
+    begin : sacc_vdp
+      bp_sacc_vdp
+       #(.bp_params_p(bp_params_p))
+       accelerator
+        (.clk_i(clk_i)
+         ,.reset_i(reset_r)
 
-       ,.lce_id_i(lce_id_li)
+         ,.lce_id_i(lce_id_li)
 
-       ,.mem_fwd_header_i(mem_fwd_header_lo)
-       ,.mem_fwd_data_i(mem_fwd_data_lo)
-       ,.mem_fwd_v_i(mem_fwd_v_lo)
-       ,.mem_fwd_ready_and_o(mem_fwd_ready_and_li)
+         ,.mem_fwd_header_i(mem_fwd_header_lo)
+         ,.mem_fwd_data_i(mem_fwd_data_lo)
+         ,.mem_fwd_v_i(mem_fwd_v_lo)
+         ,.mem_fwd_ready_and_o(mem_fwd_ready_and_li)
 
-       ,.mem_rev_header_o(mem_rev_header_li)
-       ,.mem_rev_data_o(mem_rev_data_li)
-       ,.mem_rev_v_o(mem_rev_v_li)
-       ,.mem_rev_ready_and_i(mem_rev_ready_and_lo)
-       );
-  end
-  else if (sacc_type_p == e_sacc_scratchpad) begin : sacc_scratchpad
-    bp_sacc_scratchpad
-     #(.bp_params_p(bp_params_p))
-     accelerator
-      (.clk_i(clk_i)
-       ,.reset_i(reset_r)
+         ,.mem_rev_header_o(mem_rev_header_li)
+         ,.mem_rev_data_o(mem_rev_data_li)
+         ,.mem_rev_v_o(mem_rev_v_li)
+         ,.mem_rev_ready_and_i(mem_rev_ready_and_lo)
+         );
+    end
+  else if (sacc_type_p == e_sacc_scratchpad)
+    begin : sacc_scratchpad
+      bp_sacc_scratchpad
+       #(.bp_params_p(bp_params_p))
+       accelerator
+        (.clk_i(clk_i)
+         ,.reset_i(reset_r)
 
-       ,.lce_id_i(lce_id_li)
+         ,.lce_id_i(lce_id_li)
 
-       ,.mem_fwd_header_i(mem_fwd_header_lo)
-       ,.mem_fwd_data_i(mem_fwd_data_lo)
-       ,.mem_fwd_v_i(mem_fwd_v_lo)
-       ,.mem_fwd_ready_and_o(mem_fwd_ready_and_li)
+         ,.mem_fwd_header_i(mem_fwd_header_lo)
+         ,.mem_fwd_data_i(mem_fwd_data_lo)
+         ,.mem_fwd_v_i(mem_fwd_v_lo)
+         ,.mem_fwd_ready_and_o(mem_fwd_ready_and_li)
 
-       ,.mem_rev_header_o(mem_rev_header_li)
-       ,.mem_rev_data_o(mem_rev_data_li)
-       ,.mem_rev_v_o(mem_rev_v_li)
-       ,.mem_rev_ready_and_i(mem_rev_ready_and_lo)
-       );
-  end
-  else begin : none
-    assign mem_fwd_ready_and_li = 1'b0;
-    assign mem_rev_header_li = '0;
-    assign mem_rev_data_li = '0;
-    assign mem_rev_v_li = 1'b0;
-  end
+         ,.mem_rev_header_o(mem_rev_header_li)
+         ,.mem_rev_data_o(mem_rev_data_li)
+         ,.mem_rev_v_o(mem_rev_v_li)
+         ,.mem_rev_ready_and_i(mem_rev_ready_and_lo)
+         );
+    end
+  else
+    begin : none
+      assign mem_fwd_ready_and_li = 1'b0;
+      assign mem_rev_header_li = '0;
+      assign mem_rev_data_li = '0;
+      assign mem_rev_v_li = 1'b0;
+    end
 
   // Burst to WH (lce_req_header_lo)
   bp_me_cce_id_to_cord

--- a/bp_top/test/common/bp_nonsynth_if_verif.sv
+++ b/bp_top/test/common/bp_nonsynth_if_verif.sv
@@ -99,6 +99,8 @@ module bp_nonsynth_if_verif
     $error("Error: L1 I$ requires fill width greater than bank width (block width / assoc)");
   if (dcache_fill_width_p < (dcache_block_width_p / dcache_assoc_p))
     $error("Error: L1 D$ requires fill width greater than bank width (block width / assoc)");
+  if (icache_mshr_p != 1 && dcache_mshr_p !=1 || acache_mshr_p != 1)
+    $error("MSHR must be 1 for all caches");
 
   // Address Widths
   if (vaddr_width_p != 39)

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -396,6 +396,7 @@ module testbench
            ,.block_width_p(block_width_p)
            ,.fill_width_p(fill_width_p)
            ,.ctag_width_p(ctag_width_p)
+           ,.id_width_p(id_width_p)
            )
          icache_tracer
           (.clk_i(clk_i & testbench.icache_trace_en_lo)
@@ -412,6 +413,7 @@ module testbench
            ,.block_width_p(block_width_p)
            ,.fill_width_p(fill_width_p)
            ,.ctag_width_p(ctag_width_p)
+           ,.id_width_p(id_width_p)
            )
          dcache_tracer
           (.clk_i(clk_i & testbench.dcache_trace_en_lo)


### PR DESCRIPTION
### Summary
This PR refactors the cache engine interface to more easily support MSHRs in the future

### Issue Fixed
None

### Area
I$/D$/A$/Cache engines

### Reasoning (new feature, inefficient, verbose, etc.)
The current cache engine interface has inefficient handoffs and does not indicate which request is being serviced. This can be extended to support miss under miss in D$ and prefetching in I$

### Additional Changes Required (if any)
None

### Analysis
Purely interface changing

### Verification
Linux boot

### Additional Context
None

