### PR TITLE
Fix permission error when creating Python venv in Dockerfile.ubuntu24.04

### DIFF
--- a/docker/Dockerfile.ubuntu24.04
+++ b/docker/Dockerfile.ubuntu24.04
@@ -54,16 +54,17 @@ RUN chown ${USER_NAME} ${WORKDIR}
 # Set the default workdir
 WORKDIR $WORKDIR
 
-# Set the current user
-USER $USER_NAME
-
-# Create a python virtualenv
+# Create python virtualenv as root
 ENV VIRTUAL_ENV=/opt/venv
 RUN python3 -m venv $VIRTUAL_ENV
 COPY requirements.txt /opt/venv/
 RUN /opt/venv/bin/pip install -r /opt/venv/requirements.txt
 
+# Give ownership to the user
+RUN chown -R $USER_NAME:$GROUP_NAME /opt/venv
+
+# Set the current user
+USER $USER_NAME
 # Kick off with bash
 ENTRYPOINT [ "/usr/bin/entrypoint.sh" ]
 CMD ["/bin/bash"]
-


### PR DESCRIPTION
The Docker image should build successfully and create the Python virtual environment without permission errors.

Thanks for contributing to BlackParrot! Check out the CONTRIBUTING guide, if this is your first
time. Please provide a few details:

### Summary
Fixes a permission error when creating the Python virtual environment in the Dockerfile for Ubuntu 24.04. The virtual environment is now created as root, dependencies are installed, and ownership of the virtual environment directory is transferred to the container user.

### Issue Fixed
Fixes #1240 

### Area
```
docker/Dockerfile.ubuntu24.04
```

### Reasoning (new feature, inefficient, verbose, etc.)
Previously, the virtual environment was created while running as a non-root user, which could lead to permission errors during dependency installation. Creating the environment as root and assigning ownership afterward prevents these permission issues while still allowing the container to run as a non-root user.


### Additional Changes Required (if any)
None.

### Analysis

This change only affects the Docker build process for the Ubuntu 24.04 image. It improves reliability of the image build and prevents permission-related failures when installing Python dependencies.

### Verification

- Build the Docker image using the Dockerfile.ubuntu24.04 configuration.
- Confirm that the build completes successfully.
- Verify that the Python virtual environment is created in /opt/venv.
- Confirm that the environment is owned by the specified non-root user and can be used without permission errors.

### Additional Context

The virtual environment is created before switching to the container user, and ownership is updated afterward to ensure correct permissions while maintaining the security practice of running the container as a non-root user.
