### PR TITLE
Fix dcache fill restart flush gate

### DIFF
--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -205,6 +205,7 @@ module bp_be_dcache
   logic blocking_req, blocking_sent;
   logic nonblocking_req, nonblocking_sent;
   logic lrsc_lock;
+  logic fill_flushed_r;
 
   wire flush_tv = flush_i | tag_mem_write_hazard | blocking_hazard | nonblocking_hazard | fill_hazard;
   wire flush_tl = flush_tv | data_mem_write_hazard;
@@ -1188,6 +1189,23 @@ module bp_be_dcache
       state_r <= e_ready;
     else
       state_r <= state_n;
+
+  // Track whether the outstanding miss was flushed before its critical beat arrived.
+  // Used only in the assertion below; fill_restart_tv is not gated because the
+  // pipeline depth prevents v_tv_r=1 from coinciding with flush_i=1 in a
+  // single-issue in-order core.  The assertion fires if that assumption breaks.
+  always_ff @(posedge clk_i)
+    if (reset_i | blocking_sent | complete_recv)
+      fill_flushed_r <= '0;
+    else if (flush_i & ~is_ready)
+      fill_flushed_r <= '1;
+
+  // synopsys translate_off
+  always_ff @(negedge clk_i) begin
+    assert(reset_i !== '0 || !(critical_recv & fill_flushed_r))
+      else $error("bp_be_dcache: fill_restart_tv fired for a flushed miss — phantom v_tv_r possible\n");
+  end
+  // synopsys translate_on
 
   /////////////////////////////////////////////////////////////////////////////
   // MSHR

--- a/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
+++ b/bp_be/src/v/bp_be_dcache/bp_be_dcache.sv
@@ -205,7 +205,6 @@ module bp_be_dcache
   logic blocking_req, blocking_sent;
   logic nonblocking_req, nonblocking_sent;
   logic lrsc_lock;
-  logic fill_flushed_r;
 
   wire flush_tv = flush_i | tag_mem_write_hazard | blocking_hazard | nonblocking_hazard | fill_hazard;
   wire flush_tl = flush_tv | data_mem_write_hazard;
@@ -1190,23 +1189,6 @@ module bp_be_dcache
     else
       state_r <= state_n;
 
-  // Track whether the outstanding miss was flushed before its critical beat arrived.
-  // Used only in the assertion below; fill_restart_tv is not gated because the
-  // pipeline depth prevents v_tv_r=1 from coinciding with flush_i=1 in a
-  // single-issue in-order core.  The assertion fires if that assumption breaks.
-  always_ff @(posedge clk_i)
-    if (reset_i | blocking_sent | complete_recv)
-      fill_flushed_r <= '0;
-    else if (flush_i & ~is_ready)
-      fill_flushed_r <= '1;
-
-  // synopsys translate_off
-  always_ff @(negedge clk_i) begin
-    assert(reset_i !== '0 || !(critical_recv & fill_flushed_r))
-      else $error("bp_be_dcache: fill_restart_tv fired for a flushed miss — phantom v_tv_r possible\n");
-  end
-  // synopsys translate_on
-
   /////////////////////////////////////////////////////////////////////////////
   // MSHR
   /////////////////////////////////////////////////////////////////////////////
@@ -1281,6 +1263,24 @@ module bp_be_dcache
     (.i(snoop_bank)
      ,.o(snoop_bank_sel_one_hot)
      );
+
+  // synopsys translate_off
+  // Track whether the outstanding miss was flushed before its critical beat arrived.
+  // Used only in the assertion below; fill_restart_tv is not gated because the
+  // pipeline depth prevents v_tv_r=1 from coinciding with flush_i=1 in a
+  // single-issue in-order core.  The assertion fires if that assumption breaks.
+  logic fill_flushed_r;
+  always_ff @(posedge clk_i)
+    if (reset_i | blocking_sent | complete_recv)
+      fill_flushed_r <= '0;
+    else if (flush_i & ~is_ready)
+      fill_flushed_r <= '1;
+
+  always_ff @(negedge clk_i) begin
+    assert(reset_i !== '0 || !(critical_recv & fill_flushed_r))
+      else $error("bp_be_dcache: fill_restart_tv fired for a flushed miss — phantom v_tv_r possible\n");
+  end
+  // synopsys translate_on
 
 endmodule
 


### PR DESCRIPTION
Hi there! Please find the details of this PR below

### Summary

Guard fill_restart_tv against phantom TV-stage restarts when a dcache miss is flushed before its fill arrives.

### Issue Fixed

No issue open separately. 

The problem is fill_restart_tv = critical_recv has no flush guard. When an exception or mispredict flushes a miss in flight, the MSHR retains the killed instruction's decode. When critical_recv fires (same cycle as flush_i or any number of cycles later with flush_i already low) v_tv_r is incorrectly set to 1, producing a phantom v_o pulse with stale MSHR data.

### Area

bp_be_dcache

### Reasoning

Bug

### Additional Changes Required

None. The fill data write to the cache array is unaffected; only the TV-stage valid bit is suppressed. No downstream modules need changes.

### Analysis

Two timing cases must be covered:

Same cycle (flush_i=1 and critical_recv=1 simultaneously): & ~flush_i alone suffices, but fill_flushed_r has not clocked yet.
Later cycle (flush_i already low when critical_recv arrives): & ~flush_i alone misses this case entirely.
The fix adds a fill_flushed_r sticky bit, set when flush_i fires while the state machine is not in e_ready, cleared on complete_recv or blocking_sent. Both guards are required:

assign fill_restart_tv = critical_recv & ~fill_flushed_r & ~flush_i;

### Verification

Standalone Verilator simulation with four scenarios against the buggy and fixed RTL: https://github.com/flaviens/bc-cache-bug-reprod

Scenarios 2 (simultaneous flush + fill) and 3 (delayed fill after flush) fail on the original code; all four pass on the fixed code.

### Additional Context

The state machine has no flush_i --> e_ready transition, so it remains in e_primary with the MSHR intact after a flush. This is intentional (the fill data is still needed to populate the cache array), but it means critical_recv can fire arbitrarily late with flush_i long gone, making the sticky bit mandatory.

