### PR TITLE
RAS checkpointing enhancement

### DIFF
--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -281,8 +281,8 @@
       ,caddr_width: 32
       ,asid_width : 1
 
-      ,branch_metadata_fwd_width: 47
-      ,ras_idx_width            : 3
+      ,branch_metadata_fwd_width: 49
+      ,ras_idx_width            : 4
       ,btb_tag_width            : 9
       ,btb_idx_width            : 6
       ,bht_idx_width            : 7

--- a/bp_fe/src/include/bp_fe_defines.svh
+++ b/bp_fe/src/include/bp_fe_defines.svh
@@ -22,8 +22,8 @@
       logic                                       site_return;                                    \
       logic                                       src_ras;                                        \
       logic                                       src_btb;                                        \
-      logic [ras_idx_width_mp-1:0]                ras_base;                                       \
-      logic [ras_idx_width_mp-1:0]                ras_cnt;                                        \
+      logic [ras_idx_width_mp-1:0]                ras_next;                                       \
+      logic [ras_idx_width_mp-1:0]                ras_tos;                                        \
       logic [btb_tag_width_mp-1:0]                btb_tag;                                        \
       logic [btb_idx_width_mp-1:0]                btb_idx;                                        \
       logic [bht_idx_width_mp-1:0]                bht_idx;                                        \

--- a/bp_fe/src/v/bp_fe_pc_gen.sv
+++ b/bp_fe/src/v/bp_fe_pc_gen.sv
@@ -81,7 +81,7 @@ module bp_fe_pc_gen
   logic ovr_ret, ovr_btaken, ovr_jmp, ovr_ntaken, ovr_dbranch, btb_taken;
   logic [vaddr_width_p-1:0] pc_plus4;
   logic [vaddr_width_p-1:0] ras_tgt_lo, br_tgt_lo, linear_tgt_lo;
-  logic [ras_idx_width_p-1:0] ras_base, ras_cnt;
+  logic [ras_idx_width_p-1:0] ras_next, ras_tos;
   logic [btb_tag_width_p-1:0] btb_tag;
   logic [btb_idx_width_p-1:0] btb_idx;
   logic [bht_idx_width_p-1:0] bht_idx;
@@ -128,10 +128,13 @@ module bp_fe_pc_gen
   ///////////////////////////
   logic btb_w_yumi_lo, btb_init_done_lo;
   wire btb_r_v_li = if1_we_i;
-  wire btb_w_v_li = (redirect_br_v_i & redirect_br_taken_i)
-    | (redirect_br_v_i & redirect_br_nonbr_i & redirect_br_metadata_fwd_cast_i.src_btb)
-    | (attaboy_v_i & attaboy_taken_i & ~attaboy_br_metadata_fwd_cast_i.src_btb & ~attaboy_br_metadata_fwd_cast_i.src_ras);
-  wire btb_clr_li = redirect_br_v_i & redirect_br_nonbr_i & redirect_br_metadata_fwd_cast_i.src_btb;
+  wire btb_w_v_li = (redirect_br_v_i & redirect_br_taken_i & ~redirect_br_metadata_fwd_cast_i.src_btb & ~redirect_br_metadata_fwd_cast_i.src_ras)
+    | (redirect_br_v_i & redirect_br_taken_i & redirect_br_metadata_fwd_cast_i.src_btb & ~redirect_br_metadata_fwd_cast_i.src_ras)
+    | (attaboy_v_i & attaboy_taken_i & ~attaboy_br_metadata_fwd_cast_i.src_btb & ~attaboy_br_metadata_fwd_cast_i.src_ras)
+    | (redirect_br_v_i & redirect_br_taken_i & redirect_br_metadata_fwd_cast_i.src_btb & redirect_br_metadata_fwd_cast_i.src_ras)
+    | (redirect_br_v_i & redirect_br_nonbr_i & redirect_br_metadata_fwd_cast_i.src_btb);
+  wire btb_clr_li = (redirect_br_v_i & redirect_br_taken_i & redirect_br_metadata_fwd_cast_i.src_btb & redirect_br_metadata_fwd_cast_i.src_ras)
+    | (redirect_br_v_i & redirect_br_nonbr_i & redirect_br_metadata_fwd_cast_i.src_btb);
   wire btb_jmp_li = redirect_br_v_i ? (redirect_br_metadata_fwd_cast_i.site_jal | redirect_br_metadata_fwd_cast_i.site_jalr) : (attaboy_br_metadata_fwd_cast_i.site_jal | attaboy_br_metadata_fwd_cast_i.site_jalr);
   wire [btb_tag_width_p-1:0]  btb_tag_li = redirect_br_v_i ? redirect_br_metadata_fwd_cast_i.btb_tag : attaboy_br_metadata_fwd_cast_i.btb_tag;
   wire [btb_idx_width_p-1:0]  btb_idx_li = redirect_br_v_i ? redirect_br_metadata_fwd_cast_i.btb_idx : attaboy_br_metadata_fwd_cast_i.btb_idx;
@@ -225,8 +228,8 @@ module bp_fe_pc_gen
       metadata_if1 = metadata_if1_r;
       if (fetch_instr_v_i)
         begin
-          metadata_if1.ras_base    = ras_base;
-          metadata_if1.ras_cnt     = ras_cnt;
+          metadata_if1.ras_next    = ras_next;
+          metadata_if1.ras_tos     = ras_tos;
           metadata_if1.src_ras     = ovr_ret;
           metadata_if1.site_br     = fetch_instr_scan.branch;
           metadata_if1.site_jal    = fetch_instr_scan.jal;
@@ -281,8 +284,8 @@ module bp_fe_pc_gen
   logic [vaddr_width_p-1:0] ras_addr_li;
 
   wire ras_w_v_li = redirect_br_v_i;
-  wire [ras_idx_width_p-1:0] ras_w_base_li = redirect_br_metadata_fwd_cast_i.ras_base;
-  wire [ras_idx_width_p-1:0] ras_w_cnt_li = redirect_br_metadata_fwd_cast_i.ras_cnt;
+  wire [ras_idx_width_p-1:0] ras_w_next_li = redirect_br_metadata_fwd_cast_i.ras_next;
+  wire [ras_idx_width_p-1:0] ras_w_tos_li = redirect_br_metadata_fwd_cast_i.ras_tos;
   bp_fe_ras
    #(.bp_params_p(bp_params_p))
    ras
@@ -292,16 +295,16 @@ module bp_fe_pc_gen
      ,.init_done_o(ras_init_done_lo)
 
      ,.restore_i(ras_w_v_li)
-     ,.w_base_i(ras_w_base_li)
-     ,.w_cnt_i(ras_w_cnt_li)
+     ,.w_next_i(ras_w_next_li)
+     ,.w_tos_i(ras_w_tos_li)
 
      ,.call_i(ras_call_li)
      ,.addr_i(ras_addr_li)
 
      ,.v_o(ras_valid_lo)
      ,.tgt_o(ras_tgt_lo)
-     ,.base_o(ras_base)
-     ,.cnt_o(ras_cnt)
+     ,.next_o(ras_next)
+     ,.tos_o(ras_tos)
      ,.return_i(ras_return_li)
      );
 

--- a/bp_fe/src/v/bp_fe_ras.sv
+++ b/bp_fe/src/v/bp_fe_ras.sv
@@ -17,61 +17,59 @@ module bp_fe_ras
    , output logic                       init_done_o
 
    , input                              restore_i
-   , input [ras_idx_width_p-1:0]        w_base_i
-   , input [ras_idx_width_p-1:0]        w_cnt_i
+   , input [ras_idx_width_p-1:0]        w_next_i
+   , input [ras_idx_width_p-1:0]        w_tos_i
 
    , input                              call_i
    , input [vaddr_width_p-1:0]          addr_i
 
    , output logic                       v_o
    , output logic [vaddr_width_p-1:0]   tgt_o
-   , output logic [ras_idx_width_p-1:0] base_o
-   , output logic [ras_idx_width_p-1:0] cnt_o
+   , output logic [ras_idx_width_p-1:0] next_o
+   , output logic [ras_idx_width_p-1:0] tos_o
    , input                              return_i
    );
 
   localparam ras_els_lp = 2**ras_idx_width_p;
-  logic [ras_idx_width_p-1:0] bptr_n, bptr_r;
-  logic [ras_idx_width_p-1:0] cnt_n, cnt_r;
+  logic [ras_idx_width_p-1:0] next_n, next_r;
+  logic [ras_idx_width_p-1:0] tos_n, tos_r;
+  logic [ras_idx_width_p-1:0] nos_lo;
+  logic [vaddr_width_p-1:0] tgt_lo;
 
-  wire [ras_idx_width_p-1:0] wptr = bptr_r + cnt_r; // wptr leads the base by the count
-  wire [ras_idx_width_p-1:0] rptr = wptr - 1'b1;    // rptr always lags wptr by 1
-
-  // Assume POT RAS for now, implement circular pointers if this is onerous
-  wire empty = (cnt_r == '0);
-  wire full  = (cnt_r == '1);
-
-  // We assume overflow is desired (to get latest entries)
-  // We assume underflow is benign (would need RAS/
-  assign bptr_n = restore_i ? w_base_i : (bptr_r + (call_i & ~return_i & full));
-  assign cnt_n  = restore_i ? w_cnt_i  : (cnt_r + (call_i & ~full) - (return_i & ~empty));
-  bsg_dff_reset_en
+  // Algorithm taken from "Recovery Requirements of Branch Prediction Storage
+  //   Structures in the Presence of Mispredicted-Path Execution"
+  assign next_n = restore_i ? w_next_i : call_i ? (next_r+1'b1) :                     next_r;
+  assign tos_n  = restore_i ? w_tos_i  : call_i ? (next_r+1'b0) : return_i ? nos_lo : tos_r;
+  bsg_dff_reset
    #(.width_p(2*ras_idx_width_p))
    ptr_reg
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
-     ,.en_i(restore_i | call_i | return_i)
-     ,.data_i({bptr_n, cnt_n})
-     ,.data_o({bptr_r, cnt_r})
+     ,.data_i({next_n, tos_n})
+     ,.data_o({next_r, tos_r})
      );
 
   // Needs to push/pop at the same time to comply with RISC-V hints, preventing
   //   hardening. But, we expect this to be a fairly small structure
   bsg_mem_1r1w
-   #(.width_p(vaddr_width_p), .els_p(ras_els_lp), .read_write_same_addr_p(1))
+   #(.width_p(ras_idx_width_p+vaddr_width_p), .els_p(ras_els_lp), .read_write_same_addr_p(1))
    mem
     (.w_clk_i(clk_i)
      ,.w_reset_i(reset_i)
      ,.w_v_i(call_i)
-     ,.w_addr_i(wptr)
-     ,.w_data_i(addr_i)
+     ,.w_addr_i(next_r)
+     ,.w_data_i({tos_r, addr_i})
      ,.r_v_i(return_i)
-     ,.r_addr_i(rptr)
-     ,.r_data_o(tgt_o)
+     ,.r_addr_i(tos_r)
+     ,.r_data_o({nos_lo, tgt_lo})
      );
-  assign base_o = bptr_r;
-  assign cnt_o = cnt_r;
-  assign v_o = ~empty;
+  assign tgt_o = tgt_lo;
+  assign next_o = next_r;
+  assign tos_o = tos_r;
+
+  // Keeping track is more overhead than correcting misaligned stacks. See:
+  // "Improving Prediction for Procedure Returns with Return-Address-Stack Repair Mechanisms"
+  assign v_o = 1'b1;
 
   // We use count for valid, so we're immediately ready to go
   assign init_done_o = 1'b1;


### PR DESCRIPTION
### Summary
This PR adds RAS checkpointing inspired by Patt '97.

### Issue Fixed
None

### Area
FE

### Reasoning (new feature, inefficient, verbose, etc.)
The previous RAS checkpointing strategy suffered from pop-push-pop-restore problem, which is exacerbated when fetching ahead more aggressively.

### Additional Changes Required (if any)
None

### Analysis
<0.1% area impact

### Verification
Standard regression and cycle-level debugging

### Additional Context
None

