### PR TITLE
Adding coverage to VCS and Verilator

### DIFF
--- a/.gitlab-ci.local.yml
+++ b/.gitlab-ci.local.yml
@@ -304,6 +304,8 @@ build-image:
         (cd "${BUILD_DIR}" && find -name "*.vdb" ! -name "design.vdb" -exec cp -r --parents {} "${COVERAGE_DIR}/" \;)
       elif [ "$TOOL" == "verilator" ]; then
         (cd "${BUILD_DIR}" && find -name "*.dat" ! -name "*__verFiles.dat" -exec cp -r --parents {} "${COVERAGE_DIR}/" \;)
+        # Strip the absolute CI runner path to make source file references relative
+        find "${COVERAGE_DIR}" -name "*.dat" -exec sed -i "s|${CI_PROJECT_DIR}/|../../../../../|g" {} +
       fi
   rules:
     - if: '"$[[ inputs.do_sim_riscv ]]" =~ "/on_success|on_event/" && $DOCKER_PLATFORM == "centos7"'
@@ -360,74 +362,68 @@ gather-riscv:
   extends: [.gather_riscv_job]
   needs: [{job: scatter-libs, optional: true}]
 
-    #check-design:
-    #  extends: [.check_design_job]
-    #  parallel:
-    #    matrix:
-    #      - CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
-    #  needs: [{job: build-image, optional: true}]
-    #
-    #check-loops:
-    #  extends: [.check_loops_job]
-    #  parallel:
-    #    matrix:
-    #      - CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
-    #  needs: [check-design]
-    #
-    #sv2v:
-    #  extends: [.sv2v_job]
-    #  parallel:
-    #    matrix:
-    #      - CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
-    #  needs: [check-design, gather-tools, gather-libs]
-    #
-    #scatter-sv2v:
-    #  extends: [.scatter_sv2v_job]
-    #  needs: [sv2v]
-    #
-    #gather-sv2v:
-    #  extends: [.gather_sv2v_job]
-    #  needs: [{job: scatter-sv2v, optional: true}]
-    #
-    #lint-top:
-    #  extends: [.lint_job]
-    #  parallel:
-    #    matrix:
-    #      - TOOL: ["verilator", "xcelium", "vcs"]
-    #        CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
-    #      - TOOL: ["vcs"]
-    #        CFG: ["e_bp_multicore_2_cfg", "e_bp_multicore_2_cce_ucode_cfg"]
-    #      - TOOL: ["vcs"]
-    #        CFG: ["e_bp_multicore_4_cfg", "e_bp_multicore_4_cce_ucode_cfg"]
-    #  needs: [check-design, gather-tools, gather-libs]
-    #
-    #me-regress:
-    #  extends: [.me_regress_job]
-    #  parallel:
-    #    matrix:
-    #      - TOOL: ["vcs", "verilator", "xcelium"]
-    #        CFG: ["e_bp_test_multicore_half_cce_ucode_cfg", "e_bp_test_multicore_half_cfg"]
-    #  needs: [lint-top]
+check-design:
+  extends: [.check_design_job]
+  parallel:
+    matrix:
+      - CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
+  needs: [{job: build-image, optional: true}]
 
+check-loops:
+  extends: [.check_loops_job]
+  parallel:
+    matrix:
+      - CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
+  needs: [check-design]
+
+sv2v:
+  extends: [.sv2v_job]
+  parallel:
+    matrix:
+      - CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
+  needs: [check-design, gather-tools, gather-libs]
+
+scatter-sv2v:
+  extends: [.scatter_sv2v_job]
+  needs: [sv2v]
+
+gather-sv2v:
+  extends: [.gather_sv2v_job]
+  needs: [{job: scatter-sv2v, optional: true}]
+
+lint-top:
+  extends: [.lint_job]
+  parallel:
+    matrix:
+      - TOOL: ["verilator", "vcs", "xcelium"]
+        CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
+      - TOOL: ["vcs"]
+        CFG: ["e_bp_multicore_2_cfg", "e_bp_multicore_2_cce_ucode_cfg"]
+      - TOOL: ["vcs"]
+        CFG: ["e_bp_multicore_4_cfg", "e_bp_multicore_4_cce_ucode_cfg"]
+  needs: [check-design, gather-tools, gather-libs]
+
+me-regress:
+  extends: [.me_regress_job]
+  parallel:
+    matrix:
+      - TOOL: ["vcs", "verilator", "xcelium"]
+        CFG: ["e_bp_test_multicore_half_cce_ucode_cfg", "e_bp_test_multicore_half_cfg"]
+  needs: [lint-top]
 
 sim-riscv:
   extends: [.sim_riscv_job]
   parallel:
     matrix:
       - TOOL: ["vcs", "verilator", "xcelium"]
-        CFG: ["e_bp_unicore_cfg"]
-        TESTLIST: ["bp-demos"]
-    #  parallel:
-    #    matrix:
-    #      - TOOL: ["vcs", "verilator", "xcelium"]
-    #        CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
-    #        TESTLIST: ["bp-tests", "bp-demos"]
-    #      - TOOL: ["vcs"]
-    #        CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
-    #        TESTLIST: ["beebs", "nocosim", "coremark", "riscv-arch", "riscv-dv", "riscv-tests"]
-    #      - TOOL: ["vcs"]
-    #        CFG: ["e_bp_multicore_1_cfg", "e_bp_multicore_2_cfg", "e_bp_multicore_4_cfg", "e_bp_multicore_8_cfg", "e_bp_multicore_16_cfg"]
-    #        TESTLIST: ["mc-tests"]
+        CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
+        TESTLIST: ["bp-tests", "bp-demos"]
+      - TOOL: ["vcs"]
+        CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
+        TESTLIST: ["beebs", "nocosim", "coremark", "riscv-arch", "riscv-dv", "riscv-tests"]
+      - TOOL: ["vcs"]
+        CFG: ["e_bp_multicore_1_cfg", "e_bp_multicore_2_cfg", "e_bp_multicore_4_cfg", "e_bp_multicore_8_cfg", "e_bp_multicore_16_cfg"]
+        TESTLIST: ["mc-tests"]
   needs: [{job: lint-top, optional: true}, gather-tools, gather-libs, gather-sdk, gather-riscv]
 
 coverage:

--- a/.gitlab-ci.local.yml
+++ b/.gitlab-ci.local.yml
@@ -290,11 +290,42 @@ build-image:
     TESTLIST: "setme"
     RUN_SCRIPT: "./ci/common/run-ci.sh"
     BUILD_SCRIPT: "./ci/sim-${TESTLIST}.sh"
+    COVERAGE: "1"
+    BUILD_DIR: "${CI_PROJECT_DIR}/${END}/${TOOL}/results/bp_tethered.${CFG}.sim-${TESTLIST}"
+    COVERAGE_DIR: "${CI_PROJECT_DIR}/${JOB_SUCCESS_ROOT}/coverage/${TOOL}/${CFG}"
   script:
     - echo "[CI] doing makefile checkout"
     - make -j${BSG_CI_CORES_PER_JOB} checkout
     - echo "[CI] running script for ${BUILD_SCRIPT}"
     - ${RUN_SCRIPT} ${BUILD_SCRIPT} ${TOOL} ${END} ${CFG} ${BSG_CI_CORES_PER_JOB}
+    - mkdir -p "${COVERAGE_DIR}"
+    - |
+      if [ "$TOOL" == "vcs" ]; then
+        (cd "${BUILD_DIR}" && find -name "*.vdb" ! -name "design.vdb" -exec cp -r --parents {} "${COVERAGE_DIR}/" \;)
+      elif [ "$TOOL" == "verilator" ]; then
+        (cd "${BUILD_DIR}" && find -name "*.dat" ! -name "*__verFiles.dat" -exec cp -r --parents {} "${COVERAGE_DIR}/" \;)
+      fi
+  rules:
+    - if: '"$[[ inputs.do_sim_riscv ]]" =~ "/on_success|on_event/" && $DOCKER_PLATFORM == "centos7"'
+
+.coverage_job:
+  extends: [.project_template]
+  variables:
+    TOOL: "setme"
+    END: "bp_top"
+    CFG: "setme"
+    RUN_SCRIPT: "./ci/common/run-ci.sh"
+    BUILD_SCRIPT: "./ci/coverage-merge.sh"
+    COVERAGE: "1"
+    BUILD_DIR: "${CI_PROJECT_DIR}/${END}/${TOOL}/results/bp_tethered.${CFG}"
+    COVERAGE_DIR: "${CI_PROJECT_DIR}/${JOB_DEPS_ROOT}/coverage/${TOOL}/${CFG}"
+    MERGE_DIR: "${COVERAGE_DIR}/merge"
+  script:
+    - make -C ${END}/${TOOL} build.${TOOL}
+    - mv ${COVERAGE_DIR}/* ${BUILD_DIR}
+    - make -C ${END}/${TOOL} merge.${TOOL}
+    - mkdir -p ${JOB_SUCCESS_ROOT}/coverage
+    - cp -r ${END}/${TOOL}/results/bp_tethered.${CFG}/coverage ${JOB_SUCCESS_ROOT}/coverage/${TOOL}
   rules:
     - if: '"$[[ inputs.do_sim_riscv ]]" =~ "/on_success|on_event/" && $DOCKER_PLATFORM == "centos7"'
 
@@ -329,67 +360,81 @@ gather-riscv:
   extends: [.gather_riscv_job]
   needs: [{job: scatter-libs, optional: true}]
 
-check-design:
-  extends: [.check_design_job]
-  parallel:
-    matrix:
-      - CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
-  needs: [{job: build-image, optional: true}]
+    #check-design:
+    #  extends: [.check_design_job]
+    #  parallel:
+    #    matrix:
+    #      - CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
+    #  needs: [{job: build-image, optional: true}]
+    #
+    #check-loops:
+    #  extends: [.check_loops_job]
+    #  parallel:
+    #    matrix:
+    #      - CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
+    #  needs: [check-design]
+    #
+    #sv2v:
+    #  extends: [.sv2v_job]
+    #  parallel:
+    #    matrix:
+    #      - CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
+    #  needs: [check-design, gather-tools, gather-libs]
+    #
+    #scatter-sv2v:
+    #  extends: [.scatter_sv2v_job]
+    #  needs: [sv2v]
+    #
+    #gather-sv2v:
+    #  extends: [.gather_sv2v_job]
+    #  needs: [{job: scatter-sv2v, optional: true}]
+    #
+    #lint-top:
+    #  extends: [.lint_job]
+    #  parallel:
+    #    matrix:
+    #      - TOOL: ["verilator", "xcelium", "vcs"]
+    #        CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
+    #      - TOOL: ["vcs"]
+    #        CFG: ["e_bp_multicore_2_cfg", "e_bp_multicore_2_cce_ucode_cfg"]
+    #      - TOOL: ["vcs"]
+    #        CFG: ["e_bp_multicore_4_cfg", "e_bp_multicore_4_cce_ucode_cfg"]
+    #  needs: [check-design, gather-tools, gather-libs]
+    #
+    #me-regress:
+    #  extends: [.me_regress_job]
+    #  parallel:
+    #    matrix:
+    #      - TOOL: ["vcs", "verilator", "xcelium"]
+    #        CFG: ["e_bp_test_multicore_half_cce_ucode_cfg", "e_bp_test_multicore_half_cfg"]
+    #  needs: [lint-top]
 
-check-loops:
-  extends: [.check_loops_job]
-  parallel:
-    matrix:
-      - CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
-  needs: [check-design]
-
-sv2v:
-  extends: [.sv2v_job]
-  parallel:
-    matrix:
-      - CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
-  needs: [check-design, gather-tools, gather-libs]
-
-scatter-sv2v:
-  extends: [.scatter_sv2v_job]
-  needs: [sv2v]
-
-gather-sv2v:
-  extends: [.gather_sv2v_job]
-  needs: [{job: scatter-sv2v, optional: true}]
-
-lint-top:
-  extends: [.lint_job]
-  parallel:
-    matrix:
-      - TOOL: ["verilator", "vcs", "xcelium"]
-        CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
-      - TOOL: ["vcs"]
-        CFG: ["e_bp_multicore_2_cfg", "e_bp_multicore_2_cce_ucode_cfg"]
-      - TOOL: ["vcs"]
-        CFG: ["e_bp_multicore_4_cfg", "e_bp_multicore_4_cce_ucode_cfg"]
-  needs: [check-design, gather-tools, gather-libs]
-
-me-regress:
-  extends: [.me_regress_job]
-  parallel:
-    matrix:
-      - TOOL: ["vcs", "verilator", "xcelium"]
-        CFG: ["e_bp_test_multicore_half_cce_ucode_cfg", "e_bp_test_multicore_half_cfg"]
-  needs: [lint-top]
 
 sim-riscv:
   extends: [.sim_riscv_job]
   parallel:
     matrix:
       - TOOL: ["vcs", "verilator", "xcelium"]
-        CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
-        TESTLIST: ["bp-tests", "bp-demos"]
-      - TOOL: ["vcs"]
-        CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
-        TESTLIST: ["beebs", "nocosim", "coremark", "riscv-arch", "riscv-dv", "riscv-tests"]
-      - TOOL: ["vcs"]
-        CFG: ["e_bp_multicore_1_cfg", "e_bp_multicore_2_cfg", "e_bp_multicore_4_cfg", "e_bp_multicore_8_cfg", "e_bp_multicore_16_cfg"]
-        TESTLIST: ["mc-tests"]
-  needs: [{job: lint-top, optional: true}, gather-tools, gather-libs, gather-riscv]
+        CFG: ["e_bp_unicore_cfg"]
+        TESTLIST: ["bp-demos"]
+    #  parallel:
+    #    matrix:
+    #      - TOOL: ["vcs", "verilator", "xcelium"]
+    #        CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
+    #        TESTLIST: ["bp-tests", "bp-demos"]
+    #      - TOOL: ["vcs"]
+    #        CFG: ["e_bp_unicore_cfg", "e_bp_multicore_1_cfg", "e_bp_multicore_1_cce_ucode_cfg"]
+    #        TESTLIST: ["beebs", "nocosim", "coremark", "riscv-arch", "riscv-dv", "riscv-tests"]
+    #      - TOOL: ["vcs"]
+    #        CFG: ["e_bp_multicore_1_cfg", "e_bp_multicore_2_cfg", "e_bp_multicore_4_cfg", "e_bp_multicore_8_cfg", "e_bp_multicore_16_cfg"]
+    #        TESTLIST: ["mc-tests"]
+  needs: [{job: lint-top, optional: true}, gather-tools, gather-libs, gather-sdk, gather-riscv]
+
+coverage:
+  extends: [.coverage_job]
+  parallel:
+    matrix:
+      - TOOL: ["vcs", "verilator"]
+        CFG: ["e_bp_unicore_cfg"]
+  needs: [job: sim-riscv]
 

--- a/Makefile.env
+++ b/Makefile.env
@@ -179,9 +179,12 @@ SURFER ?= surfer
 GTKWAVE ?= gtkwave
 DROMAJO ?= dromajo
 SPIKE ?= spike
+URG ?= urg
+VCOV ?= verilator_coverage
 BSG_SV2V_BIN = bsg_sv2v_run.sh
 RISCV_OBJCOPY ?= riscv64-unknown-elf-objcopy
 RISCV_OBJDUMP ?= riscv64-unknown-elf-objdump
+GENHTML ?= genhtml
 
 clean::
 	@$(RMRF) results

--- a/bp_me/test/tb/bp_cce/cm_hier.txt
+++ b/bp_me/test/tb/bp_cce/cm_hier.txt
@@ -1,0 +1,2 @@
+-tree testbench
++tree testbench.wrapper.dut

--- a/bp_top/test/tb/bp_tethered/cm_hier.txt
+++ b/bp_top/test/tb/bp_tethered/cm_hier.txt
@@ -1,0 +1,2 @@
+-tree testbench
++tree testbench.wrapper.processor

--- a/bp_top/vcs/Makefile
+++ b/bp_top/vcs/Makefile
@@ -14,6 +14,7 @@ COH_PROTO ?=
 # Flags
 ASSERT        ?= 0
 TRACE         ?= 0
+COVERAGE      ?= 0
 DROMAJO_COSIM ?= 0
 SPIKE_COSIM   ?= 0
 DISASSEMBLE   ?= 0

--- a/bp_top/verilator/Makefile
+++ b/bp_top/verilator/Makefile
@@ -14,6 +14,7 @@ COH_PROTO ?=
 # Flags
 ASSERT        ?= 0
 TRACE         ?= 0
+COVERAGE      ?= 0
 DROMAJO_COSIM ?= 0
 SPIKE_COSIM   ?= 0
 DISASSEMBLE   ?= 0

--- a/bp_top/xcelium/Makefile
+++ b/bp_top/xcelium/Makefile
@@ -13,6 +13,7 @@ COH_PROTO ?=
 
 # Flags
 ASSERT        ?= 0
+COVERAGE      ?= 0
 TRACE         ?= 0
 DROMAJO_COSIM ?= 0
 SPIKE_COSIM   ?= 0

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -30,7 +30,7 @@ RUN sed -i 's|^# baseurl=http://mirror.centos.org/centos/7|baseurl=http://vault.
 # Install EPEL modules
 RUN yum install --nogpgcheck --setopt=tsflags=nodocs -y -q \
     devtoolset-11 rh-git218 openssl11 openssl11-devel openssl11-libs \
-    parallel \
+    parallel lcov \
     && yum clean all && rm -rf /var/cache/yum
 
 # Install autotools

--- a/docker/Dockerfile.ubuntu24.04
+++ b/docker/Dockerfile.ubuntu24.04
@@ -17,7 +17,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
         device-tree-compiler \
         pkg-config tcl tcl-dev libreadline-dev libffi-dev \
         gperf virtualenv \
-        parallel dc time \
+        parallel dc time lcov \
         && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Accept arguments for user and group

--- a/docs/eval_guide.md
+++ b/docs/eval_guide.md
@@ -55,6 +55,7 @@ FLAGS:
 - COMMITLOG: Create RISCV commitlog during execution
 - DROMAJO_TRACE: Creates a dromajo-based golden trace
 - SPIKE_TRACE: Creates a spike-based golden trace
+- COVERAGE: Generates coverage data for VCS or Verilator
 
 PARAMS:
 - PERF_ENABLE_P: Enable performance profiler
@@ -144,5 +145,14 @@ cd bp_top/dc
 make check_design.dc; # Lints for a variety of common synthesis issues
 make check_loops.dc;  # Checks for timing loops in addition to lint (requires PDK)
 make sv2v.dc;         # Pickles the design
+```
+
+## Code coverage
+
+If code coverage has been enabled during simulations (COVERAGE=1), then the results can be merged into a convenient report.
+
+```bash
+make merge.vcs; # Generates a combined coverage report using URG
+make merge.verilator; # Generates a combined coverage report using Verilator
 ```
 

--- a/mk/Makefile.vcs
+++ b/mk/Makefile.vcs
@@ -17,6 +17,12 @@ VCS_BUILD_OPTS += -reportstats
 VCS_BUILD_OPTS += -ignore initializer_driver_checks
 VCS_BUILD_OPTS += -suppress=UNGB
 
+ifeq ($(COVERAGE),1)
+VCS_BUILD_OPTS += -cm line+tgl
+VCS_BUILD_OPTS += -cm_dir $(DUT_PATH)/design
+VCS_BUILD_OPTS += -cm_hier $(TB_PATH)/cm_hier.txt
+endif
+
 ifeq ($(ASSERT),1)
 VCS_BUILD_OPTS += +define+BSG_NONSYNTH_ASSERT_ENABLE
 VCS_BUILD_OPTS += -assert svaext # Enable elaboration system tasks
@@ -90,6 +96,12 @@ ifeq ($(TRACE),1)
 VCS_RUN_OPTS += +bsg_trace=$(DUMP_FILE)
 endif
 
+ifeq ($(COVERAGE),1)
+VCS_RUN_OPTS += -cm line+tgl
+VCS_RUN_OPTS += -cm_dir $(basename $(notdir $(SIM_TAG)))
+VCS_RUN_OPTS += -cm_hier $(TB_PATH)/cm_hier.txt
+endif
+
 SIM_FILE ?= $(SIM_PATH)/$(SIM_PROG)
 sim.vcs: ## runs a simulation
 sim.vcs: $(SIM_FILE)
@@ -116,4 +128,14 @@ WAVE_COLLATERAL += $(DUMP_FILE)
 wave.vcs: ## opens a waveform
 wave.vcs: $(SIM_PATH)/$(DUMP_FILE)
 	@$(VCS_WAVE_BIN) $(VCS_WAVE_OPTS) $<
+
+URG_OPTS += -full64
+URG_OPTS += -report $(DUT_PATH)/coverage
+
+ALL_COVDBS := design.vdb $(wildcard $(DUT_PATH)/*/*.vdb)
+merge.vcs: ## merges VCS coverage
+	@$(CD) $(DUT_PATH); \
+		$(URG) $(URG_OPTS) $(addprefix -dir ,$(ALL_COVDBS))
+	@$(ECHO) "Coverage report generated in $(DUT_PATH)/coverage"
+	@$(ECHO) "View with web browser such as Firefox"
 

--- a/mk/Makefile.verilator
+++ b/mk/Makefile.verilator
@@ -18,6 +18,10 @@ VV_BUILD_OPTS += --autoflush
 VV_BUILD_OPTS += +define+BSG_NO_TIMESCALE
 VV_BUILD_OPTS += --no-assert
 
+ifeq ($(COVERAGE),1)
+VV_BUILD_OPTS += --coverage
+endif
+
 ifeq ($(DROMAJO_COSIM),1)
 VV_BUILD_OPTS += -LDFLAGS "-ldromajo_cosim"
 VV_BUILD_OPTS += $(BP_DIR)/bp_be/test/common/dromajo_cosim.cpp
@@ -74,6 +78,10 @@ ifeq ($(TRACE),1)
 VV_RUN_OPTS += +bsg_trace=$(DUMP_FILE)
 endif
 
+ifeq ($(COVERAGE),1)
+VV_RUN_OPTS += +verilator+coverage+file+coverage.dat
+endif
+
 SIM_FILE ?= $(SIM_PATH)/$(SIM_PROG)
 sim.verilator: ## runs a simulation
 sim.verilator: $(SIM_FILE)
@@ -99,4 +107,17 @@ endif
 wave.verilator: ## opens a waveform
 wave.verilator: $(SIM_PATH)/$(DUMP_FILE)
 	@$(VV_WAVE_BIN) $(VV_WAVE_OPTS) $<
+
+ALL_COVDBS := $(subst $(DUT_PATH)/,,$(wildcard $(DUT_PATH)/*/coverage.dat))
+COVDIR := $(DUT_PATH)/coverage
+merge.verilator: ## merges coverage data into a single directory
+	@$(MKDIR) -p $(COVDIR)
+	@$(CD) $(DUT_PATH); \
+		$(VERILATOR)_coverage --write $(COVDIR)/merged.dat $(ALL_COVDBS); \
+		$(VERILATOR)_coverage --write-info $(COVDIR)/merged.info $(COVDIR)/merged.dat;
+	@$(CD) $(COVDIR); \
+		$(VERILATOR)_coverage --annotate annotated merged.dat; \
+		$(GENHTML) merged.info --output-directory html
+	@$(ECHO) "Coverage report generated in $(DUT_PATH)/coverage/html"
+	@$(ECHO) "View with web browser such as Firefox"
 

--- a/mk/Makefile.xcelium
+++ b/mk/Makefile.xcelium
@@ -9,6 +9,12 @@ XRUN_BUILD_OPTS += -top testbench
 XRUN_BUILD_OPTS += -f flist.vcs
 XRUN_BUILD_OPTS += "-Wcxx,-std=c++17"
 
+ifeq ($(COVERAGE),1)
+XRUN_BUILD_OPTS += -coverage b:t:f
+XRUN_BUILD_OPTS += -covdut wrapper
+XRUN_BUILD_OPTS += -covworkdir $(DUT_PATH)/design
+endif
+
 ifeq ($(ASSERT),1)
 XRUN_BUILD_OPTS += +define+BSG_NONSYNTH_ASSERT_ENABLE
 XRUN_BUILD_OPTS += -assert
@@ -58,6 +64,7 @@ endif
 XMSIM_OPTS += -64BIT
 XMSIM_OPTS += testbench
 
+
 BUILD_FILE ?= $(DUT_PATH)/simx
 build.xcelium: ## builds a simv
 build.xcelium: $(BUILD_FILE)
@@ -76,7 +83,10 @@ sim.xcelium: $(SIM_FILE)
 $(SIM_FILE): $(addprefix $(SIM_PATH)/,$(RUN_COLLATERAL))
 $(SIM_FILE): $(BUILD_FILE)
 	@$(call bsg_fn_declare_log_rpt,$(SIM_TAG))
-	$(CD) $(SIM_PATH); \
+ifeq (1,$(COVERAGE))
+	@$(eval HDL_PLUSARGS += -covtest test_$(basename $(@F)))
+endif
+	@$(CD) $(SIM_PATH); \
 		$< $(HDL_PLUSARGS) 2>&1 | $(TEE) -i $(LOG_FILE)
 	@$(call bsg_fn_fail_search,$(LOG_FILE),$(ERR_FILE))
 	@$(call bsg_fn_pass_search,$(LOG_FILE),$(ERR_FILE))
@@ -89,4 +99,8 @@ XRUN_WAVE_OPTS += -64BIT
 wave.xcelium: ## opens a waveform
 wave.xcelium: $(SIM_PATH)/$(DUMP_FILE)
 	$(XRUN_WAVE_BIN) $(XRUN_WAVE_OPTS) $<
+
+ALL_COVDBS := $(wildcard $(DUT_PATH)/*/cov_work)
+merge.xcelium: ## merges Xcelium coverage
+	@$(ECHO) "Coverage merging not currently supported in xcelium"
 


### PR DESCRIPTION
### Summary
This PR adds coverage tracking and merging for VCS and Verilator (Xcelium not supported for merging as I don't have access to IMC).

### Issue Fixed
#1222 

### Area
Makefile.vcs and Makefile.verilator primarily

### Reasoning (new feature, inefficient, verbose, etc.)
Code coverage is standard for tracking verification quality. This is a first step towards improving that.

### Additional Changes Required (if any)
None

### Analysis
No PPA impact

### Verification
Manual inspection of the reports generated

