### PR TITLE
Implement correct handling of writebacks and uncached stores in CCE

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
+    - dev_fix_uncached_rework_rebase
   before_script:
       - git submodule update --init --checkout --recursive external/
       - cp -r $CI_RTL_INSTALL_DIR install/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
     - me_dev
     - top_dev
     - sw_dev
-    - dev_fix_uncached_rework_rebase
   before_script:
       - git submodule update --init --checkout --recursive external/
       - cp -r $CI_RTL_INSTALL_DIR install/

--- a/bp_me/src/include/bp_me_cce_inst_pkgdef.svh
+++ b/bp_me/src/include/bp_me_cce_inst_pkgdef.svh
@@ -716,7 +716,7 @@
        */
       logic [$bits(bp_cce_inst_mux_sel_way_e)-1:0] msg_size;
     }                                      way_or_size;
-    bp_cce_inst_opd_gpr_e                  src_a;
+    bp_cce_inst_opd_queue_e                src_a;
     bp_cce_inst_mux_sel_lce_e              lce_sel;
     bp_cce_inst_mux_sel_addr_e             addr_sel;
     union packed

--- a/bp_me/src/v/cce/bp_cce_inst_decode.sv
+++ b/bp_me/src/v/cce/bp_cce_inst_decode.sv
@@ -607,7 +607,7 @@ module bp_cce_inst_decode
               decoded_inst_o.addr_sel = op_type_u.pushq.addr_sel;
               decoded_inst_o.lce_sel = op_type_u.pushq.lce_sel;
               decoded_inst_o.src_a_sel = e_src_sel_queue;
-              decoded_inst_o.src_a.gpr = op_type_u.pushq.src_a;
+              decoded_inst_o.src_a.q = op_type_u.pushq.src_a;
 
               // set spec bit to 1, clear rest of bits
               // Note: spec bit should only be set for mem_fwd

--- a/bp_me/src/v/cce/bp_cce_inst_decode.sv
+++ b/bp_me/src/v/cce/bp_cce_inst_decode.sv
@@ -606,7 +606,7 @@ module bp_cce_inst_decode
 
               decoded_inst_o.addr_sel = op_type_u.pushq.addr_sel;
               decoded_inst_o.lce_sel = op_type_u.pushq.lce_sel;
-              decoded_inst_o.src_a_sel = e_src_sel_gpr;
+              decoded_inst_o.src_a_sel = e_src_sel_queue;
               decoded_inst_o.src_a.gpr = op_type_u.pushq.src_a;
 
               // set spec bit to 1, clear rest of bits

--- a/bp_me/src/v/cce/bp_cce_msg.sv
+++ b/bp_me/src/v/cce/bp_cce_msg.sv
@@ -712,6 +712,8 @@ module bp_cce_msg
 
             unique case (decoded_inst_i.mem_fwd)
               e_bedrock_mem_rd: begin
+                // set uncached bit based on request property
+                mem_fwd_header_cast_o.payload.uncached = mshr.flags.uncached;
                 mem_fwd_v_o = mem_fwd_ready_then_i & ~mem_credits_empty;
                 // stall until the message send completes
                 mem_fwd_stall_o = ~(mem_fwd_v_o & mem_fwd_last_i);


### PR DESCRIPTION
### Summary
This change modifies the CCE to properly handle writebacks and mem_rev responses to writebacks and uncached store operations. For mem_fwd writes, the payload.uncached bit is set only for uncached stores being issued by the CCE. All writebacks sent to L2/memory have the payload.uncached bit cleared to indicate that no response to the LCE will be required when the mem_rev returns.

### Area
CCE

### Reasoning (new feature, inefficient, verbose, etc.)
This supports the removal of the UC operation types from the mem_fwd/rev networks.

### Verification
Standard CI runs.

