### PR TITLE
Add PMP CSR groundwork in bp_be_csr (4-entry MVP, no MMU enforcement yet)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ stack.info.*
 bsg_cadenv/
 obj_dir/
 session.dump.vpd.tcl
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TOP ?= $(shell git rev-parse --show-toplevel)
+TOP := $(shell git rev-parse --show-toplevel)
 include $(TOP)/Makefile.common
 include $(TOP)/Makefile.env
 

--- a/Makefile.env
+++ b/Makefile.env
@@ -120,7 +120,7 @@ define bsg_fn_info_search
 endef
 
 define bsg_fn_declare_log_rpt
-	$(eval export MAKEFLAGS := "")
+	$(eval export MAKEFLAGS :=)
 	$(eval $@_TOOL       := $(subst .,,$(suffix $(@F))))
 	$(eval $@_CMD        := $(basename $(@F)))
 	$(eval $@_FLATTAG    := $(subst /,.,$($@_CMD).$(1)))

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -65,9 +65,29 @@ module bp_be_csr
   rv64_mie_s sie_rwmask_li;
   rv64_mip_s sip_wmask_li, sip_rmask_li, mip_wmask_li;
 
+  localparam [1:0] pmp_a_off_lp = 2'b00;
+
   logic [rv64_priv_width_gp-1:0] priv_mode_n, priv_mode_r;
   logic debug_mode_n, debug_mode_r;
   logic translation_en_n, translation_en_r;
+
+  function automatic rv64_pmpcfg_entry_s pmpcfg_warl_entry
+    (input rv64_pmpcfg_entry_s entry_i);
+    rv64_pmpcfg_entry_s entry_o;
+    begin
+      entry_o = entry_i;
+
+      // MVP only supports OFF and TOR addressing in CSR state.
+      if (entry_o.a[1])
+        entry_o.a = pmp_a_off_lp;
+
+      // W without R is a reserved encoding, force WARL-compliant state.
+      if (~entry_o.r)
+        entry_o.w = 1'b0;
+
+      pmpcfg_warl_entry = entry_o;
+    end
+  endfunction
 
   wire is_debug_mode = debug_mode_r;
   // Debug Mode grants pseudo M-mode permission
@@ -108,7 +128,11 @@ module bp_be_csr
   `declare_csr_addr(mtval, vaddr_width_p, paddr_width_p);
   `declare_csr(mip);
 
-  // No support for PMP currently
+  `declare_csr(pmpcfg0);
+  `declare_csr(pmpaddr0);
+  `declare_csr(pmpaddr1);
+  `declare_csr(pmpaddr2);
+  `declare_csr(pmpaddr3);
 
   `declare_csr(mcycle);
   `declare_csr(minstret);
@@ -418,6 +442,12 @@ module bp_be_csr
         {`CSR_ADDR_MTVEC        }: csr_data_lo = mtvec_lo;
         {`CSR_ADDR_MCOUNTEREN   }: csr_data_lo = mcounteren_lo;
         {`CSR_ADDR_MIP          }: csr_data_lo = mip_lo;
+        {`CSR_ADDR_PMPCFG0      }: csr_data_lo = pmpcfg0_lo;
+        {`CSR_ADDR_PMPCFG2      }: csr_data_lo = '0;
+        {`CSR_ADDR_PMPADDR0     }: csr_data_lo = pmpaddr0_lo;
+        {`CSR_ADDR_PMPADDR1     }: csr_data_lo = pmpaddr1_lo;
+        {`CSR_ADDR_PMPADDR2     }: csr_data_lo = pmpaddr2_lo;
+        {`CSR_ADDR_PMPADDR3     }: csr_data_lo = pmpaddr3_lo;
         {`CSR_ADDR_MSCRATCH     }: csr_data_lo = mscratch_lo;
         {`CSR_ADDR_MEPC         }: csr_data_lo = mepc_lo;
         {`CSR_ADDR_MCAUSE       }: csr_data_lo = mcause_lo;
@@ -466,6 +496,11 @@ module bp_be_csr
       mcause_li   = mcause_lo;
       mtval_li    = mtval_lo;
       mip_li      = mip_lo;
+      pmpcfg0_li  = pmpcfg0_lo;
+      pmpaddr0_li = pmpaddr0_lo;
+      pmpaddr1_li = pmpaddr1_lo;
+      pmpaddr2_li = pmpaddr2_lo;
+      pmpaddr3_li = pmpaddr3_lo;
 
       mcycle_li        = mcycle_lo;
       minstret_li      = minstret_lo;
@@ -511,6 +546,23 @@ module bp_be_csr
         {1'b1, `CSR_ADDR_MTVEC        }: mtvec_li = csr_data_li;
         {1'b1, `CSR_ADDR_MCOUNTEREN   }: mcounteren_li = csr_data_li;
         {1'b1, `CSR_ADDR_MIP          }: mip_li = csr_data_li;
+        {1'b1, `CSR_ADDR_PMPCFG0      }:
+          for (int i = 0; i < 4; i++)
+            if (~pmpcfg0_lo.pmpcfg[i].l)
+              pmpcfg0_li.pmpcfg[i] = pmpcfg_warl_entry(rv64_pmpcfg0_s'(csr_data_li).pmpcfg[i]);
+        {1'b1, `CSR_ADDR_PMPCFG2      }: begin end
+        {1'b1, `CSR_ADDR_PMPADDR0     }:
+          if (~pmpcfg0_lo.pmpcfg[0].l)
+            pmpaddr0_li = rv64_pmpaddr0_s'(csr_data_li);
+        {1'b1, `CSR_ADDR_PMPADDR1     }:
+          if (~pmpcfg0_lo.pmpcfg[1].l)
+            pmpaddr1_li = rv64_pmpaddr1_s'(csr_data_li);
+        {1'b1, `CSR_ADDR_PMPADDR2     }:
+          if (~pmpcfg0_lo.pmpcfg[2].l)
+            pmpaddr2_li = rv64_pmpaddr2_s'(csr_data_li);
+        {1'b1, `CSR_ADDR_PMPADDR3     }:
+          if (~pmpcfg0_lo.pmpcfg[3].l)
+            pmpaddr3_li = rv64_pmpaddr3_s'(csr_data_li);
         {1'b1, `CSR_ADDR_MSCRATCH     }: mscratch_li = csr_data_li;
         {1'b1, `CSR_ADDR_MEPC         }: mepc_li = csr_data_li;
         {1'b1, `CSR_ADDR_MCAUSE       }: mcause_li = csr_data_li;

--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -65,29 +65,9 @@ module bp_be_csr
   rv64_mie_s sie_rwmask_li;
   rv64_mip_s sip_wmask_li, sip_rmask_li, mip_wmask_li;
 
-  localparam [1:0] pmp_a_off_lp = 2'b00;
-
   logic [rv64_priv_width_gp-1:0] priv_mode_n, priv_mode_r;
   logic debug_mode_n, debug_mode_r;
   logic translation_en_n, translation_en_r;
-
-  function automatic rv64_pmpcfg_entry_s pmpcfg_warl_entry
-    (input rv64_pmpcfg_entry_s entry_i);
-    rv64_pmpcfg_entry_s entry_o;
-    begin
-      entry_o = entry_i;
-
-      // MVP only supports OFF and TOR addressing in CSR state.
-      if (entry_o.a[1])
-        entry_o.a = pmp_a_off_lp;
-
-      // W without R is a reserved encoding, force WARL-compliant state.
-      if (~entry_o.r)
-        entry_o.w = 1'b0;
-
-      pmpcfg_warl_entry = entry_o;
-    end
-  endfunction
 
   wire is_debug_mode = debug_mode_r;
   // Debug Mode grants pseudo M-mode permission
@@ -108,8 +88,8 @@ module bp_be_csr
   // 0: Tapeout 0, July 2019
   // 1: Tapeout 1, June 2021
   // 2: Tapeout 2, Sept 2022
-  // 3: Current
-  wire [dword_width_gp-1:0] mimpid_lo  = 64'd3;
+  // 3: Tapeout 3, Jan 2025
+  wire [dword_width_gp-1:0] mimpid_lo  = 64'd4;
   wire [dword_width_gp-1:0] mhartid_lo = cfg_bus_cast_i.core_id;
 
   `declare_csr(mstatus);
@@ -128,12 +108,6 @@ module bp_be_csr
   `declare_csr_addr(mtval, vaddr_width_p, paddr_width_p);
   `declare_csr(mip);
 
-  `declare_csr(pmpcfg0);
-  `declare_csr(pmpaddr0);
-  `declare_csr(pmpaddr1);
-  `declare_csr(pmpaddr2);
-  `declare_csr(pmpaddr3);
-
   `declare_csr(mcycle);
   `declare_csr(minstret);
   // mhpmcounter not implemented
@@ -141,6 +115,27 @@ module bp_be_csr
   `declare_csr(mcountinhibit);
   // mhpmevent not implemented
   //   This is non-compliant. We should hardcode to 0 instead of trapping
+
+  // Up to 16 physical PMP registers are supported
+  // But if you implement one you have to implement them all
+  rv64_pmpaddr_s [15:0] pmpaddr_li, pmpaddr_lo;
+  rv64_pmpcfg_entry_s [15:0] pmpcfg_li, pmpcfg_lo;
+  `declare_csr_pmp(0, paddr_width_p, num_pmp_p);
+  `declare_csr_pmp(1, paddr_width_p, num_pmp_p);
+  `declare_csr_pmp(2, paddr_width_p, num_pmp_p);
+  `declare_csr_pmp(3, paddr_width_p, num_pmp_p);
+  `declare_csr_pmp(4, paddr_width_p, num_pmp_p);
+  `declare_csr_pmp(5, paddr_width_p, num_pmp_p);
+  `declare_csr_pmp(6, paddr_width_p, num_pmp_p);
+  `declare_csr_pmp(7, paddr_width_p, num_pmp_p);
+  `declare_csr_pmp(8, paddr_width_p, num_pmp_p);
+  `declare_csr_pmp(9, paddr_width_p, num_pmp_p);
+  `declare_csr_pmp(10, paddr_width_p, num_pmp_p);
+  `declare_csr_pmp(11, paddr_width_p, num_pmp_p);
+  `declare_csr_pmp(12, paddr_width_p, num_pmp_p);
+  `declare_csr_pmp(13, paddr_width_p, num_pmp_p);
+  `declare_csr_pmp(14, paddr_width_p, num_pmp_p);
+  `declare_csr_pmp(15, paddr_width_p, num_pmp_p);
 
   // sstatus subset of mstatus
   wire [dword_width_gp-1:0] sstatus_lo = mstatus_lo & sstatus_rmask_li;
@@ -304,6 +299,8 @@ module bp_be_csr
   wire instr_fany_li = retire_pkt_cast_i.instr.t.rtype.opcode inside
     {`RV64_FLOAD_OP, `RV64_FMADD_OP, `RV64_FMSUB_OP, `RV64_FNMSUB_OP, `RV64_FP_OP};
 
+  wire [2:0] pmpaddr_sel_li = csr_addr_li - `CSR_ADDR_PMPCFG0;
+
   logic enter_debug, exit_debug;
   bsg_dff_reset_set_clear
    #(.width_p(1))
@@ -442,12 +439,6 @@ module bp_be_csr
         {`CSR_ADDR_MTVEC        }: csr_data_lo = mtvec_lo;
         {`CSR_ADDR_MCOUNTEREN   }: csr_data_lo = mcounteren_lo;
         {`CSR_ADDR_MIP          }: csr_data_lo = mip_lo;
-        {`CSR_ADDR_PMPCFG0      }: csr_data_lo = pmpcfg0_lo;
-        {`CSR_ADDR_PMPCFG2      }: csr_data_lo = '0;
-        {`CSR_ADDR_PMPADDR0     }: csr_data_lo = pmpaddr0_lo;
-        {`CSR_ADDR_PMPADDR1     }: csr_data_lo = pmpaddr1_lo;
-        {`CSR_ADDR_PMPADDR2     }: csr_data_lo = pmpaddr2_lo;
-        {`CSR_ADDR_PMPADDR3     }: csr_data_lo = pmpaddr3_lo;
         {`CSR_ADDR_MSCRATCH     }: csr_data_lo = mscratch_lo;
         {`CSR_ADDR_MEPC         }: csr_data_lo = mepc_lo;
         {`CSR_ADDR_MCAUSE       }: csr_data_lo = mcause_lo;
@@ -455,6 +446,9 @@ module bp_be_csr
         {`CSR_ADDR_MCYCLE       }: csr_data_lo = mcycle_lo;
         {`CSR_ADDR_MINSTRET     }: csr_data_lo = minstret_lo;
         {`CSR_ADDR_MCOUNTINHIBIT}: csr_data_lo = mcountinhibit_lo;
+        {`CSR_ADDR_PMPCFG0      }: csr_data_lo = pmpcfg_lo[0+:8];
+        {`CSR_ADDR_PMPCFG2      }: csr_data_lo = pmpcfg_lo[8+:8];
+        {`CSR_ADDR_PMPADDR      }: csr_data_lo = pmpaddr_lo[pmpaddr_sel_li];
         {`CSR_ADDR_DCSR         }: csr_data_lo = dcsr_lo;
         {`CSR_ADDR_DPC          }: csr_data_lo = dpc_lo;
         {`CSR_ADDR_DSCRATCH0    }: csr_data_lo = dscratch0_lo;
@@ -496,15 +490,13 @@ module bp_be_csr
       mcause_li   = mcause_lo;
       mtval_li    = mtval_lo;
       mip_li      = mip_lo;
-      pmpcfg0_li  = pmpcfg0_lo;
-      pmpaddr0_li = pmpaddr0_lo;
-      pmpaddr1_li = pmpaddr1_lo;
-      pmpaddr2_li = pmpaddr2_lo;
-      pmpaddr3_li = pmpaddr3_lo;
 
       mcycle_li        = mcycle_lo;
       minstret_li      = minstret_lo;
       mcountinhibit_li = mcountinhibit_lo;
+
+      pmpcfg_li   = pmpcfg_lo;
+      pmpaddr_li  = pmpaddr_lo;
 
       dcsr_li     = dcsr_lo;
       dpc_li      = dpc_lo;
@@ -546,23 +538,6 @@ module bp_be_csr
         {1'b1, `CSR_ADDR_MTVEC        }: mtvec_li = csr_data_li;
         {1'b1, `CSR_ADDR_MCOUNTEREN   }: mcounteren_li = csr_data_li;
         {1'b1, `CSR_ADDR_MIP          }: mip_li = csr_data_li;
-        {1'b1, `CSR_ADDR_PMPCFG0      }:
-          for (int i = 0; i < 4; i++)
-            if (~pmpcfg0_lo.pmpcfg[i].l)
-              pmpcfg0_li.pmpcfg[i] = pmpcfg_warl_entry(rv64_pmpcfg0_s'(csr_data_li).pmpcfg[i]);
-        {1'b1, `CSR_ADDR_PMPCFG2      }: begin end
-        {1'b1, `CSR_ADDR_PMPADDR0     }:
-          if (~pmpcfg0_lo.pmpcfg[0].l)
-            pmpaddr0_li = rv64_pmpaddr0_s'(csr_data_li);
-        {1'b1, `CSR_ADDR_PMPADDR1     }:
-          if (~pmpcfg0_lo.pmpcfg[1].l)
-            pmpaddr1_li = rv64_pmpaddr1_s'(csr_data_li);
-        {1'b1, `CSR_ADDR_PMPADDR2     }:
-          if (~pmpcfg0_lo.pmpcfg[2].l)
-            pmpaddr2_li = rv64_pmpaddr2_s'(csr_data_li);
-        {1'b1, `CSR_ADDR_PMPADDR3     }:
-          if (~pmpcfg0_lo.pmpcfg[3].l)
-            pmpaddr3_li = rv64_pmpaddr3_s'(csr_data_li);
         {1'b1, `CSR_ADDR_MSCRATCH     }: mscratch_li = csr_data_li;
         {1'b1, `CSR_ADDR_MEPC         }: mepc_li = csr_data_li;
         {1'b1, `CSR_ADDR_MCAUSE       }: mcause_li = csr_data_li;
@@ -570,6 +545,10 @@ module bp_be_csr
         {1'b1, `CSR_ADDR_MCYCLE       }: mcycle_li = csr_data_li;
         {1'b1, `CSR_ADDR_MINSTRET     }: minstret_li = csr_data_li;
         {1'b1, `CSR_ADDR_MCOUNTINHIBIT}: mcountinhibit_li = csr_data_li;
+        // illegal accesses are checked in decode, so we don't need to recheck here
+        {1'b1, `CSR_ADDR_PMPCFG0      }: pmpcfg_li[0+:8] = csr_data_li;
+        {1'b1, `CSR_ADDR_PMPCFG2      }: pmpcfg_li[8+:16] = csr_data_li;
+        {1'b1, `CSR_ADDR_PMPADDR      }: pmpaddr_li[pmpaddr_sel_li] = csr_data_li;
         {1'b1, `CSR_ADDR_DCSR         }: dcsr_li = csr_data_li;
         {1'b1, `CSR_ADDR_DPC          }: dpc_li = csr_data_li;
         {1'b1, `CSR_ADDR_DSCRATCH0    }: dscratch0_li = csr_data_li;
@@ -784,8 +763,8 @@ module bp_be_csr
   assign trans_info_cast_o.base_ppn       = satp_lo.ppn;
   assign trans_info_cast_o.translation_en = translation_en_r
     | ((~is_debug_mode | dcsr_lo.mprven) & mstatus_lo.mprv & (mstatus_lo.mpp < `PRIV_MODE_M) & (satp_lo.mode == 4'd8));
-  assign trans_info_cast_o.mstatus_sum = mstatus_lo.sum;
-  assign trans_info_cast_o.mstatus_mxr = mstatus_lo.mxr;
+  assign trans_info_cast_o.mstatus_sum    = mstatus_lo.sum;
+  assign trans_info_cast_o.mstatus_mxr    = mstatus_lo.mxr;
 
   assign decode_info_cast_o.m_mode     = is_m_mode;
   assign decode_info_cast_o.s_mode     = is_s_mode;

--- a/bp_be/src/v/bp_be_checker/bp_be_instr_decoder.sv
+++ b/bp_be/src/v/bp_be_checker/bp_be_instr_decoder.sv
@@ -529,6 +529,9 @@ module bp_be_instr_decoder
                     `CSR_ADDR_CYCLE     : illegal_instr_o = !decode_info_cast_i.cycle_en;
                     `CSR_ADDR_INSTRET   : illegal_instr_o = !decode_info_cast_i.instret_en;
                     `CSR_ADDR_SATP      : illegal_instr_o = decode_info_cast_i.s_mode & decode_info_cast_i.tvm;
+                    `CSR_ADDR_PMPCFG0
+                    ,`CSR_ADDR_PMPCFG2
+                    ,`CSR_ADDR_PMPADDR  : illegal_instr_o = num_pmp_p == 0;
                     {12'b11??_????_????}: illegal_instr_o = csrw_o;
                     {12'b??01_????_????}: illegal_instr_o = decode_info_cast_i.u_mode;
                     {12'b??10_????_????}: illegal_instr_o = decode_info_cast_i.s_mode | decode_info_cast_i.u_mode;

--- a/bp_be/test/common/bp_be_nonsynth_cosim.sv
+++ b/bp_be/test/common/bp_be_nonsynth_cosim.sv
@@ -22,7 +22,7 @@ module bp_be_nonsynth_cosim
     , input                                cosim_reset_i
     );
 
-  import "DPI-C" context function chandle cosim_init(input int ncpus, input int memsize, input string prog_name);
+  import "DPI-C" context function chandle cosim_init(input int ncpus, input int memsize, input int pmps, input string prog_name);
   import "DPI-C" context function chandle cosim_finish(input chandle cosim_handle);
   import "DPI-C" context function int cosim_step(input chandle cosim_handle,
                                                    input int hartid,
@@ -176,7 +176,7 @@ module bp_be_nonsynth_cosim
       $display("FATAL: +elf_file=<filename> plusarg not found! Please provide a valid RISC-V executable.");
       $finish;
     end
-    cosim_handle = cosim_init(num_core_p, 256, prog_name);
+    cosim_handle = cosim_init(num_core_p, 256, num_pmp_p, prog_name);
   end
   final cosim_handle = cosim_finish(cosim_handle);
 

--- a/bp_be/test/common/dromajo_cosim.cpp
+++ b/bp_be/test/common/dromajo_cosim.cpp
@@ -13,13 +13,14 @@ static std::once_flag handle_init_once, handle_fini_once;
 
 void printf_stub(int hartid, const char *fmt, ...) { }
 
-extern "C" void* cosim_init(int ncpus, int memsize, const char* prog_name) {
+extern "C" void* cosim_init(int ncpus, int memsize, int pmp_enable, const char* prog_name) {
 
     std::call_once(handle_init_once, [&] {
         char argv_str[1024];
         char *argv[64];
         int argc = 0;
         // Create the argument string
+        const char *pmp_str = pmp_enable ? "--pmp_enable" : "";
         sprintf(argv_str, "dromajo --ncpus=%d --memory_size=%d %s", ncpus, memsize, prog_name);
 
         // Tokenize the string

--- a/bp_be/test/common/null_cosim.cpp
+++ b/bp_be/test/common/null_cosim.cpp
@@ -5,7 +5,7 @@
 #include <string.h>
 #include <vector>
 
-extern "C" void* __attribute__((weak)) cosim_init(int ncpus, int memsize) {
+extern "C" void* __attribute__((weak)) cosim_init(int ncpus, int memsize, int pmps, const char* prog_name) {
     return nullptr;
 }
 

--- a/bp_be/test/common/spike_cosim.cpp
+++ b/bp_be/test/common/spike_cosim.cpp
@@ -50,7 +50,7 @@ class loadmem_memif_t : public memif_t {
         size_t start;
 };
 
-extern "C" void* cosim_init(int ncpus, int memsize, const char* prog_name) {
+extern "C" void* cosim_init(int ncpus, int memsize, int pmps, const char* prog_name) {
     size_t memory_size = memsize;
     size_t base = 0x80000000;
     size_t size = memory_size*1024*1024;
@@ -62,7 +62,7 @@ extern "C" void* cosim_init(int ncpus, int memsize, const char* prog_name) {
         cfg.isa = "rv64imafdcZifencei_Zicsr_Zba_Zbb_Zbc_Zbs";
         cfg.priv = "msu";
         cfg.start_pc = base;
-        cfg.pmpregions = 0;
+        cfg.pmpregions = pmps;
 
         args.push_back(prog_name);
 

--- a/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
+++ b/bp_common/src/include/bp_common_aviary_cfg_pkgdef.svh
@@ -131,6 +131,9 @@
     // Address space ID width
     //   Currently unused, so set to 1 bit
     int asid_width;
+    // Number of physical memory protection entries supported by the core.
+    // Legal values are 0 < num_pmp < 16
+    int num_pmp;
 
     // Branch metadata information for the Front End
     // Must be kept consistent with FE
@@ -295,6 +298,7 @@
       ,daddr_width: 33
       ,caddr_width: 32
       ,asid_width : 1
+      ,num_pmp    : 0
 
       ,branch_metadata_fwd_width: 49
       ,ras_idx_width            : 4
@@ -426,6 +430,7 @@
       ,`bp_aviary_define_override(fpu_support, BP_FPU_SUPPORT, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(bitmanip_support, BP_BITMANIP_SUPPORT, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(compressed_support, BP_COMPRESSED_SUPPORT, `BP_CUSTOM_BASE_CFG)
+      ,`bp_aviary_define_override(num_pmp, BP_NUM_PMP, `BP_CUSTOM_BASE_CFG)
 
       ,`bp_aviary_define_override(branch_metadata_fwd_width, BRANCH_METADATA_FWD_WIDTH, `BP_CUSTOM_BASE_CFG)
       ,`bp_aviary_define_override(ras_idx_width, BP_RAS_IDX_WIDTH, `BP_CUSTOM_BASE_CFG)

--- a/bp_common/src/include/bp_common_aviary_defines.svh
+++ b/bp_common/src/include/bp_common_aviary_defines.svh
@@ -48,6 +48,7 @@
     , localparam daddr_width_p   = proc_param_lp.daddr_width                                       \
     , localparam caddr_width_p   = proc_param_lp.caddr_width                                       \
     , localparam asid_width_p    = proc_param_lp.asid_width                                        \
+    , localparam num_pmp_p       = proc_param_lp.num_pmp                                           \
     , localparam hio_width_p     = paddr_width_p - daddr_width_p                                   \
                                                                                                    \
     , localparam branch_metadata_fwd_width_p = proc_param_lp.branch_metadata_fwd_width             \
@@ -246,6 +247,7 @@
           ,`bp_aviary_parameter_override(fpu_support, override_cfg_mp, default_cfg_mp)             \
           ,`bp_aviary_parameter_override(compressed_support, override_cfg_mp, default_cfg_mp)      \
           ,`bp_aviary_parameter_override(bitmanip_support, override_cfg_mp, default_cfg_mp)        \
+          ,`bp_aviary_parameter_override(num_pmp, override_cfg_mp, default_cfg_mp)                 \
                                                                                                    \
           ,`bp_aviary_parameter_override(branch_metadata_fwd_width, override_cfg_mp, default_cfg_mp) \
           ,`bp_aviary_parameter_override(ras_idx_width, override_cfg_mp, default_cfg_mp)           \

--- a/bp_common/src/include/bp_common_rv64_csr_defines.svh
+++ b/bp_common/src/include/bp_common_rv64_csr_defines.svh
@@ -105,6 +105,8 @@
   `define CSR_ADDR_PMPADDR14     12'h3be
   `define CSR_ADDR_PMPADDR15     12'h3bf
 
+  `define CSR_ADDR_PMPADDR       12'h3b? // Matches PMPADDR 0-15
+
   `define CSR_ADDR_MCYCLE        12'hb00
   `define CSR_ADDR_MINSTRET      12'hb02
   `define CSR_ADDR_MHPMCOUNTER3  12'hb03
@@ -544,19 +546,16 @@
     logic          r;                                                                      \
   }  rv64_pmpcfg_entry_s;                                                                  \
                                                                                            \
+  /* Only support regions at the page granularity */                                       \
   typedef struct packed                                                                    \
   {                                                                                        \
-    rv64_pmpcfg_entry_s [7:0] pmpcfg;                                                      \
-  }  rv64_pmpcfg_s;                                                                        \
-  typedef rv64_pmpcfg_s rv64_pmpcfg0_s;                                                    \
-  typedef rv64_pmpcfg_s rv64_pmpcfg1_s;                                                    \
-                                                                                           \
-  typedef struct packed                                                                    \
-  {                                                                                        \
-    rv64_pmpcfg_entry_s [3:0] pmpcfg;                                                      \
-  }  bp_pmpcfg_s;                                                                          \
-                                                                                           \
-  typedef bp_pmpcfg_s bp_pmpcfg0_s;                                                        \
+    logic            l;                                                                    \
+    logic            napot;                                                                \
+    logic            tor;                                                                  \
+    logic            x;                                                                    \
+    logic            w;                                                                    \
+    logic            r;                                                                    \
+  }  bp_pmpcfg_entry_s;                                                                    \
                                                                                            \
   typedef struct packed                                                                    \
   {                                                                                        \
@@ -564,10 +563,11 @@
     logic [53:0] addr_55_2;                                                                \
   }  rv64_pmpaddr_s;                                                                       \
                                                                                            \
-  typedef rv64_pmpaddr_s rv64_pmpaddr0_s;                                                  \
-  typedef rv64_pmpaddr_s rv64_pmpaddr1_s;                                                  \
-  typedef rv64_pmpaddr_s rv64_pmpaddr2_s;                                                  \
-  typedef rv64_pmpaddr_s rv64_pmpaddr3_s;                                                  \
+  typedef struct packed                                                                    \
+  {                                                                                        \
+    /* G = 8 -> page aligned */                                                            \
+    logic [ptag_width_p-1:0] ptag;                                                         \
+  }  bp_pmpaddr_s;                                                                         \
                                                                                            \
   typedef struct packed                                                                    \
   {                                                                                        \
@@ -580,16 +580,6 @@
     logic       _interrupt;                                                                \
     logic [3:0] ecode;                                                                     \
   }  bp_mcause_s;                                                                          \
-                                                                                           \
-  typedef struct packed                                                                    \
-  {                                                                                        \
-    logic [(`BSG_MAX(vaddr_width_mp, paddr_width_mp)-2)-1:0] word_addr;                    \
-  }  bp_pmpaddr_s;                                                                         \
-                                                                                           \
-  typedef bp_pmpaddr_s bp_pmpaddr0_s;                                                      \
-  typedef bp_pmpaddr_s bp_pmpaddr1_s;                                                      \
-  typedef bp_pmpaddr_s bp_pmpaddr2_s;                                                      \
-  typedef bp_pmpaddr_s bp_pmpaddr3_s;                                                      \
                                                                                            \
   typedef logic [63:0] rv64_mcounter_s;                                                    \
   typedef logic [47:0] bp_mcounter_s;                                                      \
@@ -937,33 +927,30 @@
       }
 
   `define compress_pmpcfg_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) \
-    '{pmpcfg: data_cast_mp.pmpcfg[0+:4]}
-
-  `define decompress_pmpcfg_s(data_comp_mp) \
-    '{pmpcfg: ($bits(rv64_pmpcfg_entry_s)*8)'(data_comp_mp.pmpcfg)}
-
-  `define compress_pmpcfg0_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) `compress_pmpcfg_s(data_cast_mp, vaddr_width_mp, paddr_width_mp)
-  `define compress_pmpcfg1_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) `compress_pmpcfg_s(data_cast_mp, vaddr_width_mp, paddr_width_mp)
-  `define decompress_pmpcfg0_s(data_comp_mp) `decompress_pmpcfg_s(data_comp_mp)
-  `define decompress_pmpcfg1_s(data_comp_mp) `decompress_pmpcfg_s(data_comp_mp)
-
-  `define compress_pmpaddr_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) \
-    '{word_addr: data_cast_mp.addr_55_2[0+:`BSG_MAX(vaddr_width_mp, paddr_width_mp)-2]}
-
-  `define decompress_pmpaddr_s(data_comp_mp) \
-    '{addr_55_2: 54'(data_comp_mp.word_addr) \
-      ,default: '0                           \
+    '{l              : data_cast_mp.l                  \
+      ,napot         : (data_cast_mp.a == 2'b11)       \
+      ,tor           : (data_cast_mp.a == 2'b01)       \
+      ,x             : data_cast_mp.x                  \
+      ,w             : data_cast_mp.w & data_cast_mp.r \
+      ,r             : data_cast_mp.r                  \
       }
 
-  `define compress_pmpaddr0_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) `compress_pmpaddr_s(data_cast_mp, vaddr_width_mp, paddr_width_mp)
-  `define compress_pmpaddr1_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) `compress_pmpaddr_s(data_cast_mp, vaddr_width_mp, paddr_width_mp)
-  `define compress_pmpaddr2_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) `compress_pmpaddr_s(data_cast_mp, vaddr_width_mp, paddr_width_mp)
-  `define compress_pmpaddr3_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) `compress_pmpaddr_s(data_cast_mp, vaddr_width_mp, paddr_width_mp)
+  `define decompress_pmpcfg_s(data_comp_mp) \
+    '{l      : data_comp_mp.l                         \
+      ,a     : {data_comp_mp.napot, data_comp_mp.tor} \
+      ,x     : data_comp_mp.x                         \
+      ,w     : data_comp_mp.w                         \
+      ,r     : data_comp_mp.r                         \
+      ,default: '0                                    \
+      }
 
-  `define decompress_pmpaddr0_s(data_cast_mp) `decompress_pmpaddr_s(data_cast_mp)
-  `define decompress_pmpaddr1_s(data_cast_mp) `decompress_pmpaddr_s(data_cast_mp)
-  `define decompress_pmpaddr2_s(data_cast_mp) `decompress_pmpaddr_s(data_cast_mp)
-  `define decompress_pmpaddr3_s(data_cast_mp) `decompress_pmpaddr_s(data_cast_mp)
+  `define compress_pmpaddr_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) \
+    '{ptag: data_cast_mp.addr_55_2[page_offset_width_gp-2+:ptag_width_p]}
+
+  `define decompress_pmpaddr_s(data_comp_mp) \
+    '{addr_55_2: 54'(data_comp_mp.ptag << (page_offset_width_gp-2)) \
+      ,default: '0                                                  \
+      }
 
   `define compress_mcause_s(data_cast_mp, vaddr_width_mp, paddr_width_mp) \
     '{_interrupt: data_cast_mp._interrupt \
@@ -1054,20 +1041,48 @@
   `define decompress_dscratch1_s(data_comp_mp) \
     64'(data_comp_mp)
 
-  `define declare_csr_addr(csr_name_mp, vaddr_width_mp, paddr_width_mp)                           \
-    /* verilator lint_off UNUSED */                                                               \
-    rv64_``csr_name_mp``_s ``csr_name_mp``_li, ``csr_name_mp``_lo;                                \
-    bp_``csr_name_mp``_s ``csr_name_mp``_n, ``csr_name_mp``_r;                                    \
-    bsg_dff_reset                                                                                 \
-     #(.width_p($bits(bp_``csr_name_mp``_s)))                                                     \
-    ``csr_name_mp``_reg                                                                           \
-      (.clk_i(clk_i), .reset_i(reset_i), .data_i(``csr_name_mp``_n), .data_o(``csr_name_mp``_r)); \
-    assign ``csr_name_mp``_lo = `decompress_``csr_name_mp``_s(``csr_name_mp``_r);                 \
+  `define declare_csr_addr(csr_name_mp, vaddr_width_mp, paddr_width_mp) \
+    rv64_``csr_name_mp``_s ``csr_name_mp``_li, ``csr_name_mp``_lo;                                  \
+    bp_``csr_name_mp``_s ``csr_name_mp``_n, ``csr_name_mp``_r;                                      \
+    begin : creg_``csr_name_mp                                                                      \
+      bsg_dff_reset                                                                                 \
+       #(.width_p($bits(bp_``csr_name_mp``_s)))                                                     \
+      ``csr_name_mp``_reg                                                                           \
+        (.clk_i(clk_i), .reset_i(reset_i), .data_i(``csr_name_mp``_n), .data_o(``csr_name_mp``_r)); \
+    end                                                                                             \
+    assign ``csr_name_mp``_lo = `decompress_``csr_name_mp``_s(``csr_name_mp``_r);                   \
     assign ``csr_name_mp``_n  = `compress_``csr_name_mp``_s(``csr_name_mp``_li, vaddr_width_mp, paddr_width_mp)
-    /* verilator lint_on UNUSED */
+
+  `define declare_csr_pmp(index_mp, paddr_width_mp, num_pmp_mp) \
+    rv64_pmpaddr_s pmpaddr``index_mp``_li, pmpaddr``index_mp``_lo;                                             \
+    bp_pmpaddr_s pmpaddr``index_mp``_n, pmpaddr``index_mp``_r;                                                 \
+    rv64_pmpcfg_entry_s pmpcfg``index_mp``_li, pmpcfg``index_mp``_lo;                                          \
+    bp_pmpcfg_entry_s pmpcfg``index_mp``_n, pmpcfg``index_mp``_r;                                              \
+    if (index_mp < num_pmp_mp)                                                                                 \
+      begin : creg_pmp``index_mp                                                                               \
+        bsg_dff_reset_en                                                                                       \
+         #(.width_p($bits(bp_pmpcfg_entry_s)))                                                                 \
+         pmpcfg``index_mp``_reg                                                                                \
+          (.clk_i(clk_i), .reset_i(reset_i), .en_i(!pmpcfg``index_mp``_r.l)                                    \
+           ,.data_i(pmpcfg``index_mp``_n), .data_o(pmpcfg``index_mp``_r));                                     \
+        bsg_dff_reset_en                                                                                       \
+         #(.width_p($bits(bp_pmpaddr_s)))                                                                      \
+         pmpaddr``index_mp``_reg                                                                               \
+          (.clk_i(clk_i), .reset_i(reset_i), .en_i(!pmpcfg``index_mp``_r.l)                                    \
+           ,.data_i(pmpaddr``index_mp``_n), .data_o(pmpaddr``index_mp``_r));                                   \
+      end                                                                                                      \
+    else                                                                                                       \
+      begin : creg_pmp``index_mp                                                                               \
+        assign pmpaddr``index_mp``_r = '0;                                                                     \
+        assign pmpcfg``index_mp``_r = '0;                                                                      \
+      end                                                                                                      \
+     assign pmpcfg_lo[index_mp]   = `decompress_pmpcfg_s(pmpcfg``index_mp``_r);                                \
+     assign pmpaddr_lo[index_mp]  = `decompress_pmpaddr_s(pmpaddr``index_mp``_r);                              \
+     assign pmpaddr``index_mp``_n = `compress_pmpaddr_s(pmpaddr_li[index_mp], paddr_width_mp, paddr_width_mp); \
+     assign pmpcfg``index_mp``_n = `compress_pmpcfg_s(pmpcfg_li[index_mp], pcfg_width_mp, pcfg_width_mp)
 
   `define declare_csr(csr_name_mp) \
-    `declare_csr_addr(csr_name_mp, 0, 0)
+    `declare_csr_addr(csr_name_mp, 0, 0);
 
 `endif
 

--- a/bp_common/src/include/bp_common_rv64_pkgdef.svh
+++ b/bp_common/src/include/bp_common_rv64_pkgdef.svh
@@ -253,6 +253,14 @@
     ,e_fmt_double = 1'b1
   } rv64_fmt_e;
 
+  typedef enum logic [1:0]
+  {
+    e_pmp_addr_mode_off    = 2'b00
+    ,e_pmp_addr_mode_tor   = 2'b01
+    ,e_pmp_addr_mode_na4   = 2'b10
+    ,e_pmp_addr_mode_napot = 2'b11
+  } rv64_pmp_addr_mode_e;
+
   typedef struct packed
   {
     // Invalid operation

--- a/bp_top/test/common/bp_nonsynth_if_verif.sv
+++ b/bp_top/test/common/bp_nonsynth_if_verif.sv
@@ -137,6 +137,10 @@ module bp_nonsynth_if_verif
   // daddr_width_p must be less than paddr_width_p to leave room for high MMIO
   if (daddr_width_p >= paddr_width_p)
     $error("Error: daddr cannot exceed paddr");
+  if (num_pmp_p > 16)
+    $error("Error: Only up to 16 PMP registers are supported.");
+  if (num_pmp_p != 0)
+    $warning("Warning: PMP registers are implemented but not currently checked on access.");
 
   // L2 Cache
   if (l2_fill_width_p < l2_data_width_p)

--- a/bp_top/verilator/Makefile
+++ b/bp_top/verilator/Makefile
@@ -1,5 +1,5 @@
 ## Set common environment variables
-TOP ?= $(shell git rev-parse --show-toplevel)
+TOP := $(shell git rev-parse --show-toplevel)
 include $(TOP)/Makefile.common
 include $(TOP)/Makefile.env
 


### PR DESCRIPTION
Summary
This PR adds PMP CSR infrastructure in bp_be_csr as the first step toward Issue #991.

What is included
- Adds CSR state for PMPCFG0 and PMPADDR0..3.
- Adds CSR read decode for PMPCFG0, PMPCFG2 (read-as-zero), and PMPADDR0..3.
- Adds CSR write decode for PMPCFG0 and PMPADDR0..3.
- Adds lock-aware behavior: if L is set, writes to that PMPCFG entry and corresponding PMPADDR are ignored.
- Adds WARL normalization for MVP:
- Address-matching supports OFF/TOR in this phase.
- Reserved W without R encoding is normalized.

What is deferred
- No MMU PMP enforcement yet.
- No PMP access-fault generation yet.
- No full match/priority integration yet.

Next phase
- Add PMP checker module.
- Integrate checker in MMU after physical address resolution.
- Generate instruction/load/store access faults on PMP violations.