### PR TITLE
bp_be/bp_common: fix PMP configuration bugs in CSR write path and decompress macro

### DIFF
--- a/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
+++ b/bp_be/src/v/bp_be_calculator/bp_be_csr.sv
@@ -547,7 +547,7 @@ module bp_be_csr
         {1'b1, `CSR_ADDR_MCOUNTINHIBIT}: mcountinhibit_li = csr_data_li;
         // illegal accesses are checked in decode, so we don't need to recheck here
         {1'b1, `CSR_ADDR_PMPCFG0      }: pmpcfg_li[0+:8] = csr_data_li;
-        {1'b1, `CSR_ADDR_PMPCFG2      }: pmpcfg_li[8+:16] = csr_data_li;
+        {1'b1, `CSR_ADDR_PMPCFG2      }: pmpcfg_li[8+:8] = csr_data_li;
         {1'b1, `CSR_ADDR_PMPADDR      }: pmpaddr_li[pmpaddr_sel_li] = csr_data_li;
         {1'b1, `CSR_ADDR_DCSR         }: dcsr_li = csr_data_li;
         {1'b1, `CSR_ADDR_DPC          }: dpc_li = csr_data_li;

--- a/bp_common/src/include/bp_common_rv64_csr_defines.svh
+++ b/bp_common/src/include/bp_common_rv64_csr_defines.svh
@@ -937,7 +937,7 @@
 
   `define decompress_pmpcfg_s(data_comp_mp) \
     '{l      : data_comp_mp.l                         \
-      ,a     : {data_comp_mp.napot, data_comp_mp.tor} \
+      ,a     : {data_comp_mp.napot, data_comp_mp.napot | data_comp_mp.tor} \
       ,x     : data_comp_mp.x                         \
       ,w     : data_comp_mp.w                         \
       ,r     : data_comp_mp.r                         \


### PR DESCRIPTION
### Description
This PR fixes two bugs in the PMP (Physical Memory Protection) subsystem:

**Bug 1:-**
bp_be_csr.sv
where writing to the CSR_ADDR_PMPCFG2 register used an incorrect slice of the pmpcfg_li array.

Before: {1'b1, CSR_ADDR_PMPCFG2 }: pmpcfg_li[8+:16] = csr_data_li;
After: {1'b1, CSR_ADDR_PMPCFG2 }: pmpcfg_li[8+:8] = csr_data_li;

**Reasoning**
pmpcfg_li is defined as rv64_pmpcfg_entry_s [15:0].
The slice [8+:16] (accessing indices 8 to 23) was out-of-bounds for the [15:0] array.
Additionally, it attempted to assign the 64-bit input data csr_data_li to a 128-bit slice, causing a bit-width mismatch.
Changing the slice to [8+:8] correctly selects 8 elements (indices 8 to 15, totaling 64 bits), matching the read logic of the register.

**Verification**
The bug was verified and resolved using the Verilator linter:

Before the fix, running make lint.verilator triggered the following warning/error:

%Warning-SELRANGE: .../bp_be_csr.sv:550:41: Selection index out of range: 23:8 outside 15:0
%Warning-WIDTHEXPAND: .../bp_be_csr.sv:550:49: Operator ASSIGN expects 128 bits on the Assign RHS, but Assign RHS's VARREF 'csr_data_li' generates 64 bits.

After the fix, the linter compiles clean with these warnings fully resolved (reducing the overall warning count by 2).


**Bug 2:-**
NAPOT mode corruption in `decompress_pmpcfg_s` (`bp_common_rv64_csr_defines.svh`)

The `decompress_pmpcfg_s` macro reconstructed the 2-bit address-matching mode `a`
as `{napot, tor}`. This is incorrect for NAPOT entries:
| Internal bits | `{napot, tor}` | Decoded `a` | Expected |
|-------------------|--------------------|-------------------|---------------|
| napot=1, tor=0 | `2'b10` | **NA4**  | NAPOT (`2'b11`) |
| napot=0, tor=1 | `2'b01` | TOR  | TOR |
| napot=0, tor=0 | `2'b00` | OFF  | OFF |

This means any NAPOT entry read back via `CSRR` on `pmpcfg0`/`pmpcfg2` would appear as NA4 (`2'b10`) instead of NAPOT (`2'b11`). 

**Fix:** `{data_comp_mp.napot, data_comp_mp.napot | data_comp_mp.tor}`
This correctly reconstructs all three active modes (NAPOT → `2'b11`, TOR → `2'b01`,
OFF → `2'b00`). 