### PR TITLE
Fix/pipe long flush window

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_pipe_long.sv
@@ -57,8 +57,27 @@ module bp_be_pipe_long
      ,.data_i({fp_v_li, int_v_li})
      ,.data_o({fmask_r, imask_r})
      );
-  wire flush_int_li = flush_i & (imask_r | int_v_li);
-  wire flush_fp_li  = flush_i & (fmask_r | fp_v_li);
+
+  // Sticky bits: set on dispatch, cleared when the write-back is consumed.
+  // fmask_r / imask_r only cover the dispatch cycle and D+1, leaving a window
+  // where flush_fp_li / flush_int_li are permanently 0 while the unit is
+  // still computing or has completed but not yet been accepted.  These extend
+  // the flush window to the full in-flight lifetime of the operation.
+  logic fop_inflight_r, iop_inflight_r;
+  always_ff @(posedge clk_i)
+    if (reset_i | (fwb_v_o & fwb_yumi_i))
+      fop_inflight_r <= '0;
+    else if (fp_v_li)
+      fop_inflight_r <= '1;
+
+  always_ff @(posedge clk_i)
+    if (reset_i | (iwb_v_o & iwb_yumi_i))
+      iop_inflight_r <= '0;
+    else if (int_v_li)
+      iop_inflight_r <= '1;
+
+  wire flush_int_li = flush_i & (iop_inflight_r | int_v_li);
+  wire flush_fp_li  = flush_i & (fop_inflight_r | fp_v_li);
 
   wire signed_div_li = decode.fu_op inside {e_long_op_div, e_long_op_rem};
   wire rem_not_div_li = decode.fu_op inside {e_long_op_rem, e_long_op_remu};


### PR DESCRIPTION
Hi there!

### Summary

Extend the flush_fp_li / flush_int_li window in bp_be_pipe_long to cover the full in-flight lifetime of each long-latency operation, preventing zombie write-backs after a flush.

### Issue Fixed

flush_fp_li = flush_i & (fmask_r | fp_v_li) only asserts on the dispatch cycle and the one immediately after (via fmask_r, a single-cycle registered version of fp_v_li). From cycle D+2 onward, flush_fp_li is permanently 0 regardless of pipeline state. A flush arriving while the unit is computing, or after the unit has completed but before its write-back was accepted, leaves both the functional unit and fdivsqrt_pending_r un-reset.

The consequence: fwb_v_o = ~fmask_r & fdivsqrt_pending = 1 persists after the flush. Because long-pipe write-backs are gated by ~issue_pkt_cast_o.v in bp_be_scheduler, the stale result is dispatched as a force-commit synthetic packet in the first no-issue gap after the flush (typically the gap between the flush and the first instruction from the exception handler), writing a stale FP or INT result to the register file.

The same structural issue exists on the integer side: flush_int_li is equally narrow, and bsg_idiv_iterative / bsg_imul_iterative hold v_o=1 until yumi_i=1 when not reset.

Trigger sequence for both sides: ecall; fdiv.d f1, f2, f3 / ecall; div x1, x2, x3. The ecall is not blocked by mem_busy_i (it uses the sys pipe), so the long op dispatches immediately and computes speculatively. By the time ecall reaches the commit head and fires the exception, the long op has likely completed. flush_fp_li = 0 at that point; fdivsqrt_pending_r survives the flush.

### Area

bp_be_pipe_long

### Reasoning

Bug

### Additional Changes Required

None. The fix is self-contained within bp_be_pipe_long. The downstream fdivsqrt_pending_reg.reset_i and the functional unit reset inputs already consume flush_fp_li / flush_int_li — widening those signals is sufficient.

### Analysis

Two always_ff sticky bits (fop_inflight_r, iop_inflight_r) replace the 1-cycle mask as the qualifying term for the flush signals. Each bit is set on dispatch and cleared when the write-back is consumed (fwb_v_o & fwb_yumi_i / iwb_v_o & iwb_yumi_i), covering exactly the window during which a flush must reset the unit. fmask_r / imask_r are retained for ibusy_o / fbusy_o and remain correct.

No combinational loop: fop_inflight_r is clocked, so the path fwb_v_o → fop_inflight_r → flush_fp_li → fdivsqrt_pending_reg has a register at each stage.

The fix is not overkill: the inflight bits are cleared exactly when the operation's result is architecturally committed, so a legitimate write-back from a non-flushed long op is never suppressed.

### Verification

Trigger sequence: ecall; fdiv.d f1, f2, f3. Before the fix, the FP register written by fdiv is corrupted with the stale result in the first post-exception cycle. After the fix, fdivsqrt_pending_r is cleared by the flush and no write-back fires. Equivalent test for the integer side with ecall; div.

### Additional Context

bp_be_dcache has an analogous bug in #1309 in the same exception-with-younger-speculative-op pattern (fill_restart_tv unguarded on flush): a sticky fill_flushed_r bit is the fix there too. This fix follows the same pattern.