### PR TITLE
Deprecated popd opcode

### DIFF
--- a/bp_me/src/include/bp_me_cce_inst_pkgdef.svh
+++ b/bp_me/src/include/bp_me_cce_inst_pkgdef.svh
@@ -148,8 +148,9 @@
   //    and also captures the message type into the specified GPR.
   // 2. popd dequeues a single 64-bit data packet into a single GPR. The user must first have at
   //    at least done a poph to determine that data was available and so ucode can use size
-  //    field in MSHR to determine how many packets to dequeue.
-  // 3. popq dequeues only the header. We assume that all data has been popped off
+  //    field in MSHR to determine how many packets to dequeue. Note: popd is
+  //    not currently supported.
+  // 3. popq dequeues the message from the queue. We assume that all data has been popped off
   //    either by popd commands, or by the message unit auto-forward mechanism, or by issuing
   //    a pushq command that consumes the data (e.g., an explicit pushq memCmd that consumes an
   //    lceResp containing writeback data). No state is written from the message to the CCE.
@@ -158,10 +159,9 @@
     e_wfq_op                               = 4'b0000   // Wait for Queue Valid
     ,e_pushq_op                            = 4'b0001   // Push Queue
   //,e_pushqc_op                           = 4'b0001   // Push Queue Custom Message
-    ,e_popq_op                             = 4'b0010   // Pop Queue - dequeue the header
-    ,e_poph_op                             = 4'b0011   // Pop Header From Queue - does not pop message
-    // TODO: popd not yet fully supported - will be supported after serdes changes
-    ,e_popd_op                             = 4'b0100   // Pop Data From Queue
+    ,e_popq_op                             = 4'b0010   // Pop Queue
+    ,e_poph_op                             = 4'b0011   // Place Header into GPR - does not dequeue
+  //,e_popd_op                             = 4'b0100   // Place Data into GPR - does not dequeue
     ,e_specq_op                            = 4'b0101   // Write or read speculative access bits
     ,e_inv_op                              = 4'b1000   // Send all Invalidations based on sharers vector
   } bp_cce_inst_minor_queue_op_e;

--- a/bp_me/src/v/cce/bp_cce_inst_decode.sv
+++ b/bp_me/src/v/cce/bp_cce_inst_decode.sv
@@ -715,31 +715,6 @@ module bp_cce_inst_decode
                 end
               endcase
             end
-            e_popd_op: begin
-              // TODO: add full support when removing message deserialization
-              // pop 64-bits of data from src_q to a GPR
-              decoded_inst_o.popd = 1'b1;
-              decoded_inst_o.popq_qsel = op_type_u.popq.src_q;
-              decoded_inst_o.src_a_sel = e_src_sel_queue;
-              decoded_inst_o.dst_sel = e_dst_sel_gpr;
-              decoded_inst_o.dst.gpr = op_type_u.popq.dst;
-              decoded_inst_o.gpr_w_v[op_type_u.popq.dst[0+:`bp_cce_inst_gpr_sel_width]] = 1'b1;
-              unique case (op_type_u.popq.src_q)
-                e_src_q_sel_lce_resp: begin
-                  decoded_inst_o.src_a.q = e_opd_lce_resp_data;
-                end
-                e_src_q_sel_mem_rev: begin
-                  decoded_inst_o.src_a.q = e_opd_mem_rev_data;
-                end
-                e_src_q_sel_lce_req: begin
-                  decoded_inst_o.src_a.q = e_opd_lce_req_data;
-                end
-                default: begin
-                  decoded_inst_o.src_a.q = e_opd_lce_resp_data;
-                end
-              endcase
-
-            end
             e_specq_op: begin
 
               decoded_inst_o.addr_sel = op_type_u.stype.addr_sel;


### PR DESCRIPTION
### Summary

This PR deprecates the popd opcode in the CCE. This is not supported after #260 so let's make it explicit.

### Issue Fixed

#1295 #1307 #1296 

### Area
CCE

### Reasoning (new feature, inefficient, verbose, etc.)

After aligning the bedrock header and data fields, it's not possible to dequeue data without header. This opcode could perhaps be useful in the same way as poph by reading data without popping, but we don't want to include functionality that's not supported.

### Additional Changes Required (if any)

none

### Analysis

Negligible ppa improvement by simplifying decode and fsm.

### Verification

No functional change as opcode was unused in all current ucode.


