### PR TITLE
tools: add .editorconfig at repository root

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[*.mk]
+indent_style = tab


### PR DESCRIPTION
This PR adds a root-level .editorconfig file to provide consistent editor formatting defaults for contributors.

Context:
- Addresses issue #1048
- Keeps the change limited to repository editor configuration
- No generated files or functional RTL changes are included

Verification:
- Checked the file syntax and scope
- Kept Makefile indentation as tab-based
- Used space-based indentation as the default for general files

Closes #1048