### PR TITLE
[WIP] be: parameterize away FP logic when fpu_support_p is 0

### DIFF
--- a/bp_be/src/v/bp_be_checker/bp_be_detector.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_detector.sv
@@ -242,14 +242,14 @@ module bp_be_detector
       control_haz_v = fence_haz_v | fflags_haz_v;
 
       // Combine all data hazard information
-      // TODO: Parameterize away floating point data hazards without hardware support
       data_haz_v = (|irs1_data_haz_v)
                    | (|irs2_data_haz_v)
-                   | (|frs1_data_haz_v)
-                   | (|frs2_data_haz_v)
-                   | (|frs3_data_haz_v)
                    | (irs1_sb_raw_haz_v | irs2_sb_raw_haz_v | ird_sb_waw_haz_v)
-                   | (frs1_sb_raw_haz_v | frs2_sb_raw_haz_v | frs3_sb_raw_haz_v | frd_sb_waw_haz_v);
+                   | (fpu_support_p ? ((|frs1_data_haz_v)
+                                       | (|frs2_data_haz_v)
+                                       | (|frs3_data_haz_v)
+                                       | (frs1_sb_raw_haz_v | frs2_sb_raw_haz_v | frs3_sb_raw_haz_v | frd_sb_waw_haz_v))
+                                    : 1'b0);
 
       // Combine all structural hazard information
       struct_haz_v = cmd_haz_v

--- a/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_scheduler.sv
@@ -178,20 +178,29 @@ module bp_be_scheduler
      );
 
   logic [dpath_width_gp-1:0] frf_rs1, frf_rs2, frf_rs3;
-  bp_be_regfile
-  #(.bp_params_p(bp_params_p), .read_ports_p(3), .zero_x0_p(0), .data_width_p($bits(bp_be_fp_reg_s)))
-   fp_regfile
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+  if (fpu_support_p)
+    begin : gen_fp_regfile
+      bp_be_regfile
+      #(.bp_params_p(bp_params_p), .read_ports_p(3), .zero_x0_p(0), .data_width_p($bits(bp_be_fp_reg_s)))
+       fp_regfile
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
 
-     ,.rd_w_v_i(fwb_pkt_cast_i.frd_w_v)
-     ,.rd_addr_i(fwb_pkt_cast_i.rd_addr)
-     ,.rd_data_i(fwb_pkt_cast_i.rd_data)
+         ,.rd_w_v_i(fwb_pkt_cast_i.frd_w_v)
+         ,.rd_addr_i(fwb_pkt_cast_i.rd_addr)
+         ,.rd_data_i(fwb_pkt_cast_i.rd_data)
 
-     ,.rs_r_v_i({preissue_pkt.frs3_v, preissue_pkt.frs2_v, preissue_pkt.frs1_v})
-     ,.rs_addr_i({preissue_instr.rs3_addr, preissue_instr.rs2_addr, preissue_instr.rs1_addr})
-     ,.rs_data_o({frf_rs3, frf_rs2, frf_rs1})
-     );
+         ,.rs_r_v_i({preissue_pkt.frs3_v, preissue_pkt.frs2_v, preissue_pkt.frs1_v})
+         ,.rs_addr_i({preissue_instr.rs3_addr, preissue_instr.rs2_addr, preissue_instr.rs1_addr})
+         ,.rs_data_o({frf_rs3, frf_rs2, frf_rs1})
+         );
+    end
+  else
+    begin : gen_no_fp_regfile
+      assign frf_rs1 = '0;
+      assign frf_rs2 = '0;
+      assign frf_rs3 = '0;
+    end
 
   bp_be_decode_s fe_exc_decode_li;
   rv64_instr_fmatype_s fe_exc_instr_li;


### PR DESCRIPTION
## Area
bp_be/src/v/bp_be_checker/bp_be_detector.sv
bp_be/src/v/bp_be_checker/bp_be_scheduler.sv

## Current behavior
FP data hazard signals and fp_regfile are always present regardless of 
fpu_support_p. There was a TODO in bp_be_detector.sv acknowledging this

## Changes
1. bp_be_detector.sv: gate FP data hazard contributions to data_haz_v
   with fpu_support_p. When 0, frs1/frs2/frs3 hazard checks are
   optimized away

2. bp_be_scheduler.sv: gate fp_regfile instantiation with fpu_support_p.
   When 0, frf_rs1/rs2/rs3 are tied to 0 and the 3-read-port FP
   register file is not instantiated

## Verification
Full test suite passes with e_bp_default_cfg (fpu_support_p != 0):
hello_world, divide_hazard, fflags_haz, fp_precision, fp_neg_zero_nanbox,
amo_interrupt, cache_hammer, paging, virtual, timer_interrupt all [BSG-PASS]