### PR TITLE
re-enable waveform dumping when simulating with Verilator

### DIFF
--- a/bp_common/syn/Makefile.verilator
+++ b/bp_common/syn/Makefile.verilator
@@ -82,6 +82,7 @@ $(BUILD_DIR)/obj_dir: | $(VBUILD_COLLATERAL)
 build_dump.sc: VV_OPTS += --trace-fst
 build_dump.sc: VV_OPTS += --trace-structs
 build_dump.sc: VV_OPTS += --trace-depth 15
+build_dump.sc: HDL_DEFINES += +define+VERILATOR_TRACE=1
 build_dump.sc: build.sc
 
 build_cov.sc: VV_OPTS += --coverage-line

--- a/bp_top/test/tb/bp_tethered/testbench.sv
+++ b/bp_top/test/tb/bp_tethered/testbench.sv
@@ -785,4 +785,12 @@ module testbench
       end
   `endif
 
+  `ifdef VERILATOR_TRACE
+    initial
+      begin
+        $dumpfile("dump.fst");
+        $dumpvars;
+      end
+  `endif
+
 endmodule


### PR DESCRIPTION
This change re-enables waveform dumping for Verilator simulations by adding a define of VERILATOR_TRACE to the verilated executable build that is visible to the testbench.