### PR TITLE
README: add missing release date for BlackParrot v2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ BlackParrot is ideal as the basis for a lightweight accelerator host, a standalo
 
 BlackParrot v1.0 was released in March 2020 and has been up and quad core silicon has been running in the lab since April 2020.
 BlackParrot v2.0 was released in January 2024 and has been up and running in the lab since then.
-BlackParrot v2.1 was released in 
+BlackParrot v2.1 was released in November 2025
 
 Currently supported:
 - RV64IMAFDCSU\_Zfencei\_Zicsr\_Zcbo\_Zba\_Zbb\_Zbs ISA extensions


### PR DESCRIPTION
The README project status section lists the release information for previous
BlackParrot versions but leaves the release date for v2.1 incomplete.

Based on the discussion in issue #1238, the release month was confirmed as
November 2025. This PR updates the README to include the missing release date.

Fixes #1238