### PR TITLE
Add missing signal declarations in FE

### DIFF
--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -106,7 +106,7 @@ module bp_fe_top
   logic [vaddr_width_p-1:0] fetch_pc_lo;
   logic [instr_width_gp-1:0] fetch_instr_lo;
   bp_fe_scan_s fetch_scan_lo;
-  logic fetch_partial_lo, fetch_linear_lo, fetch_eager_lo, fetch_scan_lo, fetch_rebase_lo;
+  logic fetch_partial_lo, fetch_linear_lo, fetch_eager_lo, fetch_rebase_lo;
   bp_fe_pc_gen
    #(.bp_params_p(bp_params_p))
    pc_gen

--- a/bp_fe/src/v/bp_fe_top.sv
+++ b/bp_fe/src/v/bp_fe_top.sv
@@ -107,6 +107,8 @@ module bp_fe_top
   logic [instr_width_gp-1:0] fetch_instr_lo;
   bp_fe_scan_s fetch_scan_lo;
   logic fetch_partial_lo, fetch_linear_lo, fetch_eager_lo, fetch_rebase_lo;
+  logic fetch_catchup_lo;
+  logic fetch_yumi_lo;
   bp_fe_pc_gen
    #(.bp_params_p(bp_params_p))
    pc_gen


### PR DESCRIPTION
Adds a couple missing signal declarations in FE Top.

Should be merge squashed.