### PR TITLE
Add bp uvm examples fifo

### DIFF
--- a/bp_uvm_example/fifo/README.md
+++ b/bp_uvm_example/fifo/README.md
@@ -1,0 +1,67 @@
+# Minimal UVM-style Testbench Example (FIFO)
+
+A simple, Verilator-compatible SystemVerilog verification example using a FIFO design.
+
+## What
+This example demonstrates a minimal class-based testbench with:
+- driver (random stimulus generation)
+- monitor (cycle-aligned observation)
+- scoreboard (self-checking reference model)
+
+## Why
+BlackParrot currently lacks a lightweight verification reference.
+
+This example provides a starting point for building verification environments for future modules (e.g., ALU, cache, BP-Stream).
+
+## Features
+- Simple FIFO DUT (8-depth)
+- Randomized stimulus
+- Self-checking PASS/FAIL output
+- Verilator-compatible
+- Waveform generation (VCD)
+
+## How to Run
+
+### Option 1 (recommended)
+```bash
+chmod +x run.sh
+./run.sh
+```
+
+### Option 2 (manual)
+```bash
+verilator --sv --timing --trace --cc top.sv --exe sim_main.cpp
+make -C obj_dir -f Vtop.mk
+./obj_dir/Vtop
+```
+## Output
+
+The simulation prints:
+WRITE transactions
+PASS / FAIL checks
+Final summary (PASS / FAIL count)
+Example:
+```
+WRITE: 3b
+PASS: 3b
+PASS=85 FAIL=0
+```
+## Waveform Viewing:
+```bash
+gtkwave waveform.vcd
+```
+
+## Notes
+FIFO read has 1-cycle latency, handled in the monitor
+Designed to be minimal and easy to understand
+Not a full UVM implementation (no factory, sequences, coverage)
+
+## File Structure
+```
+fifo.sv         - FIFO RTL
+fifo_if.sv      - Interface with clocking blocks
+tb_classes.sv   - Driver, Monitor, Scoreboard
+top.sv          - Testbench top
+sim_main.cpp    - Verilator simulation harness
+run.sh          - Build and run script
+```

--- a/bp_uvm_example/fifo/fifo.sv
+++ b/bp_uvm_example/fifo/fifo.sv
@@ -1,0 +1,37 @@
+module fifo (
+    input  logic [7:0] data_in,
+    input  logic       wr_en,
+    input  logic       rd_en,
+    input  logic       clk,
+    input  logic       rst_n,
+    output logic [7:0] data_out,
+    output logic       full,
+    output logic       empty
+);
+    logic [7:0] mem [0:7];
+    logic [2:0] wptr, rptr;
+    logic [3:0] count;
+
+    assign full  = (count == 8);
+    assign empty = (count == 0);
+
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            wptr <= 0; rptr <= 0; count <= 0; data_out <= 0;
+        end else begin
+            if (wr_en && !full) begin
+                mem[wptr] <= data_in;
+                wptr <= wptr + 1;
+            end
+            if (rd_en && !empty) begin
+                data_out <= mem[rptr];
+                rptr <= rptr + 1;
+            end
+            // Simultaneous read/write logic
+            if ((wr_en && !full) && !(rd_en && !empty))
+                count <= count + 1;
+            else if (!(wr_en && !full) && (rd_en && !empty))
+                count <= count - 1;
+        end
+    end
+endmodule

--- a/bp_uvm_example/fifo/fifo_if.sv
+++ b/bp_uvm_example/fifo/fifo_if.sv
@@ -1,0 +1,18 @@
+interface fifo_if(input logic clk);
+    logic rst_n;
+    logic [7:0] data_in;
+    logic [7:0] data_out;
+    logic wr_en;
+    logic rd_en;
+    logic full;
+    logic empty;
+
+    clocking drv_cb @(posedge clk);
+        output rst_n, data_in, wr_en, rd_en;
+        input  full, empty;
+    endclocking
+
+    clocking mon_cb @(posedge clk);
+        input data_in, data_out, wr_en, rd_en, full, empty;
+    endclocking
+endinterface

--- a/bp_uvm_example/fifo/run.sh
+++ b/bp_uvm_example/fifo/run.sh
@@ -1,0 +1,8 @@
+rm -rf obj_dir
+rm -rf waveform.vcd
+
+verilator --sv --timing --trace --cc top.sv --exe sim_main.cpp
+
+make -C obj_dir -f Vtop.mk
+
+./obj_dir/Vtop

--- a/bp_uvm_example/fifo/sim_main.cpp
+++ b/bp_uvm_example/fifo/sim_main.cpp
@@ -1,0 +1,30 @@
+#include "Vtop.h"
+#include "verilated.h"
+#include "verilated_vcd_c.h"
+
+int main(int argc, char** argv) {
+    VerilatedContext* contextp = new VerilatedContext;
+    contextp->commandArgs(argc, argv);
+
+    Vtop* top = new Vtop{contextp};
+
+    // Enable tracing
+    Verilated::traceEverOn(true);
+
+    VerilatedVcdC* tfp = new VerilatedVcdC;
+    top->trace(tfp, 99);   // depth
+    tfp->open("waveform.vcd");
+
+    while (!contextp->gotFinish()) {
+        top->eval();
+        tfp->dump(contextp->time());   // dump wave
+        contextp->timeInc(1);
+    }
+
+    tfp->close();
+
+    top->final();
+    delete top;
+    delete contextp;
+    return 0;
+}

--- a/bp_uvm_example/fifo/tb_classes.sv
+++ b/bp_uvm_example/fifo/tb_classes.sv
@@ -18,6 +18,9 @@ class fifo_scoreboard;
                 $display("[%0t] FAIL: expected %h got %h", $time, expected, d_out);
                 error_count++;
             end
+        end else begin
+            $display("[%0t] FAIL: unexpected read got %h (model_q empty)", $time, d_out);
+            error_count++;
         end
     endfunction
 

--- a/bp_uvm_example/fifo/tb_classes.sv
+++ b/bp_uvm_example/fifo/tb_classes.sv
@@ -56,7 +56,7 @@ class fifo_driver;
             vif.drv_cb.rd_en   <= do_read;
             vif.drv_cb.data_in <= data;
 
-            if (do_write && !vif.full) begin
+            if (do_write && !vif.drv_cb.full) begin
                 sb.write_expected(data);
                 $display("[%0t] WRITE: %h", $time, data);
             end

--- a/bp_uvm_example/fifo/tb_classes.sv
+++ b/bp_uvm_example/fifo/tb_classes.sv
@@ -1,0 +1,104 @@
+class fifo_scoreboard;
+    logic [7:0] model_q[$];
+    int pass_count = 0;
+    int error_count = 0;
+
+    function void write_expected(logic [7:0] d);
+        model_q.push_back(d);
+    endfunction
+
+    function void check_actual(logic [7:0] d_out);
+        if (model_q.size() > 0) begin
+            logic [7:0] expected = model_q.pop_front();
+
+            if (d_out === expected) begin
+                $display("[%0t] PASS: %h", $time, d_out);
+                pass_count++;
+            end else begin
+                $display("[%0t] FAIL: expected %h got %h", $time, expected, d_out);
+                error_count++;
+            end
+        end
+    endfunction
+
+    function void report();
+        $display("PASS=%0d FAIL=%0d", pass_count, error_count);
+    endfunction
+endclass
+
+
+
+class fifo_driver;
+    virtual fifo_if vif;
+    fifo_scoreboard sb;
+
+    function new(virtual fifo_if v, fifo_scoreboard s);
+        vif = v;
+        sb  = s;
+    endfunction
+
+    task run();
+        bit do_write;
+        bit do_read;
+        logic [7:0] data;
+
+        forever begin
+            @(vif.drv_cb);
+
+            do_write = ($urandom_range(0,9) < 6);
+            do_read  = ($urandom_range(0,9) < 4);
+            data     = 8'($urandom_range(0,255));
+
+            vif.drv_cb.wr_en   <= do_write;
+            vif.drv_cb.rd_en   <= do_read;
+            vif.drv_cb.data_in <= data;
+
+            if (do_write && !vif.full) begin
+                sb.write_expected(data);
+                $display("[%0t] WRITE: %h", $time, data);
+            end
+        end
+    endtask
+endclass
+
+
+
+class fifo_monitor;
+    virtual fifo_if vif;
+    fifo_scoreboard sb;
+
+    bit pending_read;  // tracks delayed read
+
+    function new(virtual fifo_if v, fifo_scoreboard s);
+        vif = v;
+        sb  = s;
+        pending_read = 0;
+    endfunction
+
+    task run();
+        forever begin
+            @(vif.mon_cb);
+
+            // Step 1: check previous cycle read
+            if (pending_read) begin
+                sb.check_actual(vif.mon_cb.data_out);
+            end
+
+            // Step 2: capture new read request
+            pending_read = (vif.mon_cb.rd_en && !vif.mon_cb.empty);
+        end
+    endtask
+endclass
+
+
+class fifo_env;
+    fifo_driver drv;
+    fifo_monitor mon;
+    fifo_scoreboard sb;
+
+    function new(virtual fifo_if v);
+        sb  = new();
+        drv = new(v, sb);
+        mon = new(v, sb);
+    endfunction
+endclass

--- a/bp_uvm_example/fifo/top.sv
+++ b/bp_uvm_example/fifo/top.sv
@@ -1,0 +1,58 @@
+`include "fifo_if.sv"
+`include "fifo.sv"
+`include "tb_classes.sv"
+
+module top;
+
+    logic clk;
+
+    // Clock
+    initial begin
+        clk = 0;
+        forever #5 clk = ~clk;
+    end
+
+    fifo_if p_if(clk);
+    fifo_env env;
+
+    fifo dut (
+        .clk(clk),
+        .rst_n(p_if.rst_n),
+        .data_in(p_if.data_in),
+        .data_out(p_if.data_out),
+        .wr_en(p_if.wr_en),
+        .rd_en(p_if.rd_en),
+        .full(p_if.full),
+        .empty(p_if.empty)
+    );
+
+    initial begin
+        $dumpfile("waveform.vcd");
+        $dumpvars(0, top);
+
+        // Reset
+        p_if.rst_n = 0;
+        p_if.wr_en = 0;
+        p_if.rd_en = 0;
+
+        #50;
+        p_if.rst_n = 1;
+
+        // Create env
+        env = new(p_if);
+
+        // Run components
+        fork
+            env.drv.run();
+            env.mon.run();
+        join_none
+
+        // Run simulation
+        #2000;
+
+        env.sb.report();
+        $display("Simulation Finished");
+        $finish;
+    end
+
+endmodule

--- a/bp_uvm_example/fifo/top.sv
+++ b/bp_uvm_example/fifo/top.sv
@@ -27,9 +27,6 @@ module top;
     );
 
     initial begin
-        $dumpfile("waveform.vcd");
-        $dumpvars(0, top);
-
         // Reset
         p_if.rst_n = 0;
         p_if.wr_en = 0;


### PR DESCRIPTION
### Summary
Adds a minimal UVM-style (class-based) SystemVerilog verification example using a FIFO DUT.

This example demonstrates a simple driver, monitor, and scoreboard structure compatible with Verilator, intended as a learning and reference starting point.


### Issue Fixed
Closes #1297 

### Area
Verification / SystemVerilog testbench examples / Verilator workflow

### Reasoning (new feature, inefficient, verbose, etc.)
BlackParrot currently provides advanced simulation flows (e.g., bp_top, bp_me), but lacks a minimal standalone reference for building class-based verification environments.

This change introduces a simple example to:
- help new contributors understand verification structure
- enable experimentation with SystemVerilog class-based testbenches
- provide a foundation for future module-level verification (e.g., ALU, BP-Stream)


### Additional Changes Required (if any)
None for this PR.

Future work may extend this example to:
- additional modules (ALU, Register File)
- integration with BlackParrot components
- constrained random testing


### Analysis
Impact:
- lowers entry barrier for verification contributors
- provides a reusable template for future development
- does not affect existing RTL or simulation flows

Risk:
- minimal, as this is a standalone example

### Verification
Steps to verify:

```bash
cd bp_uvm_example/fifo
./run.sh
```
### Expected behavior:
- simulation runs successfully
- `WRITE` transactions are printed
- `PASS/FAIL` checks are displayed
final summary shows `PASS` and `FAIL` counts (e.g., `PASS=85 FAIL=0`)
Optional:
For waveform:
```bash
gtkwave waveform.vcd
```
Additional Context:
- Uses a UVM-style approach with SystemVerilog classes (not full UVM) for compatibility with Verilator
- Handles FIFO 1-cycle read latency using monitor alignment
- Intended as a stepping stone toward verifying BlackParrot modules
