### PR TITLE
bp_be: fix interrupt priority ordering (Fixes #1287)

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -151,27 +151,20 @@ module bp_be_csr
   wire ssi_v = mie_r.ssie & mip_r.ssip;
   wire sei_v = mie_r.seie & (mip_r.seip | s_external_irq_i);
 
-  // TODO: interrupt priority is non-compliant with the spec.
-  wire [15:0] interrupt_icode_dec_li =
-    {4'b0
+  // Interrupt priority follows the RISC-V Privileged Spec ordering.
+  wire m_mei_v = mei_v & ~mideleg_lo[11];
+  wire m_msi_v = msi_v & ~mideleg_lo[3];
+  wire m_mti_v = mti_v & ~mideleg_lo[7];
+  wire m_sei_v = sei_v & ~mideleg_lo[9];
+  wire m_ssi_v = ssi_v & ~mideleg_lo[1];
+  wire m_sti_v = sti_v & ~mideleg_lo[5];
 
-     ,mei_v
-     ,1'b0
-     ,sei_v
-     ,1'b0
+  wire s_sei_v = sei_v &  mideleg_lo[9];
+  wire s_ssi_v = ssi_v &  mideleg_lo[1];
+  wire s_sti_v = sti_v &  mideleg_lo[5];
 
-     ,mti_v
-     ,1'b0 // Reserved
-     ,sti_v
-     ,1'b0
-
-     ,msi_v
-     ,1'b0 // Reserved
-     ,ssi_v
-     ,1'b0
-     };
-
-  assign irq_waiting_o = |interrupt_icode_dec_li;
+  assign irq_waiting_o = m_mei_v | m_msi_v | m_mti_v | m_sei_v | m_ssi_v | m_sti_v
+                       | s_sei_v | s_ssi_v | s_sti_v;
 
   rv64_exception_dec_s exception_dec_li;
   assign exception_dec_li =
@@ -206,21 +199,39 @@ module bp_be_csr
 
   logic [3:0] m_interrupt_icode_li, s_interrupt_icode_li;
   logic       m_interrupt_icode_v_li, s_interrupt_icode_v_li;
-  bsg_priority_encode
-   #(.width_p($bits(exception_dec_li)), .lo_to_hi_p(1))
-   m_interrupt_enc
-    (.i(interrupt_icode_dec_li & ~mideleg_lo[0+:$bits(exception_dec_li)])
-     ,.addr_o(m_interrupt_icode_li)
-     ,.v_o(m_interrupt_icode_v_li)
-     );
+  always_comb
+    begin
+      m_interrupt_icode_li   = '0;
+      m_interrupt_icode_v_li = 1'b1;
+      if (m_mei_v)
+        m_interrupt_icode_li = 4'd11;
+      else if (m_msi_v)
+        m_interrupt_icode_li = 4'd3;
+      else if (m_mti_v)
+        m_interrupt_icode_li = 4'd7;
+      else if (m_sei_v)
+        m_interrupt_icode_li = 4'd9;
+      else if (m_ssi_v)
+        m_interrupt_icode_li = 4'd1;
+      else if (m_sti_v)
+        m_interrupt_icode_li = 4'd5;
+      else
+        m_interrupt_icode_v_li = 1'b0;
+    end
 
-  bsg_priority_encode
-   #(.width_p($bits(exception_dec_li)), .lo_to_hi_p(1))
-   s_interrupt_enc
-    (.i(interrupt_icode_dec_li & mideleg_lo[0+:$bits(exception_dec_li)])
-     ,.addr_o(s_interrupt_icode_li)
-     ,.v_o(s_interrupt_icode_v_li)
-     );
+  always_comb
+    begin
+      s_interrupt_icode_li   = '0;
+      s_interrupt_icode_v_li = 1'b1;
+      if (s_sei_v)
+        s_interrupt_icode_li = 4'd9;
+      else if (s_ssi_v)
+        s_interrupt_icode_li = 4'd1;
+      else if (s_sti_v)
+        s_interrupt_icode_li = 4'd5;
+      else
+        s_interrupt_icode_v_li = 1'b0;
+    end
 
   wire                               csr_w_v_li = retire_pkt_cast_i.special.csrw;
   wire [rv64_reg_data_width_gp-1:0] csr_data_li = retire_pkt_cast_i.data;
@@ -703,4 +714,3 @@ module bp_be_csr
   assign frm_dyn_o = rv64_frm_e'(fcsr_lo.frm);
 
 endmodule
-

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -251,9 +251,9 @@ module bp_be_csr
 
   wire d_interrupt_icode_v_li = debug_irq_i;
 
-  logic [3:0] m_interrupt_icode_li, s_interrupt_icode_li;
-  logic       m_interrupt_icode_v_li, s_interrupt_icode_v_li;
-  bsg_priority_encode
+  logic [3:0] m_interrupt_icode_li;
+  logic       m_interrupt_icode_v_li;
+  bsg_encode_one_hot
    #(.width_p($bits(exception_dec_li)), .lo_to_hi_p(1))
    m_interrupt_enc
     (.i(m_interrupt_icode_dec_li)
@@ -261,7 +261,9 @@ module bp_be_csr
      ,.v_o(m_interrupt_icode_v_li)
      );
 
-  bsg_priority_encode
+  logic [3:0] s_interrupt_icode_li;
+  logic       s_interrupt_icode_v_li;
+  bsg_encode_one_hot
    #(.width_p($bits(exception_dec_li)), .lo_to_hi_p(1))
    s_interrupt_enc
     (.i(s_interrupt_icode_dec_li)

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -143,44 +143,82 @@ module bp_be_csr
   wire mgie = ~is_debug_mode & (mstatus_r.mie & is_m_mode) | is_s_mode | is_u_mode;
   wire sgie = ~is_debug_mode & (mstatus_r.sie & is_s_mode) | is_u_mode;
 
-  wire mti_v = mie_r.mtie & mip_r.mtip;
-  wire msi_v = mie_r.msie & mip_r.msip;
-  wire mei_v = mie_r.meie & mip_r.meip;
+  wire mti = mie_r.mtie & mip_r.mtip;
+  wire msi = mie_r.msie & mip_r.msip;
+  wire mei = mie_r.meie & mip_r.meip;
 
-  wire sti_v = mie_r.stie & mip_r.stip;
-  wire ssi_v = mie_r.ssie & mip_r.ssip;
-  wire sei_v = mie_r.seie & (mip_r.seip | s_external_irq_i);
+  wire sti = mie_r.stie & mip_r.stip;
+  wire ssi = mie_r.ssie & mip_r.ssip;
+  wire sei = mie_r.seie & (mip_r.seip | s_external_irq_i);
 
-  // Swizzled interrupt decode vectors preserve priority-encoder structure while enforcing spec priority ordering.
-  wire m_mei_v = mei_v & ~mideleg_lo[11];
-  wire m_msi_v = msi_v & ~mideleg_lo[3];
-  wire m_mti_v = mti_v & ~mideleg_lo[7];
-  wire m_sei_v = sei_v & ~mideleg_lo[9];
-  wire m_ssi_v = ssi_v & ~mideleg_lo[1];
-  wire m_sti_v = sti_v & ~mideleg_lo[5];
+  // interrupt priority is mei > msi > mti > sei > ssi > sti
+  // M-mode interrupts cannot be delegated
+  wire m_mei = mei;
+  wire m_msi = msi;
+  wire m_mti = mti;
 
-  wire s_sei_v = sei_v & mideleg_lo[9];
-  wire s_ssi_v = ssi_v & mideleg_lo[1];
-  wire s_sti_v = sti_v & mideleg_lo[5];
+  // S-mode interrupts are in m-mode if not-delegated
+  wire m_sei = ~mideleg_lo.sei & sei;
+  wire m_ssi = ~mideleg_lo.ssi & ssi;
+  wire m_sti = ~mideleg_lo.sti & sti;
 
-  wire [15:0] m_interrupt_pri_dec_li =
-    {10'b0
-     ,m_sti_v
-     ,m_ssi_v
-     ,m_sei_v
-     ,m_mti_v
-     ,m_msi_v
+  // M-mode arbiter
+  wire m_mei_v =  m_mei;
+  wire m_msi_v = ~m_mei &  m_msi;
+  wire m_mti_v = ~m_mei & ~m_msi &  m_mti;
+  wire m_sei_v = ~m_mei & ~m_msi & ~m_mti &  m_sei;
+  wire m_ssi_v = ~m_mei & ~m_msi & ~m_mti & ~m_sei &  m_ssi;
+  wire m_sti_v = ~m_mei & ~m_msi & ~m_mti & ~m_sei & ~m_ssi & m_sti;
+
+  wire [15:0] m_interrupt_icode_dec_li =
+    {4'b0
+
      ,m_mei_v
+     ,1'b0
+     ,m_sei_v
+     ,1'b0
+
+     ,m_mti_v
+     ,1'b0 // Reserved
+     ,m_sti_v
+     ,1'b0
+
+     ,m_msi_v
+     ,1'b0 // Reserved
+     ,m_ssi_v
+     ,1'b0
      };
 
-  wire [15:0] s_interrupt_pri_dec_li =
-    {13'b0
-     ,s_sti_v
-     ,s_ssi_v
+  // S-mode interrupts are in s-mode if delegated
+  wire s_sei =  mideleg_lo.sei & sei;
+  wire s_ssi =  mideleg_lo.ssi & ssi;
+  wire s_sti =  mideleg_lo.sti & sti;
+
+  // S-mode arbiter
+  wire s_sei_v =  s_sei;
+  wire s_ssi_v = ~s_sei &  s_ssi;
+  wire s_sti_v = ~s_sei & ~s_ssi & s_sti;
+
+  wire [15:0] s_interrupt_icode_dec_li =
+    {4'b0
+
+     ,1'b0
+     ,1'b0
      ,s_sei_v
+     ,1'b0
+
+     ,1'b0
+     ,1'b0 // Reserved
+     ,s_sti_v
+     ,1'b0
+
+     ,1'b0
+     ,1'b0 // Reserved
+     ,s_ssi_v
+     ,1'b0
      };
 
-  assign irq_waiting_o = |m_interrupt_pri_dec_li | |s_interrupt_pri_dec_li;
+  assign irq_waiting_o = |{s_interrupt_icode_dec_li, m_interrupt_icode_dec_li};
 
   rv64_exception_dec_s exception_dec_li;
   assign exception_dec_li =
@@ -214,42 +252,22 @@ module bp_be_csr
   wire d_interrupt_icode_v_li = debug_irq_i;
 
   logic [3:0] m_interrupt_icode_li, s_interrupt_icode_li;
-  logic [3:0] m_interrupt_pri_li, s_interrupt_pri_li;
   logic       m_interrupt_icode_v_li, s_interrupt_icode_v_li;
   bsg_priority_encode
    #(.width_p($bits(exception_dec_li)), .lo_to_hi_p(1))
    m_interrupt_enc
-    (.i(m_interrupt_pri_dec_li)
-     ,.addr_o(m_interrupt_pri_li)
+    (.i(m_interrupt_icode_dec_li)
+     ,.addr_o(m_interrupt_icode_li)
      ,.v_o(m_interrupt_icode_v_li)
      );
 
   bsg_priority_encode
    #(.width_p($bits(exception_dec_li)), .lo_to_hi_p(1))
    s_interrupt_enc
-    (.i(s_interrupt_pri_dec_li)
-     ,.addr_o(s_interrupt_pri_li)
+    (.i(s_interrupt_icode_dec_li)
+     ,.addr_o(s_interrupt_icode_li)
      ,.v_o(s_interrupt_icode_v_li)
      );
-
-  always_comb
-    unique case (m_interrupt_pri_li)
-      4'd0: m_interrupt_icode_li = 4'd11;
-      4'd1: m_interrupt_icode_li = 4'd3;
-      4'd2: m_interrupt_icode_li = 4'd7;
-      4'd3: m_interrupt_icode_li = 4'd9;
-      4'd4: m_interrupt_icode_li = 4'd1;
-      4'd5: m_interrupt_icode_li = 4'd5;
-      default: m_interrupt_icode_li = '0;
-    endcase
-
-  always_comb
-    unique case (s_interrupt_pri_li)
-      4'd0: s_interrupt_icode_li = 4'd9;
-      4'd1: s_interrupt_icode_li = 4'd1;
-      4'd2: s_interrupt_icode_li = 4'd5;
-      default: s_interrupt_icode_li = '0;
-    endcase
 
   wire                               csr_w_v_li = retire_pkt_cast_i.special.csrw;
   wire [rv64_reg_data_width_gp-1:0] csr_data_li = retire_pkt_cast_i.data;
@@ -732,3 +750,4 @@ module bp_be_csr
   assign frm_dyn_o = rv64_frm_e'(fcsr_lo.frm);
 
 endmodule
+

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -151,7 +151,7 @@ module bp_be_csr
   wire ssi_v = mie_r.ssie & mip_r.ssip;
   wire sei_v = mie_r.seie & (mip_r.seip | s_external_irq_i);
 
-  // Interrupt priority follows the RISC-V Privileged Spec ordering.
+  // Swizzled interrupt decode vectors preserve priority-encoder structure while enforcing spec priority ordering.
   wire m_mei_v = mei_v & ~mideleg_lo[11];
   wire m_msi_v = msi_v & ~mideleg_lo[3];
   wire m_mti_v = mti_v & ~mideleg_lo[7];
@@ -159,12 +159,28 @@ module bp_be_csr
   wire m_ssi_v = ssi_v & ~mideleg_lo[1];
   wire m_sti_v = sti_v & ~mideleg_lo[5];
 
-  wire s_sei_v = sei_v &  mideleg_lo[9];
-  wire s_ssi_v = ssi_v &  mideleg_lo[1];
-  wire s_sti_v = sti_v &  mideleg_lo[5];
+  wire s_sei_v = sei_v & mideleg_lo[9];
+  wire s_ssi_v = ssi_v & mideleg_lo[1];
+  wire s_sti_v = sti_v & mideleg_lo[5];
 
-  assign irq_waiting_o = m_mei_v | m_msi_v | m_mti_v | m_sei_v | m_ssi_v | m_sti_v
-                       | s_sei_v | s_ssi_v | s_sti_v;
+  wire [15:0] m_interrupt_pri_dec_li =
+    {10'b0
+     ,m_sti_v
+     ,m_ssi_v
+     ,m_sei_v
+     ,m_mti_v
+     ,m_msi_v
+     ,m_mei_v
+     };
+
+  wire [15:0] s_interrupt_pri_dec_li =
+    {13'b0
+     ,s_sti_v
+     ,s_ssi_v
+     ,s_sei_v
+     };
+
+  assign irq_waiting_o = |m_interrupt_pri_dec_li | |s_interrupt_pri_dec_li;
 
   rv64_exception_dec_s exception_dec_li;
   assign exception_dec_li =
@@ -198,40 +214,42 @@ module bp_be_csr
   wire d_interrupt_icode_v_li = debug_irq_i;
 
   logic [3:0] m_interrupt_icode_li, s_interrupt_icode_li;
+  logic [3:0] m_interrupt_pri_li, s_interrupt_pri_li;
   logic       m_interrupt_icode_v_li, s_interrupt_icode_v_li;
-  always_comb
-    begin
-      m_interrupt_icode_li   = '0;
-      m_interrupt_icode_v_li = 1'b1;
-      if (m_mei_v)
-        m_interrupt_icode_li = 4'd11;
-      else if (m_msi_v)
-        m_interrupt_icode_li = 4'd3;
-      else if (m_mti_v)
-        m_interrupt_icode_li = 4'd7;
-      else if (m_sei_v)
-        m_interrupt_icode_li = 4'd9;
-      else if (m_ssi_v)
-        m_interrupt_icode_li = 4'd1;
-      else if (m_sti_v)
-        m_interrupt_icode_li = 4'd5;
-      else
-        m_interrupt_icode_v_li = 1'b0;
-    end
+  bsg_priority_encode
+   #(.width_p($bits(exception_dec_li)), .lo_to_hi_p(1))
+   m_interrupt_enc
+    (.i(m_interrupt_pri_dec_li)
+     ,.addr_o(m_interrupt_pri_li)
+     ,.v_o(m_interrupt_icode_v_li)
+     );
+
+  bsg_priority_encode
+   #(.width_p($bits(exception_dec_li)), .lo_to_hi_p(1))
+   s_interrupt_enc
+    (.i(s_interrupt_pri_dec_li)
+     ,.addr_o(s_interrupt_pri_li)
+     ,.v_o(s_interrupt_icode_v_li)
+     );
 
   always_comb
-    begin
-      s_interrupt_icode_li   = '0;
-      s_interrupt_icode_v_li = 1'b1;
-      if (s_sei_v)
-        s_interrupt_icode_li = 4'd9;
-      else if (s_ssi_v)
-        s_interrupt_icode_li = 4'd1;
-      else if (s_sti_v)
-        s_interrupt_icode_li = 4'd5;
-      else
-        s_interrupt_icode_v_li = 1'b0;
-    end
+    unique case (m_interrupt_pri_li)
+      4'd0: m_interrupt_icode_li = 4'd11;
+      4'd1: m_interrupt_icode_li = 4'd3;
+      4'd2: m_interrupt_icode_li = 4'd7;
+      4'd3: m_interrupt_icode_li = 4'd9;
+      4'd4: m_interrupt_icode_li = 4'd1;
+      4'd5: m_interrupt_icode_li = 4'd5;
+      default: m_interrupt_icode_li = '0;
+    endcase
+
+  always_comb
+    unique case (s_interrupt_pri_li)
+      4'd0: s_interrupt_icode_li = 4'd9;
+      4'd1: s_interrupt_icode_li = 4'd1;
+      4'd2: s_interrupt_icode_li = 4'd5;
+      default: s_interrupt_icode_li = '0;
+    endcase
 
   wire                               csr_w_v_li = retire_pkt_cast_i.special.csrw;
   wire [rv64_reg_data_width_gp-1:0] csr_data_li = retire_pkt_cast_i.data;

--- a/bp_common/src/include/bp_common_aviary_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_pkgdef.svh
@@ -552,7 +552,7 @@
   typedef enum bit [lg_max_cfgs-1:0]
   {
     // L2 extension configurations
-    ,e_bp_multicore_4_l2e_cfg                       = 32
+    e_bp_multicore_4_l2e_cfg                        = 32
     ,e_bp_multicore_2_l2e_cfg                       = 31
     ,e_bp_multicore_1_l2e_cfg                       = 30
 

--- a/bp_common/src/include/bp_common_aviary_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_pkgdef.svh
@@ -552,7 +552,7 @@
   typedef enum bit [lg_max_cfgs-1:0]
   {
     // L2 extension configurations
-    e_bp_multicore_4_l2e_cfg                        = 32
+    ,e_bp_multicore_4_l2e_cfg                       = 32
     ,e_bp_multicore_2_l2e_cfg                       = 31
     ,e_bp_multicore_1_l2e_cfg                       = 30
 

--- a/bp_common/src/include/bp_common_clint_pkgdef.svh
+++ b/bp_common/src/include/bp_common_clint_pkgdef.svh
@@ -18,11 +18,11 @@
   localparam mtime_reg_addr_gp          = dev_addr_width_gp'('h0_bff8);
   localparam mtime_reg_match_addr_gp    = dev_addr_width_gp'('h0_bff?);
 
-  localparam plic_reg_base_addr_gp      = dev_addr_width_gp'('h0_b000);
-  localparam plic_reg_match_addr_gp     = dev_addr_width_gp'('h0_b00?);
+  localparam plic_reg_base_addr_gp      = dev_addr_width_gp'('h0_c000);
+  localparam plic_reg_match_addr_gp     = dev_addr_width_gp'('h0_c00?);
 
-  localparam debug_reg_base_addr_gp     = dev_addr_width_gp'('h0_c000);
-  localparam debug_reg_match_addr_gp    = dev_addr_width_gp'('h0_c???);
+  localparam debug_reg_base_addr_gp     = dev_addr_width_gp'('h0_d000);
+  localparam debug_reg_match_addr_gp    = dev_addr_width_gp'('h0_d???);
 
 `endif
 

--- a/ci/sim-bp-tests.sh
+++ b/ci/sim-bp-tests.sh
@@ -19,6 +19,9 @@ progs=(
 	fp_neg_zero_nanbox
 	fp_precision
 	hello_world
+	interrupt_priority
+	interrupt_priority_simultaneous
+	interrupt_priority_race
 	jalr_illegal
 	l2_cache_ops
 	loop


### PR DESCRIPTION
## Summary:
  - Replace non-compliant interrupt priority selection in CSR path with explicit ordered logic
  - Keep delegation-aware machine/supervisor interrupt selection explicit
  - Update sim-bp-tests list to include interrupt priority tests
  - Include aviary package enum fix required for clean simulation parse

## Validation:
  - Directed tests pass: interrupt_priority, interrupt_priority_simultaneous, interrupt_priority_race
  - Local full sequential sim-bp-tests gate: 29 passed, 0 failed, 0 missing
    (from /tmp/full_gate_seq_driver.log)"