### PR TITLE
Adding Zba, Zbb, Zbs

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1,5 +1,6 @@
 ## Set common environment variables
 TOP ?= $(shell git rev-parse --show-toplevel)
+SHELL=/bin/bash
 
 ## Export the variables for environment substitutions in makefile
 export BP_COMMON_DIR    := $(TOP)/bp_common

--- a/bp_be/src/include/bp_be_ctl_pkgdef.svh
+++ b/bp_be/src/include/bp_be_ctl_pkgdef.svh
@@ -5,22 +5,31 @@
   typedef enum logic [5:0]
   {
     e_int_op_add        = 6'b000000
-    ,e_int_op_sub       = 6'b001000
-    ,e_int_op_sll       = 6'b000001
     ,e_int_op_slt       = 6'b000010
     ,e_int_op_sge       = 6'b001010
     ,e_int_op_sltu      = 6'b000011
     ,e_int_op_sgeu      = 6'b001011
     ,e_int_op_xor       = 6'b000100
     ,e_int_op_eq        = 6'b001100
+    ,e_int_op_sll       = 6'b001111
     ,e_int_op_srl       = 6'b000101
     ,e_int_op_sra       = 6'b001101
     ,e_int_op_or        = 6'b000110
     ,e_int_op_ne        = 6'b001110
     ,e_int_op_and       = 6'b000111
-    ,e_int_op_pass_src2 = 6'b001111
-    ,e_int_op_pass_one  = 6'b111110
-    ,e_int_op_pass_zero = 6'b111111
+    ,e_int_op_cpop      = 6'b010000
+    ,e_int_op_clz       = 6'b010001
+    ,e_int_op_min       = 6'b010010
+    ,e_int_op_minu      = 6'b010011
+    ,e_int_op_max       = 6'b010100
+    ,e_int_op_maxu      = 6'b010101
+    ,e_int_op_orcb      = 6'b010110
+    ,e_int_op_rev8      = 6'b010111
+    ,e_int_op_bclr      = 6'b100000
+    ,e_int_op_bext      = 6'b100001
+    ,e_int_op_binv      = 6'b100010
+    ,e_int_op_binvi     = 6'b100011
+    ,e_int_op_bset      = 6'b100100
   } bp_be_int_fu_op_e;
 
   typedef enum logic [5:0]
@@ -141,16 +150,22 @@
     }  t;
   }  bp_be_fu_op_s;
 
-  typedef enum logic
+  typedef enum logic [2:0]
   {
-    e_src1_is_rs1 = 1'b0
-    ,e_src1_is_pc = 1'b1
+    e_src1_is_rs1        = 3'b000
+    ,e_src1_is_rs1_lsh   = 3'b011
+    ,e_src1_is_rs1_lshn  = 3'b100
+    ,e_src1_is_rs1_rev   = 3'b101
+    ,e_src1_is_zero      = 3'b010
   } bp_be_src1_e;
 
-  typedef enum logic
+  typedef enum logic [2:0]
   {
-    e_src2_is_rs2  = 1'b0
-    ,e_src2_is_imm = 1'b1
+    e_src2_is_rs2        = 3'b000
+    ,e_src2_is_rs1_rsh   = 3'b100
+    ,e_src2_is_rs1_rshn  = 3'b110
+    ,e_src2_is_rs2n      = 3'b011
+    ,e_src2_is_zero      = 3'b010
   } bp_be_src2_e;
 
   typedef enum logic
@@ -179,8 +194,9 @@
     logic                              frs3_r_v;
     logic                              irf_w_v;
     logic                              frf_w_v;
-    logic                              branch_v;
-    logic                              jump_v;
+    logic                              br_v;
+    logic                              j_v;
+    logic                              jr_v;
     logic                              fence_v;
     logic                              dcache_r_v;
     logic                              dcache_w_v;
@@ -192,6 +208,7 @@
     logic                              score_v;
     logic                              spec_w_v;
     logic                              fmove_v;
+    logic                              carryin;
 
     logic                              irs1_unsigned;
     logic [$bits(bp_be_int_tag_e)-1:0] irs1_tag;
@@ -207,7 +224,6 @@
 
     logic [$bits(bp_be_src1_e)-1:0]    src1_sel;
     logic [$bits(bp_be_src2_e)-1:0]    src2_sel;
-    logic [$bits(bp_be_baddr_e)-1:0]   baddr_sel;
   }  bp_be_decode_s;
 
   typedef struct packed

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -97,8 +97,8 @@ module bp_be_csr
 
   `declare_csr(mstatus);
   // MISA is optionally read-write, but all fields are read-only in BlackParrot
-  //   64 bit MXLEN, IMACFDSU extensions
-  wire [dword_width_gp-1:0] misa_lo = {2'b10, 36'b0, 26'h14112d};
+  //   64 bit MXLEN, IMACFDSUB extensions
+  wire [dword_width_gp-1:0] misa_lo = {2'b10, 36'b0, 26'h14112f};
   `declare_csr(medeleg);
   `declare_csr(mideleg);
   `declare_csr(mie);

--- a/bp_be/src/v/bp_be_calculator/bp_be_int_unbox.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_int_unbox.sv
@@ -17,37 +17,36 @@ module bp_be_int_unbox
  `bp_cast_i(bp_be_int_reg_s, reg);
   wire [dword_width_gp-1:0] val = reg_cast_i.val;
 
-  logic [int_rec_width_gp-1:0] raw;
-  wire sigreg = val[63];
+  logic [dword_width_gp-1:0] raw;
   always_comb
     case (reg_cast_i.tag)
-      e_int_byte : raw = {{57{sigreg}}, val[0+: 8]};
-      e_int_hword: raw = {{49{sigreg}}, val[0+:16]};
-      e_int_word : raw = {{33{sigreg}}, val[0+:32]};
+      e_int_byte : raw = {{56{val[63]}}, val[0+: 8]};
+      e_int_hword: raw = {{48{val[63]}}, val[0+:16]};
+      e_int_word : raw = {{32{val[63]}}, val[0+:32]};
       // e_int_dword
-      default: raw = {{1{sigreg}}, val[0+:63]};
+      default: raw = {{0{val[63]}}, val[0+:64]};
     endcase
 
   wire sigbox = tag_i >= reg_cast_i.tag;
   always_comb
     unique casez ({unsigned_i, sigbox, tag_i})
       // Unsigned output always zero extends
-      {2'b1?, e_int_dword}: val_o = {{ 2{1'b0   }}, raw[0+:64]};
+      {2'b1?, e_int_dword}: val_o = {{ 1{1'b0   }}, raw[0+:64]};
       {2'b1?, e_int_word }: val_o = {{33{1'b0   }}, raw[0+:32]};
       {2'b1?, e_int_hword}: val_o = {{49{1'b0   }}, raw[0+:16]};
       {2'b1?, e_int_byte }: val_o = {{57{1'b0   }}, raw[0+: 8]};
 
       // sigboxes uses the wider sign extension
-      {2'b01, e_int_dword}: val_o = {{ 2{raw[63]}}, raw[0+:64]};
+      {2'b01, e_int_dword}: val_o = {{ 1{raw[63]}}, raw[0+:64]};
       {2'b01, e_int_word }: val_o = {{33{raw[31]}}, raw[0+:32]};
       {2'b01, e_int_hword}: val_o = {{49{raw[15]}}, raw[0+:16]};
       {2'b01, e_int_byte }: val_o = {{57{raw[ 7]}}, raw[0+: 8]};
 
       // Valid boxes use the raw sign extension
-      {2'b00, e_int_dword}: val_o = {{ 2{sigreg}}, raw[0+:64]};
-      {2'b00, e_int_word }: val_o = {{33{sigreg}}, raw[0+:32]};
-      {2'b00, e_int_hword}: val_o = {{49{sigreg}}, raw[0+:16]};
-      {2'b00, e_int_byte }: val_o = {{57{sigreg}}, raw[0+: 8]};
+      {2'b00, e_int_dword}: val_o = {{ 1{raw[63]}}, raw[0+:64]};
+      {2'b00, e_int_word }: val_o = {{33{raw[63]}}, raw[0+:32]};
+      {2'b00, e_int_hword}: val_o = {{49{raw[63]}}, raw[0+:16]};
+      {2'b00, e_int_byte }: val_o = {{57{raw[63]}}, raw[0+: 8]};
 
       default: begin end
     endcase

--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_int.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_int.sv
@@ -48,71 +48,157 @@ module bp_be_pipe_int
   assign decode = reservation.decode;
   assign instr = reservation.instr;
   wire [vaddr_width_p-1:0] pc  = reservation.pc;
-  wire [dword_width_gp-1:0] rs1 = reservation.isrc1;
-  wire [dword_width_gp-1:0] rs2 = reservation.isrc2;
-  wire [dword_width_gp-1:0] imm = reservation.isrc3;
-  wire word_op = (decode.ird_tag == e_int_word);
+  wire [int_rec_width_gp-1:0] rs1 = reservation.isrc1;
+  wire [int_rec_width_gp-1:0] rs2 = reservation.isrc2;
+  wire [int_rec_width_gp-1:0] imm = reservation.isrc3;
+  wire opw_v = (decode.irs1_tag == e_int_word);
 
-  // Sign-extend PC for calculation
-  wire [dword_width_gp-1:0] pc_sext_li = `BSG_SIGN_EXTEND(pc, dword_width_gp);
-  wire [dword_width_gp-1:0] pc_plus4   = pc_sext_li + dword_width_gp'(4);
+  localparam num_bytes_lp = dword_width_gp>>8;
+  localparam lg_bits_lp = `BSG_SAFE_CLOG2(dword_width_gp);
 
-  wire [dword_width_gp-1:0] src1  = decode.src1_sel  ? pc_sext_li : rs1;
-  wire [dword_width_gp-1:0] src2  = decode.src2_sel  ? imm        : rs2;
+  // Shift calculation
+  logic [rv64_shamt_width_gp-1:0] shamt, shamtn;
+  wire [rv64_shamt_width_gp-1:0] shmask = {!opw_v, 5'b11111};
+  assign shamt = (decode.irs2_r_v ? rs2 : imm) & shmask;
+  assign shamtn = (opw_v ? 32 : 64) - shamt;
 
-  wire [rv64_shamt_width_gp-1:0] shamt = word_op ? src2[0+:rv64_shamtw_width_gp] : src2[0+:rv64_shamt_width_gp];
+  // We need a separate adder here to do branch comparison + address calc
+  wire [vaddr_width_p-1:0] baddr = decode.jr_v ? rs1 : pc;
+  wire [vaddr_width_p-1:0] taken_raw = baddr + imm;
+  wire [vaddr_width_p-1:0] taken_tgt = taken_raw & {{vaddr_width_p-1{1'b1}}, 1'b0};
+  wire [vaddr_width_p-1:0] ntaken_tgt = pc + (decode.compressed ? 4'd2 : 4'd4);
+  wire [dword_width_gp-1:0] ntaken_data = `BSG_SIGN_EXTEND(ntaken_tgt, dword_width_gp);
+  wire [dword_width_gp-1:0] pc_data = `BSG_SIGN_EXTEND(pc, dword_width_gp);
+
+  logic [dword_width_gp-1:0] src1;
+  wire [int_rec_width_gp-1:0] rs1_rev = {<<{rs1}};
+  always_comb
+    case (decode.src1_sel)
+      e_src1_is_rs1     : src1 = decode.irs1_r_v ? rs1 : pc_data;
+      e_src1_is_rs1_rev : src1 = rs1_rev >> 1'b1;
+      e_src1_is_rs1_lsh : src1 = rs1 <<  shamt;
+      e_src1_is_rs1_lshn: src1 = rs1 << shamtn;
+      e_src1_is_zero    : src1 = '0;
+      // e_src1_is_zero
+      default : src1 = '0;
+    endcase
+
+  logic [dword_width_gp-1:0] src2;
+  always_comb
+    case (decode.src2_sel)
+      e_src2_is_rs2     : src2 = decode.irs2_r_v ? rs2 : imm;
+      e_src2_is_rs2n    : src2 = ~rs2;
+      e_src2_is_rs1_rsh : src2 = $signed(rs1) >>>  shamt;
+      e_src2_is_rs1_rshn: src2 = $signed(rs1) >>> shamtn;
+      // e_src2_is_zero
+      default : src2 = '0;
+    endcase
+
+  // Main adder
+  logic carry;
+  logic [dword_width_gp:0] sum;
+  assign {carry, sum} = {src1[dword_width_gp-1], src1} + {src2[dword_width_gp-1], src2} + decode.carryin;
+  wire sum_zero = ~|sum;
+  wire sum_sign = sum[dword_width_gp];
+
+  // Comparator (also used for branching)
+  logic comp_result;
+  always_comb
+    unique case (decode.fu_op)
+      // Comparator
+      e_int_op_min  ,
+      e_int_op_slt  : comp_result =  sum_sign;
+      e_int_op_minu ,
+      e_int_op_sltu : comp_result = !carry;
+      e_int_op_max  ,
+      e_int_op_sge  : comp_result = !sum_sign;
+      e_int_op_maxu ,
+      e_int_op_sgeu : comp_result = carry;
+
+      e_int_op_ne   : comp_result = !sum_zero;
+      // e_int_op_eq
+      default : comp_result = sum_zero;
+    endcase
+
+  // Bitmanip
+  logic [`BSG_WIDTH(dword_width_gp)-1:0] popcount;
+  bsg_popcount
+   #(.width_p(dword_width_gp))
+   popc
+    (.i(rs1[0+:dword_width_gp]), .o(popcount));
+
+  logic [`BSG_WIDTH(word_width_gp)-1:0] clzh, clzl;
+  wire [`BSG_WIDTH(dword_width_gp)-1:0] clz = !clzh[5] ? clzh : (!opw_v << 5) | clzl;
+  bsg_counting_leading_zeros
+   #(.width_p(word_width_gp))
+   bclzh
+    (.a_i(rs1[word_width_gp+:word_width_gp]), .num_zero_o(clzh));
+
+  bsg_counting_leading_zeros
+   #(.width_p(word_width_gp))
+   bclzl
+    (.a_i(rs1[0+:word_width_gp]), .num_zero_o(clzl));
+
+  logic [num_bytes_lp-1:0][7:0] orcb;
+  for (genvar i = 0; i < num_bytes_lp; i++)
+    begin : rof_orcb
+      assign orcb[i] = {8{|rs1[8*i+:8]}};
+    end
+
+  logic [num_bytes_lp-1:0][7:0] rev8;
+  for (genvar i = 0; i < num_bytes_lp; i++)
+    begin : rof_rev8
+      assign rev8[i] = rs1[(7-i)*8+:8];
+    end
 
   // ALU
   logic [dword_width_gp-1:0] alu_result;
+  wire [lg_bits_lp-1:0] bindex = src2 & shmask;
   always_comb
     unique case (decode.fu_op)
-      e_int_op_add       : alu_result = src1 +  src2;
-      e_int_op_sub       : alu_result = src1 -  src2;
-      e_int_op_xor       : alu_result = src1 ^  src2;
-      e_int_op_or        : alu_result = src1 |  src2;
-      e_int_op_and       : alu_result = src1 &  src2;
-      e_int_op_sll       : alu_result = src1 << shamt;
-      e_int_op_srl       : alu_result = word_op ? $unsigned(src1[0+:word_width_gp]) >>> shamt : $unsigned(src1) >>> shamt;
-      // TODO: not a final solution
-      e_int_op_sra       : alu_result = word_op ? $signed(src1[0+:word_width_gp]) >>> shamt : $signed(src1) >>> shamt;
-      e_int_op_pass_src2 : alu_result = src2;
-      e_int_op_pass_one  : alu_result = 1'b1;
-      e_int_op_pass_zero : alu_result = 1'b0;
+      // Arithmetic
+      e_int_op_add       : alu_result = sum;
 
-      // Single bit results
-      e_int_op_eq   : alu_result = (dword_width_gp)'(src1 == src2);
-      e_int_op_ne   : alu_result = (dword_width_gp)'(src1 != src2);
-      e_int_op_slt  : alu_result = (dword_width_gp)'($signed(src1) <  $signed(src2));
-      e_int_op_sltu : alu_result = (dword_width_gp)'(src1 <  src2);
-      e_int_op_sge  : alu_result = (dword_width_gp)'($signed(src1) >= $signed(src2));
-      e_int_op_sgeu : alu_result = (dword_width_gp)'(src1 >= src2);
-      default       : alu_result = '0;
+      // Logic
+      e_int_op_xor       : alu_result = src1 ^ src2;
+      e_int_op_or        : alu_result = src1 | src2;
+      e_int_op_and       : alu_result = src1 & src2;
+
+      // Bitmanip
+      e_int_op_cpop      : alu_result = popcount;
+      e_int_op_clz       : alu_result = clz;
+      e_int_op_max, e_int_op_maxu, e_int_op_min, e_int_op_minu
+                         : alu_result = comp_result ? rs1 : rs2;
+      e_int_op_orcb      : alu_result = orcb;
+      e_int_op_rev8      : alu_result = rev8;
+
+      // Bit ops
+      e_int_op_bclr      : alu_result = rs1 & ~(1'b1 << bindex);
+      e_int_op_bext      : alu_result = (rs1 >> bindex) & 1'b1;
+      e_int_op_binv      : alu_result = rs1 ^ (1'b1 << bindex);
+      e_int_op_bset      : alu_result = rs1 | (1'b1 << bindex);
+
+      // Comparator
+      default : alu_result = comp_result;
     endcase
 
-  wire [vaddr_width_p-1:0] baddr = decode.baddr_sel ? rs1 : pc;
-  wire [vaddr_width_p-1:0] taken_raw = baddr + imm;
-  wire [vaddr_width_p-1:0] taken_tgt = {taken_raw[vaddr_width_p-1:1], 1'b0};
-  wire [vaddr_width_p-1:0] ntaken_tgt = pc + (decode.compressed ? 4'd2 : 4'd4);
-
   logic [dpath_width_gp-1:0] ird_data_lo;
-  wire [dpath_width_gp-1:0] br_result = dpath_width_gp'($signed(ntaken_tgt));
-  wire [dword_width_gp-1:0] int_result = decode.branch_v ? br_result : alu_result;
   bp_be_int_box
    #(.bp_params_p(bp_params_p))
    box
-    (.raw_i(int_result)
+    (.raw_i(alu_result)
      ,.tag_i(decode.ird_tag)
      ,.unsigned_i(1'b0)
      ,.reg_o(ird_data_lo)
      );
 
-  assign data_o = ird_data_lo;
+  assign data_o = (decode.j_v | decode.jr_v) ? ntaken_data : ird_data_lo;
   assign v_o    = en_i & reservation.v & reservation.decode.pipe_int_v;
 
   assign instr_misaligned_v_o = en_i & btaken_o & (taken_tgt[1:0] != 2'b00) & !compressed_support_p;
 
-  assign branch_o = decode.branch_v;
-  assign btaken_o = decode.branch_v & (decode.jump_v | alu_result[0]);
+  assign branch_o = decode.br_v | decode.j_v | decode.jr_v;
+  assign btaken_o = (decode.br_v & comp_result) || decode.j_v || decode.jr_v;
   assign npc_o = btaken_o ? taken_tgt : ntaken_tgt;
 
 endmodule

--- a/bp_be/src/v/bp_be_checker/bp_be_instr_decoder.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_instr_decoder.sv
@@ -104,27 +104,46 @@ module bp_be_instr_decoder
             if (instr.opcode == `RV64_OP_32_OP)
               begin
                 decode_cast_o.irs1_tag = e_int_word;
-                decode_cast_o.irs2_tag = e_int_word;
-                decode_cast_o.ird_tag = e_int_word;
+                decode_cast_o.irs2_tag = instr inside {`RV64_ADDUW, `RV64_SH1ADDUW, `RV64_SH2ADDUW, `RV64_SH3ADDUW} ? e_int_dword : e_int_word;
+                decode_cast_o.ird_tag = instr inside {`RV64_ADDUW, `RV64_SH1ADDUW, `RV64_SH2ADDUW, `RV64_SH3ADDUW} ? e_int_dword : e_int_word;
               end
 
-            if (instr inside {`RV64_MULHU, `RV64_DIVU, `RV64_DIVUW, `RV64_REMU, `RV64_REMUW})
+            if (instr inside {`RV64_ZEXTH})
+              decode_cast_o.irs1_tag = e_int_hword;
+
+            if (instr inside {`RV64_MULHU,`RV64_DIVU, `RV64_DIVUW, `RV64_REMU, `RV64_REMUW, `RV64_SRL, `RV64_SRLW, `RV64_ADDUW
+                              ,`RV64_SH1ADDUW, `RV64_SH2ADDUW, `RV64_SH3ADDUW, `RV64_ZEXTH
+                              ,`RV64_ROR, `RV64_RORW, `RV64_ROL, `RV64_ROLW})
               decode_cast_o.irs1_unsigned = 1'b1;
 
             if (instr inside {`RV64_MULHSU, `RV64_MULHU, `RV64_DIVU, `RV64_DIVUW, `RV64_REMU, `RV64_REMUW})
               decode_cast_o.irs2_unsigned = 1'b1;
 
             unique casez (instr)
-              `RV64_ADD, `RV64_ADDW : decode_cast_o.fu_op = e_int_op_add;
-              `RV64_SUB, `RV64_SUBW : decode_cast_o.fu_op = e_int_op_sub;
-              `RV64_SLL, `RV64_SLLW : decode_cast_o.fu_op = e_int_op_sll;
-              `RV64_SRL, `RV64_SRLW : decode_cast_o.fu_op = e_int_op_srl;
-              `RV64_SRA, `RV64_SRAW : decode_cast_o.fu_op = e_int_op_sra;
+              `RV64_ADD, `RV64_ADDW , `RV64_ADDUW,
+              `RV64_SUB, `RV64_SUBW ,
+              `RV64_SLL, `RV64_SLLW ,
+              `RV64_SRL, `RV64_SRLW ,
+              `RV64_SH1ADD, `RV64_SH1ADDUW,
+              `RV64_SH2ADD, `RV64_SH2ADDUW,
+              `RV64_SH3ADD, `RV64_SH3ADDUW,
+              `RV64_ZEXTH           ,
+              `RV64_SRA, `RV64_SRAW : decode_cast_o.fu_op = e_int_op_add;
               `RV64_SLT             : decode_cast_o.fu_op = e_int_op_slt;
               `RV64_SLTU            : decode_cast_o.fu_op = e_int_op_sltu;
-              `RV64_XOR             : decode_cast_o.fu_op = e_int_op_xor;
-              `RV64_OR              : decode_cast_o.fu_op = e_int_op_or;
-              `RV64_AND             : decode_cast_o.fu_op = e_int_op_and;
+              `RV64_MIN             : decode_cast_o.fu_op = e_int_op_min;
+              `RV64_MINU            : decode_cast_o.fu_op = e_int_op_minu;
+              `RV64_MAX             : decode_cast_o.fu_op = e_int_op_max;
+              `RV64_MAXU            : decode_cast_o.fu_op = e_int_op_maxu;
+              `RV64_XOR, `RV64_XNOR : decode_cast_o.fu_op = e_int_op_xor;
+              `RV64_ROL, `RV64_ROLW ,
+              `RV64_ROR, `RV64_RORW ,
+              `RV64_OR, `RV64_ORN   : decode_cast_o.fu_op = e_int_op_or;
+              `RV64_AND, `RV64_ANDN : decode_cast_o.fu_op = e_int_op_and;
+              `RV64_BCLR            : decode_cast_o.fu_op = e_int_op_bclr;
+              `RV64_BEXT            : decode_cast_o.fu_op = e_int_op_bext;
+              `RV64_BINV            : decode_cast_o.fu_op = e_int_op_binv;
+              `RV64_BSET            : decode_cast_o.fu_op = e_int_op_bset;
 
               `RV64_MUL, `RV64_MULW   : decode_cast_o.fu_op = e_fma_op_imul;
               `RV64_MULH              : decode_cast_o.fu_op = e_long_op_mulh;
@@ -137,8 +156,51 @@ module bp_be_instr_decoder
               default : illegal_instr_o = 1'b1;
             endcase
 
-            decode_cast_o.src1_sel   = e_src1_is_rs1;
-            decode_cast_o.src2_sel   = e_src2_is_rs2;
+            if (instr inside {`RV64_SUB, `RV64_SUBW, `RV64_SLT, `RV64_SLTU, `RV64_MIN, `RV64_MINU, `RV64_MAX, `RV64_MAXU})
+              begin
+                decode_cast_o.src1_sel = e_src1_is_rs1;
+                decode_cast_o.src2_sel = e_src2_is_rs2n;
+                decode_cast_o.carryin  = 1'b1;
+              end
+
+            if (instr inside {`RV64_ANDN, `RV64_ORN, `RV64_XNOR})
+              begin
+                decode_cast_o.src2_sel = e_src2_is_rs2n;
+              end
+
+            if (instr inside {`RV64_SLL, `RV64_SLLW})
+              begin
+                decode_cast_o.src1_sel = e_src1_is_rs1_lsh;
+                decode_cast_o.src2_sel = e_src2_is_zero;
+              end
+
+            if (instr inside {`RV64_SRL, `RV64_SRLW, `RV64_SRA, `RV64_SRAW})
+              begin
+                decode_cast_o.src1_sel = e_src1_is_zero;
+                decode_cast_o.src2_sel = e_src2_is_rs1_rsh;
+              end
+
+            if (instr inside {`RV64_ROL, `RV64_ROLW})
+              begin
+                decode_cast_o.src1_sel = e_src1_is_rs1_lsh;
+                decode_cast_o.src2_sel = e_src2_is_rs1_rshn;
+              end
+
+            if (instr inside {`RV64_ROR, `RV64_RORW})
+              begin
+                decode_cast_o.src1_sel = e_src1_is_rs1_lshn;
+                decode_cast_o.src2_sel = e_src2_is_rs1_rsh;
+              end
+
+            if (instr inside {`RV64_ZEXTH})
+              begin
+                decode_cast_o.src2_sel = e_src2_is_zero;
+              end
+
+            if (instr inside {`RV64_SH1ADD, `RV64_SH1ADDUW, `RV64_SH2ADD, `RV64_SH2ADDUW, `RV64_SH3ADD, `RV64_SH3ADDUW})
+              begin
+                decode_cast_o.src1_sel = e_src1_is_rs1_lsh;
+              end
           end
         `RV64_OP_IMM_OP, `RV64_OP_IMM_32_OP:
           begin
@@ -147,64 +209,106 @@ module bp_be_instr_decoder
             if (instr.opcode == `RV64_OP_IMM_32_OP)
               begin
                 decode_cast_o.irs1_tag = e_int_word;
-                decode_cast_o.ird_tag = e_int_word;
+                decode_cast_o.ird_tag = instr inside {`RV64_SLLIUW} ? e_int_dword : e_int_word;
               end
 
             unique casez (instr)
-              `RV64_ADDI, `RV64_ADDIW : decode_cast_o.fu_op = e_int_op_add;
-              `RV64_SLLI, `RV64_SLLIW : decode_cast_o.fu_op = e_int_op_sll;
-              `RV64_SRLI, `RV64_SRLIW : decode_cast_o.fu_op = e_int_op_srl;
-              `RV64_SRAI, `RV64_SRAIW : decode_cast_o.fu_op = e_int_op_sra;
+              `RV64_SEXTB: decode_cast_o.irs1_tag = e_int_byte;
+              `RV64_SEXTH: decode_cast_o.irs1_tag = e_int_hword;
+              default: begin end
+            endcase
+
+            unique casez (instr)
+              `RV64_ADDI, `RV64_ADDIW ,
+              `RV64_SLLI, `RV64_SLLIW , `RV64_SLLIUW,
+              `RV64_SRLI, `RV64_SRLIW ,
+              `RV64_SEXTB, `RV64_SEXTH,
+              `RV64_SRAI, `RV64_SRAIW : decode_cast_o.fu_op = e_int_op_add;
               `RV64_SLTI              : decode_cast_o.fu_op = e_int_op_slt;
               `RV64_SLTIU             : decode_cast_o.fu_op = e_int_op_sltu;
               `RV64_XORI              : decode_cast_o.fu_op = e_int_op_xor;
+              `RV64_RORI, `RV64_RORIW ,
               `RV64_ORI               : decode_cast_o.fu_op = e_int_op_or;
               `RV64_ANDI              : decode_cast_o.fu_op = e_int_op_and;
+              `RV64_CPOP, `RV64_CPOPW : decode_cast_o.fu_op = e_int_op_cpop;
+              `RV64_CTZ, `RV64_CTZW   ,
+              `RV64_CLZ, `RV64_CLZW   : decode_cast_o.fu_op = e_int_op_clz;
+              `RV64_ORCB              : decode_cast_o.fu_op = e_int_op_orcb;
+              `RV64_REV8              : decode_cast_o.fu_op = e_int_op_rev8;
+              `RV64_BCLRI            : decode_cast_o.fu_op = e_int_op_bclr;
+              `RV64_BEXTI            : decode_cast_o.fu_op = e_int_op_bext;
+              `RV64_BINVI            : decode_cast_o.fu_op = e_int_op_binv;
+              `RV64_BSETI            : decode_cast_o.fu_op = e_int_op_bset;
               default : illegal_instr_o = 1'b1;
             endcase
 
-            decode_cast_o.src1_sel   = e_src1_is_rs1;
-            decode_cast_o.src2_sel   = e_src2_is_imm;
+            if (instr inside {`RV64_CTZ, `RV64_CTZW})
+              begin
+                decode_cast_o.src1_sel = e_src1_is_rs1_rev;
+              end
+
+            if (instr inside {`RV64_SRLI, `RV64_SRLIW, `RV64_SLLIUW, `RV64_CPOPW, `RV64_CLZW, `RV64_CTZW})
+              begin
+                decode_cast_o.irs1_unsigned = 1'b1;
+                decode_cast_o.src2_sel = e_src2_is_zero;
+              end
+
+            if (instr inside {`RV64_SEXTB, `RV64_SEXTH})
+              begin
+                decode_cast_o.src2_sel = e_src2_is_zero;
+              end
+
+            if (instr inside {`RV64_SLLI, `RV64_SLLIW, `RV64_SLLIUW})
+              begin
+                decode_cast_o.src1_sel = e_src1_is_rs1_lsh;
+                decode_cast_o.src2_sel = e_src2_is_zero;
+              end
+
+            if (instr inside {`RV64_RORI, `RV64_RORIW})
+              begin
+                decode_cast_o.irs1_unsigned = 1'b1;
+                decode_cast_o.src1_sel = e_src1_is_rs1_lshn;
+                decode_cast_o.src2_sel = e_src2_is_rs1_rsh;
+              end
+
+            if (instr inside {`RV64_SRLI, `RV64_SRLIW, `RV64_SRAI, `RV64_SRAIW})
+              begin
+                decode_cast_o.src1_sel = e_src1_is_zero;
+                decode_cast_o.src2_sel = e_src2_is_rs1_rsh;
+              end
+
+            if (instr inside {`RV64_SLTI, `RV64_SLTIU})
+              begin
+                decode_cast_o.carryin = 1'b1;
+              end
           end
         `RV64_LUI_OP:
           begin
             decode_cast_o.pipe_int_v = 1'b1;
             decode_cast_o.irf_w_v    = (instr.rd_addr != '0);
-            decode_cast_o.fu_op      = e_int_op_pass_src2;
-            decode_cast_o.src2_sel   = e_src2_is_imm;
+            decode_cast_o.fu_op      = e_int_op_add;
+            decode_cast_o.src1_sel   = e_src1_is_zero;
           end
         `RV64_AUIPC_OP:
           begin
             decode_cast_o.pipe_int_v = 1'b1;
             decode_cast_o.irf_w_v    = (instr.rd_addr != '0);
             decode_cast_o.fu_op      = e_int_op_add;
-            decode_cast_o.src1_sel   = e_src1_is_pc;
-            decode_cast_o.src2_sel   = e_src2_is_imm;
           end
-        `RV64_JAL_OP:
+        `RV64_JAL_OP, `RV64_JALR_OP:
           begin
             decode_cast_o.pipe_int_v = 1'b1;
-            decode_cast_o.branch_v   = 1'b1;
-            decode_cast_o.jump_v     = 1'b1;
+            decode_cast_o.j_v        = instr inside {`RV64_JAL};
+            decode_cast_o.jr_v       = instr inside {`RV64_JALR};
             decode_cast_o.irf_w_v    = (instr.rd_addr != '0);
-            decode_cast_o.fu_op      = e_int_op_pass_one;
-            decode_cast_o.baddr_sel  = e_baddr_is_pc;
-          end
-        `RV64_JALR_OP:
-          begin
-            decode_cast_o.pipe_int_v = 1'b1;
-            decode_cast_o.irf_w_v    = (instr.rd_addr != '0);
-            decode_cast_o.branch_v   = 1'b1;
-            decode_cast_o.jump_v     = 1'b1;
-            decode_cast_o.fu_op      = e_int_op_pass_one;
-            decode_cast_o.baddr_sel  = e_baddr_is_rs1;
+            decode_cast_o.fu_op      = e_int_op_add;
 
-            illegal_instr_o = ~(instr inside {`RV64_JALR});
+            illegal_instr_o = ~(instr inside {`RV64_JAL, `RV64_JALR});
           end
         `RV64_BRANCH_OP:
           begin
             decode_cast_o.pipe_int_v = 1'b1;
-            decode_cast_o.branch_v   = 1'b1;
+            decode_cast_o.br_v       = 1'b1;
             unique casez (instr)
               `RV64_BEQ  : decode_cast_o.fu_op = e_int_op_eq;
               `RV64_BNE  : decode_cast_o.fu_op = e_int_op_ne;
@@ -214,7 +318,10 @@ module bp_be_instr_decoder
               `RV64_BGEU : decode_cast_o.fu_op = e_int_op_sgeu;
               default : illegal_instr_o = 1'b1;
             endcase
-            decode_cast_o.baddr_sel  = e_baddr_is_pc;
+
+            decode_cast_o.src1_sel  = e_src1_is_rs1;
+            decode_cast_o.src2_sel  = e_src2_is_rs2n;
+            decode_cast_o.carryin   = 1'b1;
           end
         `RV64_LOAD_OP:
           begin
@@ -239,11 +346,11 @@ module bp_be_instr_decoder
           begin
             decode_cast_o.pipe_mem_final_v = 1'b1;
             decode_cast_o.frf_w_v          = 1'b1;
+            decode_cast_o.fmove_v          = 1'b1;
             decode_cast_o.spec_w_v         = 1'b1;
             decode_cast_o.score_v          = 1'b1;
             decode_cast_o.dcache_r_v       = 1'b1;
             decode_cast_o.mem_v            = 1'b1;
-            decode_cast_o.fmove_v          = 1'b1;
             if (instr inside {`RV64_FL_W})
               decode_cast_o.frd_tag = e_fp_sp;
 
@@ -272,8 +379,8 @@ module bp_be_instr_decoder
           begin
             decode_cast_o.pipe_mem_early_v = 1'b1;
             decode_cast_o.dcache_w_v       = 1'b1;
-            decode_cast_o.mem_v            = 1'b1;
             decode_cast_o.fmove_v          = 1'b1;
+            decode_cast_o.mem_v            = 1'b1;
 
             illegal_instr_o = ~decode_info_cast_i.fpu_en;
 
@@ -493,40 +600,40 @@ module bp_be_instr_decoder
                 begin
                   decode_cast_o.pipe_aux_v   = 1'b1;
                   decode_cast_o.irf_w_v      = (instr.rd_addr != '0);
+                  decode_cast_o.fmove_v      = 1'b1;
                   decode_cast_o.fu_op        = e_aux_op_fmvi;
                   decode_cast_o.frs1_tag     = instr inside {`RV64_FMV_XW} ? e_fp_sp : e_fp_dp;
                   decode_cast_o.ird_tag      = instr inside {`RV64_FMV_XW} ? e_int_word : e_int_dword;
-                  decode_cast_o.fmove_v      = 1'b1;
                 end
               `RV64_FMV_WX, `RV64_FMV_DX:
                 begin
                   decode_cast_o.pipe_aux_v   = 1'b1;
                   decode_cast_o.frf_w_v      = 1'b1;
+                  decode_cast_o.fmove_v      = 1'b1;
                   decode_cast_o.fu_op        = e_aux_op_imvf;
                   decode_cast_o.irs1_tag     = instr inside {`RV64_FMV_WX} ? e_int_word : e_int_dword;
                   decode_cast_o.frd_tag      = instr inside {`RV64_FMV_WX} ? e_fp_sp : e_fp_dp;
-                  decode_cast_o.fmove_v      = 1'b1;
                 end
               `RV64_FSGNJ_S, `RV64_FSGNJ_D:
                 begin
                   decode_cast_o.pipe_aux_v   = 1'b1;
                   decode_cast_o.frf_w_v      = 1'b1;
-                  decode_cast_o.fu_op        = e_aux_op_fsgnj;
                   decode_cast_o.fmove_v      = 1'b1;
+                  decode_cast_o.fu_op        = e_aux_op_fsgnj;
                 end
               `RV64_FSGNJN_S, `RV64_FSGNJN_D:
                 begin
                   decode_cast_o.pipe_aux_v   = 1'b1;
                   decode_cast_o.frf_w_v      = 1'b1;
-                  decode_cast_o.fu_op        = e_aux_op_fsgnjn;
                   decode_cast_o.fmove_v      = 1'b1;
+                  decode_cast_o.fu_op        = e_aux_op_fsgnjn;
                 end
               `RV64_FSGNJX_S, `RV64_FSGNJX_D:
                 begin
                   decode_cast_o.pipe_aux_v   = 1'b1;
                   decode_cast_o.frf_w_v      = 1'b1;
-                  decode_cast_o.fu_op        = e_aux_op_fsgnjx;
                   decode_cast_o.fmove_v      = 1'b1;
+                  decode_cast_o.fu_op        = e_aux_op_fsgnjx;
                 end
               `RV64_FMIN_S, `RV64_FMIN_D:
                 begin
@@ -700,6 +807,15 @@ module bp_be_instr_decoder
           imm_o = `rv64_signext_i_imm(instr);
         //`RV64_AMO_OP:
         default: imm_o = '0;
+      endcase
+
+      // Instruction-specific overrides
+      unique casez (instr)
+        `RV64_SLTI, `RV64_SLTIU     : imm_o = ~`rv64_signext_i_imm(instr);
+        `RV64_SH1ADD, `RV64_SH1ADDUW: imm_o = 3'd1;
+        `RV64_SH2ADD, `RV64_SH2ADDUW: imm_o = 3'd2;
+        `RV64_SH3ADD, `RV64_SH3ADDUW: imm_o = 3'd3;
+        default: begin end
       endcase
     end
 

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -42,6 +42,14 @@
     ,e_fdivsqrt2b = 2'b10
   } bp_fpu_support_e;
 
+  typedef enum logic [1:0]
+  {
+    e_zba         = 2'b00
+    ,e_zbb        = 2'b01
+    ,e_zbc        = 2'b10
+    ,e_zbs        = 2'b11
+  } bp_bitmanip_support_e;
+
   typedef enum logic [15:0]
   {
     e_sacc_none = 0
@@ -201,13 +209,15 @@
     //   bit 2: iterative mulh
     //   bit 3: 2b iterative div
     integer unsigned muldiv_support;
-    // Whether to emulate FPU
+    // Whether to support FPU
     //   bit 0: fma
     //   bit 1: iterative fdivsqrt
     //   bit 2: 2b iterative fdivsqrt
     integer unsigned fpu_support;
     // Whether to enable the "c" extension.
     integer unsigned compressed_support;
+    // Whether to enable bitmanip extensions
+    integer unsigned bitmanip_support;
 
     // Whether the coherence network is on the core clock or on its own clock
     integer unsigned async_coh_clk;
@@ -340,6 +350,7 @@
                            | (1 << e_imulh)
                            | (1 << e_idiv2b)
       ,fpu_support       : (1 << e_fma) | (1 << e_fdivsqrt) | (1 << e_fdivsqrt2b)
+      ,bitmanip_support  : (1 << e_zba) | (1 << e_zbb) | (1 << e_zbs)
       ,compressed_support: 1
 
       ,async_coh_clk       : 0
@@ -396,6 +407,7 @@
       ,`bp_aviary_define_override(integer_support, BP_INTEGER_SUPPORT, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(muldiv_support, BP_MULDIV_SUPPORT, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(fpu_support, BP_FPU_SUPPORT, `BP_CUSTOM_BASE_CFG)
+      ,`bp_aviary_define_override(bitmanip_support, BP_BITMANIP_SUPPORT, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(compressed_support, BP_COMPRESSED_SUPPORT, `BP_CUSTOM_BASE_CFG)
 
       ,`bp_aviary_define_override(branch_metadata_fwd_width, BRANCH_METADATA_FWD_WIDTH, `BP_CUSTOM_BASE_CFG)

--- a/bp_common/src/include/bp_common_aviary_defines.svh
+++ b/bp_common/src/include/bp_common_aviary_defines.svh
@@ -123,6 +123,7 @@
     , localparam muldiv_support_p     = proc_param_lp.muldiv_support                               \
     , localparam fpu_support_p        = proc_param_lp.fpu_support                                  \
     , localparam compressed_support_p = proc_param_lp.compressed_support                           \
+    , localparam bitmanip_support_p   = proc_param_lp.bitmanip_support                             \
                                                                                                    \
     , localparam async_coh_clk_p        = proc_param_lp.async_coh_clk                              \
     , localparam coh_noc_max_credits_p  = proc_param_lp.coh_noc_max_credits                        \
@@ -224,6 +225,7 @@
           ,`bp_aviary_parameter_override(muldiv_support, override_cfg_mp, default_cfg_mp)          \
           ,`bp_aviary_parameter_override(fpu_support, override_cfg_mp, default_cfg_mp)             \
           ,`bp_aviary_parameter_override(compressed_support, override_cfg_mp, default_cfg_mp)      \
+          ,`bp_aviary_parameter_override(bitmanip_support, override_cfg_mp, default_cfg_mp)        \
                                                                                                    \
           ,`bp_aviary_parameter_override(branch_metadata_fwd_width, override_cfg_mp, default_cfg_mp) \
           ,`bp_aviary_parameter_override(ras_idx_width, override_cfg_mp, default_cfg_mp)           \

--- a/bp_common/src/include/bp_common_host_pkgdef.svh
+++ b/bp_common/src/include/bp_common_host_pkgdef.svh
@@ -20,6 +20,9 @@
   localparam signature_base_addr_gp    = (dev_addr_width_gp)'('h0_4000);
   localparam signature_match_addr_gp   = (dev_addr_width_gp)'('h0_4???);
 
+  localparam putint_base_addr_gp       = (dev_addr_width_gp)'('h0_5000);
+  localparam putint_match_addr_gp      = (dev_addr_width_gp)'('h0_5???);
+
   localparam bootrom_base_addr_gp      = (dev_addr_width_gp)'('h1_0000);
   localparam bootrom_match_addr_gp     = (dev_addr_width_gp)'('h1_????);
 

--- a/bp_common/src/include/bp_common_rv64_instr_defines.svh
+++ b/bp_common/src/include/bp_common_rv64_instr_defines.svh
@@ -313,5 +313,60 @@
   `define RV64_CFSWSP     `rv64_cl_type(`RV64_C2_OP,3'b111)
   `define RV64_CFSDSP     `rv64_cl_type(`RV64_C2_OP,3'b101)
 
+  // Bitmanip
+  // expansions
+  `define rv64_fi_type(op, funct3, funct12) {``funct12``,{5{1'b?}},``funct3``,{5{1'b?}},``op``}
+
+  // Zba
+  `define RV64_ADDUW      `rv64_r_type(`RV64_OP_32_OP,3'b000,7'b0000100)
+  `define RV64_SH1ADD     `rv64_r_type(`RV64_OP_OP,3'b010,7'b0010000)
+  `define RV64_SH1ADDUW   `rv64_r_type(`RV64_OP_32_OP,3'b010,7'b0010000)
+  `define RV64_SH2ADD     `rv64_r_type(`RV64_OP_OP,3'b100,7'b0010000)
+  `define RV64_SH2ADDUW   `rv64_r_type(`RV64_OP_32_OP,3'b100,7'b0010000)
+  `define RV64_SH3ADD     `rv64_r_type(`RV64_OP_OP,3'b110,7'b0010000)
+  `define RV64_SH3ADDUW   `rv64_r_type(`RV64_OP_32_OP,3'b110,7'b0010000)
+  `define RV64_SLLIUW     `rv64_fi_type(`RV64_OP_IMM_32_OP,3'b001,12'b000010??????)
+
+  // Zbb
+  `define RV64_ANDN       `rv64_r_type(`RV64_OP_OP,3'b111,7'b0100000)
+  `define RV64_CLZ        `rv64_fi_type(`RV64_OP_IMM_OP,3'b001,12'b0110000_00000)
+  `define RV64_CLZW       `rv64_fi_type(`RV64_OP_IMM_32_OP,3'b001,12'b0110000_00000)
+  `define RV64_CPOP       `rv64_fi_type(`RV64_OP_IMM_OP,3'b001,12'b0110000_00010)
+  `define RV64_CPOPW      `rv64_fi_type(`RV64_OP_IMM_32_OP,3'b001,12'b0110000_00010)
+  `define RV64_CTZ        `rv64_fi_type(`RV64_OP_IMM_OP,3'b001,12'b0110000_00001)
+  `define RV64_CTZW       `rv64_fi_type(`RV64_OP_IMM_32_OP,3'b001,12'b0110000_00001)
+  `define RV64_MAX        `rv64_r_type(`RV64_OP_OP,3'b110,7'b0000101)
+  `define RV64_MAXU       `rv64_r_type(`RV64_OP_OP,3'b111,7'b0000101)
+  `define RV64_MIN        `rv64_r_type(`RV64_OP_OP,3'b100,7'b0000101)
+  `define RV64_MINU       `rv64_r_type(`RV64_OP_OP,3'b101,7'b0000101)
+  `define RV64_ORCB       `rv64_fi_type(`RV64_OP_IMM_OP,3'b101,12'b0010100_00111)
+  `define RV64_ORN        `rv64_r_type(`RV64_OP_OP,3'b110,7'b0100000)
+  `define RV64_REV8       `rv64_fi_type(`RV64_OP_IMM_OP,3'b101,12'b011010111000)
+  `define RV64_ROL        `rv64_r_type(`RV64_OP_OP,3'b001,7'b0110000)
+  `define RV64_ROLW       `rv64_r_type(`RV64_OP_32_OP,3'b001,7'b0110000)
+  `define RV64_ROR        `rv64_r_type(`RV64_OP_OP,3'b101,7'b0110000)
+  `define RV64_RORI       `rv64_fi_type(`RV64_OP_IMM_OP,3'b101,12'b011000_??????)
+  `define RV64_RORIW      `rv64_fi_type(`RV64_OP_IMM_32_OP,3'b101,12'b0110000_?????)
+  `define RV64_RORW       `rv64_r_type(`RV64_OP_32_OP,3'b101,7'b0110000)
+  `define RV64_SEXTB      `rv64_fi_type(`RV64_OP_IMM_OP,3'b001,12'b0110000_00100)
+  `define RV64_SEXTH      `rv64_fi_type(`RV64_OP_IMM_OP,3'b001,12'b0110000_00101)
+  `define RV64_XNOR       `rv64_r_type(`RV64_OP_OP,3'b100,7'b0100000)
+  `define RV64_ZEXTH      `rv64_r_type(`RV64_OP_32_OP,3'b100,7'b0000100)
+
+  // Zbc
+  `define RV64_CLMUL      `rv64_r_type(`RV64_OP_OP,3'b001,7'b0000101)
+  `define RV64_CLMULH     `rv64_r_type(`RV64_OP_OP,3'b011,7'b0000101)
+  `define RV64_CLMULR     `rv64_r_type(`RV64_OP_OP,3'b010,7'b0000101)
+
+  // Zbs
+  `define RV64_BCLR       `rv64_r_type(`RV64_OP_OP,3'b001,7'b0100100)
+  `define RV64_BCLRI      `rv64_fi_type(`RV64_OP_IMM_OP,3'b001,12'b010010_??????)
+  `define RV64_BEXT       `rv64_r_type(`RV64_OP_OP,3'b101,7'b0100100)
+  `define RV64_BEXTI      `rv64_fi_type(`RV64_OP_IMM_OP,3'b101,12'b010010_??????)
+  `define RV64_BINV       `rv64_r_type(`RV64_OP_OP,3'b001,7'b0110100)
+  `define RV64_BINVI      `rv64_fi_type(`RV64_OP_IMM_OP,3'b001,12'b011010_??????)
+  `define RV64_BSET       `rv64_r_type(`RV64_OP_OP,3'b001,7'b0010100)
+  `define RV64_BSETI      `rv64_fi_type(`RV64_OP_IMM_OP,3'b001,12'b001010_??????)
+
 `endif
 

--- a/bp_top/syn/flist.vcs
+++ b/bp_top/syn/flist.vcs
@@ -178,7 +178,6 @@ $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_decoder_dor.sv
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_input_control.sv
 $BASEJUMP_STL_DIR/bsg_noc/bsg_wormhole_router_output_control.sv
 # HardFloat files
-$HARDFLOAT_DIR/source/addRecFN.v
 $HARDFLOAT_DIR/source/compareRecFN.v
 $HARDFLOAT_DIR/source/divSqrtRecFN.v
 $HARDFLOAT_DIR/source/divSqrtRecFN_medium.v
@@ -210,7 +209,6 @@ $BP_BE_DIR/src/v/bp_be_calculator/bp_be_fp_rebox.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_fp_unbox.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_int_unbox.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_int_box.sv
-$BP_BE_DIR/src/v/bp_be_calculator/bp_be_rec_to_raw.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_int.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_aux.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_fma.sv
@@ -218,6 +216,7 @@ $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_long.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_mem.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_pipe_sys.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_ptw.sv
+$BP_BE_DIR/src/v/bp_be_calculator/bp_be_rec_to_raw.sv
 $BP_BE_DIR/src/v/bp_be_calculator/bp_be_reservation.sv
 # Checker
 $BP_BE_DIR/src/v/bp_be_checker/bp_be_cmd_queue.sv

--- a/bp_top/test/common/bp_nonsynth_host.sv
+++ b/bp_top/test/common/bp_nonsynth_host.sv
@@ -70,9 +70,9 @@ module bp_nonsynth_host
       signature = $fopen("DUT-blackparrot.signature", "w");
     end
 
-  localparam bedrock_reg_els_lp = 7;
-  logic signature_r_v_li, paramrom_r_v_li, bootrom_r_v_li, finish_r_v_li, getchar_r_v_li, putchar_r_v_li, putch_core_r_v_li;
-  logic signature_w_v_li, paramrom_w_v_li, bootrom_w_v_li, finish_w_v_li, getchar_w_v_li, putchar_w_v_li, putch_core_w_v_li;
+  localparam bedrock_reg_els_lp = 8;
+  logic putint_r_v_li, signature_r_v_li, paramrom_r_v_li, bootrom_r_v_li, finish_r_v_li, getchar_r_v_li, putchar_r_v_li, putch_core_r_v_li;
+  logic putint_w_v_li, signature_w_v_li, paramrom_w_v_li, bootrom_w_v_li, finish_w_v_li, getchar_w_v_li, putchar_w_v_li, putch_core_w_v_li;
   logic [dev_addr_width_gp-1:0] addr_lo;
   logic [`BSG_WIDTH(`BSG_SAFE_CLOG2(dword_width_gp/8))-1:0] size_lo;
   logic [dword_width_gp-1:0] data_lo;
@@ -82,12 +82,12 @@ module bp_nonsynth_host
      ,.reg_data_width_p(dword_width_gp)
      ,.reg_addr_width_p(dev_addr_width_gp)
      ,.els_p(bedrock_reg_els_lp)
-     ,.base_addr_p({signature_match_addr_gp, paramrom_match_addr_gp, bootrom_match_addr_gp, finish_match_addr_gp, getchar_match_addr_gp, putchar_match_addr_gp, putch_core_match_addr_gp})
+     ,.base_addr_p({putint_match_addr_gp, signature_match_addr_gp, paramrom_match_addr_gp, bootrom_match_addr_gp, finish_match_addr_gp, getchar_match_addr_gp, putchar_match_addr_gp, putch_core_match_addr_gp})
      )
    register
     (.*
-     ,.r_v_o({signature_r_v_li, paramrom_r_v_li, bootrom_r_v_li, finish_r_v_li, getchar_r_v_li, putchar_r_v_li, putch_core_r_v_li})
-     ,.w_v_o({signature_w_v_li, paramrom_w_v_li, bootrom_w_v_li, finish_w_v_li, getchar_w_v_li, putchar_w_v_li, putch_core_w_v_li})
+     ,.r_v_o({putint_r_v_li, signature_r_v_li, paramrom_r_v_li, bootrom_r_v_li, finish_r_v_li, getchar_r_v_li, putchar_r_v_li, putch_core_r_v_li})
+     ,.w_v_o({putint_w_v_li, signature_w_v_li, paramrom_w_v_li, bootrom_w_v_li, finish_w_v_li, getchar_w_v_li, putchar_w_v_li, putch_core_w_v_li})
      ,.addr_o(addr_lo)
      ,.size_o(size_lo)
      ,.data_o(data_lo)
@@ -133,6 +133,10 @@ module bp_nonsynth_host
         $fwrite(stdout[addr_core_enc], "%c", data_lo[0+:8]);
       end
 
+      if (putint_w_v_li) begin
+        $write("%x", data_lo[0+:dword_width_gp]);
+      end
+
       if (getchar_r_v_li)
         ret = $fscanf(32'h8000_0001, "%c", ch);
 
@@ -150,6 +154,10 @@ module bp_nonsynth_host
 
       if (signature_w_v_li)
         $fwrite(signature, "%8x\n", data_lo[0+:32]);
+
+      if (putint_w_v_li) begin
+        $write("%x", data_lo);
+      end
 
       if (&finish_r)
         begin

--- a/bp_top/test/tb/bp_tethered/Makefile.testlist
+++ b/bp_top/test/tb/bp_tethered/Makefile.testlist
@@ -406,7 +406,11 @@ SPEC_TESTS := \
 
 SPEC_TESTLIST := $(addprefix spec@, $(SPEC_TESTS))
 
-RVARCH_TESTLIST := \
+# These are bugged in spike, but pass in dromajo
+#  cebreak-01
+#  ebreak
+
+RVARCH_TESTS := \
   add-01 \
   addi-01 \
   addiw-01 \
@@ -448,7 +452,6 @@ RVARCH_TESTLIST := \
   candi-01 \
   cbeqz-01 \
   cbnez-01 \
-  cebreak-01 \
   cj-01 \
   cjalr-01 \
   cjr-01 \
@@ -475,7 +478,6 @@ RVARCH_TESTLIST := \
   divu-01 \
   divuw-01 \
   divw-01 \
-  ebreak \
   ecall \
   fcvt.d.l_b25-01 \
   fcvt.d.l_b26-01 \
@@ -585,7 +587,49 @@ RVARCH_TESTLIST := \
   subw-01 \
   sw-align-01 \
   xor-01 \
-  xori-01
+  xori-01 \
+  add.uw-01 \
+  andn-01 \
+  bclr-01 \
+  bclri-01 \
+  bext-01 \
+  bexti-01 \
+  binv-01 \
+  binvi-01 \
+  bset-01 \
+  bseti-01 \
+  clz-01 \
+  clzw-01 \
+  cpop-01 \
+  cpopw-01 \
+  ctz-01 \
+  ctzw-01 \
+  max-01 \
+  maxu-01 \
+  min-01 \
+  minu-01 \
+  orcb_64-01 \
+  orn-01 \
+  rev8-01 \
+  rol-01 \
+  rolw-01 \
+  ror-01 \
+  rori-01 \
+  roriw-01 \
+  rorw-01 \
+  sext.b-01 \
+  sext.h-01 \
+  sh1add-01 \
+  sh1add.uw-01 \
+  sh2add-01 \
+  sh2add.uw-01 \
+  sh3add-01 \
+  sh3add.uw-01 \
+  slli.uw-01 \
+  xnor-01 \
+  zext.h_64-01
+
+RVARCH_TESTLIST := $(addprefix riscv-arch@, $(RVARCH_TESTS))
 
 BASELINE_TESTLIST := \
   bp-tests@hello_world \

--- a/bp_top/test/tb/bp_tethered/Makefile.vcs
+++ b/bp_top/test/tb/bp_tethered/Makefile.vcs
@@ -134,7 +134,7 @@ sigcheck.v: SIGCHECK_LOG    := $(LOG_DIR)/$(TB).$(CFG).$(TAG).sigcheck.$(SUITE).
 sigcheck.v: SIGCHECK_REPORT := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).sigcheck.$(SUITE).$(PROG).rpt
 sigcheck.v: SIGCHECK_ERROR  := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).sigcheck.$(SUITE).$(PROG).err
 $(SIM_DIR)/run_sigcheckv:
-	-diff $(@D)/DUT-blackparrot.signature $(BP_SDK_PROG_DIR)/$(SUITE)/$(PROG).signature > $(SIGCHECK_LOG)
+	-diff <(tail -n +9 $(@D)/DUT-blackparrot.signature | head -n -0) <(tail -n +9 $(BP_SDK_PROG_DIR)/$(SUITE)/$(PROG).signature | head -n -2) > $(SIGCHECK_LOG)
 	echo "Mismatches: " > $(SIGCHECK_REPORT)
 	wc -l < $(SIGCHECK_LOG) >> $(SIGCHECK_REPORT)
 	-@grep [1-9] $(SIGCHECK_REPORT) && echo "FAILED" > $(SIGCHECK_ERROR)

--- a/bp_top/test/tb/bp_tethered/Makefile.verilator
+++ b/bp_top/test/tb/bp_tethered/Makefile.verilator
@@ -121,7 +121,7 @@ sigcheck.sc: SIGCHECK_LOG    := $(LOG_DIR)/$(TB).$(CFG).$(TAG).sigcheck.$(SUITE)
 sigcheck.sc: SIGCHECK_REPORT := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).sigcheck.$(SUITE).$(PROG).rpt
 sigcheck.sc: SIGCHECK_ERROR  := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).sigcheck.$(SUITE).$(PROG).err
 $(SIM_DIR)/run_sigchecksc:
-	-diff $(@D)/DUT-blackparrot.signature $(BP_SDK_PROG_DIR)/$(SUITE)/$(PROG).signature > $(SIGCHECK_LOG)
+	-diff <(tail -n +9 $(@D)/DUT-blackparrot.signature | head -n -0) <(tail -n +9 $(BP_SDK_PROG_DIR)/$(SUITE)/$(PROG).signature | head -n -2) > $(SIGCHECK_LOG)
 	echo "Mismatches: " > $(SIGCHECK_REPORT)
 	wc -l < $(SIGCHECK_LOG) >> $(SIGCHECK_REPORT)
 	-@grep [1-9] $(SIGCHECK_REPORT) && echo "FAILED" > $(SIGCHECK_ERROR)

--- a/bp_top/test/tb/bp_tethered/Makefile.xcelium
+++ b/bp_top/test/tb/bp_tethered/Makefile.xcelium
@@ -114,7 +114,7 @@ sigcheck.x: SIGCHECK_LOG    := $(LOG_DIR)/$(TB).$(CFG).$(TAG).sigcheck.$(SUITE).
 sigcheck.x: SIGCHECK_REPORT := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).sigcheck.$(SUITE).$(PROG).rpt
 sigcheck.x: SIGCHECK_ERROR  := $(REPORT_DIR)/$(TB).$(CFG).$(TAG).sigcheck.$(SUITE).$(PROG).err
 $(SIM_DIR)/run_sigcheckx:
-	-diff $(@D)/DUT-blackparrot.signature $(BP_SDK_PROG_DIR)/$(SUITE)/$(PROG).signature > $(SIGCHECK_LOG)
+	-diff <(tail -n +9 $(@D)/DUT-blackparrot.signature | head -n -0) <(tail -n +9 $(BP_SDK_PROG_DIR)/$(SUITE)/$(PROG).signature | head -n -2) > $(SIGCHECK_LOG)
 	echo "Mismatches: " > $(SIGCHECK_REPORT)
 	wc -l < $(SIGCHECK_LOG) >> $(SIGCHECK_REPORT)
 	-@grep [1-9] $(SIGCHECK_REPORT) && echo "FAILED" > $(SIGCHECK_ERROR)


### PR DESCRIPTION
### Summary
This PR adds the newly frozen bit manipulation extension to BlackParrot. B includes Zba, Zbb and Zbs (but not Zbc), and is predicted to be required for future standard versions of Linux.

### Issue Fixed
None

### Area
Integer execution units

### Reasoning (new feature, inefficient, verbose, etc.)
This is expected to be a standard feature and can help with many 32b and embedded systems use-cases.

### Additional Changes Required (if any)
None

### Analysis
Less than 1% area impact. Performance impact TBD.

### Verification
added riscv-arch-test compliance and spike co-simulation. Additionally, still boots Linux. Critical path unchanged and minimal area impact.

### Additional Context
None

