### PR TITLE
make: export BP_DIR from Makefile.env

### DIFF
--- a/Makefile.env
+++ b/Makefile.env
@@ -7,9 +7,8 @@
 # Project-specific configuration
 ##############################
 
-BP_DIR         ?= $(TOP)
-export BP_DIR
-BP_WORK_DIR    ?= $(BP_DIR)/work
+export BP_DIR         ?= $(TOP)
+export BP_WORK_DIR    ?= $(BP_DIR)/work
 
 # Use meta-installation if available
 ifeq (1,$(IS_SUBMODULE))


### PR DESCRIPTION
Summary
Export BP_DIR from Makefile.env so it is consistently available during Verilator filelist generation.

Issue Fixed
Related to black-parrot-sim issue #33.

Area
Makefile.env

Reasoning
During local bring-up under WSL Ubuntu 24.04, the documented Verilator smoke test failed because the generated flist.vcs retained literal $BP_DIR paths. In issue #33, Dan suggested trying `export BP_DIR` in Makefile.env as the preferred fix. This change makes BP_DIR available earlier and more consistently in the build environment.

Additional Changes Required
None.

Verification
Tested using the documented simulation flow:
- make checkout
- make prep_lite
- make -C black-parrot/bp_top/verilator build.verilator sim.verilator

Confirmed that the first Verilator smoke test completed successfully without manually expanding $BP_DIR in flist.vcs, producing:
- Hello World!
- [CORE FSH] PASS
- [BSG-PASS]