### PR TITLE
rework dram hash encode/decode to account for 0-width fields

### DIFF
--- a/bp_me/src/v/dev/bp_me_dram_hash_decode.sv
+++ b/bp_me/src/v/dev/bp_me_dram_hash_decode.sv
@@ -54,9 +54,15 @@ module bp_me_dram_hash_decode
   wire [l2_tag_width_lp-1:0]            tag = daddr_i[l2_tag_offset_lp+:l2_tag_width_lp];
 
   // assemble the address
-  assign daddr_o = {tag, {(l2_sets_p>1){set}}, {(l2_banks_p>1){bank}},
-                    {(l2_slices_p>1){slice}}, {(num_cce_p>1){cce}}, block
-                   };
+  logic [daddr_width_p-1:0] addr;
+  assign addr[l2_tag_offset_lp+:l2_tag_width_lp] = tag;
+  assign addr[0+:l2_block_offset_width_lp]       = block;
+  if (num_cce_p > 1)   assign addr[l2_cce_offset_lp+:lg_num_cce_lp]      = cce;
+  if (l2_slices_p > 1) assign addr[l2_slice_offset_lp+:lg_l2_slices_lp]  = slice;
+  if (l2_banks_p > 1)  assign addr[l2_bank_offset_lp+:lg_l2_banks_lp]    = bank;
+  if (l2_sets_p > 1)   assign addr[l2_set_offset_lp+:lg_l2_sets_lp]      = set;
+
+  assign daddr_o = addr;
 
 endmodule
 

--- a/bp_me/src/v/dev/bp_me_dram_hash_decode.sv
+++ b/bp_me/src/v/dev/bp_me_dram_hash_decode.sv
@@ -54,6 +54,8 @@ module bp_me_dram_hash_decode
   wire [l2_tag_width_lp-1:0]            tag = daddr_i[l2_tag_offset_lp+:l2_tag_width_lp];
 
   // assemble the address
+  // note: using concatentation and replication operators would be preferred here,
+  // but Vivado (xsim) v2022.1 throws a fatal error when using them to assemble addr.
   logic [daddr_width_p-1:0] addr;
   assign addr[l2_tag_offset_lp+:l2_tag_width_lp] = tag;
   assign addr[0+:l2_block_offset_width_lp]       = block;

--- a/bp_me/src/v/dev/bp_me_dram_hash_decode.sv
+++ b/bp_me/src/v/dev/bp_me_dram_hash_decode.sv
@@ -5,8 +5,8 @@
  * Description:
  *   This module reverses the bit swizzling applied by bp_me_dram_hash_encode.
  *
- *   IN :  [ taghi ][ bank ][ slice ][ cce ][         taglo         ][     indexhi    ][ block ]
- *   OUT:  [ taghi ][         taglo        ][     indexhi     ][ bank ][ slice ][ cce ][ block ]
+ *   IN:   [ tag ][ bank ][ slice ][ cce ][ set ][ block ]
+ *   OUT:  [ tag ][ set ][ bank ][ slice ][ cce ][ block ]
  *
  */
 
@@ -16,29 +16,47 @@ module bp_me_dram_hash_decode
  import bp_common_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
    `declare_bp_proc_params(bp_params_p)
+
    , localparam lg_num_cce_lp   = `BSG_SAFE_CLOG2(num_cce_p)
    , localparam lg_l2_slices_lp = `BSG_SAFE_CLOG2(l2_slices_p)
    , localparam lg_l2_banks_lp  = `BSG_SAFE_CLOG2(l2_banks_p)
+   , localparam lg_l2_sets_lp   = `BSG_SAFE_CLOG2(l2_sets_p)
    )
   (input [daddr_width_p-1:0]          daddr_i
    , output logic [daddr_width_p-1:0] daddr_o
    );
 
+  // set, bank, slice, and cce index widths may be 0 (if there is only 1 cce, slice per cce,
+  // bank per slice, or set per bank), which needs to be accounted for when extracting bits
+
   localparam l2_block_offset_width_lp = `BSG_SAFE_CLOG2(l2_block_width_p/8);
-  localparam l2_tag_offset_width_lp   = `BSG_SAFE_CLOG2(l2_block_width_p*l2_sets_p/8);
-  localparam l2_hash_offset_width_lp  = lg_num_cce_lp + lg_l2_slices_lp + lg_l2_banks_lp;
-  localparam l2_indexhi_width_lp = `BSG_MAX(1, `BSG_SAFE_CLOG2(l2_sets_p) - l2_hash_offset_width_lp);
-  localparam l2_taghi_width_lp = daddr_width_p - l2_tag_offset_width_lp - l2_hash_offset_width_lp;
+  localparam l2_set_index_width_lp = (l2_sets_p > 1) ? lg_l2_sets_lp : 0;
+  localparam l2_bank_index_width_lp = (l2_banks_p > 1) ? lg_l2_banks_lp : 0;
+  localparam l2_slice_index_width_lp = (l2_slices_p > 1) ? lg_l2_slices_lp : 0;
+  localparam l2_cce_index_width_lp = (num_cce_p > 1) ? lg_num_cce_lp : 0;
 
+  // compute offsets for each field in the IN address
+  localparam l2_set_offset_lp   = l2_block_offset_width_lp;
+  localparam l2_cce_offset_lp   = l2_set_offset_lp + l2_set_index_width_lp;
+  localparam l2_slice_offset_lp = l2_cce_offset_lp + l2_cce_index_width_lp;
+  localparam l2_bank_offset_lp  = l2_slice_offset_lp + l2_slice_index_width_lp;
+  localparam l2_tag_offset_lp   = l2_bank_offset_lp + l2_bank_index_width_lp;
+
+  // compute tag width (remaining high-order bits)
+  localparam l2_tag_width_lp = daddr_width_p - l2_tag_offset_lp;
+
+  // extract fields (use offset above to compute start bit, but extract bits ignoring if size of field is 0)
   wire [l2_block_offset_width_lp-1:0] block = daddr_i[0+:l2_block_offset_width_lp];
-  wire [l2_indexhi_width_lp-1:0]    indexhi = daddr_i[l2_block_offset_width_lp+:l2_indexhi_width_lp];
-  wire [l2_hash_offset_width_lp-1:0]  taglo = daddr_i[l2_block_offset_width_lp+l2_indexhi_width_lp+:l2_hash_offset_width_lp];
-  wire [lg_num_cce_lp-1:0]              cce = daddr_i[l2_tag_offset_width_lp+:lg_num_cce_lp];
-  wire [lg_l2_slices_lp-1:0]          slice = daddr_i[l2_tag_offset_width_lp+lg_num_cce_lp+:lg_l2_slices_lp];
-  wire [lg_l2_banks_lp-1:0]            bank = daddr_i[l2_tag_offset_width_lp+lg_num_cce_lp+lg_l2_slices_lp+:lg_l2_banks_lp];
-  wire [l2_taghi_width_lp-1:0]        taghi = daddr_i[daddr_width_p-1-:l2_taghi_width_lp];
+  wire [lg_l2_sets_lp-1:0]              set = daddr_i[l2_set_offset_lp+:lg_l2_sets_lp];
+  wire [lg_num_cce_lp-1:0]              cce = daddr_i[l2_cce_offset_lp+:lg_num_cce_lp];
+  wire [lg_l2_slices_lp-1:0]          slice = daddr_i[l2_slice_offset_lp+:lg_l2_slices_lp];
+  wire [lg_l2_banks_lp-1:0]            bank = daddr_i[l2_bank_offset_lp+:lg_l2_banks_lp];
+  wire [l2_tag_width_lp-1:0]            tag = daddr_i[l2_tag_offset_lp+:l2_tag_width_lp];
 
-  assign daddr_o = {taghi, taglo, indexhi, bank, slice, cce, block};
+  // assemble the address
+  assign daddr_o = {tag, {(l2_sets_p>1){set}}, {(l2_banks_p>1){bank}},
+                    {(l2_slices_p>1){slice}}, {(num_cce_p>1){cce}}, block
+                   };
 
 endmodule
 

--- a/bp_me/src/v/dev/bp_me_dram_hash_encode.sv
+++ b/bp_me/src/v/dev/bp_me_dram_hash_encode.sv
@@ -83,6 +83,8 @@ module bp_me_dram_hash_encode
   wire [l2_tag_width_lp-1:0]            tag = daddr[l2_tag_offset_lp+:l2_tag_width_lp];
 
   // assemble the address
+  // note: using concatentation and replication operators would be preferred here,
+  // but Vivado (xsim) v2022.1 throws a fatal error when using them to assemble addr.
   logic [daddr_width_p-1:0] addr;
   assign addr[l2_tag_offset_lp+:l2_tag_width_lp] = tag;
   assign addr[0+:l2_block_offset_width_lp]       = block;

--- a/bp_me/src/v/dev/bp_me_dram_hash_encode.sv
+++ b/bp_me/src/v/dev/bp_me_dram_hash_encode.sv
@@ -83,9 +83,13 @@ module bp_me_dram_hash_encode
   wire [l2_tag_width_lp-1:0]            tag = daddr[l2_tag_offset_lp+:l2_tag_width_lp];
 
   // assemble the address
-  wire [daddr_width_p-1:0] addr = {tag, {(l2_banks_p>1){bank}}, {(l2_slices_p>1){slice}},
-                                   {(num_cce_p>1){cce}}, {(l2_sets_p>1){set}}, block
-                                  };
+  logic [daddr_width_p-1:0] addr;
+  assign addr[l2_tag_offset_lp+:l2_tag_width_lp] = tag;
+  assign addr[0+:l2_block_offset_width_lp]       = block;
+  if (num_cce_p > 1)   assign addr[l2_cce_offset_lp+:lg_num_cce_lp]      = cce;
+  if (l2_slices_p > 1) assign addr[l2_slice_offset_lp+:lg_l2_slices_lp]  = slice;
+  if (l2_banks_p > 1)  assign addr[l2_bank_offset_lp+:lg_l2_banks_lp]    = bank;
+  if (l2_sets_p > 1)   assign addr[l2_set_offset_lp+:lg_l2_sets_lp]      = set;
 
   wire [dev_id_width_gp-1:0] tag_dev   = paddr_i[dev_addr_width_gp+:dev_id_width_gp];
   wire [lg_l2_slices_lp-1:0] tag_slice = tag_dev - cache_dev_gp;

--- a/bp_me/src/v/dev/bp_me_dram_hash_encode.sv
+++ b/bp_me/src/v/dev/bp_me_dram_hash_encode.sv
@@ -6,8 +6,16 @@
  *   This module swizzles bits in an address, primarily to enable uniform access to L2/memory
  *   in a BlackParrot multicore.
  *
- *   IN:  [ taghi ][         taglo        ][     indexhi     ][ bank ][ slice ][ cce ][ block ]
- *   OUT: [ taghi ][ bank ][ slice ][ cce ][         taglo         ][     indexhi    ][ block ]
+ *   ADDR: [             block number           ][ block ]
+ *   IN:   [ tag ][ set ][ bank ][ slice ][ cce ][ block ]
+ *   OUT:  [ tag ][ bank ][ slice ][ cce ][ set ][ block ]
+ *
+ *   Blocks are striped across CCEs by bsg_hash_bank using least-significant log2(num_cce_p) bits
+ *   from the block number field. Blocks are then distributed across slices and across banks at
+ *   the selected L2.
+ *
+ *   This hashing assumes the number of slices, banks, and sets are powers of two. The number
+ *   of CCEs (L2s) must be a value supported by bsg_hash_bank.
  *
  */
 
@@ -24,7 +32,6 @@ module bp_me_dram_hash_encode
    , localparam lg_l2_slices_lp = `BSG_SAFE_CLOG2(l2_slices_p)
    , localparam lg_l2_banks_lp  = `BSG_SAFE_CLOG2(l2_banks_p)
    , localparam lg_l2_sets_lp   = `BSG_SAFE_CLOG2(l2_sets_p)
-   , localparam lg_l2_assoc_lp  = `BSG_SAFE_CLOG2(l2_assoc_p)
    )
   (input [paddr_width_p-1:0]            paddr_i
    , input [bedrock_fill_width_p-1:0]   data_i
@@ -36,11 +43,6 @@ module bp_me_dram_hash_encode
    , output logic [l2_data_width_p-1:0] data_o
    );
 
-  localparam l2_block_offset_width_lp = `BSG_SAFE_CLOG2(l2_block_width_p/8);
-  localparam l2_tag_offset_width_lp   = `BSG_SAFE_CLOG2(l2_block_width_p*l2_sets_p/8);
-  localparam l2_hash_offset_width_lp  = lg_num_cce_lp + lg_l2_slices_lp + lg_l2_banks_lp;
-  localparam l2_indexhi_width_lp = `BSG_MAX(1, `BSG_SAFE_CLOG2(l2_sets_p) - l2_hash_offset_width_lp);
-  localparam l2_taghi_width_lp = daddr_width_p - l2_tag_offset_width_lp - l2_hash_offset_width_lp;
   bp_me_l2_csr_addr_s tag_addr_li;
   assign tag_addr_li = paddr_i;
 
@@ -49,20 +51,44 @@ module bp_me_dram_hash_encode
   wire is_tag_op  = is_csr_addr & paddr_i[0+:dev_addr_width_gp] inside {cache_tagop_match_addr_gp};
   wire is_lock_op = is_csr_addr & paddr_i[0+:dev_addr_width_gp] inside {cache_alock_match_addr_gp};
   wire is_addr_op = is_csr_addr & paddr_i[0+:dev_addr_width_gp] inside {cache_addrop_match_addr_gp};
-  wire [daddr_width_p-1:0] tag_addr = {tag_addr_li.way, tag_addr_li.index} << l2_block_offset_width_lp;
 
+  // set, bank, slice, and cce index widths may be 0 (if there is only 1 cce, slice per cce,
+  // bank per slice, or set per bank), which needs to be accounted for when extracting bits
+
+  localparam l2_block_offset_width_lp = `BSG_SAFE_CLOG2(l2_block_width_p/8);
+  localparam l2_set_index_width_lp = (l2_sets_p > 1) ? lg_l2_sets_lp : 0;
+  localparam l2_bank_index_width_lp = (l2_banks_p > 1) ? lg_l2_banks_lp : 0;
+  localparam l2_slice_index_width_lp = (l2_slices_p > 1) ? lg_l2_slices_lp : 0;
+  localparam l2_cce_index_width_lp = (num_cce_p > 1) ? lg_num_cce_lp : 0;
+
+  // compute offsets for each field in the IN address
+  localparam l2_cce_offset_lp   = l2_block_offset_width_lp;
+  localparam l2_slice_offset_lp = l2_cce_offset_lp + l2_cce_index_width_lp;
+  localparam l2_bank_offset_lp  = l2_slice_offset_lp + l2_slice_index_width_lp;
+  localparam l2_set_offset_lp   = l2_bank_offset_lp + l2_bank_index_width_lp;
+  localparam l2_tag_offset_lp   = l2_set_offset_lp + l2_set_index_width_lp;
+
+  // compute tag width (remaining high-order bits)
+  localparam l2_tag_width_lp = daddr_width_p - l2_tag_offset_lp;
+
+  wire [daddr_width_p-1:0] tag_addr = {tag_addr_li.way, tag_addr_li.index} << l2_block_offset_width_lp;
   wire [daddr_width_p-1:0] daddr = is_tag_op ? tag_addr : is_addr_op ? data_i : paddr_i;
+
+  // extract fields (use offset above to compute start bit, but extract bits ignoring if size of field is 0)
   wire [l2_block_offset_width_lp-1:0] block = daddr[0+:l2_block_offset_width_lp];
-  wire [lg_num_cce_lp-1:0]              cce = daddr[l2_block_offset_width_lp+:lg_num_cce_lp];
-  wire [lg_l2_slices_lp-1:0]          slice = daddr[l2_block_offset_width_lp+lg_num_cce_lp+:lg_l2_slices_lp];
-  wire [lg_l2_banks_lp-1:0]            bank = daddr[l2_block_offset_width_lp+lg_num_cce_lp+lg_l2_slices_lp+:lg_l2_banks_lp];
-  wire [l2_indexhi_width_lp-1:0]    indexhi = daddr[l2_block_offset_width_lp+l2_hash_offset_width_lp+:l2_indexhi_width_lp];
-  wire [l2_hash_offset_width_lp-1:0]  taglo = daddr[l2_tag_offset_width_lp+:l2_hash_offset_width_lp];
-  wire [l2_taghi_width_lp-1:0]        taghi = daddr[daddr_width_p-1-:l2_taghi_width_lp];
-  wire [daddr_width_p-1:0]             addr = {taghi, bank, slice, cce, taglo, indexhi, block};
+  wire [lg_num_cce_lp-1:0]              cce = daddr[l2_cce_offset_lp+:lg_num_cce_lp];
+  wire [lg_l2_slices_lp-1:0]          slice = daddr[l2_slice_offset_lp+:lg_l2_slices_lp];
+  wire [lg_l2_banks_lp-1:0]            bank = daddr[l2_bank_offset_lp+:lg_l2_banks_lp];
+  wire [lg_l2_sets_lp-1:0]              set = daddr[l2_set_offset_lp+:lg_l2_sets_lp];
+  wire [l2_tag_width_lp-1:0]            tag = daddr[l2_tag_offset_lp+:l2_tag_width_lp];
+
+  // assemble the address
+  wire [daddr_width_p-1:0] addr = {tag, {(l2_banks_p>1){bank}}, {(l2_slices_p>1){slice}},
+                                   {(num_cce_p>1){cce}}, {(l2_sets_p>1){set}}, block
+                                  };
 
   wire [dev_id_width_gp-1:0] tag_dev   = paddr_i[dev_addr_width_gp+:dev_id_width_gp];
-  wire [lg_l2_slices_lp-1:0] tag_slice = is_tag_op ? (tag_dev - cache_dev_gp) : slice;
+  wire [lg_l2_slices_lp-1:0] tag_slice = tag_dev - cache_dev_gp;
 
   assign dram_o  = is_dram_addr;
   assign daddr_o =                     is_tag_op ? tag_addr          : addr          ;


### PR DESCRIPTION
This PR does two things:
1. fixes the L2/DRAM hashing to account for fields that may have 0-width (CCE, slice, bank, and set indices)
2. prevents aliasing of blocks outside the L2 capacity

The purpose of the hash function is to distribute the L2 blocks evenly across the L2 slices/banks. This algorithm distributes blocks first to CCEs, then across slices and across banks (i.e., slice 0, bank 0 - slice 1, bank 0 - slice 0, bank 1 - slice 1, bank 0, etc.).

By definition (at least for POT number of CCEs), this algorithm guarantees that if there are N total sets across all L2s, then blocks [0, N) will remap to the same range and not alias outside the the L2 capacity.

Number of CCEs can be NPOT, but number of slices, banks, and sets must be POT >= 1.