### PR TITLE
Add L2 and Front End telemetry to bp_nonsynth_if_verif

### DIFF
--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -358,8 +358,8 @@
       ,l2_slices           : 2
       ,l2_banks            : 1
       ,l2_data_width       : 128
-      ,l2_sets             : 32
-      ,l2_assoc            : 2
+      ,l2_sets             : 256
+      ,l2_assoc            : 4
       ,l2_block_width      : 512
       ,l2_fill_width       : 128
 

--- a/bp_me/src/v/cce/bp_cce_fsm.sv
+++ b/bp_me/src/v/cce/bp_cce_fsm.sv
@@ -483,7 +483,7 @@ module bp_cce_fsm
 
   // Counter for message send/receive
   logic cnt_rst;
-  logic [2:0] cnt_inc, cnt_dec;
+  logic cnt_inc, cnt_dec;
   logic [`BSG_WIDTH(num_lce_p+1)-1:0] cnt;
   bsg_counter_up_down
     #(.max_val_p(num_lce_p+1)

--- a/bp_top/flist.vcs
+++ b/bp_top/flist.vcs
@@ -59,6 +59,7 @@ $BP_DIR/external/basejump_stl/bsg_dataflow/bsg_fifo_1r1w_large.sv
 $BP_DIR/external/basejump_stl/bsg_dataflow/bsg_fifo_1r1w_pseudo_large.sv
 $BP_DIR/external/basejump_stl/bsg_dataflow/bsg_fifo_1r1w_small.sv
 $BP_DIR/external/basejump_stl/bsg_dataflow/bsg_fifo_1r1w_small_unhardened.sv
+$BP_DIR/external/basejump_stl/bsg_dataflow/bsg_fifo_1r1w_small_hardened.sv
 $BP_DIR/external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.sv
 $BP_DIR/external/basejump_stl/bsg_dataflow/bsg_fifo_tracker.sv
 $BP_DIR/external/basejump_stl/bsg_dataflow/bsg_flow_counter.sv

--- a/bp_top/src/v/bp_core_tile.sv
+++ b/bp_top/src/v/bp_core_tile.sv
@@ -422,6 +422,8 @@ module bp_core_tile
      ,.concentrated_link_v_o(req_concentrated_link_lo.v)
      ,.concentrated_link_data_o(req_concentrated_link_lo.data)
      ,.concentrated_link_ready_and_rev_i(req_concentrated_link_li.ready_and_rev)
+
+     ,.links_credit_late_o()
      );
   assign lce_req_link_li[1].v = 1'b0;
   assign lce_req_link_li[0].v = 1'b0;
@@ -500,6 +502,8 @@ module bp_core_tile
      ,.concentrated_link_v_o(resp_concentrated_link_lo.v)
      ,.concentrated_link_data_o(resp_concentrated_link_lo.data)
      ,.concentrated_link_ready_and_rev_i(resp_concentrated_link_li.ready_and_rev)
+
+     ,.links_credit_late_o()
      );
   assign lce_resp_link_li[1].v = 1'b0;
   assign lce_resp_link_li[0].v = 1'b0;

--- a/bp_top/test/common/bp_nonsynth_if_verif.sv
+++ b/bp_top/test/common/bp_nonsynth_if_verif.sv
@@ -68,32 +68,32 @@ module bp_nonsynth_if_verif
       
       $display("MEM FWD Header Flits:    %0d", ($bits(bp_bedrock_mem_fwd_header_s) + mem_noc_flit_width_p - 1) / mem_noc_flit_width_p);
       $display("MEM REV Header Flits:    %0d", ($bits(bp_bedrock_mem_rev_header_s) + mem_noc_flit_width_p - 1) / mem_noc_flit_width_p);
-	  
-	 // L2 Cache Total Size (if L2 exists)
-	if (l2_features_p[e_cfg_enabled])
-		begin
-		$display("L2 Cache Total Size: %0d KB",
-		  (l2_sets_p * l2_assoc_p * l2_block_width_p * num_cce_p) / 8192);
-		$display("L2 Cache: %0d sets, %0d-way, %0d B/line, %0d banks (one per CCE), data width %0d B",
-		  l2_sets_p,
-		  l2_assoc_p,
-		  l2_block_width_p / 8,
-		  num_cce_p,
-		  l2_data_width_p / 8);
-		end
-	else
-		$display("L2 Cache: not present (UCE unicore config)");
-		
-	  // Front End Fetch Throughput Logic
-    begin
-        real instr_width_bytes = 4.0; 
-        real icache_cap_bytes = real'(icache_sets_p * icache_assoc_p * icache_block_width_p) / 8.0;
-        real total_instr_slots = icache_cap_bytes / instr_width_bytes;
-        
+
+      if (l2_features_p[e_cfg_enabled])
+        begin
+          $display("L2 Cache Total Size: %0d KB",
+            (l2_sets_p * l2_assoc_p * l2_block_width_p * l2_slices_p * l2_banks_p * num_cce_p) / 8192
+            );
+          $display("L2 Cache: %0d sets, %0d-way, %0d B/line, %0d banks, data width %0d B",
+            l2_sets_p
+            , l2_assoc_p
+            , l2_block_width_p / 8
+            , num_cce_p * l2_slices_p * l2_banks_p
+            , l2_data_width_p / 8
+            );
+        end
+      else
+        $display("L2 Cache: disabled");
+
+      begin
+        int instr_width_bytes = instr_width_gp / 8;
+        int icache_cap_bytes = (icache_sets_p * icache_assoc_p * icache_block_width_p) / 8;
+        int total_instr_slots = icache_cap_bytes / instr_width_bytes;
+
         $display("Fetch Throughput Stats:-");
-        $display("I-Cache Capacity:      %0.0f Bytes", icache_cap_bytes);
-        $display("Instruction Slots:     %0.0f units", total_instr_slots);
-    end
+        $display("I-Cache Capacity:      %0d Bytes", icache_cap_bytes);
+        $display("Instruction Slots:     %0d units", total_instr_slots);
+      end
       $display("#############################################");
       if (!(num_cce_p inside {1,2,3,4,6,7,8,12,14,15,16,24,28,30,31,32})) begin
         $error("Error: unsupported number of CCE's");

--- a/bp_top/test/common/bp_nonsynth_if_verif.sv
+++ b/bp_top/test/common/bp_nonsynth_if_verif.sv
@@ -68,6 +68,32 @@ module bp_nonsynth_if_verif
       
       $display("MEM FWD Header Flits:    %0d", ($bits(bp_bedrock_mem_fwd_header_s) + mem_noc_flit_width_p - 1) / mem_noc_flit_width_p);
       $display("MEM REV Header Flits:    %0d", ($bits(bp_bedrock_mem_rev_header_s) + mem_noc_flit_width_p - 1) / mem_noc_flit_width_p);
+	  
+	 // L2 Cache Total Size (if L2 exists)
+	if (l2_features_p[e_cfg_enabled])
+		begin
+		$display("L2 Cache Total Size: %0d KB",
+		  (l2_sets_p * l2_assoc_p * l2_block_width_p * num_cce_p) / 8192);
+		$display("L2 Cache: %0d sets, %0d-way, %0d B/line, %0d banks (one per CCE), data width %0d B",
+		  l2_sets_p,
+		  l2_assoc_p,
+		  l2_block_width_p / 8,
+		  num_cce_p,
+		  l2_data_width_p / 8);
+		end
+	else
+		$display("L2 Cache: not present (UCE unicore config)");
+		
+	  // Front End Fetch Throughput Logic
+    begin
+        real instr_width_bytes = 4.0; 
+        real icache_cap_bytes = real'(icache_sets_p * icache_assoc_p * icache_block_width_p) / 8.0;
+        real total_instr_slots = icache_cap_bytes / instr_width_bytes;
+        
+        $display("Fetch Throughput Stats:-");
+        $display("I-Cache Capacity:      %0.0f Bytes", icache_cap_bytes);
+        $display("Instruction Slots:     %0.0f units", total_instr_slots);
+    end
       $display("#############################################");
       if (!(num_cce_p inside {1,2,3,4,6,7,8,12,14,15,16,24,28,30,31,32})) begin
         $error("Error: unsupported number of CCE's");
@@ -190,4 +216,3 @@ module bp_nonsynth_if_verif
     $error("BP Fatal: mem_noc_cid_width_p (%0d) cannot concentrate l2_dmas_p (%0d).", mem_noc_cid_width_p, l2_dmas_p);
 
 endmodule
-

--- a/bp_top/test/common/bp_nonsynth_if_verif.sv
+++ b/bp_top/test/common/bp_nonsynth_if_verif.sv
@@ -71,15 +71,17 @@ module bp_nonsynth_if_verif
 
       if (l2_features_p[e_cfg_enabled])
         begin
-          $display("L2 Cache Total Size: %0d KB",
-            (l2_sets_p * l2_assoc_p * l2_block_width_p * l2_slices_p * l2_banks_p * num_cce_p) / 8192
-            );
-          $display("L2 Cache: %0d sets, %0d-way, %0d B/line, %0d banks, data width %0d B",
+          $display("L2 Cache (per core): %0d sets, %0d-way, %0d B/line, %0dx%0dx%0d banks, data width %0d B",
             l2_sets_p
             , l2_assoc_p
             , l2_block_width_p / 8
-            , num_cce_p * l2_slices_p * l2_banks_p
+            , num_cce_p
+            , l2_slices_p
+            , l2_banks_p
             , l2_data_width_p / 8
+            );
+          $display("L2 Cache Total Size: %0d kB",
+            (l2_sets_p * l2_assoc_p * l2_block_width_p * l2_slices_p * l2_banks_p * num_cce_p) / 8192
             );
         end
       else
@@ -90,9 +92,8 @@ module bp_nonsynth_if_verif
         int icache_cap_bytes = (icache_sets_p * icache_assoc_p * icache_block_width_p) / 8;
         int total_instr_slots = icache_cap_bytes / instr_width_bytes;
 
-        $display("Fetch Throughput Stats:-");
-        $display("I-Cache Capacity:      %0d Bytes", icache_cap_bytes);
-        $display("Instruction Slots:     %0d units", total_instr_slots);
+        $display("I-Cache Capacity:      %0d kB", icache_cap_bytes/1024);
+        $display("Instruction Slots:     %0d", total_instr_slots);
       end
       $display("#############################################");
       if (!(num_cce_p inside {1,2,3,4,6,7,8,12,14,15,16,24,28,30,31,32})) begin


### PR DESCRIPTION

### Summary
Adds L2 cache total size #1272 (accounts for slices as mentioned) to the derived statistics printed by bp_nonsynth_if_verif.sv Adds Front End Throughput Logic to the derived statistics printed by bp_nonsynth_if_verif.sv

### Issue Fixed
fixes the issue #343 and also builds on additions by #1241 and includes #1272 with the minor correction made

### Area
bp_top/test/common/bp_nonsynth_if_verif.sv

### Reasoning (new feature, inefficient, verbose, etc.)
The issue #1272 had some changes to be made also did not include expected simulation output. The Front End validation was added to provide an immediate "sanity check" for the processor's instruction fetch capacity. It ensures that the simulated I-Cache size matches the developer's intent and establishes a baseline to see if a test program is large enough to actually stress the hardware's storage limits.

### Additional Changes Required (if any)
Might require the removal of L2 cache total size part of the code if the implementation is changed and updated in issue #1272 

### Analysis
There is zero impact on the synthesized hardware. The logic adds a negligible amount of overhead to the initial simulation startup to calculate and print these parameters to the console.

### Verification
Verified using the Verilator Simulation workflow. 
Ran make -C bp_top/verilator build.verilator sim.verilator
L2 Validation: Confirmed correct aggregate capacity calculation for multicore and "Not Present" reporting for Unicore (UCE) builds.
Front End Validation: Verified that the I-Cache byte capacity and instruction slot counts correctly reflect the icache_sets_p, icache_assoc_p, and icache_block_width_p parameters.
Ran sanity check using bsg_mem instantiation prints(32 * 128 bits * 2 = 8192 bits = 8KB)
OUTPUT log snippet:
########### DERIVED STATISTICS ##############
L1 I-Cache Total Size:   32 KB
L1 D-Cache Total Size:   32 KB
LCE REQ Header Flits:    1
LCE CMD Header Flits:    1
LCE FILL Header Flits:   1
LCE RESP Header Flits:   1
MEM FWD Header Flits:    1
MEM REV Header Flits:    1
L2 Cache Total Size: 8 KB
L2 Cache: 32 sets, 2-way, 64 B/line, 2 banks, data width 16 B
Fetch Throughput Stats:-
I-Cache Capacity:      32768 Bytes
Instruction Slots:     8192 units
#############################################
